### PR TITLE
fix: BiW scale tool is not working correctly

### DIFF
--- a/unity-renderer/Assets/Builder/Scripts/Gizmos/DCLBuilderScaleGizmo.cs
+++ b/unity-renderer/Assets/Builder/Scripts/Gizmos/DCLBuilderScaleGizmo.cs
@@ -27,7 +27,7 @@ namespace Builder.Gizmos
             if (axis == axisProportionalScale)
             {
                 scaleDirection = Vector3.one;
-                float inputDirection = lastMousePosition.y - initialMousePosition.y;
+                float inputDirection = (lastMousePosition.x - initialMousePosition.x) + (lastMousePosition.y - initialMousePosition.y);
                 if (inputDirection < 0)
                 {
                     scaleDirection = -Vector3.one;
@@ -45,7 +45,7 @@ namespace Builder.Gizmos
 
             Vector3 newScale = entityTransform.localScale + scaleDirection * axisValue;
 
-            if (Mathf.Abs(newScale.x) < MINIMUN_SCALE_ALLOWED || Mathf.Abs(newScale.y) < MINIMUN_SCALE_ALLOWED || Mathf.Abs(newScale.y) < MINIMUN_SCALE_ALLOWED)
+            if (Mathf.Abs(newScale.x) < MINIMUN_SCALE_ALLOWED || Mathf.Abs(newScale.y) < MINIMUN_SCALE_ALLOWED)
             {
                 newScale += scaleDirection * MINIMUN_SCALE_ALLOWED;
             }

--- a/unity-renderer/Assets/Builder/Scripts/Gizmos/DCLBuilderScaleGizmo.cs
+++ b/unity-renderer/Assets/Builder/Scripts/Gizmos/DCLBuilderScaleGizmo.cs
@@ -26,11 +26,11 @@ namespace Builder.Gizmos
         public override float TransformEntity(Transform entityTransform, DCLBuilderGizmoAxis axis, float axisValue)
         {
             // In order to avoid to make the scale of each selected entity dependent of the 'entityTransform' parent,
-            // we temporally move all entities to the local position (0,0,0) before calculate the new scale.
+            // we temporally move all entities to the same position as 'entityTransform' before calculate the new scale.
             foreach (Transform entity in entityTransform)
             {
                 entitiesOriginalPositions.Add(entity, entity.transform.position);
-                entity.transform.localPosition = Vector3.zero;
+                entity.transform.position = entityTransform.position;
             }
 
             Vector3 scaleDirection = GetScaleDirection(entityTransform, axis);

--- a/unity-renderer/Assets/Builder/Scripts/Gizmos/DCLBuilderScaleGizmo.cs
+++ b/unity-renderer/Assets/Builder/Scripts/Gizmos/DCLBuilderScaleGizmo.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Builder.Gizmos
@@ -12,6 +13,7 @@ namespace Builder.Gizmos
         private Vector2 initialMousePosition;
         private Vector3 initialHitPoint;
         private Vector3 lastHitPoint;
+        private Dictionary<Transform, Vector3> entitiesOriginalPositions = new Dictionary<Transform, Vector3>();
 
         public override void Initialize(Camera camera, Transform cameraTransform)
         {
@@ -22,6 +24,32 @@ namespace Builder.Gizmos
         public override void SetSnapFactor(DCLBuilderGizmoManager.SnapInfo snapInfo) { snapFactor = snapInfo.scale; }
 
         public override float TransformEntity(Transform entityTransform, DCLBuilderGizmoAxis axis, float axisValue)
+        {
+            // In order to avoid to make the scale of each selected entity dependent of the 'entityTransform' parent,
+            // we temporally move all entities to the local position (0,0,0) before calculate the new scale.
+            foreach (Transform entity in entityTransform)
+            {
+                entitiesOriginalPositions.Add(entity, entity.transform.position);
+                entity.transform.localPosition = Vector3.zero;
+            }
+
+            Vector3 scaleDirection = GetScaleDirection(entityTransform, axis);
+            entityTransform.localScale = GetNewScale(entityTransform, axisValue, scaleDirection);
+
+            // Once the new scale has been calculated, we restore the original positions of all the selected entities.
+            using (var enumerator = entitiesOriginalPositions.GetEnumerator())
+            {
+                while (enumerator.MoveNext())
+                {
+                    enumerator.Current.Key.position = enumerator.Current.Value;
+                }
+            }
+            entitiesOriginalPositions.Clear();
+
+            return axisValue;
+        }
+
+        private Vector3 GetScaleDirection(Transform entityTransform, DCLBuilderGizmoAxis axis)
         {
             Vector3 scaleDirection = activeAxis.transform.forward;
             if (axis == axisProportionalScale)
@@ -43,6 +71,11 @@ namespace Builder.Gizmos
                 scaleDirection.z = Mathf.Abs(scaleDirection.z);
             }
 
+            return scaleDirection;
+        }
+
+        private static Vector3 GetNewScale(Transform entityTransform, float axisValue, Vector3 scaleDirection)
+        {
             Vector3 newScale = entityTransform.localScale + scaleDirection * axisValue;
 
             if (Mathf.Abs(newScale.x) < MINIMUN_SCALE_ALLOWED || Mathf.Abs(newScale.y) < MINIMUN_SCALE_ALLOWED)
@@ -50,8 +83,7 @@ namespace Builder.Gizmos
                 newScale += scaleDirection * MINIMUN_SCALE_ALLOWED;
             }
 
-            entityTransform.localScale = newScale;
-            return axisValue;
+            return newScale;
         }
 
         protected override void SetPreviousAxisValue(float axisValue, float transformValue)


### PR DESCRIPTION
## Fixed bugs
- [x] **Scale gizmos on all axis is not working correctly** (Fixes #316)
_Scale gizmos is working strange when you try to scale in the three axis at the same time_
- [x] **Scale on Z axis with multiple entities** (Fixes #317)
_If you have multiple entities selected and scale in the Z axis, they move as well when they should only scale_

## Testing
1. Go to: https://play.decentraland.zone/?index.html&renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-scale-is-not-working-correctly&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=100,100
2. Press `K` to open the Builder In World editor.