### PR TITLE
feat: biw undo/redo top button and some improvements

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -4,9 +4,9 @@ namespace DCL.Configuration
 {
     public static class BuilderInWorldSettings
     {
-        public const string BASE_URL_CATALOG = "https://builder-api.decentraland.org/v1/storage/contents/";
-        public const string BASE_URL_ASSETS_PACK = "https://builder-api.decentraland.org/v1/assetPacks";
-        public const string BASE_URL_ASSETS_PACK_CONTENT = "https://builder-api.decentraland.org/v1/storage/assetPacks/";
+        public const string BASE_URL_CATALOG = "https://builder-api.decentraland.io/v1/storage/contents/";
+        public const string BASE_URL_ASSETS_PACK = "https://builder-api.decentraland.io/v1/assetPacks";
+        public const string BASE_URL_ASSETS_PACK_CONTENT = "https://builder-api.decentraland.io/v1/storage/assetPacks/";
 
         public static readonly int SELECTION_LAYER = LayerMask.NameToLayer("Selection");
         public static readonly int DEFAULT_LAYER = LayerMask.NameToLayer("Default");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderEntity/DCLBuilderInWorldEntity.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderEntity/DCLBuilderInWorldEntity.cs
@@ -85,7 +85,6 @@ public class DCLBuilderInWorldEntity : EditableEntity
     private Dictionary<string, List<GameObject>> collidersGameObjectDictionary = new Dictionary<string, List<GameObject>>();
 
     private Vector3 lastPositionReported;
-    private Vector3 initialPosition;
 
     public void Init(IDCLEntity entity, Material editMaterial)
     {
@@ -101,7 +100,6 @@ public class DCLBuilderInWorldEntity : EditableEntity
         IsVisible = rootEntity.gameObject.activeSelf;
 
         isShapeComponentSet = false;
-        initialPosition = entity.gameObject.transform.position;
         InitRotation();
 
         if (rootEntity.meshRootGameObject && rootEntity.meshesInfo.renderers.Length > 0)
@@ -152,12 +150,7 @@ public class DCLBuilderInWorldEntity : EditableEntity
         IsNew = false;
         IsSelected = false;
         if (rootEntity.gameObject != null)
-        {
             rootEntity.gameObject.transform.SetParent(originalParent);
-
-            if (IsNew)
-                initialPosition = rootEntity.gameObject.transform.position;
-        }
 
         SetOriginalMaterials();
     }
@@ -333,7 +326,6 @@ public class DCLBuilderInWorldEntity : EditableEntity
     {
         currentRotation = Vector3.zero;
         rootEntity.gameObject.transform.eulerAngles = currentRotation;
-        rootEntity.gameObject.transform.position = initialPosition;
 
         OnStatusUpdate?.Invoke(this);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.prefab
@@ -1605,10 +1605,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxDistanceToSelectEntities: 9999
-  snapFactor: 1
+  snapFactor: 0.5
   snapRotationDegresFactor: 0.261799
   snapScaleFactor: 0.5
-  snapDistanceToActivateMovement: 1
+  snapDistanceToActivateMovement: 0.1
   builderInWorldEntityHandler: {fileID: 1676156629805984034}
   biwSaveController: {fileID: 6802675824613373767}
   actionController: {fileID: 1208871512032110241}
@@ -2630,9 +2630,8 @@ MonoBehaviour:
   builderInWorldEntityHandler: {fileID: 1676156629805984034}
   dclBuilderMeshLoadIndicatorController: {fileID: 4453536760248188691}
   meshLoadIndicator: {fileID: 4025507285860166352}
-  builderInWorldBridge: {fileID: 0}
   biwCreatorController: {fileID: 2072020105617305708}
-  builderInWorldController: {fileID: 1208871511274338203}
+  biwSaveController: {fileID: 0}
   floorPrefab: {fileID: 3848538323447533592, guid: ea1dee13f58202f409bb86c92a202112,
     type: 3}
 --- !u!1001 &1309221167772459722

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/GodMode/TopActionsButtons/ExtraActionsView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/GodMode/TopActionsButtons/ExtraActionsView.prefab
@@ -528,7 +528,7 @@ RectTransform:
   - {fileID: 1949570748826987764}
   - {fileID: 1949570748036042359}
   m_Father: {fileID: 1949570749023691520}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1034,6 +1034,7 @@ RectTransform:
   m_Children:
   - {fileID: 1949570749520384123}
   - {fileID: 1949570747602755670}
+  - {fileID: 2449493492750598812}
   - {fileID: 1949570748160068137}
   - {fileID: 1949570749038049157}
   m_Father: {fileID: 0}
@@ -1059,6 +1060,7 @@ MonoBehaviour:
   hideUIBtn: {fileID: 1949570749520384100}
   controlsBtn: {fileID: 1949570747602755671}
   tutorialBtn: {fileID: 1949570748160068138}
+  resetBtn: {fileID: 7362914434681410737}
   toggleUIVisibilityInputAction: {fileID: 11400000, guid: 406d4343cf8bb7a4c9abde62ea95895c,
     type: 2}
   toggleControlsVisibilityInputAction: {fileID: 11400000, guid: efecb0671e927ba4fa1dffff33d267a2,
@@ -1097,7 +1099,7 @@ RectTransform:
   - {fileID: 1949570748092328573}
   - {fileID: 1949570749184235720}
   m_Father: {fileID: 1949570749023691520}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1499,3 +1501,363 @@ MonoBehaviour:
   playClick: 1
   playRelease: 1
   extraClickEvent: {fileID: 0}
+--- !u!1 &3567265508271040267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2449493492750598812}
+  - component: {fileID: 3563547083209272811}
+  - component: {fileID: 4681160148655340538}
+  - component: {fileID: 7362914434681410737}
+  - component: {fileID: 637942352210024698}
+  m_Layer: 5
+  m_Name: ResetBtn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2449493492750598812
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3567265508271040267}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 809485945884616376}
+  - {fileID: 1423156552761709165}
+  m_Father: {fileID: 1949570749023691520}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 75.83895, y: -89.999985}
+  m_SizeDelta: {x: 151.67796, y: 30.569275}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3563547083209272811
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3567265508271040267}
+  m_CullTransparentMesh: 0
+--- !u!114 &4681160148655340538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3567265508271040267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1d87276c2aafe3349ba41d503b1ea57c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7362914434681410737
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3567265508271040267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.5294118, g: 0.5294118, b: 0.5294118, a: 1}
+    m_PressedColor: {r: 0.20784314, g: 0.20784314, b: 0.20784314, a: 1}
+    m_SelectedColor: {r: 0.5283019, g: 0.5283019, b: 0.5283019, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4681160148655340538}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: ChangeVisibilityOfControls
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &637942352210024698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3567265508271040267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
+--- !u!1 &7926448627438033898
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 809485945884616376}
+  - component: {fileID: 2471024856956275563}
+  - component: {fileID: 4295698679698110621}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &809485945884616376
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7926448627438033898}
+  m_LocalRotation: {x: -0, y: -0, z: 0.0015440919, w: 0.9999988}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2449493492750598812}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.177}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -54.299995, y: -0.39000034}
+  m_SizeDelta: {x: -132.37361, y: -12.641613}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2471024856956275563
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7926448627438033898}
+  m_CullTransparentMesh: 0
+--- !u!114 &4295698679698110621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7926448627438033898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ceb1f6f7126f81445b99917280533ea4, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9077958801265815273
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1423156552761709165}
+  - component: {fileID: 1542315149428535319}
+  - component: {fileID: 7403272590316335474}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1423156552761709165
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9077958801265815273}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2449493492750598812}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 14.23, y: -0.000014782}
+  m_SizeDelta: {x: 102.60901, y: 14.971123}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1542315149428535319
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9077958801265815273}
+  m_CullTransparentMesh: 0
+--- !u!114 &7403272590316335474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9077958801265815273}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Reset '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 70f3d6b07a517476dbd2b89cf148f858, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/GodMode/TopActionsButtons/TopActionsButtonsView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/GodMode/TopActionsButtons/TopActionsButtonsView.prefab
@@ -887,7 +887,8 @@ MonoBehaviour:
   translateBtn: {fileID: 3820961471278150080}
   rotateBtn: {fileID: 3820961472385422874}
   scaleBtn: {fileID: 3820961472348082252}
