### PR TITLE
fix: re-trigger non-looping animations now works when the animation f…

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
@@ -111,7 +111,7 @@ namespace DCL.Components
                 {
                     AnimationState unityState = animComponent[state.clip];
                     unityState.weight = state.weight;
-                    unityState.wrapMode = state.looping ? WrapMode.Loop : WrapMode.ClampForever;
+                    unityState.wrapMode = state.looping ? WrapMode.Loop : WrapMode.Default;
                     unityState.clip.wrapMode = unityState.wrapMode;
                     unityState.speed = state.speed;
 


### PR DESCRIPTION
…inish

## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fixes #436

When an AnimationState finish, it wasn't playing again when we call it with another `play()`.

## Why?
I changed the `wrapMode` of the AnimationState from `ClampForever` to `Default`.

ClampForever: Plays back the animation. When it reaches the end, it will keep playing the last frame and never stop playing.

So, ClampForever was blocking the behavior of restarting the animation when it finish.

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
Go to: https://play.decentraland.zone/branch/fix/animation-play/?index.html&renderer=urn:decentraland:off-chain:renderer-artifacts:fix/animation-play

Sample video of correct funtionality (before this PR it was triggering the animation just once):

https://user-images.githubusercontent.com/12563266/118543348-8dc5ec00-b72a-11eb-9479-9ba6f8373466.mp4


## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md