### PR TITLE
feat: BiW - Add functionality to reset the camera view

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -469,11 +469,10 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         SetLookAtObject(parcelScene);
 
         // NOTE(Adrian): Take into account that right now to get the relative scale of the gizmos, we set the gizmos in the player position and the camera
-        Vector3 cameraPosition = DCLCharacterController.i.characterPosition.unityPosition;
-        freeCameraController.SetPosition(cameraPosition + Vector3.up * distanceEagleCamera);
-        //
-
+        Vector3 cameraPosition = DCLCharacterController.i.characterPosition.unityPosition + Vector3.up * distanceEagleCamera;
+        freeCameraController.SetPosition(cameraPosition);
         freeCameraController.LookAt(lookAtT);
+        freeCameraController.SetResetConfiguration(cameraPosition, lookAtT);
 
         cameraController.SetCameraMode(CameraMode.ModeId.BuildingToolGodMode);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -101,10 +101,10 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         HUDController.i.builderInWorldMainHud.OnSelectedObjectPositionChange -= UpdateSelectionPosition;
         HUDController.i.builderInWorldMainHud.OnSelectedObjectRotationChange -= UpdateSelectionRotation;
         HUDController.i.builderInWorldMainHud.OnSelectedObjectScaleChange -= UpdateSelectionScale;
-
         HUDController.i.builderInWorldMainHud.OnTranslateSelectedAction -= TranslateMode;
         HUDController.i.builderInWorldMainHud.OnRotateSelectedAction -= RotateMode;
         HUDController.i.builderInWorldMainHud.OnScaleSelectedAction -= ScaleMode;
+        HUDController.i.builderInWorldMainHud.OnResetCameraAction -= ResetCamera;
     }
 
     private void Update()
@@ -240,6 +240,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
             HUDController.i.builderInWorldMainHud.OnSelectedObjectPositionChange += UpdateSelectionPosition;
             HUDController.i.builderInWorldMainHud.OnSelectedObjectRotationChange += UpdateSelectionRotation;
             HUDController.i.builderInWorldMainHud.OnSelectedObjectScaleChange += UpdateSelectionScale;
+            HUDController.i.builderInWorldMainHud.OnResetCameraAction += ResetCamera;
         }
     }
 
@@ -759,4 +760,6 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
 
         return Vector3.zero;
     }
+
+    private void ResetCamera() { freeCameraController.ResetCameraPosition(); }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/FreeCameraMovement.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/FreeCameraMovement.cs
@@ -72,6 +72,9 @@ public class FreeCameraMovement : CameraStateBase
     private InputAction_Hold.Started cameraPanStartDelegate;
     private InputAction_Hold.Finished cameraPanFinishedDelegate;
 
+    private Vector3 originalCameraPosition;
+    private Transform originalCameraLookAt;
+
     private void Awake()
     {
         BuilderInWorldInputWrapper.OnMouseDrag += MouseDrag;
@@ -360,5 +363,17 @@ public class FreeCameraMovement : CameraStateBase
         }
         yaw = transform.eulerAngles.y;
         pitch = transform.eulerAngles.x;
+    }
+
+    public void SetResetConfiguration(Vector3 position, Transform lookAt)
+    {
+        originalCameraPosition = position;
+        originalCameraLookAt = lookAt;
+    }
+
+    public void ResetCameraPosition()
+    {
+        SetPosition(originalCameraPosition);
+        LookAt(originalCameraLookAt);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/BuildModeHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/BuildModeHUD.prefab
@@ -787,7 +787,7 @@ PrefabInstance:
     - target: {fileID: 5913909372522835466, guid: a8cf4aa467ddc0c4d9503c4913860cc2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 320
+      value: 350
       objectReference: {fileID: 0}
     - target: {fileID: 5913909372522835466, guid: a8cf4aa467ddc0c4d9503c4913860cc2,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/GodMode/TopActionsButtons/ExtraActionsView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/GodMode/TopActionsButtons/ExtraActionsView.prefab
@@ -38,9 +38,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 75.83895, y: -52.7}
+  m_AnchoredPosition: {x: 75.83895, y: -35}
   m_SizeDelta: {x: 151.67796, y: 30.569275}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1949570747602755665
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -185,8 +185,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 14.23, y: -0.000014782}
-  m_SizeDelta: {x: 102.60901, y: 14.971123}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1949570748036042353
 CanvasRenderer:
@@ -317,10 +317,10 @@ RectTransform:
   m_Father: {fileID: 1949570749038049157}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.177}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -52.36, y: -0.31000042}