-  resetBtn: {fileID: 3820961471574413565}
+  undoBtn: {fileID: 3820961471574413565}
+  redoBtn: {fileID: 3052169535672528431}
   duplicateBtn: {fileID: 3820961471389997161}
   deleteBtn: {fileID: 3820961471485577506}
   logOutBtn: {fileID: 8929500230923893616}
@@ -900,8 +901,6 @@ MonoBehaviour:
     type: 2}
   toggleScaleInputAction: {fileID: 11400000, guid: 9e5ca5b6a25bef24eaa80d22ea3959ae,
     type: 2}
-  toggleResetInputAction: {fileID: 11400000, guid: 9d995e577b758d248b97f78c9825d831,
-    type: 2}
   toggleDuplicateInputAction: {fileID: 11400000, guid: 43948507e81566e499e81e633a1dcf23,
     type: 2}
   toggleDeleteInputAction: {fileID: 11400000, guid: 9ec10551302c6334da92572890605db3,
@@ -910,7 +909,8 @@ MonoBehaviour:
   translateEventTrigger: {fileID: 3820961471278150093}
   rotateEventTrigger: {fileID: 3820961472385422855}
   scaleEventTrigger: {fileID: 3820961472348082250}
-  resetEventTrigger: {fileID: 3820961471574413567}
+  undoEventTrigger: {fileID: 3820961471574413567}
+  redoEventTrigger: {fileID: 8860970556398268412}
   duplicateEventTrigger: {fileID: 3820961471389997162}
   deleteEventTrigger: {fileID: 3820961471485577507}
   moreActionsEventTrigger: {fileID: 8221625501305900034}
@@ -920,7 +920,8 @@ MonoBehaviour:
   translateTooltipText: Translate (G)
   rotateTooltipText: Rotate (R)
   scaleTooltipText: Scale (S)
-  resetTooltipText: Reset
+  undoTooltipText: Undo (Shift+Z)
+  redoTooltipText: Redo (Shift+Y)
   duplicateTooltipText: Duplicate (D)
   deleteTooltipText: Delete (Del) or (Backspace)
   moreActionsTooltipText: Extra Actions

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/GodMode/TopActionsButtons/TopActionsButtonsView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/GodMode/TopActionsButtons/TopActionsButtonsView.prefab
@@ -38,8 +38,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -240.84004, y: -18.644318}
-  m_SizeDelta: {x: 50.015106, y: 37.28856}
+  m_AnchoredPosition: {x: -244.85, y: -18.644318}
+  m_SizeDelta: {x: 48, y: 37.28856}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5970491396011367381
 CanvasRenderer:
