### PR TITLE
fix: enormous transform values physics breakdown

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Runtime.CompilerServices;
 using DCL.Controllers;
+using DCL.Helpers;
 using DCL.Models;
 using UnityEngine;
 
@@ -58,8 +59,8 @@ namespace DCL.Components
             else
             {
                 // If we don't cap these vectors, some scenes may trigger a physics breakdown when messaging enormous values
-                DCLTransform.model.position = CapVector3(DCLTransform.model.position);
-                DCLTransform.model.scale = CapVector3(DCLTransform.model.scale);
+                DCLTransform.model.position = DCLTransform.model.position.Capped(VECTOR3_MEMBER_CAP);
+                DCLTransform.model.scale = DCLTransform.model.scale.Capped(VECTOR3_MEMBER_CAP);
 
                 entity.gameObject.transform.localPosition = DCLTransform.model.position;
                 entity.gameObject.transform.localRotation = DCLTransform.model.rotation;
@@ -67,20 +68,6 @@ namespace DCL.Components
 
                 DCL.Environment.i.world.sceneBoundsChecker?.AddEntityToBeChecked(entity);
             }
-        }
-
-        private Vector3 CapVector3(Vector3 targetVector)
-        {
-            if (Mathf.Abs(targetVector.x) > VECTOR3_MEMBER_CAP)
-                targetVector.x = VECTOR3_MEMBER_CAP * Mathf.Sign(targetVector.x);
-
-            if (Mathf.Abs(targetVector.y) > VECTOR3_MEMBER_CAP)
-                targetVector.y = VECTOR3_MEMBER_CAP * Mathf.Sign(targetVector.y);
-
-            if (Mathf.Abs(targetVector.z) > VECTOR3_MEMBER_CAP)
-                targetVector.z = VECTOR3_MEMBER_CAP * Mathf.Sign(targetVector.z);
-
-            return targetVector;
         }
 
         public IEnumerator ApplyChanges(BaseModel model) { return null; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
@@ -1,14 +1,17 @@
 ﻿using System.Collections;
 using System.Net.Configuration;
+using System.Runtime.CompilerServices;
 using DCL.Controllers;
 using DCL.Models;
 using UnityEngine;
+
+[assembly: InternalsVisibleTo("TransformTests")]
 
 namespace DCL.Components
 {
     public class DCLTransform : IEntityComponent
     {
-        const float VECTOR3_MEMBER_CAP = 1000000; // Value measured when genesis plaza glitch triggered a physics engine breakdown
+        internal const float VECTOR3_MEMBER_CAP = 1000000; // Value measured when genesis plaza glitch triggered a physics engine breakdown
 
         [System.Serializable]
         public class Model : BaseModel

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
@@ -8,6 +8,8 @@ namespace DCL.Components
 {
     public class DCLTransform : IEntityComponent
     {
+        const float VECTOR3_MEMBER_CAP = 1000000; // Value measured when genesis plaza glitch triggered a physics engine breakdown
+
         [System.Serializable]
         public class Model : BaseModel
         {
@@ -53,12 +55,30 @@ namespace DCL.Components
             }
             else
             {
+                // If we don't cap these vectors, some scenes may trigger a physics breakdown when messaging enormous values
+                DCLTransform.model.position = CapVector3(DCLTransform.model.position);
+                DCLTransform.model.scale = CapVector3(DCLTransform.model.scale);
+
                 entity.gameObject.transform.localPosition = DCLTransform.model.position;
                 entity.gameObject.transform.localRotation = DCLTransform.model.rotation;
                 entity.gameObject.transform.localScale = DCLTransform.model.scale;
 
                 DCL.Environment.i.world.sceneBoundsChecker?.AddEntityToBeChecked(entity);
             }
+        }
+
+        private Vector3 CapVector3(Vector3 targetVector)
+        {
+            if (Mathf.Abs(targetVector.x) > VECTOR3_MEMBER_CAP)
+                targetVector.x = VECTOR3_MEMBER_CAP * Mathf.Sign(targetVector.x);
+
+            if (Mathf.Abs(targetVector.y) > VECTOR3_MEMBER_CAP)
+                targetVector.y = VECTOR3_MEMBER_CAP * Mathf.Sign(targetVector.y);
+
+            if (Mathf.Abs(targetVector.z) > VECTOR3_MEMBER_CAP)
+                targetVector.z = VECTOR3_MEMBER_CAP * Mathf.Sign(targetVector.z);
+
+            return targetVector;
         }
 
         public IEnumerator ApplyChanges(BaseModel model) { return null; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System.Net.Configuration;
 using System.Runtime.CompilerServices;
 using DCL.Controllers;
 using DCL.Models;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/Tests/TransformTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/Tests/TransformTests.cs
@@ -1,8 +1,10 @@
+using System.Collections;
 using DCL.Components;
 using DCL.Helpers;
 using DCL.Models;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Tests
 {
@@ -128,6 +130,27 @@ namespace Tests
             Assert.IsTrue(targetPosition == entity.gameObject.transform.localPosition);
             Assert.IsTrue(targetRotation == entity.gameObject.transform.localRotation);
             Assert.IsTrue(targetScale == entity.gameObject.transform.localScale);
+        }
+
+        [UnityTest]
+        public IEnumerator TransformPosAndScaleAreCapped()
+        {
+            IDCLEntity entity = TestHelpers.CreateSceneEntity(scene);
+
+            Vector3 targetPosition = new Vector3(999999999f, 999999999f, 999999999f);
+            Vector3 targetScale = new Vector3(999999999f, 999999999f, 999999999f);
+
+            DCLTransform.Model componentModel = new DCLTransform.Model
+            {
+                position = targetPosition,
+                scale = targetScale
+            };
+
+            TestHelpers.SetEntityTransform(scene, entity, componentModel);
+            yield return null;
+
+            // If we don't cap these vectors, some scenes may trigger a physics breakdown when messaging enormous values
+            Assert.IsFalse(entity.gameObject.transform.position.x > DCLTransform.VECTOR3_MEMBER_CAP);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -592,5 +592,24 @@ namespace DCL.Helpers
                 SetLayerRecursively(child, layer);
             }
         }
+
+        /// <summary>
+        /// Returns this vector with its members capped (signs will remain intact).
+        /// </summary>
+        /// <param name="cap">The cap to be applied (signs will be kept)</param>
+        /// <returns>The capped vector</returns>
+        public static Vector3 Capped(this Vector3 vec, float cap)
+        {
+            if (Mathf.Abs(vec.x) > cap)
+                vec.x = cap * Mathf.Sign(vec.x);
+
+            if (Mathf.Abs(vec.y) > cap)
+                vec.y = cap * Mathf.Sign(vec.y);
+
+            if (Mathf.Abs(vec.z) > cap)
+                vec.z = cap * Mathf.Sign(vec.z);
+
+            return vec;
+        }
     }
 }


### PR DESCRIPTION
**WHY**
The physics engine sync suffers a breakdown when loading the Genesis Plaza from far away (when the clouds start moving), this is due to receiving super large values for some entities position and scale, the details and evidence can be seen at the [corresponding issue](https://app.zenhub.com/workspaces/unity-6047bad476c3c0001942ee91/issues/decentraland/unity-renderer/494).

**WHAT**
Added pos and scale capping to avoid enormous values breaking the physics engine in runtime

**TESTING**
Repro steps:
1. Enter the world at `-11, -11`
2. Wait until the genesys plaza ends  its loading and then a bit more for the clouds system to start running
3. You will notice that some objects in the road at `-11, -10` are not colliding with the character (this is what the PR fixes)
4. Move to the Genesis Plaza NFTShapes gallery and you will see the picture frames are not there. (not fixed by this PR since that is consecuence of the scene code crashing)

* Production (bugged): https://play.decentraland.org/?position=-11,-11&LOS=4&realm=fenrir-amber

* This branch (fixed): https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/EnormousTransformValuesPhysicsBreakdown&ENV=org&position=-11,-11&LOS=4&realm=fenrir-amber