-  m_SizeDelta: {x: -133.87357, y: -12.026661}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 21.7, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1949570748092328575
 CanvasRenderer:
@@ -394,8 +394,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 14.23, y: -0.000014782}
-  m_SizeDelta: {x: 102.60901, y: 14.971123}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1949570748130786301
 CanvasRenderer:
@@ -528,13 +528,13 @@ RectTransform:
   - {fileID: 1949570748826987764}
   - {fileID: 1949570748036042359}
   m_Father: {fileID: 1949570749023691520}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 75.83895, y: -90}
+  m_AnchoredPosition: {x: 75.83895, y: -140}
   m_SizeDelta: {x: 151.67796, y: 30.569275}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1949570748160068308
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -679,8 +679,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 14.23, y: -0.000014782}
-  m_SizeDelta: {x: 102.60901, y: 14.971123}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1949570748326907354
 CanvasRenderer:
@@ -811,10 +811,10 @@ RectTransform:
   m_Father: {fileID: 1949570749520384123}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.177}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -54.299995, y: -0.39000034}
-  m_SizeDelta: {x: -132.37361, y: -18.872469}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 21.7, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1949570748447916822
 CanvasRenderer:
@@ -886,10 +886,10 @@ RectTransform:
   m_Father: {fileID: 1949570748160068137}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.177}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -53.700005, y: -0.31000042}
-  m_SizeDelta: {x: -138.6222, y: -12.026661}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 21.7, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1949570748826987766
 CanvasRenderer:
@@ -961,10 +961,10 @@ RectTransform:
   m_Father: {fileID: 1949570747602755670}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.177}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -54.299995, y: -0.39000034}
-  m_SizeDelta: {x: -132.37361, y: -12.641613}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 21.7, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1949570748845206231
 CanvasRenderer:
@@ -1035,6 +1035,7 @@ RectTransform:
   - {fileID: 1949570749520384123}
   - {fileID: 1949570747602755670}
   - {fileID: 2449493492750598812}
+  - {fileID: 2021294922335030686}
   - {fileID: 1949570748160068137}
   - {fileID: 1949570749038049157}
   m_Father: {fileID: 0}
@@ -1061,6 +1062,7 @@ MonoBehaviour:
   controlsBtn: {fileID: 1949570747602755671}
   tutorialBtn: {fileID: 1949570748160068138}
   resetBtn: {fileID: 7362914434681410737}
+  resetCameraBtn: {fileID: 6668914640440548395}
   toggleUIVisibilityInputAction: {fileID: 11400000, guid: 406d4343cf8bb7a4c9abde62ea95895c,
     type: 2}
   toggleControlsVisibilityInputAction: {fileID: 11400000, guid: efecb0671e927ba4fa1dffff33d267a2,
@@ -1099,13 +1101,13 @@ RectTransform:
   - {fileID: 1949570748092328573}
   - {fileID: 1949570749184235720}
   m_Father: {fileID: 1949570749023691520}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 75.83895, y: -127.69}
+  m_AnchoredPosition: {x: 75.83895, y: -175}
   m_SizeDelta: {x: 151.67796, y: 30.569275}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1949570749038049152
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1250,8 +1252,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 14.23, y: -0.000014782}
-  m_SizeDelta: {x: 102.60901, y: 14.971123}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1949570749184235722
 CanvasRenderer:
@@ -1388,9 +1390,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 75.83895, y: -15.279999}
+  m_AnchoredPosition: {x: 75.83895, y: 0}
   m_SizeDelta: {x: 151.67796, y: 30.569275}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1949570749520384102
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1501,6 +1503,157 @@ MonoBehaviour:
   playClick: 1
   playRelease: 1
   extraClickEvent: {fileID: 0}