@@ -257,7 +257,7 @@ RectTransform:
   m_LocalScale: {x: -1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 3820961472153102125}
-  m_RootOrder: 9
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -411,7 +411,7 @@ RectTransform:
   m_Children:
   - {fileID: 3820961471468593792}
   m_Father: {fileID: 3820961472153102125}
-  m_RootOrder: 12
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -867,8 +867,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -0.6, y: -113.95}
-  m_SizeDelta: {x: 531.6861, y: 193.1091}
+  m_AnchoredPosition: {x: 3.4111, y: -113.95}
+  m_SizeDelta: {x: 539.7083, y: 193.1091}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5127593872766953183
 MonoBehaviour:
@@ -963,7 +963,7 @@ RectTransform:
   m_LocalScale: {x: -1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 3820961472153102125}
-  m_RootOrder: 7
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1269,7 +1269,7 @@ RectTransform:
   m_Children:
   - {fileID: 3820961470834295582}
   m_Father: {fileID: 3820961472153102125}
-  m_RootOrder: 8
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1496,7 +1496,7 @@ RectTransform:
   m_Children:
   - {fileID: 3820961470558227732}
   m_Father: {fileID: 3820961472153102125}
-  m_RootOrder: 10
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1781,7 +1781,7 @@ GameObject:
   - component: {fileID: 3820961471574413552}
   - component: {fileID: 7638350700963788046}
   m_Layer: 5
-  m_Name: ResetBtn
+  m_Name: UndoBtn
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2105,6 +2105,8 @@ RectTransform:
   - {fileID: 3820961472348082248}
   - {fileID: 3820961471355289481}
   - {fileID: 3820961471574413564}
+  - {fileID: 5722719774625661418}
+  - {fileID: 7267437795460807128}
   - {fileID: 3820961471198908671}
   - {fileID: 3820961471389997160}
   - {fileID: 3820961470450997036}
@@ -2116,8 +2118,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -17.61997, y: 0}
-  m_SizeDelta: {x: 346.1725, y: 37.288544}
+  m_AnchoredPosition: {x: 0.000019073, y: -0.00012207031}
+  m_SizeDelta: {x: 391.77, y: 37.2885}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &3820961472153102126
 MonoBehaviour:
@@ -2592,7 +2594,7 @@ RectTransform:
   m_LocalScale: {x: -1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 3820961472153102125}
-  m_RootOrder: 11
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2825,8 +2827,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 206.00003, y: -18.644318}
-  m_SizeDelta: {x: 50.015106, y: 37.28856}
+  m_AnchoredPosition: {x: 244.85, y: -18.644}
+  m_SizeDelta: {x: 48, y: 37.28856}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6238104477675108811
 CanvasRenderer:
@@ -2939,6 +2941,308 @@ MonoBehaviour:
   playClick: 1
   playRelease: 1
   extraClickEvent: {fileID: 0}
+--- !u!1 &5703653804408759178
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7267437795460807128}
+  - component: {fileID: 6193855928760847521}
+  - component: {fileID: 3052169535672528431}
+  - component: {fileID: 8860970556398268412}
+  - component: {fileID: 8834516314217852525}
+  - component: {fileID: 8572157748103463584}
+  m_Layer: 5
+  m_Name: RedoBtn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7267437795460807128
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5703653804408759178}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1374740226905250547}
+  m_Father: {fileID: 3820961472153102125}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 47.182655, y: 34.210693}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6193855928760847521
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5703653804408759178}
+  m_CullTransparentMesh: 0
+--- !u!114 &3052169535672528431
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5703653804408759178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 1, g: 0.6462264, b: 0.6462264, a: 1}
+    m_PressedColor: {r: 1, g: 0, b: 0, a: 1}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_DisabledColor: {r: 0.5943396, g: 0.5943396, b: 0.5943396, a: 1}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 3821363456965662337}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &8860970556398268412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5703653804408759178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates: []
+--- !u!114 &8834516314217852525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5703653804408759178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8572157748103463584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5703653804408759178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
+--- !u!1 &5794989315679819314
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1374740226905250547}
+  - component: {fileID: 7837457230232866943}
+  - component: {fileID: 3821363456965662337}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1374740226905250547
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5794989315679819314}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: -1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7267437795460807128}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -10, y: -10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7837457230232866943
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5794989315679819314}
+  m_CullTransparentMesh: 0
+--- !u!114 &3821363456965662337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5794989315679819314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ceb1f6f7126f81445b99917280533ea4, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7137598204412248428
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5722719774625661418}
+  - component: {fileID: 2167629484827851527}
+  - component: {fileID: 3590495915161842435}
+  m_Layer: 5
+  m_Name: Separator (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5722719774625661418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7137598204412248428}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: -1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3820961472153102125}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2167629484827851527
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7137598204412248428}
+  m_CullTransparentMesh: 0
+--- !u!114 &3590495915161842435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7137598204412248428}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3773585, g: 0.37379852, b: 0.37201852, a: 0.25490198}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &3317055549520373084
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
@@ -13,6 +13,8 @@ public class BuildModeHUDController : IHUD
     public event Action OnRotateSelectedAction;
     public event Action OnScaleSelectedAction;
     public event Action OnResetAction;
+    public event Action OnUndoAction;
+    public event Action OnRedoAction;
     public event Action OnDuplicateSelectedAction;
     public event Action OnDeleteSelectedAction;
     public event Action OnEntityListVisible;
