### PR TITLE
fix: builder projects panel the graph and catalyst fetch cache

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/BuilderProjectsPanel.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/BuilderProjectsPanel.asmdef
@@ -21,7 +21,9 @@
         "GUID:0e967802b778d404eac1ca5ea340e290",
         "GUID:3d1a503a92d494d8aa3f35909695fa1f",
         "GUID:4441321ef4d7544189dc9aaf74e00438",
-        "GUID:c6bd0bfc5ddce41fa8c1488f7cb3a889"
+        "GUID:c6bd0bfc5ddce41fa8c1488f7cb3a889",
+        "GUID:3f4c1b4f55716479ea104c4254afe172",
+        "GUID:760a1d365aad58044916992b072cf2a6"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/Views/SceneCardView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/Views/SceneCardView.cs
@@ -73,6 +73,7 @@ internal class SceneCardView : MonoBehaviour, ISceneCardView
     Vector3 ISceneCardView.contextMenuButtonPosition => contextMenuButton.transform.position;
 
     private ISceneData sceneData;
+    private string thumbnailUrl = null;
     private AssetPromise_Texture thumbnailPromise;
     private bool isDestroyed = false;
     private Transform defaultParent;
@@ -144,6 +145,11 @@ internal class SceneCardView : MonoBehaviour, ISceneCardView
 
     void ISceneCardView.SetThumbnail(string thumbnailUrl)
     {
+        if (this.thumbnailUrl == thumbnailUrl)
+            return;
+
+        this.thumbnailUrl = thumbnailUrl;
+
         isLoadingThumbnail = true;
         loadingAnimator.SetBool(isLoadingAnimation, isLoadingThumbnail);
 
@@ -152,6 +158,7 @@ internal class SceneCardView : MonoBehaviour, ISceneCardView
             AssetPromiseKeeper_Texture.i.Forget(thumbnailPromise);
             thumbnailPromise = null;
         }
+
 
         if (string.IsNullOrEmpty(thumbnailUrl))
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Tests/BuilderProjectsPanelControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Tests/BuilderProjectsPanelControllerShould.cs
@@ -27,7 +27,7 @@ namespace Tests
             ITheGraph theGraph = Substitute.For<ITheGraph>();
             theGraph.Query(Arg.Any<string>(), Arg.Any<string>()).Returns(new Promise<string>());
             theGraph.Query(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<QueryVariablesBase>()).Returns(new Promise<string>());
