### PR TITLE
fix: BiW - Several fixes on thumbnails management

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Catalog/UI/Adapters/CatalogItemAdapter.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Catalog/UI/Adapters/CatalogItemAdapter.cs
@@ -108,8 +108,13 @@ public class CatalogItemAdapter : MonoBehaviour, IBeginDragHandler, IEndDragHand
         RectTransform newAdapterRT = GetComponent<RectTransform>();
         canvasGroup.blocksRaycasts = false;
         canvasGroup.alpha = 0.6f;
-        favImg.enabled = false;
-        backgroundImg.enabled = false;
+
+        if (favImg != null)
+            favImg.enabled = false;
+
+        if (backgroundImg != null)
+            backgroundImg.enabled = false;
+
         newAdapterRT.sizeDelta = sizeDelta * ADAPTER_DRAGGING_SIZE_SCALE;
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Catalog/UI/Adapters/CatalogItemAdapter.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Catalog/UI/Adapters/CatalogItemAdapter.cs
@@ -108,6 +108,8 @@ public class CatalogItemAdapter : MonoBehaviour, IBeginDragHandler, IEndDragHand
         RectTransform newAdapterRT = GetComponent<RectTransform>();
         canvasGroup.blocksRaycasts = false;
         canvasGroup.alpha = 0.6f;
+        favImg.enabled = false;
+        backgroundImg.enabled = false;
         newAdapterRT.sizeDelta = sizeDelta * ADAPTER_DRAGGING_SIZE_SCALE;
     }
 


### PR DESCRIPTION
## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
### Fixes #469 (**Quickbar thumbnails are sometimes missing**)
- [x] When we drag an entity thumbnail from a quickbar slot to other one and we change the tab in the catalog panel, the moved thumbnail is missing its sprite.

### Fixes #466 (**Draged entity preview should not show the background or favorite icon**)
- [x] When we drag an entity from the catalog panel to the scene, we should see the dragged icon only with the entity sprite, removing the box background and any other icon that is not the own entity.

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-fixes-on-catalog-item-thumbnails&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=80,154
2. Press 'K' to open the Builer In World editor.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md