@@ -159,7 +161,8 @@ public class BuildModeHUDController : IHUD
         controllers.topActionsButtonsController.OnTranslateClick += () => OnTranslateSelectedAction?.Invoke();
         controllers.topActionsButtonsController.OnRotateClick += () => OnRotateSelectedAction?.Invoke();
         controllers.topActionsButtonsController.OnScaleClick += () => OnScaleSelectedAction?.Invoke();
-        controllers.topActionsButtonsController.OnResetClick += () => OnResetAction?.Invoke();
+        controllers.topActionsButtonsController.OnUndoClick += () => OnUndoAction?.Invoke();
+        controllers.topActionsButtonsController.OnRedoClick += () => OnRedoAction?.Invoke();
         controllers.topActionsButtonsController.OnDuplicateClick += () => OnDuplicateSelectedAction?.Invoke();
         controllers.topActionsButtonsController.OnDeleteClick += () => OnDeleteSelectedAction?.Invoke();
         controllers.topActionsButtonsController.OnSnapModeClick += () => OnChangeSnapModeAction?.Invoke();
@@ -439,6 +442,9 @@ public class BuildModeHUDController : IHUD
     public void SetActionsButtonsInteractable(bool isInteractable) { controllers.topActionsButtonsController.SetActionsInteractable(isInteractable); }
 
     public void SetSnapModeActive(bool isActive) { controllers.topActionsButtonsController.SetSnapActive(isActive); }
+
+    public void SetUndoButtonInteractable(bool isInteractable) { controllers.topActionsButtonsController.SetUndoInteractable(isInteractable); }
+    public void SetRedoButtonInteractable(bool isInteractable) { controllers.topActionsButtonsController.SetRedoInteractable(isInteractable); }
 
     #endregion
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
@@ -166,6 +166,7 @@ public class BuildModeHUDController : IHUD
         controllers.topActionsButtonsController.OnLogOutClick += ExitStart;
         controllers.topActionsButtonsController.extraActionsController.OnControlsClick += ChangeVisibilityOfControls;
         controllers.topActionsButtonsController.extraActionsController.OnHideUIClick += ChangeVisibilityOfUI;
+        controllers.topActionsButtonsController.extraActionsController.OnResetClick += () => OnResetAction?.Invoke();
         controllers.topActionsButtonsController.extraActionsController.OnTutorialClick += () => OnTutorialAction?.Invoke();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/ExtraActionsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/ExtraActionsController.cs
@@ -4,7 +4,8 @@ public interface IExtraActionsController
 {
     event Action OnControlsClick,
                  OnHideUIClick,
-                 OnTutorialClick;
+                 OnTutorialClick,
+                 OnResetClick;
 
     void Initialize(IExtraActionsView extraActionsView);
     void Dispose();
@@ -18,7 +19,8 @@ public class ExtraActionsController : IExtraActionsController
 {
     public event Action OnControlsClick,
                         OnHideUIClick,
-                        OnTutorialClick;
+                        OnTutorialClick,
+                        OnResetClick;
 
     internal IExtraActionsView extraActionsView;
 
@@ -29,6 +31,7 @@ public class ExtraActionsController : IExtraActionsController
         extraActionsView.OnControlsClicked += ControlsClicked;
         extraActionsView.OnHideUIClicked += HideUIClicked;
         extraActionsView.OnTutorialClicked += TutorialClicked;
+        extraActionsView.OnResetClicked += ResetClicked;
     }
 
     public void Dispose()
@@ -36,6 +39,7 @@ public class ExtraActionsController : IExtraActionsController
         extraActionsView.OnControlsClicked -= ControlsClicked;
         extraActionsView.OnHideUIClicked -= HideUIClicked;
         extraActionsView.OnTutorialClicked -= TutorialClicked;
+        extraActionsView.OnResetClicked -= ResetClicked;
     }
 
     public void SetActive(bool isActive)
@@ -43,6 +47,8 @@ public class ExtraActionsController : IExtraActionsController
         if (extraActionsView != null)
             extraActionsView.SetActive(isActive);
     }
