### PR TITLE
fix: [BiW Editor] Entities selection issues during publication process

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldInputWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldInputWrapper.cs
@@ -51,7 +51,11 @@ public class BuilderInWorldInputWrapper : MonoBehaviour
 
     private void MouseUp(int buttonId, Vector3 mousePosition)
     {
-        currentClickIsOnUi = false;
+        if (currentClickIsOnUi)
+        {
+            currentClickIsOnUi = false;
+            return;
+        }
 
         if (!canInputBeMade)
             return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -798,6 +798,8 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
 
     private void TakeSceneScreenshot()
     {
+        builderInWorldEntityHandler.DeselectEntities();
+
         freeCameraController.TakeSceneScreenshot((sceneSnapshot) =>
         {
             HUDController.i.builderInWorldMainHud?.SetBuilderProjectScreenshot(sceneSnapshot);


### PR DESCRIPTION
## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
### Fixes #580 
- [x] Entities should not be selectable during publishing process.

#### Steps to reproduce:

1. Go to BiW.
2. Edit a Scene.
3. Add entities.
4. Click on Publish.
5. Click on the Entities in the background.

### Fixes #581 
- [x] Scene screenshot should not show highlights nor gizmos.

#### Steps to reproduce:
1. Go to Builder in World.
2. Edit a Scene.
3. Select an entity with rotation tool.
4. Start Publish flow.
5. Rotation gizmo and highlights are shown in the thumbnail.

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/BiW-Entities-selection-issues-during-publication-process&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=80,154
2. Press 'K' to open the Builer In World editor.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md