### PR TITLE
fix: BiW - Entities in the scene dont un-highlight if you interact with the UI

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.prefab
@@ -2296,6 +2296,9 @@ MonoBehaviour:
     type: 2}
   builderInWorldEntityHandler: {fileID: 1676156629805984034}
   biwInputHandler: {fileID: 6563051222090226857}
+  layerToStopOutline:
+    serializedVersion: 2
+    m_Bits: 2048
 --- !u!1 &5373867681970374750
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWOutlinerController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWOutlinerController.cs
@@ -49,6 +49,10 @@ public class BIWOutlinerController : BIWController
                 if (entity != null && !entity.IsSelected)
                     OutlineEntity(entity);
             }
+            else
+            {
+                CancelUnselectedOutlines();
+            }
 
             outlinerOptimizationCounter = 0;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWOutlinerController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWOutlinerController.cs
@@ -1,13 +1,9 @@
 using Builder;
-using DCL;
 using DCL.Configuration;
 using DCL.Controllers;
-using DCL.Models;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering.Universal;
-using UnityEngine.Serialization;
 
 public class BIWOutlinerController : BIWController
 {
@@ -18,6 +14,7 @@ public class BIWOutlinerController : BIWController
 
     [SerializeField] internal BuilderInWorldEntityHandler builderInWorldEntityHandler;
     public BIWInputHandler biwInputHandler;
+    public LayerMask layerToStopOutline;
 
     private List<DCLBuilderInWorldEntity> entitiesOutlined = new List<DCLBuilderInWorldEntity>();
     private int outlinerOptimizationCounter = 0;
@@ -41,7 +38,7 @@ public class BIWOutlinerController : BIWController
     {
         if (outlinerOptimizationCounter >= 10 && isOutlineCheckActive)
         {
-            if (!BuilderInWorldUtils.IsPointerOverUIElement())
+            if (!BuilderInWorldUtils.IsPointerOverUIElement() && !BuilderInWorldUtils.IsPointerOverMaskElement(layerToStopOutline))
             {
                 DCLBuilderInWorldEntity entity = builderInWorldEntityHandler.GetEntityOnPointer();
                 RemoveEntitiesOutsidePointerOrUnselected();


### PR DESCRIPTION
## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
### Fixes #440  (**Entities in the scene dont un-highlight if you interact with the UI**)
- [x] If you mouse over an entity , and it gets highlighted, and you move the cursor to a UI that is next to it, the entity does not unhiglight until you move the cursor out to the world.
- [x] If an object is behind and gizmo, it gets highlighted as well

![image](https://user-images.githubusercontent.com/41490935/118258186-dd4cb380-b4af-11eb-8441-971133b40bfe.png)

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-Entities-in-the-scene-dont-un-highlight-if-you-interact-with-the-UI&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=80,154
2. Press 'K' to open the Builer In World editor.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md