### PR TITLE
feat: add helper to fetch user deployed scenes

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+<<<<<<< HEAD:unity-client/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher.meta
+guid: df9095f4e18b8486b93b9365d363ecf7
+=======
+guid: 04855ba00ccd048dfb21eaf3667644c5
+>>>>>>> 545821505e4507f4c7d64d7eb4745f244a2cde6f:unity-client/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst.meta
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "DeployedScenesFetcher",
+    "rootNamespace": "",
+    "references": [
+        "GUID:1b07639381de24d0f932014911b5b207",
+        "GUID:3d1a503a92d494d8aa3f35909695fa1f",
+        "GUID:b1087c5731ff68448a0a9c625bb7e52d"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.asmdef.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.asmdef.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+<<<<<<< HEAD:unity-client/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.asmdef.meta
+guid: 4441321ef4d7544189dc9aaf74e00438
+=======
+guid: 3d1a503a92d494d8aa3f35909695fa1f
+>>>>>>> 545821505e4507f4c7d64d7eb4745f244a2cde6f:unity-client/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.asmdef.meta
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.cs
@@ -1,0 +1,219 @@
+using System.Collections.Generic;
+using System.Linq;
+using DCL.Helpers;
+using UnityEngine;
+
+public static class DeployedScenesFetcher
+{
+    public static Promise<DeployedScene[]> FetchScenes(ICatalyst catalyst, string[] parcels)
+    {
+        Promise<DeployedScene[]> promise = new Promise<DeployedScene[]>();
+        catalyst.GetDeployedScenes(parcels)
+                .Then(result =>
+                {
+                    promise.Resolve(result.Select(deployment => new DeployedScene(deployment, catalyst.contentUrl)).ToArray());
+                })
+                .Catch(err => promise.Reject(err));
+        return promise;
+    }
+
+    public static Promise<LandWithAccess[]> FetchLandsFromOwner(ICatalyst catalyst, ITheGraph theGraph, string ethAddress, string tld)
+    {
+        Promise<LandWithAccess[]> resultPromise = new Promise<LandWithAccess[]>();
+
+        List<Land> lands = new List<Land>();
+
+        Promise<string[]> getOwnedParcelsPromise = new Promise<string[]>();
+        Promise<DeployedScene[]> getDeployedScenesPromise = new Promise<DeployedScene[]>();
+
+        theGraph.QueryLands(tld, ethAddress, TheGraphCache.UseCache)
+                .Then(landsReceived =>
+                {
+                    lands = landsReceived;
+
+                    List<string> parcels = new List<string>();
+                    for (int i = 0; i < landsReceived.Count; i++)
+                    {
+                        if (landsReceived[i].parcels == null)
+                            continue;
+
+                        parcels.AddRange(landsReceived[i].parcels.Select(parcel => $"{parcel.x},{parcel.y}"));
+                    }
+                    getOwnedParcelsPromise.Resolve(parcels.ToArray());
+                })
+                .Catch(err => getOwnedParcelsPromise.Reject(err));
+
+        getOwnedParcelsPromise.Then(parcels =>
+                              {
+                                  if (parcels.Length > 0)
+                                  {
+                                      FetchScenes(catalyst, parcels)
+                                          .Then(scenes => getDeployedScenesPromise.Resolve(scenes))
+                                          .Catch(err => getDeployedScenesPromise.Reject(err));
+                                  }
+                                  else
+                                  {
+                                      getDeployedScenesPromise.Resolve(new DeployedScene[] { });
+                                  }
+                              })
+                              .Catch(err => getDeployedScenesPromise.Reject(err));
+
+        getDeployedScenesPromise.Then(scenes =>
+                                {
+                                    resultPromise.Resolve(GetLands(lands, scenes));
+                                })
+                                .Catch(err => resultPromise.Reject(err));
+
+        return resultPromise;
+    }
+
+    private static LandWithAccess[] GetLands(List<Land> lands, DeployedScene[] scenes)
+    {
+        LandWithAccess[] result = new LandWithAccess[lands.Count];
+
+        for (int i = 0; i < lands.Count; i++)
+        {
+            result[i] = ProcessLand(lands[i], scenes);
+        }
+
+        return result;
+    }
+
+    private static LandWithAccess ProcessLand(Land land, DeployedScene[] scenes)
+    {
+        List<DeployedScene> scenesInLand = new List<DeployedScene>();
+
+        LandWithAccess result = new LandWithAccess(land);
+        for (int i = 0; i < result.parcels.Length; i++)
+        {
+            DeployedScene sceneInParcel = scenes.FirstOrDefault(scene => scene.parcels.Contains(result.parcels[i]) && !scenesInLand.Contains(scene));
+            if (sceneInParcel != null)
+            {
+                sceneInParcel.sceneLand = result;
+                scenesInLand.Add(sceneInParcel);
+            }
+        }
+        result.scenes = scenesInLand;
+
+        return result;
+    }
+}
+
+public class LandWithAccess
+{
+    public string id => rawData.id;
+    public LandType type => rawData.type;
+    public LandRole role => rawData.role;
+    public int size => rawData.size;
+    public string name => rawData.name;
+    public string owner => rawData.owner;
+
+    public List<DeployedScene> scenes;
+    public Vector2Int[] parcels;
+    public Vector2Int @base;
+    public Land rawData;
+
+    public LandWithAccess(Land land)
+    {
+        rawData = land;
+        parcels = land.parcels.Select(parcel => new Vector2Int(parcel.x, parcel.y)).ToArray();
+        @base = land.type == LandType.PARCEL ? new Vector2Int(land.x, land.y) : parcels[0];
+    }
+}
+
+public class DeployedScene
+{
+    public enum Source { BUILDER, BUILDER_IN_WORLD, SDK }
+
+    public string title => metadata.display.title;
+    public string description => metadata.display.description;
+    public string author => metadata.contact.name;
+    public string navmapThumbnail => thumbnail;
+    public Vector2Int @base => baseCoord;
+    public Vector2Int[] parcels => parcelsCoord;
+    public string id => entityId;
+    public Source source => deploymentSource;
+    public LandWithAccess land => sceneLand;
+    public string[] requiredPermissions => metadata.requiredPermissions;
+    public string contentRating => metadata.policy?.contentRating;
+    public bool voiceEnabled => metadata.policy?.voiceEnabled ?? false;
+    public string[] bannedUsers => metadata.policy?.blacklist;
+    public string projectId => metadata.source?.projectId;
+
+    private CatalystSceneEntityMetadata metadata;
+    private Source deploymentSource;
+    private Vector2Int baseCoord;
+    private Vector2Int[] parcelsCoord;
+    private string thumbnail;
+    private string entityId;
+
+    internal LandWithAccess sceneLand;
+
+    public DeployedScene() { }
+
+    public DeployedScene(CatalystSceneEntityPayload pointerData, string contentUrl)
+    {
+        const string builderInWorldStateJson = "scene-state-definition.json";
+        const string builderSourceName = "builder";
+
+        metadata = pointerData.metadata;
+        entityId = pointerData.id;
+
+        deploymentSource = Source.SDK;
+
+        if (pointerData.content != null && pointerData.content.Any(content => content.file == builderInWorldStateJson))
+        {
+            deploymentSource = Source.BUILDER_IN_WORLD;
+        }
+        else if (metadata.source != null && metadata.source.origin == builderSourceName)
+        {
+            deploymentSource = Source.BUILDER;
+        }
+
+        baseCoord = StringToVector2Int(metadata.scene.@base);
+        parcelsCoord = metadata.scene.parcels.Select(StringToVector2Int).ToArray();
+        thumbnail = GetNavmapThumbnailUrl(pointerData, contentUrl);
+    }
+
+    static Vector2Int StringToVector2Int(string coords)
+    {
+        string[] coordSplit = coords.Split(',');
+        if (coordSplit.Length == 2 && int.TryParse(coordSplit[0], out int x) && int.TryParse(coordSplit[1], out int y))
+        {
+            return new Vector2Int(x, y);
+        }
+        return Vector2Int.zero;
+    }
+
+    static string GetNavmapThumbnailUrl(CatalystSceneEntityPayload pointerData, string contentUrl)
+    {
+        const string contentDownloadUrlFormat = "{0}/contents/{1}";
+        const string builderUrlFormat = "https://builder-api.decentraland.org/v1/projects/{0}/media/preview.png";
+
+        string thumbnail = pointerData.metadata.display.navmapThumbnail;
+
+        bool isThumbnailPresent = !string.IsNullOrEmpty(thumbnail);
+        bool isThumbnailFileDeployed = isThumbnailPresent && !thumbnail.StartsWith("http");
+
+        if (isThumbnailPresent && !isThumbnailFileDeployed)
+        {
+            return thumbnail;
+        }
+
+        if (isThumbnailFileDeployed && pointerData.content != null)
+        {
+            string thumbnailHash = pointerData.content.FirstOrDefault(content => content.file == thumbnail)?.hash;
+            if (!string.IsNullOrEmpty(thumbnailHash))
+            {
+                return string.Format(contentDownloadUrlFormat, contentUrl, thumbnailHash);
+            }
+        }
+
+        if (pointerData.metadata.source != null && !string.IsNullOrEmpty(pointerData.metadata.source.projectId))
+        {
+            return string.Format(builderUrlFormat, pointerData.metadata.source.projectId);
+        }
+
+        return thumbnail;
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8028ce40c12af4b779e158f0d1a2d504
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/CatalystTypes.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/CatalystTypes.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 public static class CatalystEntitiesType
 {
@@ -80,11 +81,31 @@ public class CatalystSceneEntityMetadata
         public Vector3 cameraTarget;
     }
 
+    [Serializable]
+    public class Source
+    {
+        [Serializable]
+        public class Layout
+        {
+            public string rows;
+            public string cols;
+        }
+
+        public int version;
+        public string origin;
+        public string projectId;
+        public Vector2Int point;
+        public string rotation;
+        public Layout layout;
+    }
+
     public Display display;
     public Contact contact;
     public Scene scene;
     public Policy policy;
+    public Source source;
     public SpawnPoint[] spawnPoints;
     public string owner;
     public string[] tags;
+    public string[] requiredPermissions;
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/Land/LandHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/Land/LandHelper.cs
@@ -77,10 +77,12 @@ internal static class LandHelper
             operators = new List<string>()
         };
 
-        if (int.TryParse(parcel.x, out int x))
+        if (int.TryParse(parcel.x, out int x) && int.TryParse(parcel.y, out int y))
+        {
             result.x = x;
-        if (int.TryParse(parcel.y, out int y))
             result.y = y;
+            result.parcels = new List<Parcel>() { new Parcel() { id = CoordsToId(parcel.x, parcel.y), x = x, y = y } };
+        }
 
         if (!string.IsNullOrEmpty(parcel.updateOperator))
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraph.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraph.cs
@@ -102,21 +102,30 @@ public class TheGraph : ITheGraph
 
     private void ProcessReceivedLandsData(Promise<List<Land>> landPromise, string jsonValue, string lowerCaseAddress, bool cache)
     {
+        bool hasException = false;
+        List<Land> lands = null;
+
         try
         {
             LandQueryResultWrapped result = JsonUtility.FromJson<LandQueryResultWrapped>(jsonValue);
-            List<Land> lands = LandHelper.ConvertQueryResult(result.data, lowerCaseAddress);
+            lands = LandHelper.ConvertQueryResult(result.data, lowerCaseAddress);
 
             if (cache)
             {
                 landQueryCache[lowerCaseAddress] = new QueryLandCache() { lands = lands, lastUpdate = Time.unscaledTime };
             }
-
-            landPromise.Resolve(lands);
         }
         catch (Exception exception)
         {
             landPromise.Reject(exception.Message);
+            hasException = true;
+        }
+        finally
+        {
+            if (!hasException)
+            {
+                landPromise.Resolve(lands);
+            }
         }
     }
 }


### PR DESCRIPTION
Helper class to fetch:
* Lands (with their scenes) owned (or with permissions) by a ETH address
* Deployed scenes at chosen parcels