### PR TITLE
fix: null references in avatar renderer

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -358,7 +358,17 @@ namespace DCL
             }
         }
 
-        void OnWearableLoadingSuccess(WearableController wearableController) { wearableController.SetupDefaultMaterial(defaultMaterial, model.skinColor, model.hairColor); }
+        void OnWearableLoadingSuccess(WearableController wearableController)
+        {
+            if (wearableController == null || model == null)
+            {
+                Debug.LogWarning($"WearableSuccess was called wrongly: IsWearableControllerNull=>{wearableController == null}, IsModelNull=>{model == null}");
+                OnWearableLoadingFail(wearableController, 0);
+                return;
+            }
+
+            wearableController.SetupDefaultMaterial(defaultMaterial, model.skinColor, model.hairColor);
+        }
 
         void OnBodyShapeLoadingFail(WearableController wearableController)
         {


### PR DESCRIPTION
#323 

There's for sure an underlying issue dwelling around that causes the null reference. Unfortunately I havent been able to reproduce it once.

Along the null checks to avoid the exception I'm adding some debug information in case we encounter it again.