### PR TITLE
fix: materials on facial features were being destroyed while loading

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -108,6 +108,9 @@ namespace DCL
             eyesController?.CleanUp();
             eyesController = null;
 
+            mouthController?.CleanUp();
+            mouthController = null;
+
             bodyShapeController?.CleanUp();
             bodyShapeController = null;
 
@@ -147,21 +150,6 @@ namespace DCL
                     wearable.CleanUp();
                     wearableControllers.Remove(currentId);
                 }
-            }
-
-            if (eyebrowsController != null && !model.wearables.Contains(eyebrowsController.wearableId))
-            {
-                eyebrowsController.CleanUp();
-            }
-
-            if (eyesController != null && !model.wearables.Contains(eyesController.wearableId))
-            {
-                eyesController.CleanUp();
-            }
-
-            if (mouthController != null && !model.wearables.Contains(mouthController.wearableId))
-            {
-                mouthController.CleanUp();
             }
         }
 


### PR DESCRIPTION
Sometimes the materials attached to the facial features are destroyed. It can be "easily" tested in our current .zone build when going through the signup process in a couple of our default avatars.

![image](https://user-images.githubusercontent.com/50231608/120647485-f3c8a800-c47a-11eb-8ed0-74cab2eeaa75.png)
