### PR TITLE
chore: update asset bundles folder git ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ TestResults/
 Assets/InitTestScene*.unity
 Assets/InitTestScene*.unity.meta
 **/CurrentTestImages/
-unity-renderer/AssetBundles/
 
 .DS_Store
 .DS_Store?

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ TestResults/
 Assets/InitTestScene*.unity
 Assets/InitTestScene*.unity.meta
 **/CurrentTestImages/
-/AssetBundles/
+unity-renderer/AssetBundles/
 
 .DS_Store
 .DS_Store?

--- a/unity-renderer/.gitignore
+++ b/unity-renderer/.gitignore
@@ -11,5 +11,5 @@ TestResults/
 Assets/InitTestScene*.unity
 Assets/InitTestScene*.unity.meta
 **/CurrentTestImages/
-AssetBundles/
+/AssetBundles/
 Logs/


### PR DESCRIPTION
**WHY**
The locally dumped ABs folder duplicated rule in the `/root/.gitignore` file is triggering problems tracking the [ABs controllers folder](https://github.com/decentraland/unity-renderer/tree/master/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles) when creating new repos like @kuruk-mm  is doing for the desktop-client repo.

**WHAT**
* Removed unneeded ABs folder rule at `/root/.gitignore` (since we already have a rule for the dumped local ABs at `/root/unity-renderer/.gitignore`
* Updated `/root/unity-renderer/.gitignore` ABs folder rule to point to the closest relative `/AssetBundles/` folder (the one used when dumping ABs locally, that we don't want to track in git)
* Tested that everything is tracked and ignored correctly locally