+--- !u!1 &3278580096274495498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2021294922335030686}
+  - component: {fileID: 1972921530555288035}
+  - component: {fileID: 2460736801282869938}
+  - component: {fileID: 6668914640440548395}
+  - component: {fileID: 2644395038842912440}
+  m_Layer: 5
+  m_Name: ResetCameraBtn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2021294922335030686
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3278580096274495498}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2709402861193063737}
+  - {fileID: 8392531980584753049}
+  m_Father: {fileID: 1949570749023691520}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 75.83895, y: -105}
+  m_SizeDelta: {x: 151.67796, y: 30.569275}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &1972921530555288035
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3278580096274495498}
+  m_CullTransparentMesh: 0
+--- !u!114 &2460736801282869938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3278580096274495498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1d87276c2aafe3349ba41d503b1ea57c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6668914640440548395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3278580096274495498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.5294118, g: 0.5294118, b: 0.5294118, a: 1}
+    m_PressedColor: {r: 0.20784314, g: 0.20784314, b: 0.20784314, a: 1}
+    m_SelectedColor: {r: 0.5283019, g: 0.5283019, b: 0.5283019, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2460736801282869938}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: ChangeVisibilityOfControls
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2644395038842912440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3278580096274495498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &3567265508271040267
 GameObject:
   m_ObjectHideFlags: 0
@@ -1539,9 +1692,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 75.83895, y: -89.999985}
+  m_AnchoredPosition: {x: 75.83895, y: -70}
   m_SizeDelta: {x: 151.67796, y: 30.569275}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &3563547083209272811
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1652,6 +1805,81 @@ MonoBehaviour:
   playClick: 1
   playRelease: 1
   extraClickEvent: {fileID: 0}
+--- !u!1 &4704264687429338825
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2709402861193063737}
+  - component: {fileID: 1163624922169872368}
+  - component: {fileID: 8185154404107224766}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2709402861193063737
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4704264687429338825}
+  m_LocalRotation: {x: -0, y: -0, z: 0.0015440919, w: 0.9999988}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2021294922335030686}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.177}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 21.7, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1163624922169872368
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4704264687429338825}
+  m_CullTransparentMesh: 0
+--- !u!114 &8185154404107224766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4704264687429338825}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c983eea4ebd9d43579acbb2e5c500480, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7926448627438033898
 GameObject:
   m_ObjectHideFlags: 0
@@ -1684,10 +1912,10 @@ RectTransform:
   m_Father: {fileID: 2449493492750598812}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.177}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -54.299995, y: -0.39000034}
-  m_SizeDelta: {x: -132.37361, y: -12.641613}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 21.7, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2471024856956275563
 CanvasRenderer:
@@ -1727,6 +1955,140 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8086918479358645754
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8392531980584753049}
+  - component: {fileID: 5246320907812120823}
+  - component: {fileID: 8182022246280249494}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8392531980584753049
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8086918479358645754}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2021294922335030686}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5246320907812120823
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8086918479358645754}
+  m_CullTransparentMesh: 0
+--- !u!114 &8182022246280249494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8086918479358645754}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Reset Camera
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 70f3d6b07a517476dbd2b89cf148f858, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &9077958801265815273
 GameObject:
   m_ObjectHideFlags: 0
@@ -1761,8 +2123,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 14.23, y: -0.000014782}
-  m_SizeDelta: {x: 102.60901, y: 14.971123}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: 100, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1542315149428535319
 CanvasRenderer:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
@@ -13,6 +13,7 @@ public class BuildModeHUDController : IHUD
     public event Action OnRotateSelectedAction;
     public event Action OnScaleSelectedAction;
     public event Action OnResetAction;
+    public event Action OnResetCameraAction;
     public event Action OnUndoAction;
     public event Action OnRedoAction;
     public event Action OnDuplicateSelectedAction;
@@ -172,6 +173,7 @@ public class BuildModeHUDController : IHUD
         controllers.topActionsButtonsController.extraActionsController.OnHideUIClick += ChangeVisibilityOfUI;
         controllers.topActionsButtonsController.extraActionsController.OnResetClick += () => OnResetAction?.Invoke();
         controllers.topActionsButtonsController.extraActionsController.OnTutorialClick += () => OnTutorialAction?.Invoke();
