### PR TITLE
fix: [BiW] Dragging/Unselecting when multiple entities are selected center them in the pointer

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -266,18 +266,13 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
             Vector3 destination;
             Vector3 currentPoint = GetFloorPointAtMouse(mousePosition);
 
-
             if (isSnapActive)
             {
                 currentPoint.x = Mathf.Round(currentPoint.x / snapDragFactor) * snapDragFactor;
                 currentPoint.z = Mathf.Round(currentPoint.z / snapDragFactor) * snapDragFactor;
-                destination = currentPoint;
-            }
-            else
-            {
-                destination = currentPoint - dragStartedPoint + editionGO.transform.position;
             }
 
+            destination = currentPoint - dragStartedPoint + editionGO.transform.position;
             editionGO.transform.position = destination;
             dragStartedPoint = currentPoint;
         }


### PR DESCRIPTION
## Fixed bugs
- [x] **Dragging/Unselecting when multiple entities are selected center them in the pointer** (Fixes #301)
_In builder in world, if you select multiple entities and start dragging ( or unselect them clicking on a selected entity) them from a entity, all entities will be centered in the pointer. The desired movement will be to drag them from where they are with the mouse offset, instead of center them._

## Testing
1. Go to: https://play.decentraland.zone/?index.html&renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-Dragging-multiple-entities-centers-them-in-the-pointer&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=100,100
2. Press `K` to open the Builder In World editor.