### PR TITLE
fix: Floor loading placeholder is visible after the floor is loaded s…

### DIFF
--- a/unity-renderer/Assets/Builder/Scripts/MeshLoadIndicator/DCLBuilderMeshLoadIndicatorController.cs
+++ b/unity-renderer/Assets/Builder/Scripts/MeshLoadIndicator/DCLBuilderMeshLoadIndicatorController.cs
@@ -124,6 +124,9 @@ namespace Builder.MeshLoadIndicator
 
         public void HideAllIndicators()
         {
+            if (indicatorsInUse == null)
+                return;
+
             for (int i = 0; i < indicatorsInUse.Count; i++)
             {
                 indicatorsInUse[i].gameObject.SetActive(false);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWFloorHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWFloorHandler.cs
@@ -33,9 +33,21 @@ public class BIWFloorHandler : BIWController
     private CatalogItem lastFloorCalalogItemUsed;
     private readonly Dictionary<string, GameObject> floorPlaceHolderDict = new Dictionary<string, GameObject>();
 
-    private void Start() { meshLoadIndicator.SetCamera(Camera.main); }
+    private void Start()
+    {
+        builderInWorldEntityHandler.OnEntityDeleted += BuilderInWorldEntityHandler_OnEntityDeleted;
 
-    private void OnDestroy() { Clean(); }
+        meshLoadIndicator.SetCamera(Camera.main);
+    }
+
+    private void OnDestroy()
+    {
+        builderInWorldEntityHandler.OnEntityDeleted -= BuilderInWorldEntityHandler_OnEntityDeleted;
+
+        Clean();
+    }
+
+    private void BuilderInWorldEntityHandler_OnEntityDeleted(string entityId) { dclBuilderMeshLoadIndicatorController.HideIndicator(entityId); }
 
     public void Clean()
     {
@@ -92,7 +104,6 @@ public class BIWFloorHandler : BIWController
         {
             DCLBuilderInWorldEntity decentralandEntity = biwCreatorController.CreateCatalogItem(floorSceneObject, WorldStateUtils.ConvertPointInSceneToUnityPosition(initialPosition, parcel), false, true);
             decentralandEntity.rootEntity.OnShapeUpdated += OnFloorLoaded;
-            dclBuilderMeshLoadIndicatorController.HideAllIndicators();
             dclBuilderMeshLoadIndicatorController.ShowIndicator(decentralandEntity.rootEntity.gameObject.transform.position, decentralandEntity.rootEntity.entityId);
 
             GameObject floorPlaceHolder = GameObject.Instantiate(floorPrefab, decentralandEntity.rootEntity.gameObject.transform.position, Quaternion.identity);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWFloorHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWFloorHandler.cs
@@ -92,6 +92,7 @@ public class BIWFloorHandler : BIWController
         {
             DCLBuilderInWorldEntity decentralandEntity = biwCreatorController.CreateCatalogItem(floorSceneObject, WorldStateUtils.ConvertPointInSceneToUnityPosition(initialPosition, parcel), false, true);
             decentralandEntity.rootEntity.OnShapeUpdated += OnFloorLoaded;
+            dclBuilderMeshLoadIndicatorController.HideAllIndicators();
             dclBuilderMeshLoadIndicatorController.ShowIndicator(decentralandEntity.rootEntity.gameObject.transform.position, decentralandEntity.rootEntity.entityId);
 
             GameObject floorPlaceHolder = GameObject.Instantiate(floorPrefab, decentralandEntity.rootEntity.gameObject.transform.position, Quaternion.identity);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BuilderInWorldEntityHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BuilderInWorldEntityHandler.cs
@@ -684,6 +684,8 @@ public class BuilderInWorldEntityHandler : BIWController
 
     public void DeleteEntity(DCLBuilderInWorldEntity entityToDelete, bool checkSelection = true)
     {
+        OnEntityDeleted?.Invoke(entityToDelete.rootEntity.entityId);
+
         if (entityToDelete.IsSelected && checkSelection)
             DeselectEntity(entityToDelete);
 
@@ -710,7 +712,6 @@ public class BuilderInWorldEntityHandler : BIWController
         hudController?.RefreshCatalogAssetPack();
         EntityListChanged();
         builderInWorldBridge?.RemoveEntityOnKernel(idToRemove, sceneToEdit);
-        OnEntityDeleted?.Invoke(entityToDelete.rootEntity.entityId);
     }
 
     public void DeleteSingleEntity(DCLBuilderInWorldEntity entityToDelete)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BuilderInWorldEntityHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BuilderInWorldEntityHandler.cs
@@ -55,6 +55,7 @@ public class BuilderInWorldEntityHandler : BIWController
     public event Action<DCLBuilderInWorldEntity> OnEntityDeselected;
     public event Action OnEntitySelected;
     public event Action<List<DCLBuilderInWorldEntity>> OnDeleteSelectedEntities;
+    public event Action<string> OnEntityDeleted;
 
     private DCLBuilderInWorldEntity lastClickedEntity;
     private float lastTimeEntityClicked;
@@ -709,6 +710,7 @@ public class BuilderInWorldEntityHandler : BIWController
         hudController?.RefreshCatalogAssetPack();
         EntityListChanged();
         builderInWorldBridge?.RemoveEntityOnKernel(idToRemove, sceneToEdit);
+        OnEntityDeleted?.Invoke(entityToDelete.rootEntity.entityId);
     }
 
     public void DeleteSingleEntity(DCLBuilderInWorldEntity entityToDelete)


### PR DESCRIPTION
## What this PR includes?
- **BUG FIX:** "Floor loading placeholder is visible after the floor is loaded sometimes" (Fixes #342)
_If the floor is not loaded and you try to load another floor, the loading placeholder of the first floor will stay._

## How to test it?
1. Go to: https://play.decentraland.zone/?index.html&renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-Floor-loading-placeholder-is-visible-after-the-floor-is-loaded-sometimes&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=100,100
2. Press `K` to open the Builder In World editor.
3. Open the catalog panel (right side of the screen).
4. Select different floors several times in a row without letting them finish loading.
5. Notice that the loading spinner is always being hidden after the last floos has been loaded.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md