+        controllers.topActionsButtonsController.extraActionsController.OnResetCameraClick += () => OnResetCameraAction?.Invoke();
     }
 
     private void ConfigureCatalogItemDropController()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/ExtraActionsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/ExtraActionsController.cs
@@ -5,7 +5,8 @@ public interface IExtraActionsController
     event Action OnControlsClick,
                  OnHideUIClick,
                  OnTutorialClick,
-                 OnResetClick;
+                 OnResetClick,
+                 OnResetCameraClick;
 
     void Initialize(IExtraActionsView extraActionsView);
     void Dispose();
@@ -13,6 +14,7 @@ public interface IExtraActionsController
     void ControlsClicked();
     void HideUIClicked();
     void TutorialClicked();
+    void ResetCameraClicked();
 }
 
 public class ExtraActionsController : IExtraActionsController
@@ -20,7 +22,8 @@ public class ExtraActionsController : IExtraActionsController
     public event Action OnControlsClick,
                         OnHideUIClick,
                         OnTutorialClick,
-                        OnResetClick;
+                        OnResetClick,
+                        OnResetCameraClick;
 
     internal IExtraActionsView extraActionsView;
 
@@ -32,6 +35,7 @@ public class ExtraActionsController : IExtraActionsController
         extraActionsView.OnHideUIClicked += HideUIClicked;
         extraActionsView.OnTutorialClicked += TutorialClicked;
         extraActionsView.OnResetClicked += ResetClicked;
+        extraActionsView.OnResetCameraClicked += ResetCameraClicked;
     }
 
     public void Dispose()
@@ -40,6 +44,7 @@ public class ExtraActionsController : IExtraActionsController
         extraActionsView.OnHideUIClicked -= HideUIClicked;
         extraActionsView.OnTutorialClicked -= TutorialClicked;
         extraActionsView.OnResetClicked -= ResetClicked;
+        extraActionsView.OnResetCameraClicked -= ResetCameraClicked;
     }
 
     public void SetActive(bool isActive)
@@ -48,11 +53,33 @@ public class ExtraActionsController : IExtraActionsController
             extraActionsView.SetActive(isActive);
     }
 
-    public void ResetClicked() { OnResetClick?.Invoke(); }
+    public void ResetClicked()
+    {
+        OnResetClick?.Invoke();
+        SetActive(false);
+    }
 
-    public void ControlsClicked() { OnControlsClick?.Invoke(); }
+    public void ControlsClicked()
+    {
+        OnControlsClick?.Invoke();
+        SetActive(false);
+    }
 
-    public void HideUIClicked() { OnHideUIClick?.Invoke(); }
+    public void HideUIClicked()
+    {
+        OnHideUIClick?.Invoke();
+        SetActive(false);
+    }
 
-    public void TutorialClicked() { OnTutorialClick?.Invoke(); }
+    public void TutorialClicked()
+    {
+        OnTutorialClick?.Invoke();
+        SetActive(false);
+    }
+
+    public void ResetCameraClicked()
+    {
+        OnResetCameraClick?.Invoke();
+        SetActive(false);
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/ExtraActionsView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/ExtraActionsView.cs
@@ -7,12 +7,15 @@ public interface IExtraActionsView
     event Action OnControlsClicked,
                  OnHideUIClicked,
                  OnTutorialClicked,
-                 OnResetClicked;
+                 OnResetClicked,
+                 OnResetCameraClicked;
 
     void OnControlsClick(DCLAction_Trigger action);
     void OnHideUIClick(DCLAction_Trigger action);
     void OnTutorialClick();
     void SetActive(bool isActive);
+    void OnResetClick();
+    void OnResetCameraClick();
 }
 
 public class ExtraActionsView : MonoBehaviour, IExtraActionsView
@@ -20,13 +23,15 @@ public class ExtraActionsView : MonoBehaviour, IExtraActionsView
     public event Action OnControlsClicked,
                         OnHideUIClicked,
                         OnTutorialClicked,
-                        OnResetClicked;
+                        OnResetClicked,
+                        OnResetCameraClicked;
 
     [Header("Buttons")]
     [SerializeField] internal Button hideUIBtn;
     [SerializeField] internal Button controlsBtn;
     [SerializeField] internal Button tutorialBtn;
     [SerializeField] internal Button resetBtn;
