### PR TITLE
fix: culling controller avatar editor issue

### DIFF
--- a/unity-renderer/Assets/Rendering/Culling/CullingController.cs
+++ b/unity-renderer/Assets/Rendering/Culling/CullingController.cs
@@ -53,6 +53,8 @@ namespace DCL.Rendering
             else
                 objectsTracker = cullingObjectsTracker;
 
+            objectsTracker.SetIgnoredLayersMask(settings.ignoredLayersMask);
+
             this.urpAsset = urpAsset;
             this.settings = settings;
         }
@@ -330,12 +332,14 @@ namespace DCL.Rendering
 
             for (var i = 0; i < animations?.Length; i++)
             {
-                animations[i].cullingType = AnimationCullingType.AlwaysAnimate;
+                if ( animations[i] != null )
+                    animations[i].cullingType = AnimationCullingType.AlwaysAnimate;
             }
 
             for (var i = 0; i < renderers?.Length; i++)
             {
-                renderers[i].forceRenderingOff = false;
+                if ( renderers[i] != null )
+                    renderers[i].forceRenderingOff = false;
             }
         }
 
@@ -386,6 +390,8 @@ namespace DCL.Rendering
         {
             this.settings = settings;
             profiles = new List<CullingControllerProfile> { settings.rendererProfile, settings.skinnedRendererProfile };
+
+            objectsTracker?.SetIgnoredLayersMask(settings.ignoredLayersMask);
             objectsTracker?.MarkDirty();
             MarkDirty();
         }

--- a/unity-renderer/Assets/Rendering/Culling/CullingObjectsTracker.cs
+++ b/unity-renderer/Assets/Rendering/Culling/CullingObjectsTracker.cs
@@ -18,6 +18,7 @@ namespace DCL.Rendering
         Animation[] animations;
 
         bool dirty = true;
+        private int ignoredLayersMask;
 
         /// <summary>
         /// If the dirty flag is true, this coroutine will re-populate all the tracked objects.
@@ -28,15 +29,27 @@ namespace DCL.Rendering
                 yield break;
 
             renderers = Object.FindObjectsOfType<Renderer>()
-                              .Where(x => !(x is SkinnedMeshRenderer) && !(x is ParticleSystemRenderer))
-                              .ToArray();
+                .Where(x => !(x is SkinnedMeshRenderer)
+                            && !(x is ParticleSystemRenderer)
+                            && ((1 << x.gameObject.layer) & ignoredLayersMask) == 0)
+                .ToArray();
 
             yield return null;
-            skinnedRenderers = Object.FindObjectsOfType<SkinnedMeshRenderer>();
+
+            skinnedRenderers = Object.FindObjectsOfType<SkinnedMeshRenderer>()
+                .Where(x => ((1 << x.gameObject.layer) & ignoredLayersMask) == 0)
+                .ToArray();
+
             yield return null;
+
             animations = Object.FindObjectsOfType<Animation>();
 
             dirty = false;
+        }
+
+        public void SetIgnoredLayersMask(int ignoredLayersMask)
+        {
+            this.ignoredLayersMask = ignoredLayersMask;
         }
 
         /// <summary>