+
+    public void ResetClicked() { OnResetClick?.Invoke(); }
 
     public void ControlsClicked() { OnControlsClick?.Invoke(); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/ExtraActionsView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/ExtraActionsView.cs
@@ -6,7 +6,8 @@ public interface IExtraActionsView
 {
     event Action OnControlsClicked,
                  OnHideUIClicked,
-                 OnTutorialClicked;
+                 OnTutorialClicked,
+                 OnResetClicked;
 
     void OnControlsClick(DCLAction_Trigger action);
     void OnHideUIClick(DCLAction_Trigger action);
@@ -18,12 +19,14 @@ public class ExtraActionsView : MonoBehaviour, IExtraActionsView
 {
     public event Action OnControlsClicked,
                         OnHideUIClicked,
-                        OnTutorialClicked;
+                        OnTutorialClicked,
+                        OnResetClicked;
 
     [Header("Buttons")]
     [SerializeField] internal Button hideUIBtn;
     [SerializeField] internal Button controlsBtn;
     [SerializeField] internal Button tutorialBtn;
+    [SerializeField] internal Button resetBtn;
 
     [Header("Input Actions")]
     [SerializeField] internal InputAction_Trigger toggleUIVisibilityInputAction;
@@ -45,6 +48,7 @@ public class ExtraActionsView : MonoBehaviour, IExtraActionsView
     {
         hideUIBtn.onClick.AddListener(() => OnHideUIClick(dummyActionTrigger));
         controlsBtn.onClick.AddListener(() => OnControlsClick(dummyActionTrigger));
+        resetBtn.onClick.AddListener(() => OnResetClicked?.Invoke());
         tutorialBtn.onClick.AddListener(OnTutorialClick);
 
         toggleUIVisibilityInputAction.OnTriggered += OnHideUIClick;
@@ -55,6 +59,7 @@ public class ExtraActionsView : MonoBehaviour, IExtraActionsView
     {
         hideUIBtn.onClick.RemoveAllListeners();
         controlsBtn.onClick.RemoveAllListeners();
+        resetBtn.onClick.RemoveAllListeners();
         tutorialBtn.onClick.RemoveListener(OnTutorialClick);
 
         toggleUIVisibilityInputAction.OnTriggered -= OnHideUIClick;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsController.cs
@@ -9,6 +9,7 @@ public interface ITopActionsButtonsController
     event Action OnRotateClick;
     event Action OnScaleClick;
     event Action OnUndoClick;
+    event Action OnRedoClick;
     event Action OnDuplicateClick;
     event Action OnDeleteClick;
     event Action OnLogOutClick;
@@ -23,7 +24,8 @@ public interface ITopActionsButtonsController
     void TranslateClicked();
     void RotateClicked();
     void ScaleClicked();
-    void ResetClicked();
+    void UndoClicked();
+    void RedoClicked();
     void DuplicateClicked();
     void DeleteClicked();
     void LogoutClicked();
@@ -34,6 +36,8 @@ public interface ITopActionsButtonsController
     void SetGizmosActive(string gizmos);
     void SetActionsInteractable(bool isActive);
     void SetSnapActive(bool isActive);
+    void SetUndoInteractable(bool isActive);
+    void SetRedoInteractable(bool isActive);
 }
 
 public class TopActionsButtonsController : ITopActionsButtonsController
@@ -43,7 +47,8 @@ public class TopActionsButtonsController : ITopActionsButtonsController
     public event Action OnTranslateClick;
     public event Action OnRotateClick;
     public event Action OnScaleClick;
-    public event Action OnResetClick;
+    public event Action OnUndoClick;
+    public event Action OnRedoClick;
     public event Action OnDuplicateClick;
     public event Action OnDeleteClick;
     public event Action OnLogOutClick;
@@ -64,7 +69,8 @@ public class TopActionsButtonsController : ITopActionsButtonsController
         topActionsButtonsView.OnTranslateClicked += TranslateClicked;
         topActionsButtonsView.OnRotateClicked += RotateClicked;
         topActionsButtonsView.OnScaleClicked += ScaleClicked;
-        topActionsButtonsView.OnResetClicked += ResetClicked;
+        topActionsButtonsView.OnUndoClicked += OnUndoClick;
+        topActionsButtonsView.OnRedoClicked += OnRedoClick;
         topActionsButtonsView.OnDuplicateClicked += DuplicateClicked;
         topActionsButtonsView.OnDeleteClicked += DeleteClicked;
         topActionsButtonsView.OnLogOutClicked += LogoutClicked;
@@ -73,7 +79,8 @@ public class TopActionsButtonsController : ITopActionsButtonsController
         topActionsButtonsView.OnTranslatePointerEnter += TooltipPointerEntered;
         topActionsButtonsView.OnRotatePointerEnter += TooltipPointerEntered;
         topActionsButtonsView.OnScalePointerEnter += TooltipPointerEntered;
-        topActionsButtonsView.OnResetPointerEnter += TooltipPointerEntered;
+        topActionsButtonsView.OnUndoPointerEnter += TooltipPointerEntered;
+        topActionsButtonsView.OnRedoPointerEnter += TooltipPointerEntered;
         topActionsButtonsView.OnDuplicatePointerEnter += TooltipPointerEntered;
         topActionsButtonsView.OnDeletePointerEnter += TooltipPointerEntered;
         topActionsButtonsView.OnMoreActionsPointerEnter += TooltipPointerEntered;
@@ -92,7 +99,8 @@ public class TopActionsButtonsController : ITopActionsButtonsController
         topActionsButtonsView.OnTranslateClicked -= TranslateClicked;
         topActionsButtonsView.OnRotateClicked -= RotateClicked;
         topActionsButtonsView.OnScaleClicked -= ScaleClicked;
-        topActionsButtonsView.OnResetClicked -= ResetClicked;
+        topActionsButtonsView.OnUndoClicked -= UndoClicked;
+        topActionsButtonsView.OnRedoClicked -= RedoClicked;
         topActionsButtonsView.OnDuplicateClicked -= DuplicateClicked;
         topActionsButtonsView.OnDeleteClicked -= DeleteClicked;
         topActionsButtonsView.OnLogOutClicked -= LogoutClicked;
@@ -101,7 +109,8 @@ public class TopActionsButtonsController : ITopActionsButtonsController
         topActionsButtonsView.OnTranslatePointerEnter -= TooltipPointerEntered;
         topActionsButtonsView.OnRotatePointerEnter -= TooltipPointerEntered;
         topActionsButtonsView.OnScalePointerEnter -= TooltipPointerEntered;
-        topActionsButtonsView.OnResetPointerEnter -= TooltipPointerEntered;
+        topActionsButtonsView.OnUndoPointerEnter -= TooltipPointerEntered;
+        topActionsButtonsView.OnRedoPointerEnter -= TooltipPointerEntered;
         topActionsButtonsView.OnDuplicatePointerEnter -= TooltipPointerEntered;
         topActionsButtonsView.OnDeletePointerEnter -= TooltipPointerEntered;
         topActionsButtonsView.OnMoreActionsPointerEnter -= TooltipPointerEntered;
@@ -118,13 +127,16 @@ public class TopActionsButtonsController : ITopActionsButtonsController
 
     public void ScaleClicked() { OnScaleClick?.Invoke(); }
 
-    public void ResetClicked() { OnResetClick?.Invoke(); }
+    public void UndoClicked() { OnUndoClick?.Invoke(); }
+
+    public void RedoClicked() { OnRedoClick?.Invoke(); }
 
     public void DuplicateClicked() { OnDuplicateClick?.Invoke(); }
 
     public void DeleteClicked() { OnDeleteClick?.Invoke(); }
 
     public void LogoutClicked() { OnLogOutClick?.Invoke(); }
+
     public void SnapModeClicked() { OnSnapModeClick?.Invoke(); }
 
     public void ConfirmLogout(BuildModeModalType modalType)
@@ -147,4 +159,7 @@ public class TopActionsButtonsController : ITopActionsButtonsController
     public void SetGizmosActive(string gizmos) { topActionsButtonsView.SetGizmosActive(gizmos); }
     public void SetActionsInteractable(bool isActive) { topActionsButtonsView.SetActionsInteractable(isActive); }
     public void SetSnapActive(bool isActive) { topActionsButtonsView.SetSnapActive(isActive); }
+    public void SetUndoInteractable(bool isActive) { topActionsButtonsView.SetUndoInteractable(isActive); }
+
+    public void SetRedoInteractable(bool isActive) { topActionsButtonsView.SetRedoInteractable(isActive); }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsController.cs
@@ -8,7 +8,7 @@ public interface ITopActionsButtonsController
     event Action OnTranslateClick;
     event Action OnRotateClick;
     event Action OnScaleClick;
-    event Action OnResetClick;
+    event Action OnUndoClick;
     event Action OnDuplicateClick;
     event Action OnDeleteClick;
     event Action OnLogOutClick;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsView.cs
@@ -11,7 +11,8 @@ public interface ITopActionsButtonsView
                  OnTranslateClicked,
                  OnRotateClicked,
                  OnScaleClicked,
-                 OnResetClicked,
+                 OnUndoClicked,
+                 OnRedoClicked,
                  OnDuplicateClicked,
                  OnDeleteClicked,
                  OnLogOutClicked,
@@ -22,7 +23,8 @@ public interface ITopActionsButtonsView
                                         OnTranslatePointerEnter,
                                         OnRotatePointerEnter,
                                         OnScalePointerEnter,
-                                        OnResetPointerEnter,
+                                        OnUndoPointerEnter,
+                                        OnRedoPointerEnter,
                                         OnDuplicatePointerEnter,
                                         OnDeletePointerEnter,
                                         OnMoreActionsPointerEnter,
@@ -35,7 +37,6 @@ public interface ITopActionsButtonsView
     void OnDuplicateClick(DCLAction_Trigger action);
     void OnExtraClick(DCLAction_Trigger action);
     void OnLogOutClick(DCLAction_Trigger action);
-    void OnResetClick(DCLAction_Trigger action);
     void OnRotateClick(DCLAction_Trigger action);
     void OnScaleClick(DCLAction_Trigger action);
     void OnTranslateClick(DCLAction_Trigger action);
@@ -51,7 +52,8 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
                         OnTranslateClicked,
                         OnRotateClicked,
                         OnScaleClicked,
-                        OnResetClicked,
+                        OnUndoClicked,
+                        OnRedoClicked,
                         OnDuplicateClicked,
                         OnDeleteClicked,
                         OnLogOutClicked,
@@ -62,7 +64,8 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
                                                OnTranslatePointerEnter,
                                                OnRotatePointerEnter,
                                                OnScalePointerEnter,
-                                               OnResetPointerEnter,
+                                               OnUndoPointerEnter,
+                                               OnRedoPointerEnter,
                                                OnDuplicatePointerEnter,
                                                OnDeletePointerEnter,
                                                OnMoreActionsPointerEnter,
@@ -75,7 +78,8 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
     [SerializeField] internal Button translateBtn;
     [SerializeField] internal Button rotateBtn;
     [SerializeField] internal Button scaleBtn;
-    [SerializeField] internal Button resetBtn;
+    [SerializeField] internal Button undoBtn;
+    [SerializeField] internal Button redoBtn;
     [SerializeField] internal Button duplicateBtn;
     [SerializeField] internal Button deleteBtn;
     [SerializeField] internal Button logOutBtn;
@@ -86,7 +90,6 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
     [SerializeField] internal InputAction_Trigger toggleTranslateInputAction;
     [SerializeField] internal InputAction_Trigger toggleRotateInputAction;
     [SerializeField] internal InputAction_Trigger toggleScaleInputAction;
-    [SerializeField] internal InputAction_Trigger toggleResetInputAction;
     [SerializeField] internal InputAction_Trigger toggleDuplicateInputAction;
     [SerializeField] internal InputAction_Trigger toggleDeleteInputAction;
 
@@ -95,7 +98,8 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
     [SerializeField] internal EventTrigger translateEventTrigger;
     [SerializeField] internal EventTrigger rotateEventTrigger;
     [SerializeField] internal EventTrigger scaleEventTrigger;
-    [SerializeField] internal EventTrigger resetEventTrigger;
+    [SerializeField] internal EventTrigger undoEventTrigger;
+    [SerializeField] internal EventTrigger redoEventTrigger;
     [SerializeField] internal EventTrigger duplicateEventTrigger;
     [SerializeField] internal EventTrigger deleteEventTrigger;
     [SerializeField] internal EventTrigger moreActionsEventTrigger;
@@ -107,7 +111,8 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
     [SerializeField] internal string translateTooltipText = "Translate (M)";
     [SerializeField] internal string rotateTooltipText = "Rotate (R)";
     [SerializeField] internal string scaleTooltipText = "Scale (G)";
-    [SerializeField] internal string resetTooltipText = "Reset (Control+R)";
+    [SerializeField] internal string undoTooltipText = "Undo (Shift+Z)";
+    [SerializeField] internal string redoTooltipText = "Redo (Shift+Y)";
     [SerializeField] internal string duplicateTooltipText = "Duplicate (Control+D)";
     [SerializeField] internal string deleteTooltipText = "Delete (Del) or (Backspace)";
     [SerializeField] internal string moreActionsTooltipText = "Extra Actions";
@@ -146,7 +151,8 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
         translateBtn.onClick.AddListener(() => OnTranslateClick(dummyActionTrigger));
         rotateBtn.onClick.AddListener(() => OnRotateClick(dummyActionTrigger));
         scaleBtn.onClick.AddListener(() => OnScaleClick(dummyActionTrigger));
-        resetBtn.onClick.AddListener(() => OnResetClick(dummyActionTrigger));
+        undoBtn.onClick.AddListener(OnUndoClick);
+        redoBtn.onClick.AddListener(OnRedoClick);
         duplicateBtn.onClick.AddListener(() => OnDuplicateClick(dummyActionTrigger));
         deleteBtn.onClick.AddListener(() => OnDeleteClick(dummyActionTrigger));
         logOutBtn.onClick.AddListener(() => OnLogOutClick(dummyActionTrigger));
@@ -194,12 +200,22 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
             (eventData) => OnPointerExit?.Invoke());
 
         BuilderInWorldUtils.ConfigureEventTrigger(
-            resetEventTrigger,
+            undoEventTrigger,
             EventTriggerType.PointerEnter,
-            (eventData) => OnResetPointerEnter?.Invoke(eventData, resetTooltipText));
+            (eventData) => OnUndoPointerEnter?.Invoke(eventData, undoTooltipText));
 
         BuilderInWorldUtils.ConfigureEventTrigger(
-            resetEventTrigger,
+            undoEventTrigger,
+            EventTriggerType.PointerExit,
+            (eventData) => OnPointerExit?.Invoke());
+
+        BuilderInWorldUtils.ConfigureEventTrigger(
+            redoEventTrigger,
+            EventTriggerType.PointerEnter,
+            (eventData) => OnRedoPointerEnter?.Invoke(eventData, redoTooltipText));
+
+        BuilderInWorldUtils.ConfigureEventTrigger(
+            redoEventTrigger,
             EventTriggerType.PointerExit,
             (eventData) => OnPointerExit?.Invoke());
 
@@ -258,7 +274,6 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
         toggleTranslateInputAction.OnTriggered += OnTranslateClick;
         toggleRotateInputAction.OnTriggered += OnRotateClick;
         toggleScaleInputAction.OnTriggered += OnScaleClick;
-        toggleResetInputAction.OnTriggered += OnResetClick;
         toggleDuplicateInputAction.OnTriggered += OnDuplicateClick;
         toggleDeleteInputAction.OnTriggered += OnDeleteClick;
     }
@@ -269,7 +284,8 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
         translateBtn.onClick.RemoveAllListeners();
         rotateBtn.onClick.RemoveAllListeners();
         scaleBtn.onClick.RemoveAllListeners();
-        resetBtn.onClick.RemoveAllListeners();
+        undoBtn.onClick.RemoveAllListeners();
+        redoBtn.onClick.RemoveAllListeners();
         duplicateBtn.onClick.RemoveAllListeners();
         deleteBtn.onClick.RemoveAllListeners();
         logOutBtn.onClick.RemoveAllListeners();
@@ -284,8 +300,10 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
         BuilderInWorldUtils.RemoveEventTrigger(rotateEventTrigger, EventTriggerType.PointerExit);
         BuilderInWorldUtils.RemoveEventTrigger(scaleEventTrigger, EventTriggerType.PointerEnter);
         BuilderInWorldUtils.RemoveEventTrigger(scaleEventTrigger, EventTriggerType.PointerExit);
-        BuilderInWorldUtils.RemoveEventTrigger(resetEventTrigger, EventTriggerType.PointerEnter);
-        BuilderInWorldUtils.RemoveEventTrigger(resetEventTrigger, EventTriggerType.PointerExit);
+        BuilderInWorldUtils.RemoveEventTrigger(undoEventTrigger, EventTriggerType.PointerEnter);
+        BuilderInWorldUtils.RemoveEventTrigger(undoEventTrigger, EventTriggerType.PointerExit);
+        BuilderInWorldUtils.RemoveEventTrigger(redoEventTrigger, EventTriggerType.PointerEnter);
+        BuilderInWorldUtils.RemoveEventTrigger(redoEventTrigger, EventTriggerType.PointerExit);
         BuilderInWorldUtils.RemoveEventTrigger(duplicateEventTrigger, EventTriggerType.PointerEnter);
         BuilderInWorldUtils.RemoveEventTrigger(duplicateEventTrigger, EventTriggerType.PointerExit);
         BuilderInWorldUtils.RemoveEventTrigger(deleteEventTrigger, EventTriggerType.PointerEnter);
@@ -301,7 +319,6 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
         toggleTranslateInputAction.OnTriggered -= OnTranslateClick;
         toggleRotateInputAction.OnTriggered -= OnRotateClick;
         toggleScaleInputAction.OnTriggered -= OnScaleClick;
-        toggleResetInputAction.OnTriggered -= OnResetClick;
         toggleDuplicateInputAction.OnTriggered -= OnDuplicateClick;
         toggleDeleteInputAction.OnTriggered -= OnDeleteClick;
 
@@ -346,7 +363,6 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
 
     public void SetActionsInteractable(bool isActive)
     {
-        resetBtn.interactable = isActive;
         duplicateBtn.interactable = isActive;
         deleteBtn.interactable = isActive;
     }
@@ -355,7 +371,8 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
 
     public void OnScaleClick(DCLAction_Trigger action) { OnScaleClicked?.Invoke(); }
 
-    public void OnResetClick(DCLAction_Trigger action) { OnResetClicked?.Invoke(); }
+    public void OnUndoClick() { OnUndoClicked?.Invoke(); }
+    public void OnRedoClick() { OnRedoClicked?.Invoke(); }
 
     public void OnDuplicateClick(DCLAction_Trigger action) { OnDuplicateClicked?.Invoke(); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsView.cs
@@ -42,6 +42,8 @@ public interface ITopActionsButtonsView
     void OnTranslateClick(DCLAction_Trigger action);
     void SetGizmosActive(string gizmos);
     void SetActionsInteractable(bool isActive);
+    void SetUndoInteractable(bool isActive);
+    void SetRedoInteractable(bool isActive);
     void SetSnapActive(bool isActive);
 }
 
@@ -366,6 +368,10 @@ public class TopActionsButtonsView : MonoBehaviour, ITopActionsButtonsView
         duplicateBtn.interactable = isActive;
         deleteBtn.interactable = isActive;
     }
