### PR TITLE
chore: fix ci unity.loader.js name

### DIFF
--- a/browser-interface/scripts/publish.ts
+++ b/browser-interface/scripts/publish.ts
@@ -19,7 +19,7 @@ async function checkFiles() {
   console.assert(packageJson.typings, "package.json must contain typings file")
   ensureFileExists(DIST_ROOT, packageJson.main)
   ensureFileExists(DIST_ROOT, packageJson.typings)
-  ensureFileExists(DIST_ROOT, "UnityLoader.js")
+  ensureFileExists(DIST_ROOT, "unity.loader.js")
 }
 
 export async function publish(npmTags: string[], access: string, workingDirectory: string): Promise<string> {


### PR DESCRIPTION
# What? <!-- what is this PR? -->
UnityLoader.js was renamed to unity.loader.js in #279