--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingObjectsTracker.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingObjectsTracker.cs
@@ -6,6 +6,7 @@ namespace DCL.Rendering
 {
     public interface ICullingObjectsTracker : IDisposable
     {
+        void SetIgnoredLayersMask(int ignoredLayersMask);
         void MarkDirty();
         bool IsDirty();
         Renderer[] GetRenderers();

--- a/unity-renderer/Assets/Rendering/Culling/Tests/CullingControllerShould.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Tests/CullingControllerShould.cs
@@ -4,6 +4,7 @@ using DCL.Rendering;
 using NSubstitute;
 using NSubstitute.Exceptions;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;

--- a/unity-renderer/Assets/Rendering/Culling/Tests/CullingObjectsTrackerShould.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Tests/CullingObjectsTrackerShould.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections;
+using System.Linq;
+using DCL.Rendering;
+using UnityEngine;
+using UnityEngine.Assertions;
+using UnityEngine.TestTools;
+
+namespace CullingControllerTests
+{
+    public class CullingObjectsTrackerShould
+    {
+        [UnityTest]
+        public IEnumerator FilterIgnoredLayerMasksCorrectly()
+        {
+            // Arrange
+            int layer = 5;
+            int layerMask = 1 << layer;
+            var tracker = new CullingObjectsTracker();
+            tracker.SetIgnoredLayersMask(layerMask);
+
+            var testGameObjectA = new GameObject();
+            var originalRendererA = testGameObjectA.AddComponent<MeshRenderer>();
+            testGameObjectA.layer = layer;
+
+            var testGameObjectB = new GameObject();
+            var originalRendererB = testGameObjectB.AddComponent<MeshRenderer>();
+            testGameObjectB.layer = 0;
+
+            var testGameObjectC = new GameObject();
+            var originalRendererC = testGameObjectC.AddComponent<SkinnedMeshRenderer>();
+            testGameObjectC.layer = layer;
+
+            var testGameObjectD = new GameObject();
+            var originalRendererD = testGameObjectD.AddComponent<SkinnedMeshRenderer>();
+            testGameObjectD.layer = 0;
+
+            Renderer[] renderers = null;
+            Renderer obtainedRendererA = null, obtainedRendererB = null, obtainedRendererC = null, obtainedRendererD = null;
+
+            // Act
+            yield return tracker.PopulateRenderersList();
+
+            renderers = tracker.GetRenderers();
+            obtainedRendererA = renderers.FirstOrDefault( x => x == originalRendererA );
+            obtainedRendererB = renderers.FirstOrDefault( x => x == originalRendererB );
+            obtainedRendererC = tracker.GetSkinnedRenderers().FirstOrDefault( x => x == originalRendererC );
+            obtainedRendererD = tracker.GetSkinnedRenderers().FirstOrDefault( x => x == originalRendererD );
+
+            // Assert
+            Assert.IsTrue(originalRendererA != null);
+            Assert.IsTrue(originalRendererB != null);
+            Assert.IsTrue(originalRendererC != null);
+            Assert.IsTrue(originalRendererD != null);
+
+            Assert.IsTrue(obtainedRendererA == null, "Renderer should be null because it has an invalid layer");
+            Assert.IsTrue(obtainedRendererB != null, "Renderer should not be null because it has a valid layer");
+            Assert.IsTrue(obtainedRendererC == null, "Skinned renderer should be null because it has a invalid layer");
+            Assert.IsTrue(obtainedRendererD != null, "Skinned renderer should not be null because it has a valid layer");
+
+            // Cleanup
+            Object.Destroy(testGameObjectA);
+            Object.Destroy(testGameObjectB);
+            Object.Destroy(testGameObjectC);
+            Object.Destroy(testGameObjectD);
+
+            yield return null;
+        }
+    }
+}

--- a/unity-renderer/Assets/Rendering/Culling/Tests/CullingObjectsTrackerShould.cs.meta
+++ b/unity-renderer/Assets/Rendering/Culling/Tests/CullingObjectsTrackerShould.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ff861c1ea9724be0ab2de01eb169ada0
+timeCreated: 1622655235


### PR DESCRIPTION
## What this PR includes?

This PR attempts to fix the CullingController issue that prevents the "Done" button to work correctly on avatar editor due to a nullRef error.

![image](https://user-images.githubusercontent.com/6875814/120530213-a5040b00-c3b3-11eb-8342-f3d80d151733.png)

- added null checks on `CullingController.ResetObjects()`
- ensure `CullingObjectsTracker` doesn't include the avatar preview meshes.

## How to test it?
Go to avatar editor, put some wearables and click on Done.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md