+
+    public void SetUndoInteractable(bool isActive) { undoBtn.interactable = isActive; }
+
+    public void SetRedoInteractable(bool isActive) { redoBtn.interactable = isActive; }
 
     public void OnRotateClick(DCLAction_Trigger action) { OnRotateClicked?.Invoke(); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/TopActionsButtonsControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/TopActionsButtonsControllerShould.cs
@@ -92,14 +92,28 @@ namespace Tests.BuildModeHUDControllers
         }
 
         [Test]
-        public void ClickOnResetCorrectly()
+        public void ClickOnUndoCorrectly()
         {
             // Arrange
             bool clicked = false;
-            topActionsButtonsController.OnResetClick += () => { clicked = true; };
+            topActionsButtonsController.OnUndoClick += () => { clicked = true; };
 
             // Act
-            topActionsButtonsController.ResetClicked();
+            topActionsButtonsController.UndoClicked();
+
+            // Assert
+            Assert.IsTrue(clicked, "The clicked is false!");
+        }
+
+        [Test]
+        public void ClickOnRedoCorrectly()
+        {
+            // Arrange
+            bool clicked = false;
+            topActionsButtonsController.OnRedoClick += () => { clicked = true; };
+
+            // Act
+            topActionsButtonsController.RedoClicked();
 
             // Assert
             Assert.IsTrue(clicked, "The clicked is false!");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/TopActionsButtonsViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/TopActionsButtonsViewShould.cs
@@ -102,17 +102,31 @@ namespace Tests.BuildModeHUDViews
         }
 
         [Test]