-            theGraph.QueryLands(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TheGraphCache>()).Returns(new Promise<List<Land>>());
+            theGraph.QueryLands(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>()).Returns(new Promise<List<Land>>());
 
             ICatalyst catalyst = Substitute.For<ICatalyst>();
             catalyst.contentUrl.Returns(string.Empty);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a77544ca0f3cb4981a15596995cf3833
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/DataCache.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/DataCache.asmdef
@@ -1,11 +1,9 @@
 {
-    "name": "Catalyst",
+    "name": "DataCache",
     "rootNamespace": "",
     "references": [
-        "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:e9cee4050cfa5534d9b26e2782df20be",
-        "GUID:0fc00a8222da047548225b34aab7d977"
+        "GUID:760a1d365aad58044916992b072cf2a6",
+        "GUID:3f4c1b4f55716479ea104c4254afe172"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/DataCache.asmdef.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/DataCache.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0fc00a8222da047548225b34aab7d977
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/DataCache.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/DataCache.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DataCache<T> : IDataCache<T>
+{
+    private class CacheType
+    {
+        public T value;
+        public float lastUpdate;
+        public float maxAge;
+        public Coroutine expireCacheRoutine;
+    }
+
+    private readonly Dictionary<string, CacheType> cache = new Dictionary<string, CacheType>();
+
+    public void Add(string key, T value, float maxAge)
+    {
+        if (cache.TryGetValue(key, out CacheType storedCache))
+        {
+            CoroutineStarter.Stop(storedCache.expireCacheRoutine);
+        }
+        else
+        {
+            storedCache = new CacheType();
+            cache[key] = storedCache;
+        }
+
+        storedCache.value = value;
+        storedCache.maxAge = maxAge;
+        storedCache.lastUpdate = Time.unscaledTime;
+        storedCache.expireCacheRoutine = CoroutineStarter.Start(RemoveCache(key, storedCache.maxAge));
+    }
+
+    public bool TryGet(string key, out T value, out float lastUpdate)
+    {
+        value = default(T);
+        lastUpdate = 0;
+
+        if (cache.TryGetValue(key, out CacheType storedCache))
+        {
+            value = storedCache.value;
+            lastUpdate = storedCache.lastUpdate;
+            return true;
+        }
+
+        return false;
+    }
+
+    public void Forget(string key)
+    {
+        if (cache.TryGetValue(key, out CacheType storedCache))
+        {
+            CoroutineStarter.Stop(storedCache.expireCacheRoutine);
+            cache.Remove(key);
+        }
+    }
+
+    public void Dispose()
+    {
+        using (var iterator = cache.GetEnumerator())
+        {
+            while (iterator.MoveNext())
+            {
+                CoroutineStarter.Stop(iterator.Current.Value.expireCacheRoutine);
+            }
+        }
+        cache.Clear();
+    }
+
+    private IEnumerator RemoveCache(string key, float delay)
+    {
+        yield return WaitForSecondsCache.Get(delay);
+        cache?.Remove(key);
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/DataCache.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/DataCache.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 17955fbc2ac240b981c53015a0060dd1
+timeCreated: 1620339590

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/IDataCache.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/IDataCache.cs
@@ -1,0 +1,8 @@
+using System;
+
+public interface IDataCache<T> : IDisposable
+{
+    void Add(string key, T value, float maxAge);
+    bool TryGet(string key, out T value, out float lastUpdate);
+    void Forget(string key);
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/IDataCache.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataCache/IDataCache.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0582e599a36846c8b813e4e58d426132
+timeCreated: 1620339590

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScene.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using UnityEngine;
+
+public class DeployedScene
+{
+    public enum Source { BUILDER, BUILDER_IN_WORLD, SDK }
+
+    public string title => metadata.display.title;
+    public string description => metadata.display.description;
+    public string author => metadata.contact.name;
+    public string navmapThumbnail => thumbnail;
+    public Vector2Int @base => baseCoord;
+    public Vector2Int[] parcels => parcelsCoord;
+    public string id => entityId;
+    public Source source => deploymentSource;
+    public LandWithAccess land => sceneLand;
+    public string[] requiredPermissions => metadata.requiredPermissions;
+    public string contentRating => metadata.policy?.contentRating;
+    public bool voiceEnabled => metadata.policy?.voiceEnabled ?? false;
+    public string[] bannedUsers => metadata.policy?.blacklist;
+    public string projectId => metadata.source?.projectId;
+
+    private CatalystSceneEntityMetadata metadata;
+    private Source deploymentSource;
+    private Vector2Int baseCoord;
+    private Vector2Int[] parcelsCoord;
+    private string thumbnail;
+    private string entityId;
+
+    internal LandWithAccess sceneLand;
+
+    public DeployedScene() { }
+
+    public DeployedScene(CatalystSceneEntityPayload pointerData, string contentUrl)
+    {
+        const string builderInWorldStateJson = "scene-state-definition.json";
+        const string builderSourceName = "builder";
+
+        metadata = pointerData.metadata;
+        entityId = pointerData.id;
+
+        deploymentSource = Source.SDK;
+
+        if (pointerData.content != null && pointerData.content.Any(content => content.file == builderInWorldStateJson))
+        {
+            deploymentSource = Source.BUILDER_IN_WORLD;
+        }
+        else if (metadata.source != null && metadata.source.origin == builderSourceName)
+        {
+            deploymentSource = Source.BUILDER;
+        }
+
+        baseCoord = StringToVector2Int(metadata.scene.@base);
+        parcelsCoord = metadata.scene.parcels.Select(StringToVector2Int).ToArray();
+        thumbnail = GetNavmapThumbnailUrl(pointerData, contentUrl);
+    }
+
+    static Vector2Int StringToVector2Int(string coords)
+    {
+        string[] coordSplit = coords.Split(',');
+        if (coordSplit.Length == 2 && int.TryParse(coordSplit[0], out int x) && int.TryParse(coordSplit[1], out int y))
+        {
+            return new Vector2Int(x, y);
+        }
+        return Vector2Int.zero;
+    }
+
+    static string GetNavmapThumbnailUrl(CatalystSceneEntityPayload pointerData, string contentUrl)
+    {
+        const string contentDownloadUrlFormat = "{0}/contents/{1}";
+        const string builderUrlFormat = "https://builder-api.decentraland.org/v1/projects/{0}/media/preview.png";
+
+        string thumbnail = pointerData.metadata.display.navmapThumbnail;
+
+        bool isThumbnailPresent = !string.IsNullOrEmpty(thumbnail);
+        bool isThumbnailFileDeployed = isThumbnailPresent && !thumbnail.StartsWith("http");
+
+        if (isThumbnailPresent && !isThumbnailFileDeployed)
+        {
+            return thumbnail;
+        }
+
+        if (isThumbnailFileDeployed && pointerData.content != null)
+        {
+            string thumbnailHash = pointerData.content.FirstOrDefault(content => content.file == thumbnail)?.hash;
+            if (!string.IsNullOrEmpty(thumbnailHash))
+            {
+                return string.Format(contentDownloadUrlFormat, contentUrl, thumbnailHash);
+            }
+        }
+
+        if (pointerData.metadata.source != null && !string.IsNullOrEmpty(pointerData.metadata.source.projectId))
+        {
+            return string.Format(builderUrlFormat, pointerData.metadata.source.projectId);
+        }
+
+        return thumbnail;
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScene.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScene.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d970d4766b7f41738d31933660bbe9e5
+timeCreated: 1620340118

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/DeployedScenesFetcher.cs
@@ -1,14 +1,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using DCL.Helpers;
-using UnityEngine;
 
 public static class DeployedScenesFetcher
 {
-    public static Promise<DeployedScene[]> FetchScenes(ICatalyst catalyst, string[] parcels)
+    private const float DEFAULT_SCENES_CACHE_TIME = 3 * 60;
+    private const float DEFAULT_LAND_CACHE_TIME = 5 * 60;
+
+    public static Promise<DeployedScene[]> FetchScenes(ICatalyst catalyst, string[] parcels, float cacheMaxAgeSeconds = DEFAULT_SCENES_CACHE_TIME)
     {
         Promise<DeployedScene[]> promise = new Promise<DeployedScene[]>();
-        catalyst.GetDeployedScenes(parcels)
+        catalyst.GetDeployedScenes(parcels, cacheMaxAgeSeconds)
                 .Then(result =>
                 {
                     promise.Resolve(result.Select(deployment => new DeployedScene(deployment, catalyst.contentUrl)).ToArray());
@@ -17,7 +19,8 @@ public static class DeployedScenesFetcher
         return promise;
     }
 
-    public static Promise<LandWithAccess[]> FetchLandsFromOwner(ICatalyst catalyst, ITheGraph theGraph, string ethAddress, string tld)
+    public static Promise<LandWithAccess[]> FetchLandsFromOwner(ICatalyst catalyst, ITheGraph theGraph, string ethAddress, string tld,
+        float cacheMaxAgeSecondsLand = DEFAULT_LAND_CACHE_TIME, float cacheMaxAgeSecondsScenes = DEFAULT_SCENES_CACHE_TIME)
     {
         Promise<LandWithAccess[]> resultPromise = new Promise<LandWithAccess[]>();
 
@@ -26,7 +29,7 @@ public static class DeployedScenesFetcher
         Promise<string[]> getOwnedParcelsPromise = new Promise<string[]>();
         Promise<DeployedScene[]> getDeployedScenesPromise = new Promise<DeployedScene[]>();
 
-        theGraph.QueryLands(tld, ethAddress, TheGraphCache.UseCache)
+        theGraph.QueryLands(tld, ethAddress, cacheMaxAgeSecondsLand)
                 .Then(landsReceived =>
                 {
                     lands = landsReceived;
@@ -47,7 +50,7 @@ public static class DeployedScenesFetcher
                               {
                                   if (parcels.Length > 0)
                                   {
-                                      FetchScenes(catalyst, parcels)
+                                      FetchScenes(catalyst, parcels, cacheMaxAgeSecondsScenes)
                                           .Then(scenes => getDeployedScenesPromise.Resolve(scenes))
                                           .Catch(err => getDeployedScenesPromise.Reject(err));
                                   }
@@ -96,124 +99,5 @@ public static class DeployedScenesFetcher
         result.scenes = scenesInLand;
 
         return result;
-    }
-}
-
-public class LandWithAccess
-{
-    public string id => rawData.id;
-    public LandType type => rawData.type;
-    public LandRole role => rawData.role;
-    public int size => rawData.size;
-    public string name => rawData.name;
-    public string owner => rawData.owner;
-
-    public List<DeployedScene> scenes;
-    public Vector2Int[] parcels;
-    public Vector2Int @base;
-    public Land rawData;
-
-    public LandWithAccess(Land land)
-    {
-        rawData = land;
-        parcels = land.parcels.Select(parcel => new Vector2Int(parcel.x, parcel.y)).ToArray();
-        @base = land.type == LandType.PARCEL ? new Vector2Int(land.x, land.y) : parcels[0];
-    }
-}
-
-public class DeployedScene
-{
-    public enum Source { BUILDER, BUILDER_IN_WORLD, SDK }
-
-    public string title => metadata.display.title;
-    public string description => metadata.display.description;
-    public string author => metadata.contact.name;
-    public string navmapThumbnail => thumbnail;
-    public Vector2Int @base => baseCoord;
-    public Vector2Int[] parcels => parcelsCoord;
-    public string id => entityId;
-    public Source source => deploymentSource;
-    public LandWithAccess land => sceneLand;
-    public string[] requiredPermissions => metadata.requiredPermissions;
-    public string contentRating => metadata.policy?.contentRating;
-    public bool voiceEnabled => metadata.policy?.voiceEnabled ?? false;
-    public string[] bannedUsers => metadata.policy?.blacklist;
-    public string projectId => metadata.source?.projectId;
-
-    private CatalystSceneEntityMetadata metadata;
-    private Source deploymentSource;
-    private Vector2Int baseCoord;
-    private Vector2Int[] parcelsCoord;
-    private string thumbnail;
-    private string entityId;
-
-    internal LandWithAccess sceneLand;
-
-    public DeployedScene() { }
-
-    public DeployedScene(CatalystSceneEntityPayload pointerData, string contentUrl)
-    {
-        const string builderInWorldStateJson = "scene-state-definition.json";
-        const string builderSourceName = "builder";
-
-        metadata = pointerData.metadata;
-        entityId = pointerData.id;
-
-        deploymentSource = Source.SDK;
-
-        if (pointerData.content != null && pointerData.content.Any(content => content.file == builderInWorldStateJson))
-        {
-            deploymentSource = Source.BUILDER_IN_WORLD;
-        }
-        else if (metadata.source != null && metadata.source.origin == builderSourceName)
-        {
-            deploymentSource = Source.BUILDER;
-        }
-
-        baseCoord = StringToVector2Int(metadata.scene.@base);
-        parcelsCoord = metadata.scene.parcels.Select(StringToVector2Int).ToArray();
-        thumbnail = GetNavmapThumbnailUrl(pointerData, contentUrl);
-    }
-
-    static Vector2Int StringToVector2Int(string coords)
-    {
-        string[] coordSplit = coords.Split(',');
-        if (coordSplit.Length == 2 && int.TryParse(coordSplit[0], out int x) && int.TryParse(coordSplit[1], out int y))
-        {
-            return new Vector2Int(x, y);
-        }
-        return Vector2Int.zero;
-    }
-
-    static string GetNavmapThumbnailUrl(CatalystSceneEntityPayload pointerData, string contentUrl)
-    {
-        const string contentDownloadUrlFormat = "{0}/contents/{1}";
-        const string builderUrlFormat = "https://builder-api.decentraland.org/v1/projects/{0}/media/preview.png";
-
-        string thumbnail = pointerData.metadata.display.navmapThumbnail;
-
-        bool isThumbnailPresent = !string.IsNullOrEmpty(thumbnail);
-        bool isThumbnailFileDeployed = isThumbnailPresent && !thumbnail.StartsWith("http");
-
-        if (isThumbnailPresent && !isThumbnailFileDeployed)
-        {
-            return thumbnail;
-        }
-
-        if (isThumbnailFileDeployed && pointerData.content != null)
-        {
-            string thumbnailHash = pointerData.content.FirstOrDefault(content => content.file == thumbnail)?.hash;
-            if (!string.IsNullOrEmpty(thumbnailHash))
-            {
-                return string.Format(contentDownloadUrlFormat, contentUrl, thumbnailHash);
-            }
-        }
-
-        if (pointerData.metadata.source != null && !string.IsNullOrEmpty(pointerData.metadata.source.projectId))
-        {
-            return string.Format(builderUrlFormat, pointerData.metadata.source.projectId);
-        }
-
-        return thumbnail;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/LandWithAccess.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/LandWithAccess.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class LandWithAccess
+{
+    public string id => rawData.id;
+    public LandType type => rawData.type;
+    public LandRole role => rawData.role;
+    public int size => rawData.size;
+    public string name => rawData.name;
+    public string owner => rawData.owner;
+
+    public List<DeployedScene> scenes;
+    public Vector2Int[] parcels;
+    public Vector2Int @base;
+    public Land rawData;
+
+    public LandWithAccess(Land land)
+    {
+        rawData = land;
+        parcels = land.parcels.Select(parcel => new Vector2Int(parcel.x, parcel.y)).ToArray();
+        @base = land.type == LandType.PARCEL ? new Vector2Int(land.x, land.y) : parcels[0];
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/LandWithAccess.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DeployedScenesFetcher/LandWithAccess.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 16377f4923f0479b95de7cdbfda92ed7
+timeCreated: 1620340078

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraph.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraph.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:e9cee4050cfa5534d9b26e2782df20be"
+        "GUID:e9cee4050cfa5534d9b26e2782df20be",
+        "GUID:0fc00a8222da047548225b34aab7d977"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
* **add**: class `DataCache<T>` to store data that will be cleaned after a set period of time
* **refactor**: `Catalyst` and `TheGraph` classes to be able to set a custom time for caching apis' response
* **refactor**: `BuilderProjectsPanelController` class to reduce the time of deployed scenes cache and fetch for updates on interval
* **refactor**: promote `DeployedScene` and `LandWithAccess` classes to their own file script.
* **fix**: `SceneCardView` trying to fetch thumbnail even if it was the same as the previous thumbnail