### PR TITLE
fix: [BiW Panel] Search in collections should not be case sensitive

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/SearchHandler/SearchHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/SearchHandler/SearchHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,7 +17,11 @@ public static class SearchHelper
         if (string.IsNullOrEmpty(text))
             return true;
 
-        return item.keywords.Any(keyword => !string.IsNullOrEmpty(keyword) && keyword.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0);
+        // NOTE: Due to an Unity known issue, the use of 'StringComparison.OrdinalIgnoreCase' in WebGL is case sensitive when shouldn't be.
+        // Absurd as it may seem, Unity says it is working in this way "by design", so it seems they're not going to fix it.
+        // A work-around is to use '.ToLower()' in both strings.
+        // More info: https://issuetracker.unity3d.com/issues/webgl-build-system-dot-stringcomparison-dot-ordinalignorecase-is-case-sensitive
+        return item.keywords.Any(keyword => !string.IsNullOrEmpty(keyword) && keyword.ToLower().IndexOf(text.ToLower(), StringComparison.OrdinalIgnoreCase) >= 0);
     }
 
     public static void Sort<T>(string sortType, List<T> input, bool descendingOrder) where T : ISortable<T> { input.Sort((a, b) => a.Compare(sortType, descendingOrder, b)); }


### PR DESCRIPTION
## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
### Fixes #525 
- [x] Search in BiW Panel is case sensitive. It should not be.

![image](https://user-images.githubusercontent.com/64659061/120215603-377ea000-c236-11eb-9fd8-d85edaf7390f.png)

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-Panel-Search-in-collections-should-not-be-case-sensitive&ENV=zone&ENABLE_BUILDER_IN_WORLD
2. Click on the "**Builder In World**" button in the taskbar.
3. Use the search textbox.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md