-        public void ClickOnResetCorrectly()
+        public void ClickOnUndoCorrectly()
         {
             // Arrange
-            bool resetClicked = false;
-            topActionsButtonsView.OnResetClicked += () => resetClicked = true;
+            bool undoClicked = false;
+            topActionsButtonsView.OnUndoClicked += () => undoClicked = true;
 
             // Act
-            topActionsButtonsView.OnResetClick(new DCLAction_Trigger());
+            topActionsButtonsView.OnUndoClick();
 
             // Assert
-            Assert.IsTrue(resetClicked, "resetClicked is false!");
+            Assert.IsTrue(undoClicked, "undoClicked is false!");
+        }
+
+        [Test]
+        public void ClickOnRedoCorrectly()
+        {
+            // Arrange
+            bool redoClicked = false;
+            topActionsButtonsView.OnRedoClicked += () => redoClicked = true;
+
+            // Act
+            topActionsButtonsView.OnRedoClick();
+
+            // Assert
+            Assert.IsTrue(redoClicked, "undoClicked is false!");
         }
 
         [Test]
@@ -225,8 +239,6 @@ namespace Tests.BuildModeHUDViews
             //Act
             topActionsButtonsView.SetActionsInteractable(isActive);
 
-            //Assert
-            Assert.AreEqual(isActive, topActionsButtonsView.resetBtn.IsInteractable());
             Assert.AreEqual(isActive, topActionsButtonsView.duplicateBtn.IsInteractable());
             Assert.AreEqual(isActive, topActionsButtonsView.deleteBtn.IsInteractable());
         }


### PR DESCRIPTION
## What this PR includes?

-Add buttons for undo/redo in the top action bar
-Move the reset button to the extra buttons in the top action bar
-Changes the functionality of the reset to only reset, scale, and rotation
-Changes the URL of the builder to always point to.io

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/?index.html&renderer=urn:decentraland:off-chain:renderer-artifacts:{branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md