### PR TITLE
fix: [BiW Editor] Error while reseting scale values from details panel

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -210,7 +210,13 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         if (selectedEntities.Count != 1)
             return;
 
-        editionGO.transform.localScale = scale;
+        var entityToUpdate = selectedEntities[0];
+
+        // Before change the scale, we unparent the entity to not to make it dependant on the editionGO and after that, reparent it
+        entityToUpdate.transform.SetParent(null);
+        entityToUpdate.transform.localScale = scale;
+        editionGO.transform.localScale = Vector3.one;
+        entityToUpdate.transform.SetParent(editionGO.transform);
     }
 
     public void UpdateGizmosToSelectedEntities()


### PR DESCRIPTION
## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
### Fixes #380 
- [x] If you modify the scale of an entity in different axes and then you reset it to 1:1:1 in the details panel, the scale is corrupted.

![image](https://user-images.githubusercontent.com/64659061/120020885-9fd94180-bfea-11eb-92d3-5539638bd4d7.png)

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-Editor-Error-while-reseting-scale-values&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=80,154
2. Press 'K' to open the Builer In World editor.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md