### PR TITLE
chore: add AB converter own visual tests helper

### DIFF
--- a/unity-renderer/Assets/ABConverter/ABConverter.asmdef
+++ b/unity-renderer/Assets/ABConverter/ABConverter.asmdef
@@ -1,27 +1,27 @@
 {
-  "name": "ABConverter",
-  "rootNamespace": "",
-  "references": [
-    "GUID:478a2357cc57436488a56e564b08d223",
-    "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-    "GUID:54b09a4a10c111e46a817873fcea53fe",
-    "GUID:6183c84bf01987b429b45d5077b08eec",
-    "GUID:b24824f3bc2a60641a01e2083614f802",
-    "GUID:7ac9f9c835ec1084ab35e3f9b176cf1e",
-    "GUID:442475ca22441254d94d13faf49e36ee",
-    "GUID:e65144cdbd5b744238fa03c40df6cd71",
-    "GUID:8f18b4ef38b9d4637b8190231eb24e38",
-    "GUID:6e6a87f97192ec947993f360104e75b7"
-  ],
-  "includePlatforms": [
-    "Editor"
-  ],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "ABConverter",
+    "rootNamespace": "",
+    "references": [
+        "GUID:478a2357cc57436488a56e564b08d223",
+        "GUID:b1087c5731ff68448a0a9c625bb7e52d",
+        "GUID:54b09a4a10c111e46a817873fcea53fe",
+        "GUID:6183c84bf01987b429b45d5077b08eec",
+        "GUID:b24824f3bc2a60641a01e2083614f802",
+        "GUID:7ac9f9c835ec1084ab35e3f9b176cf1e",
+        "GUID:442475ca22441254d94d13faf49e36ee",
+        "GUID:d0e3b53faf13d4a85bf5db51fc8bfd2f",
+        "GUID:8f18b4ef38b9d4637b8190231eb24e38",
+        "GUID:6e6a87f97192ec947993f360104e75b7"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/unity-renderer/Assets/ABConverter/VisualTests.cs
+++ b/unity-renderer/Assets/ABConverter/VisualTests.cs
@@ -13,8 +13,8 @@ namespace DCL.ABConverter
 {
     public static class VisualTests
     {
-        static readonly string baselinePath = VisualTestHelpers.baselineImagesPath;
-        static readonly string testImagesPath = VisualTestHelpers.testImagesPath;
+        static readonly string baselinePath = AssetBundlesVisualTestHelpers.baselineImagesPath;
+        static readonly string testImagesPath = AssetBundlesVisualTestHelpers.testImagesPath;
         static string abPath = Application.dataPath + "/../AssetBundles/";
         static int skippedAssets = 0;
 
@@ -48,8 +48,8 @@ namespace DCL.ABConverter
             var scene = EditorSceneManager.OpenScene($"Assets/ABConverter/VisualTestScene.unity", OpenSceneMode.Single);
             yield return new WaitUntil(() => scene.isLoaded);
 
-            VisualTestHelpers.baselineImagesPath += "ABConverter/";
-            VisualTestHelpers.testImagesPath += "ABConverter/";
+            AssetBundlesVisualTestHelpers.baselineImagesPath += "ABConverter/";
+            AssetBundlesVisualTestHelpers.testImagesPath += "ABConverter/";
             skippedAssets = 0;
 
             var gltfs = LoadAndInstantiateAllGltfAssets();
@@ -65,7 +65,7 @@ namespace DCL.ABConverter
             // Take prewarm snapshot to make sure the scene is correctly loaded
             yield return TakeObjectSnapshot(new GameObject(), $"ABConverter_Warmup.png");
 
-            VisualTestHelpers.generateBaseline = true;
+            AssetBundlesVisualTestHelpers.generateBaseline = true;
 
             foreach (GameObject go in gltfs)
             {
@@ -90,7 +90,7 @@ namespace DCL.ABConverter
                 go.SetActive(false);
             }
 
-            VisualTestHelpers.generateBaseline = false;
+            AssetBundlesVisualTestHelpers.generateBaseline = false;
 
             var abs = LoadAndInstantiateAllAssetBundles();
 
@@ -115,9 +115,9 @@ namespace DCL.ABConverter
 
                 yield return TakeObjectSnapshot(go, testName);
 
-                bool result = VisualTestHelpers.TestSnapshot(
-                    VisualTestHelpers.baselineImagesPath + testName,
-                    VisualTestHelpers.testImagesPath + testName,
+                bool result = AssetBundlesVisualTestHelpers.TestSnapshot(
+                    AssetBundlesVisualTestHelpers.baselineImagesPath + testName,
+                    AssetBundlesVisualTestHelpers.testImagesPath + testName,
                     95,
                     false);
 
@@ -140,8 +140,8 @@ namespace DCL.ABConverter
                 go.SetActive(false);
             }
 
-            VisualTestHelpers.baselineImagesPath = baselinePath;
-            VisualTestHelpers.testImagesPath = testImagesPath;
+            AssetBundlesVisualTestHelpers.baselineImagesPath = baselinePath;
+            AssetBundlesVisualTestHelpers.testImagesPath = testImagesPath;
 
             Debug.Log("Visual Test Detection: Finished converted assets testing...skipped assets: " + skippedAssets);
             OnFinish?.Invoke(skippedAssets);
@@ -177,7 +177,7 @@ namespace DCL.ABConverter
 
             Vector3 cameraPosition = new Vector3(mergedBounds.min.x - offset.x, mergedBounds.max.y + offset.y, mergedBounds.min.z - offset.z);
 
-            yield return VisualTestHelpers.TakeSnapshot(testName, Camera.main, cameraPosition, mergedBounds.center);
+            yield return AssetBundlesVisualTestHelpers.TakeSnapshot(testName, Camera.main, cameraPosition, mergedBounds.center);
 
             targetGO.transform.localScale = originalScale;
         }

--- a/unity-renderer/Assets/ABConverter/VisualTests.meta
+++ b/unity-renderer/Assets/ABConverter/VisualTests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7bf10b6e70454633ac67b9b84ebcf41
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/ABConverter/VisualTests/AssetBundlesVisualTestHelpers.asmdef
+++ b/unity-renderer/Assets/ABConverter/VisualTests/AssetBundlesVisualTestHelpers.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "AssetBundlesVisualTestHelpers",
+    "rootNamespace": "",
+    "references": [
+        "GUID:cc6bfabbfe87b7949aa248893f89ce37"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-renderer/Assets/ABConverter/VisualTests/AssetBundlesVisualTestHelpers.asmdef.meta
+++ b/unity-renderer/Assets/ABConverter/VisualTests/AssetBundlesVisualTestHelpers.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d0e3b53faf13d4a85bf5db51fc8bfd2f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/ABConverter/VisualTests/AssetBundlesVisualTestHelpers.cs
+++ b/unity-renderer/Assets/ABConverter/VisualTests/AssetBundlesVisualTestHelpers.cs
@@ -1,0 +1,261 @@
+using DCL.Configuration;
+using System.Collections;
+using System.IO;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace DCL.Helpers
+{
+    /// <summary>
+    /// Visual tests helper class used to validate Asset Bundle conversions. Based on 'Scripts/Tests/VisualTests/VisualTestHelpers.cs'.
+    /// </summary>
+    public static class AssetBundlesVisualTestHelpers
+    {
+        public static string testImagesPath = Application.dataPath + "/../TestResources/VisualTests/CurrentTestImages/";
+
+        public static string baselineImagesPath = Application.dataPath + "/../TestResources/VisualTests/BaselineImages/";
+
+        public static bool generateBaseline = false;
+
+        public static IEnumerator TakeSnapshot(string snapshotName, Camera camera, Vector3? shotPosition = null, Vector3? shotTarget = null)
+        {
+            if (shotPosition.HasValue || shotTarget.HasValue)
+            {
+                RepositionVisualTestsCamera(camera, shotPosition, shotTarget);
+            }
+
+            yield return null;
+            yield return null;
+
+            int snapshotsWidth = TestSettings.VISUAL_TESTS_SNAPSHOT_WIDTH;
+            int snapshotsHeight = TestSettings.VISUAL_TESTS_SNAPSHOT_HEIGHT;
+
+            if (generateBaseline || !File.Exists(baselineImagesPath + snapshotName))
+            {
+                yield return TakeSnapshot(baselineImagesPath, snapshotName, camera,
+                    snapshotsWidth, snapshotsHeight);
+            }
+            else
+            {
+                yield return TakeSnapshot(testImagesPath, snapshotName, camera, snapshotsWidth, snapshotsHeight);
+            }
+        }
+
+        public static bool TestSnapshot(string baselineImagePathWithFilename, string testImagePathWithFilename, float ratio, bool assert = true)
+        {
+            if (generateBaseline || !File.Exists(baselineImagePathWithFilename))
+                return false;
+
+            float ratioResult =
+                ComputeImageAffinityPercentage(baselineImagePathWithFilename, testImagePathWithFilename);
+
+            if (assert)
+            {
+                Assert.IsTrue(ratioResult > ratio,
+                    $"{Path.GetFileName(baselineImagePathWithFilename)} has {ratioResult}% affinity, the minimum is {ratio}%. A diff image has been generated. Check it out at {testImagesPath}");
+            }
+
+            return ratioResult > ratio;
+        }
+
+        /// <summary>
+        /// This coroutine will take a visual test snapshot using the camera provided, with the given image size.
+        /// The image will be saved to disk as png.
+        /// </summary>
+        /// <param name="snapshotPath">Path to the directory where the image will be saved. Will be created if not exists.</param>
+        /// <param name="snapshotName">output filename, it should include the png extension</param>
+        /// <param name="camera">camera used to take the shot</param>
+        /// <param name="width">Width of the final image</param>
+        /// <param name="height">Height of the final image</param>
+        public static IEnumerator TakeSnapshot(string snapshotPath, string snapshotName, Camera camera, int width,
+            int height)
+        {
+            if (string.IsNullOrEmpty(snapshotName) || camera == null)
+            {
+                Debug.Log("snapshot name or camera is not valid. Snapshot aborted.");
+                yield break;
+            }
+
+            var previousQualityLevel = QualitySettings.GetQualityLevel();
+            QualitySettings.SetQualityLevel((int) QualityLevel.Good, true);
+
+            string finalPath = snapshotPath + snapshotName;
+
+            if (File.Exists(finalPath))
+            {
+                File.Delete(finalPath);
+
+                // Just in case, wait until the file is deleted
+                yield return new WaitUntil(() => { return !File.Exists(finalPath); });
+            }
+
+            // We should only read the screen buffer after rendering is complete
+            yield return null;
+
+            RenderTexture renderTexture = new RenderTexture(width, height, 24);
+            camera.targetTexture = renderTexture;
+            camera.Render();
+
+            RenderTexture.active = renderTexture;
+            Texture2D currentSnapshot = new Texture2D(width, height, TextureFormat.RGB24, false);
+            currentSnapshot.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+            currentSnapshot.Apply();
+
+            yield return null;
+
+            if (!Directory.Exists(snapshotPath))
+            {
+                Directory.CreateDirectory(snapshotPath);
+            }
+
+            byte[] bytes = currentSnapshot.EncodeToPNG();
+            File.WriteAllBytes(finalPath, bytes);
+
+            // Just in case, wait until the file is created
+            yield return new WaitUntil(() => { return File.Exists(finalPath); });
+
+            RenderTexture.active = null;
+            renderTexture.Release();
+
+            yield return new WaitForSeconds(0.2f);
+
+            QualitySettings.SetQualityLevel(previousQualityLevel, true);
+        }
+
+        public static float ComputeImageAffinityPercentage(string baselineImagePathWithFilename,
+            string testImagePathWithFilename)
+        {
+            Texture2D baselineSnapshot = new Texture2D(TestSettings.VISUAL_TESTS_SNAPSHOT_WIDTH,
+                TestSettings.VISUAL_TESTS_SNAPSHOT_HEIGHT, TextureFormat.RGB24, false);
+            baselineSnapshot.LoadImage(File.ReadAllBytes(baselineImagePathWithFilename));
+
+            Texture2D currentSnapshot = new Texture2D(TestSettings.VISUAL_TESTS_SNAPSHOT_WIDTH,
+                TestSettings.VISUAL_TESTS_SNAPSHOT_HEIGHT, TextureFormat.RGB24, false);
+            currentSnapshot.LoadImage(File.ReadAllBytes(testImagePathWithFilename));
+
+            string finalDiffPath = Path.GetDirectoryName(testImagePathWithFilename) + "/" +
+                                   Path.GetFileNameWithoutExtension(testImagePathWithFilename) + "_diff" +
+                                   Path.GetExtension(testImagePathWithFilename);
+
+            return ComputeImageAffinityPercentage(baselineSnapshot, currentSnapshot, finalDiffPath);
+        }
+
+        /// <summary>
+        /// This will compare the pixels of two images in order to make visual tests.
+        /// </summary>
+        /// <param name="baselineImage">Reference or "golden" image</param>
+        /// <param name="testImage">Image to compare</param>
+        /// <param name="diffImagePath"></param>
+        /// <returns>Affinity percentage</returns>
+        public static float ComputeImageAffinityPercentage(Texture2D baselineImage, Texture2D testImage,
+            string diffImagePath)
+        {
+            baselineImage = DuplicateTextureAsReadable(baselineImage);
+            testImage = DuplicateTextureAsReadable(testImage);
+
+            if (string.IsNullOrEmpty(diffImagePath))
+            {
+                Debug.Log("diff image path is not valid. Image affinity percentage check aborted.");
+
+                return -1;
+            }
+
+            if (baselineImage.width != testImage.width || baselineImage.height != testImage.height)
+            {
+                Debug.Log("CAN'T COMPARE IMAGES WITH DIFFERENT DIMENSIONS:");
+                Debug.Log("baseline image dimensions: " + baselineImage.width + "," + baselineImage.height);
+                Debug.Log("test image dimensions: " + testImage.width + "," + testImage.height);
+
+                return -1;
+            }
+
+            Color32[] baselineImagePixels = baselineImage.GetPixels32();
+            Color32[] testImagePixels = testImage.GetPixels32();
+            Color32[] diffImagePixels = new Color32[testImagePixels.Length];
+            Color32 diffColor = new Color32(255, 0, 0, 255);
+            int differentPixels = 0;
+
+            for (int i = 0; i < testImagePixels.Length; i++)
+            {
+                if (!IsSamePixel(testImagePixels[i], baselineImagePixels[i],
+                    TestSettings.VISUAL_TESTS_PIXELS_CHECK_THRESHOLD))
+                {
+                    differentPixels++;
+                    diffImagePixels[i] = diffColor;
+                }
+                else
+                {
+                    diffImagePixels[i] = baselineImagePixels[i];
+                }
+            }
+
+            // Calculate Image Affinity
+            float imageAffinity = ((testImagePixels.Length - differentPixels) * 100) / testImagePixels.Length;
+
+            // Save diff image
+            if (imageAffinity < TestSettings.VISUAL_TESTS_APPROVED_AFFINITY)
+            {
+                Texture2D diffImage = new Texture2D(baselineImage.width, baselineImage.height);
+                diffImage.SetPixels32(diffImagePixels);
+                diffImage.Apply();
+                byte[] bytes = diffImage.EncodeToPNG();
+                File.WriteAllBytes(diffImagePath, bytes);
+            }
+            else if (File.Exists(diffImagePath))
+            {
+                File.Delete(diffImagePath);
+
+                if (File.Exists(diffImagePath + ".meta"))
+                    File.Delete(diffImagePath + ".meta");
+            }
+
+            return imageAffinity;
+        }
+
+        public static Texture2D DuplicateTextureAsReadable(Texture2D source)
+        {
+            RenderTexture renderTex = RenderTexture.GetTemporary(
+                source.width,
+                source.height,
+                0,
+                RenderTextureFormat.Default,
+                RenderTextureReadWrite.Linear);
+
+            Graphics.Blit(source, renderTex);
+
+            RenderTexture previous = RenderTexture.active;
+            RenderTexture.active = renderTex;
+
+            Texture2D readableText = new Texture2D(source.width, source.height);
+            readableText.ReadPixels(new Rect(0, 0, renderTex.width, renderTex.height), 0, 0);
+            readableText.Apply();
+
+            RenderTexture.active = previous;
+            RenderTexture.ReleaseTemporary(renderTex);
+
+            return readableText;
+        }
+
+        public static bool IsSamePixel(Color32 pixelA, Color32 pixelB, float checkThreshold)
+        {
+            return (pixelA.r > pixelB.r - checkThreshold && pixelA.r < pixelB.r + checkThreshold) &&
+                   (pixelA.g > pixelB.g - checkThreshold && pixelA.g < pixelB.g + checkThreshold) &&
+                   (pixelA.b > pixelB.b - checkThreshold && pixelA.b < pixelB.b + checkThreshold);
+        }
+
+        public static void RepositionVisualTestsCamera(Transform cameraTransform, Vector3? position = null, Vector3? target = null)
+        {
+            if (position.HasValue)
+            {
+                cameraTransform.position = position.Value;
+            }
+
+            if (target.HasValue)
+            {
+                cameraTransform.forward = target.Value - cameraTransform.position;
+            }
+        }
+
+        public static void RepositionVisualTestsCamera(Camera camera, Vector3? position = null, Vector3? target = null) { RepositionVisualTestsCamera(camera.transform, position, target); }
+    }
+}

--- a/unity-renderer/Assets/ABConverter/VisualTests/AssetBundlesVisualTestHelpers.cs.meta
+++ b/unity-renderer/Assets/ABConverter/VisualTests/AssetBundlesVisualTestHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebc835a2713444d04afc8d165a15cb79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/ABConverter/VisualTests/Editor.meta
+++ b/unity-renderer/Assets/ABConverter/VisualTests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 663a4ebe6902f4e01a7268afc2c6d7b0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/ABConverter/VisualTests/Editor/GameViewUtils.cs
+++ b/unity-renderer/Assets/ABConverter/VisualTests/Editor/GameViewUtils.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Reflection;
+using UnityEditor;
+
+//NOTE(Brian): Code adapted from this answer https://answers.unity.com/questions/956123/add-and-select-game-view-resolution.html
+public static class GameViewUtils
+{
+    static object gameViewSizesInstance;
+    static MethodInfo getGroup;
+
+    static GameViewUtils()
+    {
+        var sizesType = typeof(Editor).Assembly.GetType("UnityEditor.GameViewSizes");
+        var singleType = typeof(ScriptableSingleton<>).MakeGenericType(sizesType);
+        var instanceProp = singleType.GetProperty("instance");
+        getGroup = sizesType.GetMethod("GetGroup");
+        gameViewSizesInstance = instanceProp.GetValue(null, null);
+    }
+
+    public enum GameViewSizeType
+    {
+        AspectRatio, FixedResolution
+    }
+
+    public static void SetSize(int index)
+    {
+        var gvWndType = typeof(Editor).Assembly.GetType("UnityEditor.GameView");
+
+        var selectedSizeIndexProp = gvWndType.GetProperty("selectedSizeIndex",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        var gvWnd = EditorWindow.GetWindow(gvWndType);
+
+        selectedSizeIndexProp.SetValue(gvWnd, index, null);
+    }
+
+    public static int AddOrGetCustomSize(GameViewSizeType viewSizeType, GameViewSizeGroupType sizeGroupType, int width, int height, string text)
+    {
+        int id = FindSize(sizeGroupType, width, height);
+
+        if (id != -1)
+            return id;
+
+        var group = GetGroup(sizeGroupType);
+        var addCustomSize = getGroup.ReturnType.GetMethod("AddCustomSize"); // or group.GetType().
+        var gvsType = typeof(Editor).Assembly.GetType("UnityEditor.GameViewSize");
+        var enumType = typeof(Editor).Assembly.GetType("UnityEditor.GameViewSizeType");
+        var ctor = gvsType.GetConstructor(new Type[] { enumType, typeof(int), typeof(int), typeof(string) });
+        var newSize = ctor.Invoke(new object[] { (int)viewSizeType, width, height, text });
+        addCustomSize.Invoke(group, new object[] { newSize });
+
+        return FindSize(sizeGroupType, width, height);
+    }
+
+    public static void RemoveCustomSize(GameViewSizeGroupType sizeGroupType, int index)
+    {
+        var group = GetGroup(sizeGroupType);
+        var addCustomSize = getGroup.ReturnType.GetMethod("RemoveCustomSize");
+        addCustomSize.Invoke(group, new object[] { index });
+    }
+
+    public static bool SizeExists(GameViewSizeGroupType sizeGroupType, string text) { return FindSize(sizeGroupType, text) != -1; }
+
+    public static int FindSize(GameViewSizeGroupType sizeGroupType, string text)
+    {
+        var group = GetGroup(sizeGroupType);
+        var getDisplayTexts = group.GetType().GetMethod("GetDisplayTexts");
+        var displayTexts = getDisplayTexts.Invoke(group, null) as string[];
+        for (int i = 0; i < displayTexts.Length; i++)
+        {
+            string display = displayTexts[i];
+
+            // the text we get is "Name (W:H)" if the size has a name, or just "W:H" e.g. 16:9
+            // so if we're querying a custom size text we substring to only get the name
+            // You could see the outputs by just logging
+            int pren = display.IndexOf('(');
+
+            if (pren != -1)
+                display = display.Substring(0, pren - 1); // -1 to remove the space that's before the prens. This is very implementation-depdenent
+
+            if (display == text)
+                return i;
+        }
+        return -1;
+    }
+
+    public static bool SizeExists(GameViewSizeGroupType sizeGroupType, int width, int height) { return FindSize(sizeGroupType, width, height) != -1; }
+
+    public static int FindSize(GameViewSizeGroupType sizeGroupType, int width, int height)
+    {
+        object group = GetGroup(sizeGroupType);
+        var groupType = group.GetType();
+        var getBuiltinCount = groupType.GetMethod("GetBuiltinCount");
+        var getCustomCount = groupType.GetMethod("GetCustomCount");
+        int sizesCount = (int)getBuiltinCount.Invoke(group, null) + (int)getCustomCount.Invoke(group, null);
+        var getGameViewSize = groupType.GetMethod("GetGameViewSize");
+        var gvsType = getGameViewSize.ReturnType;
+        var widthProp = gvsType.GetProperty("width");
+        var heightProp = gvsType.GetProperty("height");
+        var indexValue = new object[1];
+
+        for (int i = 0; i < sizesCount; i++)
+        {
+            indexValue[0] = i;
+            var size = getGameViewSize.Invoke(group, indexValue);
+            int sizeWidth = (int)widthProp.GetValue(size, null);
+            int sizeHeight = (int)heightProp.GetValue(size, null);
+
+            if (sizeWidth == width && sizeHeight == height)
+                return i;
+        }
+
+        return -1;
+    }
+
+    static object GetGroup(GameViewSizeGroupType type) { return getGroup.Invoke(gameViewSizesInstance, new object[] { (int)type }); }
+
+    public static GameViewSizeGroupType GetCurrentGroupType()
+    {
+        var getCurrentGroupTypeProp = gameViewSizesInstance.GetType().GetProperty("currentGroupType");
+
+        return (GameViewSizeGroupType)(int)getCurrentGroupTypeProp.GetValue(gameViewSizesInstance, null);
+    }
+}

--- a/unity-renderer/Assets/ABConverter/VisualTests/Editor/GameViewUtils.cs.meta
+++ b/unity-renderer/Assets/ABConverter/VisualTests/Editor/GameViewUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fc202e1c03c74aa7b86d587e5635573
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/ABConverter/VisualTests/Editor/GameViewUtilsTests.cs
+++ b/unity-renderer/Assets/ABConverter/VisualTests/Editor/GameViewUtilsTests.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UnityEditor;
+
+namespace Tests
+{
+    public class GameViewUtilsTests
+    {
+        [Test]
+        [Category("Visual Tests")]
+        public static void SizeIsAddedAndRemovedCorrectly()
+        {
+            GameViewUtils.AddOrGetCustomSize(GameViewUtils.GameViewSizeType.FixedResolution, GameViewSizeGroupType.Standalone, 123, 456, "Test size");
+
+            int idx = GameViewUtils.FindSize(GameViewSizeGroupType.Standalone, 123, 456);
+            Assert.AreNotEqual(-1, idx);
+            GameViewUtils.RemoveCustomSize(GameViewSizeGroupType.Standalone, idx);
+
+            idx = GameViewUtils.FindSize(GameViewSizeGroupType.Standalone, 123, 456);
+            Assert.AreEqual(-1, idx);
+        }
+    }
+}

--- a/unity-renderer/Assets/ABConverter/VisualTests/Editor/GameViewUtilsTests.cs.meta
+++ b/unity-renderer/Assets/ABConverter/VisualTests/Editor/GameViewUtilsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1cb017e8523f64913bda629f1b867272
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added AB converter own visual tests helper to avoid problems when importing unity-renderer project as a UPM in desktop-client.