### PR TITLE
fix: BiW Editor dropping an entity in the scene should place it right there

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWCreatorController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWCreatorController.cs
@@ -1,11 +1,8 @@
 using DCL;
 using DCL.Components;
 using DCL.Configuration;
-using DCL.Controllers;
-using DCL.Helpers;
 using DCL.Models;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -45,7 +42,10 @@ public class BIWCreatorController : BIWController
     {
         toggleCreateLastSceneObjectInputAction.OnTriggered -= createLastSceneObjectDelegate;
         if (HUDController.i.builderInWorldMainHud != null)
+        {
             HUDController.i.builderInWorldMainHud.OnCatalogItemSelected -= OnCatalogItemSelected;
+            HUDController.i.builderInWorldMainHud.OnCatalogItemDropped -= OnCatalogItemDropped;
+        }
         Clean();
     }
 
@@ -63,7 +63,10 @@ public class BIWCreatorController : BIWController
     {
         base.Init();
         if (HUDController.i.builderInWorldMainHud != null)
+        {
             HUDController.i.builderInWorldMainHud.OnCatalogItemSelected += OnCatalogItemSelected;
+            HUDController.i.builderInWorldMainHud.OnCatalogItemDropped += OnCatalogItemDropped;
+        }
     }
 
     private bool IsInsideTheLimits(CatalogItem sceneObject)
@@ -113,7 +116,7 @@ public class BIWCreatorController : BIWController
         return true;
     }
 
-    public DCLBuilderInWorldEntity CreateCatalogItem(CatalogItem catalogItem, bool autoSelect = true, bool isFloor = false) { return CreateCatalogItem(catalogItem, biwModeController.GetModeCreationEntryPoint(), autoSelect, isFloor); }
+    public void CreateCatalogItem(CatalogItem catalogItem, bool autoSelect = true, bool isFloor = false) { CreateCatalogItem(catalogItem, biwModeController.GetModeCreationEntryPoint(), autoSelect, isFloor); }
 
     public DCLBuilderInWorldEntity CreateCatalogItem(CatalogItem catalogItem, Vector3 startPosition, bool autoSelect = true, bool isFloor = false)
     {
@@ -318,5 +321,11 @@ public class BIWCreatorController : BIWController
         {
             CreateCatalogItem(catalogItem);
         }
+    }
+
+    private void OnCatalogItemDropped(CatalogItem catalogItem)
+    {
+        OnCatalogItemSelected(catalogItem);
+        builderInWorldEntityHandler.DeselectEntities();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
@@ -26,6 +26,7 @@ public class BuildModeHUDController : IHUD
     public event Action OnLogoutAction;
     public event Action OnChangeSnapModeAction;
     public event Action<CatalogItem> OnCatalogItemSelected;
+    public event Action<CatalogItem> OnCatalogItemDropped;
     public event Action<DCLBuilderInWorldEntity> OnEntityClick;
     public event Action<DCLBuilderInWorldEntity> OnEntityDelete;
     public event Action<DCLBuilderInWorldEntity> OnEntityLock;
@@ -176,7 +177,7 @@ public class BuildModeHUDController : IHUD
     private void ConfigureCatalogItemDropController()
     {
         catalogItemDropController.catalogGroupListView = view.sceneCatalog.catalogGroupListView;
-        catalogItemDropController.OnCatalogItemDropped += CatalogItemSelected;
+        catalogItemDropController.OnCatalogItemDropped += CatalogItemDropped;
     }
 
     private void ConfigureSaveHUDController() { OnLogoutAction += controllers.saveHUDController.StopAnimation; }
@@ -316,15 +317,23 @@ public class BuildModeHUDController : IHUD
     public void StopInput()
     {
         OnStopInput?.Invoke();
-
-        if (controllers.sceneCatalogController.IsCatalogExpanded())
-            controllers.sceneCatalogController.ToggleCatalogExpanse();
+        ToggleCatalogIfExpanded();
     }
 
     public void CatalogItemSelected(CatalogItem catalogItem)
     {
         OnCatalogItemSelected?.Invoke(catalogItem);
+        ToggleCatalogIfExpanded();
+    }
 
+    public void CatalogItemDropped(CatalogItem catalogItem)
+    {
+        OnCatalogItemDropped?.Invoke(catalogItem);
+        ToggleCatalogIfExpanded();
+    }
+
+    private void ToggleCatalogIfExpanded()
+    {
         if (controllers.sceneCatalogController.IsCatalogExpanded())
             controllers.sceneCatalogController.ToggleCatalogExpanse();
     }


### PR DESCRIPTION
## What this PR includes?
If you drag and drop an entity from the collection menu the entity is not created when you drop but when you click again in the scene. The entity should be created right when you drop it in the scene (Fixes #383).

## How to test it?
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-Editor-dropping-an-entity-in-the-scene-should-place-it-right-there&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=100,100
2. Press 'K' to open the Builer In World editor.
3. Drag some items from the Catalog to the scene.
4. Notice that the item is directly placed in the floor.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md