+    [SerializeField] internal Button resetCameraBtn;
 
     [Header("Input Actions")]
     [SerializeField] internal InputAction_Trigger toggleUIVisibilityInputAction;
@@ -48,7 +53,8 @@ public class ExtraActionsView : MonoBehaviour, IExtraActionsView
     {
         hideUIBtn.onClick.AddListener(() => OnHideUIClick(dummyActionTrigger));
         controlsBtn.onClick.AddListener(() => OnControlsClick(dummyActionTrigger));
-        resetBtn.onClick.AddListener(() => OnResetClicked?.Invoke());
+        resetBtn.onClick.AddListener(OnResetClick);
+        resetCameraBtn.onClick.AddListener(OnResetCameraClick);
         tutorialBtn.onClick.AddListener(OnTutorialClick);
 
         toggleUIVisibilityInputAction.OnTriggered += OnHideUIClick;
@@ -60,6 +66,7 @@ public class ExtraActionsView : MonoBehaviour, IExtraActionsView
         hideUIBtn.onClick.RemoveAllListeners();
         controlsBtn.onClick.RemoveAllListeners();
         resetBtn.onClick.RemoveAllListeners();
+        resetCameraBtn.onClick.RemoveAllListeners();
         tutorialBtn.onClick.RemoveListener(OnTutorialClick);
 
         toggleUIVisibilityInputAction.OnTriggered -= OnHideUIClick;
@@ -77,4 +84,8 @@ public class ExtraActionsView : MonoBehaviour, IExtraActionsView
     public void OnHideUIClick(DCLAction_Trigger action) { OnHideUIClicked?.Invoke(); }
 
     public void OnTutorialClick() { OnTutorialClicked?.Invoke(); }
+
+    public void OnResetClick() { OnResetClicked?.Invoke(); }
+
+    public void OnResetCameraClick() { OnResetCameraClicked?.Invoke(); }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/ExtraActionsControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/ExtraActionsControllerShould.cs
@@ -70,5 +70,19 @@ namespace Tests.BuildModeHUDControllers
             // Assert
             Assert.IsTrue(clicked, "clicked is false!");
         }
+
+        [Test]
+        public void ClickOnResetCameraCorrectly()
+        {
+            // Arrange
+            bool clicked = false;
+            extraActionsController.OnResetCameraClick += () => { clicked = true; };
+
+            // Act
+            extraActionsController.ResetCameraClicked();
+
+            // Assert
+            Assert.IsTrue(clicked, "clicked is false!");
+        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/ExtraActionsViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/ExtraActionsViewShould.cs
@@ -69,5 +69,33 @@ namespace Tests.BuildModeHUDViews
             // Assert
             Assert.IsTrue(isClicked, "isClicked is false!");
         }
+
+        [Test]
+        public void ClickOnResetCorrectly()
+        {
+            // Arrange
+            bool isClicked = false;
+            extraActionsView.OnResetClicked += () => isClicked = true;
+
+            // Act
+            extraActionsView.OnResetClick();
+
+            // Assert
+            Assert.IsTrue(isClicked, "isClicked is false!");
+        }
+
+        [Test]
+        public void ClickOnResetCameraCorrectly()
+        {
+            // Arrange
+            bool isClicked = false;
+            extraActionsView.OnResetCameraClicked += () => isClicked = true;
+
+            // Act
+            extraActionsView.OnResetCameraClick();
+
+            // Assert
+            Assert.IsTrue(isClicked, "isClicked is false!");
+        }
     }
 }


### PR DESCRIPTION
## What this PR includes?
The camera view should be reset to the center of the scene (Fixes #375).

We have added a new "Reset Camera" option menu:

![image](https://user-images.githubusercontent.com/64659061/117963835-24f10500-b321-11eb-89bf-a05e8244f1ad.png)

## How to test it?
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:feat/BiW-editor-add-functionality-to-reset-the-camera-view&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=100,100
2. Press 'K' to open the Builer In World editor.
3. Move the camera around the scene.
4. Click on the "Reset Camera" button.
5. Notice that the camera is reset to its original position.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md