### PR TITLE
fix: Fixes on Undo/Redo and Shortcuts

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
@@ -241,6 +241,7 @@ public class BuilderInWorldController : MonoBehaviour
         biwFloorHandler.Init();
         bIWInputHandler.Init();
         biwSaveController.Init();
+        actionController.Init();
     }
 
     private void StartTutorial() { TutorialController.i.SetBuilderInWorldTutorialEnabled(); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/TopActionsButtons/TopActionsButtonsController.cs
@@ -69,8 +69,8 @@ public class TopActionsButtonsController : ITopActionsButtonsController
         topActionsButtonsView.OnTranslateClicked += TranslateClicked;
         topActionsButtonsView.OnRotateClicked += RotateClicked;
         topActionsButtonsView.OnScaleClicked += ScaleClicked;
-        topActionsButtonsView.OnUndoClicked += OnUndoClick;
-        topActionsButtonsView.OnRedoClicked += OnRedoClick;
+        topActionsButtonsView.OnUndoClicked += UndoClicked;
+        topActionsButtonsView.OnRedoClicked += RedoClicked;
         topActionsButtonsView.OnDuplicateClicked += DuplicateClicked;
         topActionsButtonsView.OnDeleteClicked += DeleteClicked;
         topActionsButtonsView.OnLogOutClicked += LogoutClicked;


### PR DESCRIPTION
## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
### Fixes #442
We can trigger the undo/redo by using the shortcuts but not using the buttons on the toolbar.

### Fixes #441
- [ ] Duplicate = Shift + D
- [ ] Reset Camera = Shift + C
- [ ] Reset  = Shift + R
- [ ] Controls panel shortcut needs to be C instead of N

![image](https://user-images.githubusercontent.com/41490935/118253866-b8097680-b4aa-11eb-8baa-a857e43a973e.png)

- [ ] Snap Icon does not have a tooltip with text + shorcut

![image](https://user-images.githubusercontent.com/41490935/118254056-f2731380-b4aa-11eb-846d-ecfc26016ed9.png)

- [ ] + to zoom in, - to zoom out

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-undo-redo-and-shortcuts-fixes&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=100,100
2. Press 'K' to open the Builer In World editor.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md