### PR TITLE
chore: add gitattribute to treat shell scripts as lf (line feed) and …

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -70,3 +70,5 @@
 #*.RTF   diff=astextplain
 TestResources/Audio/Train.wav filter=lfs diff=lfs merge=lfs -text
 *.jspre linguist-language=JavaScript
+# Shell scripts require LF
+*.sh text eol=lf 


### PR DESCRIPTION
…avoid conflicts in windows os with crlf (carriage return + line feed)

# What?
Similar to decentraland/explorer#2331 for unity-renderer repository

The main reason is to avoid future issues executing .sh scripts in Windows (using a VM)