### PR TITLE
feat: [BiW Editor] BiW should update Project metadata and thumbnail (Unity side)

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldBridge/BuilderInWorldBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldBridge/BuilderInWorldBridge.cs
@@ -16,6 +16,8 @@ using Environment = DCL.Environment;
 /// </summary>
 public class BuilderInWorldBridge : MonoBehaviour
 {
+    public BuilderProjectPayload builderProject { get => builderProjectPayload; }
+
     //Note Adrian: OnKernelUpdated in not called in the update of the transform, since it will give a lot of 
     //events and probably dont need to get called with that frecuency
     public event Action OnKernelUpdated;
@@ -27,6 +29,7 @@ public class BuilderInWorldBridge : MonoBehaviour
 
     StoreSceneStateEvent storeSceneState = new StoreSceneStateEvent();
     SaveSceneStateEvent saveSceneState = new SaveSceneStateEvent();
+    SaveSceneInfoEvent saveSceneInfo = new SaveSceneInfoEvent();
     ModifyEntityComponentEvent modifyEntityComponentEvent = new ModifyEntityComponentEvent();
     EntityPayload entityPayload = new EntityPayload();
     EntitySingleComponentPayload entitySingleComponentPayload = new EntitySingleComponentPayload();
@@ -51,6 +54,15 @@ public class BuilderInWorldBridge : MonoBehaviour
     {
         saveSceneState.payload = JsonUtility.ToJson(builderProjectPayload);
         WebInterface.SendSceneEvent(scene.sceneData.id, BuilderInWorldSettings.STATE_EVENT_NAME, saveSceneState);
+    }
+
+    public void SaveSceneInfo(ParcelScene scene, string sceneName, string sceneDescription, string sceneScreenshot)
+    {
+        saveSceneInfo.payload.title = sceneName;
+        saveSceneInfo.payload.description = sceneDescription;
+        saveSceneInfo.payload.screenshot = sceneScreenshot;
+
+        WebInterface.SendSceneEvent(scene.sceneData.id, BuilderInWorldSettings.STATE_EVENT_NAME, saveSceneInfo);
     }
 
     public void PublishSceneResult(string payload)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldBridge/BuilderInWorldBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldBridge/BuilderInWorldBridge.cs
@@ -30,7 +30,7 @@ public class BuilderInWorldBridge : MonoBehaviour
 
     StoreSceneStateEvent storeSceneState = new StoreSceneStateEvent();
     SaveSceneStateEvent saveSceneState = new SaveSceneStateEvent();
-    SaveSceneInfoEvent saveSceneInfo = new SaveSceneInfoEvent();
+    SaveProjectInfoEvent saveProjectInfo = new SaveProjectInfoEvent();
     ModifyEntityComponentEvent modifyEntityComponentEvent = new ModifyEntityComponentEvent();
     EntityPayload entityPayload = new EntityPayload();
     EntitySingleComponentPayload entitySingleComponentPayload = new EntitySingleComponentPayload();
@@ -89,11 +89,11 @@ public class BuilderInWorldBridge : MonoBehaviour
 
     public void SaveSceneInfo(ParcelScene scene, string sceneName, string sceneDescription, string sceneScreenshot)
     {
-        saveSceneInfo.payload.title = sceneName;
-        saveSceneInfo.payload.description = sceneDescription;
-        saveSceneInfo.payload.screenshot = sceneScreenshot;
+        saveProjectInfo.payload.title = sceneName;
+        saveProjectInfo.payload.description = sceneDescription;
+        saveProjectInfo.payload.screenshot = sceneScreenshot;
 
-        WebInterface.SendSceneEvent(scene.sceneData.id, BuilderInWorldSettings.STATE_EVENT_NAME, saveSceneInfo);
+        WebInterface.SendSceneEvent(scene.sceneData.id, BuilderInWorldSettings.STATE_EVENT_NAME, saveProjectInfo);
     }
 
     public void SaveSceneState(ParcelScene scene)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldBridge/BuilderInWorldBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldBridge/BuilderInWorldBridge.cs
@@ -38,15 +38,6 @@ public class BuilderInWorldBridge : MonoBehaviour
 
     #region MessagesFromKernel
 
-    public void SaveSceneInfo(ParcelScene scene, string sceneName, string sceneDescription, string sceneScreenshot)
-    {
-        saveSceneInfo.payload.title = sceneName;
-        saveSceneInfo.payload.description = sceneDescription;
-        saveSceneInfo.payload.screenshot = sceneScreenshot;
-
-        WebInterface.SendSceneEvent(scene.sceneData.id, BuilderInWorldSettings.STATE_EVENT_NAME, saveSceneInfo);
-    }
-
     public void PublishSceneResult(string payload)
     {
         PublishSceneResultPayload publishSceneResultPayload = JsonUtility.FromJson<PublishSceneResultPayload>(payload);
@@ -94,6 +85,15 @@ public class BuilderInWorldBridge : MonoBehaviour
         entitySingleComponentPayload.data = smartItemComponent.GetValues();
 
         ChangeEntityComponent(entitySingleComponentPayload, scene);
+    }
+
+    public void SaveSceneInfo(ParcelScene scene, string sceneName, string sceneDescription, string sceneScreenshot)
+    {
+        saveSceneInfo.payload.title = sceneName;
+        saveSceneInfo.payload.description = sceneDescription;
+        saveSceneInfo.payload.screenshot = sceneScreenshot;
+
+        WebInterface.SendSceneEvent(scene.sceneData.id, BuilderInWorldSettings.STATE_EVENT_NAME, saveSceneInfo);
     }
 
     public void SaveSceneState(ParcelScene scene)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
@@ -91,7 +91,9 @@ public class BuilderInWorldController : MonoBehaviour
 
     private void OnDestroy()
     {
-        userProfile.OnUpdate -= OnUserProfileUpdate;
+        if (userProfile != null)
+            userProfile.OnUpdate -= OnUserProfileUpdate;
+
         CoroutineStarter.Stop(updateLandsWithAcessCoroutine);
 
         if (sceneToEdit != null)
@@ -503,6 +505,7 @@ public class BuilderInWorldController : MonoBehaviour
                 inputController.inputTypeMode = InputTypeMode.BUILD_MODE;
                 HUDController.i.builderInWorldMainHud?.SetVisibility(true);
                 CommonScriptableObjects.allUIHidden.Set(previousAllUIHidden);
+                OpenNewProjectDetailsIfNeeded();
             });
         }
 
@@ -530,7 +533,14 @@ public class BuilderInWorldController : MonoBehaviour
             inputController.inputTypeMode = InputTypeMode.BUILD_MODE;
             HUDController.i.builderInWorldMainHud.SetVisibility(true);
             CommonScriptableObjects.allUIHidden.Set(previousAllUIHidden);
+            OpenNewProjectDetailsIfNeeded();
         });
+    }
+
+    private void OpenNewProjectDetailsIfNeeded()
+    {
+        if (builderInWorldBridge.builderProject.isNewEmptyProject)
+            editorMode.OpenNewProjectDetails();
     }
 
     public void CancelLoading()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
@@ -118,6 +118,7 @@ public class BuilderInWorldController : MonoBehaviour
         if (HUDController.i.builderInWorldMainHud != null)
         {
             HUDController.i.builderInWorldMainHud.OnTutorialAction -= StartTutorial;
+            HUDController.i.builderInWorldMainHud.OnStartExitAction -= StartExitMode;
             HUDController.i.builderInWorldMainHud.OnLogoutAction -= ExitEditMode;
         }
 
@@ -209,6 +210,7 @@ public class BuilderInWorldController : MonoBehaviour
 
         HUDController.i.builderInWorldInititalHud.OnEnterEditMode += TryStartEnterEditMode;
         HUDController.i.builderInWorldMainHud.OnTutorialAction += StartTutorial;
+        HUDController.i.builderInWorldMainHud.OnStartExitAction += StartExitMode;
         HUDController.i.builderInWorldMainHud.OnLogoutAction += ExitEditMode;
 
         BuilderInWorldTeleportAndEdit.OnTeleportEnd += OnPlayerTeleportedToEditScene;
@@ -566,8 +568,20 @@ public class BuilderInWorldController : MonoBehaviour
         ExitEditMode();
     }
 
+    public void StartExitMode()
+    {
+        if (biwSaveController.numberOfSaves > 0)
+            editorMode.TakeSceneScreenshotForExit();
+    }
+
     public void ExitEditMode()
     {
+        if (biwSaveController.numberOfSaves > 0)
+        {
+            HUDController.i.builderInWorldMainHud?.SaveSceneInfo();
+            biwSaveController.ResetNumberOfSaves();
+        }
+
         biwFloorHandler.OnAllParcelsFloorLoaded -= OnAllParcelsFloorLoaded;
         initialLoadingController.Hide(true);
         inputController.inputTypeMode = InputTypeMode.GENERAL;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWSaveController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWSaveController.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using DCL.Controllers;
 using UnityEngine;
 
@@ -11,6 +8,8 @@ public class BIWSaveController : BIWController
 
     [Header("Prefab reference")]
     public BuilderInWorldBridge builderInWorldBridge;
+
+    public int numberOfSaves { get; private set; } = 0;
 
     private float nextTimeToSave;
     private bool canActivateSave = true;
@@ -23,7 +22,7 @@ public class BIWSaveController : BIWController
             builderInWorldBridge.OnKernelUpdated += TryToSave;
 
         if (HUDController.i.builderInWorldMainHud != null)
-            HUDController.i.builderInWorldMainHud.OnConfirmNewProjectAction += SaveSceneInfo;
+            HUDController.i.builderInWorldMainHud.OnSaveSceneInfoAction += SaveSceneInfo;
     }
 
     private void OnDestroy()
@@ -32,15 +31,18 @@ public class BIWSaveController : BIWController
             builderInWorldBridge.OnKernelUpdated -= TryToSave;
 
         if (HUDController.i.builderInWorldMainHud != null)
-            HUDController.i.builderInWorldMainHud.OnConfirmNewProjectAction -= SaveSceneInfo;
+            HUDController.i.builderInWorldMainHud.OnSaveSceneInfoAction -= SaveSceneInfo;
     }
 
     public void ResetSaveTime() { nextTimeToSave = 0; }
+
+    public void ResetNumberOfSaves() { numberOfSaves = 0; }
 
     public override void EnterEditMode(ParcelScene scene)
     {
         base.EnterEditMode(scene);
         nextTimeToSave = DCLTime.realtimeSinceStartup + msBetweenSaves / 1000f;
+        ResetNumberOfSaves();
     }
 
     public void SetSaveActivation(bool isActive, bool tryToSave = false)
@@ -66,6 +68,7 @@ public class BIWSaveController : BIWController
         builderInWorldBridge.SaveSceneState(sceneToEdit);
         nextTimeToSave = DCLTime.realtimeSinceStartup + msBetweenSaves / 1000f;
         HUDController.i.builderInWorldMainHud?.SceneSaved();
+        numberOfSaves++;
     }
 
     public void SaveSceneInfo(string sceneName, string sceneDescription, string sceneScreenshot) { builderInWorldBridge.SaveSceneInfo(sceneToEdit, sceneName, sceneDescription, sceneScreenshot); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWSaveController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWSaveController.cs
@@ -18,8 +18,21 @@ public class BIWSaveController : BIWController
     public override void Init()
     {
         base.Init();
+
         if (builderInWorldBridge != null)
             builderInWorldBridge.OnKernelUpdated += TryToSave;
+
+        if (HUDController.i.builderInWorldMainHud != null)
+            HUDController.i.builderInWorldMainHud.OnConfirmNewProjectAction += SaveSceneInfo;
+    }
+
+    private void OnDestroy()
+    {
+        if (builderInWorldBridge != null)
+            builderInWorldBridge.OnKernelUpdated -= TryToSave;
+
+        if (HUDController.i.builderInWorldMainHud != null)
+            HUDController.i.builderInWorldMainHud.OnConfirmNewProjectAction -= SaveSceneInfo;
     }
 
     public void ResetSaveTime() { nextTimeToSave = 0; }
@@ -54,4 +67,6 @@ public class BIWSaveController : BIWController
         nextTimeToSave = DCLTime.realtimeSinceStartup + msBetweenSaves / 1000f;
         HUDController.i.builderInWorldMainHud?.SceneSaved();
     }
+
+    public void SaveSceneInfo(string sceneName, string sceneDescription, string sceneScreenshot) { builderInWorldBridge.SaveSceneInfo(sceneToEdit, sceneName, sceneDescription, sceneScreenshot); }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -4,6 +4,7 @@ using DCL.Configuration;
 using DCL.Controllers;
 using DCL.Helpers;
 using DCL.Models;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Environment = DCL.Environment;
@@ -99,7 +100,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         HUDController.i.builderInWorldMainHud.OnRotateSelectedAction -= RotateMode;
         HUDController.i.builderInWorldMainHud.OnScaleSelectedAction -= ScaleMode;
         HUDController.i.builderInWorldMainHud.OnResetCameraAction -= ResetCamera;
-        HUDController.i.builderInWorldMainHud.OnPublishAction -= TakeSceneScreenshot;
+        HUDController.i.builderInWorldMainHud.OnPublishAction -= TakePublishSceneScreenshot;
     }
 
     private void Update()
@@ -248,7 +249,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
             HUDController.i.builderInWorldMainHud.OnSelectedObjectRotationChange += UpdateSelectionRotation;
             HUDController.i.builderInWorldMainHud.OnSelectedObjectScaleChange += UpdateSelectionScale;
             HUDController.i.builderInWorldMainHud.OnResetCameraAction += ResetCamera;
-            HUDController.i.builderInWorldMainHud.OnPublishAction += TakeSceneScreenshot;
+            HUDController.i.builderInWorldMainHud.OnPublishAction += TakePublishSceneScreenshot;
         }
     }
 
@@ -799,13 +800,23 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
 
     private void ResetCamera() { freeCameraController.ResetCameraPosition(); }
 
-    private void TakeSceneScreenshot()
+    private void TakePublishSceneScreenshot()
     {
         builderInWorldEntityHandler.DeselectEntities();
 
         freeCameraController.TakeSceneScreenshot((sceneSnapshot) =>
         {
             HUDController.i.builderInWorldMainHud?.SetBuilderProjectScreenshot(sceneSnapshot);
+        });
+    }
+
+    public void OpenNewProjectDetails()
+    {
+        builderInWorldEntityHandler.DeselectEntities();
+
+        freeCameraController.TakeSceneScreenshot((sceneSnapshot) =>
+        {
+            HUDController.i.builderInWorldMainHud?.NewProjectStart(sceneSnapshot);
         });
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -100,7 +100,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         HUDController.i.builderInWorldMainHud.OnRotateSelectedAction -= RotateMode;
         HUDController.i.builderInWorldMainHud.OnScaleSelectedAction -= ScaleMode;
         HUDController.i.builderInWorldMainHud.OnResetCameraAction -= ResetCamera;
-        HUDController.i.builderInWorldMainHud.OnPublishAction -= TakePublishSceneScreenshot;
+        HUDController.i.builderInWorldMainHud.OnPublishAction -= TakeSceneScreenshotForPublish;
     }
 
     private void Update()
@@ -249,7 +249,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
             HUDController.i.builderInWorldMainHud.OnSelectedObjectRotationChange += UpdateSelectionRotation;
             HUDController.i.builderInWorldMainHud.OnSelectedObjectScaleChange += UpdateSelectionScale;
             HUDController.i.builderInWorldMainHud.OnResetCameraAction += ResetCamera;
-            HUDController.i.builderInWorldMainHud.OnPublishAction += TakePublishSceneScreenshot;
+            HUDController.i.builderInWorldMainHud.OnPublishAction += TakeSceneScreenshotForPublish;
         }
     }
 
@@ -800,11 +800,21 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
 
     private void ResetCamera() { freeCameraController.ResetCameraPosition(); }
 
-    private void TakePublishSceneScreenshot()
+    private void TakeSceneScreenshotForPublish()
     {
         builderInWorldEntityHandler.DeselectEntities();
 
         freeCameraController.TakeSceneScreenshot((sceneSnapshot) =>
+        {
+            HUDController.i.builderInWorldMainHud?.SetBuilderProjectScreenshot(sceneSnapshot);
+        });
+    }
+
+    public void TakeSceneScreenshotForExit()
+    {
+        builderInWorldEntityHandler.DeselectEntities();
+
+        freeCameraController.TakeSceneScreenshotFromResetPosition((sceneSnapshot) =>
         {
             HUDController.i.builderInWorldMainHud?.SetBuilderProjectScreenshot(sceneSnapshot);
         });

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/FreeCameraMovement.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/FreeCameraMovement.cs
@@ -414,11 +414,32 @@ public class FreeCameraMovement : CameraStateBase
         yield return null;
 
         Texture2D sceneScreenshot = ScreenshotFromCamera(SCENE_SNAPSHOT_WIDTH_RES, SCENE_SNAPSHOT_HEIGHT_RES);
+        camera.targetTexture = current;
+        callback?.Invoke(sceneScreenshot);
+    }
+
+    public void TakeSceneScreenshotFromResetPosition(OnSnapshotsReady onSuccess) { StartCoroutine(TakeSceneScreenshotFromResetPositionCoroutine(onSuccess)); }
+
+    private IEnumerator TakeSceneScreenshotFromResetPositionCoroutine(OnSnapshotsReady callback)
+    {
+        // Store current camera position/direction
+        Vector3 currentPos = transform.position;
+        Vector3 currentLookAt = transform.forward;
+        SetPosition(originalCameraPosition);
+        transform.LookAt(originalCameraLookAt);
+
+        var current = camera.targetTexture;
+        camera.targetTexture = null;
 
         yield return null;
 
+        Texture2D sceneScreenshot = ScreenshotFromCamera(SCENE_SNAPSHOT_WIDTH_RES, SCENE_SNAPSHOT_HEIGHT_RES);
         camera.targetTexture = current;
         callback?.Invoke(sceneScreenshot);
+
+        // Restore camera position/direction after the screenshot
+        SetPosition(currentPos);
+        transform.forward = currentLookAt;
     }
 
     private Texture2D ScreenshotFromCamera(int width, int height)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/BuildModeHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/BuildModeHUD.prefab
@@ -35,6 +35,7 @@ RectTransform:
   - {fileID: 1296877563891201531}
   - {fileID: 851071765481101389}
   - {fileID: 7115505017810700446}
+  - {fileID: 6599429117766555830}
   - {fileID: 4497176644702821786}
   - {fileID: 9136931939368659436}
   m_Father: {fileID: 851071764747098679}
@@ -120,6 +121,7 @@ MonoBehaviour:
   topActionsButtonsView: {fileID: 8782452489027953282}
   buildModeConfirmationModalView: {fileID: 2597530036226113637}
   saveView: {fileID: 6156681422144908546}
+  newProjectDetailsView: {fileID: 2917871582703021880}
   publicationDetailsView: {fileID: 5585188370584300052}
 --- !u!223 &851071764747098676
 Canvas:
@@ -569,7 +571,7 @@ PrefabInstance:
     - target: {fileID: 9185754462392474648, guid: 92f068ec1838d554f9ac9501828a3154,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 9185754462392474648, guid: 92f068ec1838d554f9ac9501828a3154,
         type: 3}
@@ -1143,6 +1145,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 87168468c2cfb69488d253203087a611, type: 3}
+--- !u!224 &851071763679374502 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 404395253880102918, guid: 87168468c2cfb69488d253203087a611,
+    type: 3}
+  m_PrefabInstance: {fileID: 1032219410684300448}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6319890495403155759 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6478407165026938255, guid: 87168468c2cfb69488d253203087a611,
@@ -1155,12 +1163,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7b8d1b2e789fb754eb21833ad286c03e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &851071763679374502 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 404395253880102918, guid: 87168468c2cfb69488d253203087a611,
-    type: 3}
-  m_PrefabInstance: {fileID: 1032219410684300448}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1928757586443201240
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1285,12 +1287,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d885487724a96044590f78d774928c25, type: 3}
---- !u!224 &304367758979097732 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2232947670913027676, guid: d885487724a96044590f78d774928c25,
-    type: 3}
-  m_PrefabInstance: {fileID: 1928757586443201240}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5311777085830099614 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6013268484056619078, guid: d885487724a96044590f78d774928c25,
@@ -1303,6 +1299,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d50955c51c76b604d82574ff618226f6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &304367758979097732 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2232947670913027676, guid: d885487724a96044590f78d774928c25,
+    type: 3}
+  m_PrefabInstance: {fileID: 1928757586443201240}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3123080924568739189
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2589,12 +2591,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b2a6643fbcb4f48489266dfd55d41f8f, type: 3}
---- !u!224 &851071765682423715 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2634397278814532114, guid: b2a6643fbcb4f48489266dfd55d41f8f,
-    type: 3}
-  m_PrefabInstance: {fileID: 3404966633656251825}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &851071765682423724 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2634397278814532125, guid: b2a6643fbcb4f48489266dfd55d41f8f,
@@ -2607,6 +2603,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2db603d5d3caaee43b2104269cdd622a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &851071765682423715 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2634397278814532114, guid: b2a6643fbcb4f48489266dfd55d41f8f,
+    type: 3}
+  m_PrefabInstance: {fileID: 3404966633656251825}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3627603786530746826
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3790,12 +3792,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ef41f96126fcdd54eb890ffb1647825a, type: 3}
---- !u!224 &851071764515424546 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4150149718372546792, guid: ef41f96126fcdd54eb890ffb1647825a,
-    type: 3}
-  m_PrefabInstance: {fileID: 3627603786530746826}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2858140822079303849 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1584688192203948387, guid: ef41f96126fcdd54eb890ffb1647825a,
@@ -3808,6 +3804,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 63ca2ec1bcf6c364fbd37f25eee7e8d2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &851071764515424546 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4150149718372546792, guid: ef41f96126fcdd54eb890ffb1647825a,
+    type: 3}
+  m_PrefabInstance: {fileID: 3627603786530746826}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3748207766858722380
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4352,12 +4354,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 480cf87cad8afb64899325872dfec6b6, type: 3}
---- !u!224 &851071765317287519 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3627911379302986151, guid: 480cf87cad8afb64899325872dfec6b6,
-    type: 3}
-  m_PrefabInstance: {fileID: 4149912503933620216}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7322161856441836932 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6632386108540529276, guid: 480cf87cad8afb64899325872dfec6b6,
@@ -4370,6 +4366,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa5019b11f04b9f43a72456bcb0e747b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &851071765317287519 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3627911379302986151, guid: 480cf87cad8afb64899325872dfec6b6,
+    type: 3}
+  m_PrefabInstance: {fileID: 4149912503933620216}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4497750450741531008
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8502,18 +8504,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f8027087020999148b343f3dcbb03692, type: 3}
---- !u!114 &192312229024249996 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4351162786530458833, guid: f8027087020999148b343f3dcbb03692,
-    type: 3}
-  m_PrefabInstance: {fileID: 4524241258113123421}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &851071764040329045 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3820961471177876232, guid: f8027087020999148b343f3dcbb03692,
@@ -8530,6 +8520,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dafa4f78cf7f85d42aa869dbbff2d895, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &192312229024249996 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4351162786530458833, guid: f8027087020999148b343f3dcbb03692,
+    type: 3}
+  m_PrefabInstance: {fileID: 4524241258113123421}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &4689220654139769218
@@ -8562,7 +8564,7 @@ PrefabInstance:
     - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
         type: 3}
@@ -8656,12 +8658,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a667e4860d347ba44b17be7a83df9f51, type: 3}
---- !u!224 &4497176644702821786 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
-    type: 3}
-  m_PrefabInstance: {fileID: 4689220654139769218}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5585188370584300052 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 905758353273973654, guid: a667e4860d347ba44b17be7a83df9f51,
@@ -8674,6 +8670,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6cc7fc3e141a7a0438cf1a210787799f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &4497176644702821786 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+    type: 3}
+  m_PrefabInstance: {fileID: 4689220654139769218}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5936990463147434520
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9093,12 +9095,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7a32b28ae22a8914bb4ad345be91e30f, type: 3}
---- !u!224 &7998504489506734443 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4423669712238568307, guid: 7a32b28ae22a8914bb4ad345be91e30f,
-    type: 3}
-  m_PrefabInstance: {fileID: 5936990463147434520}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3377244296335278993 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8987509843347612041, guid: 7a32b28ae22a8914bb4ad345be91e30f,
@@ -9111,6 +9107,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a847ffb54adab514b956f641b7c276de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &7998504489506734443 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4423669712238568307, guid: 7a32b28ae22a8914bb4ad345be91e30f,
+    type: 3}
+  m_PrefabInstance: {fileID: 5936990463147434520}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6089806714433841560
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17793,12 +17795,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 5236192534774864452, guid: 2ac3a56ee8936454c87991fa3e93bcea, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 2ac3a56ee8936454c87991fa3e93bcea, type: 3}
---- !u!224 &851071763985788047 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6867087504011609367, guid: 2ac3a56ee8936454c87991fa3e93bcea,
-    type: 3}
-  m_PrefabInstance: {fileID: 6089806714433841560}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8959533887765265647 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2942537657974822263, guid: 2ac3a56ee8936454c87991fa3e93bcea,
@@ -17809,6 +17805,154 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe0690e219f4fc741a20d6389e57af56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &851071763985788047 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6867087504011609367, guid: 2ac3a56ee8936454c87991fa3e93bcea,
+    type: 3}
+  m_PrefabInstance: {fileID: 6089806714433841560}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7783818252655233289
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6729323985037442845}
+    m_Modifications:
+    - target: {fileID: 62400446008656826, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_Name
+      value: NewProjectDetailsView
+      objectReference: {fileID: 0}
+    - target: {fileID: 62400446008656826, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7db124fcb005be34f904b1366d8152cc, type: 3}
+--- !u!224 &6599429117766555830 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4003784339840029119, guid: 7db124fcb005be34f904b1366d8152cc,
+    type: 3}
+  m_PrefabInstance: {fileID: 7783818252655233289}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2917871582703021880 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4934803672682980913, guid: 7db124fcb005be34f904b1366d8152cc,
+    type: 3}
+  m_PrefabInstance: {fileID: 7783818252655233289}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6cc7fc3e141a7a0438cf1a210787799f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &7963828991800142307
@@ -17935,6 +18079,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c57e64e27f56c143925f8c47f6ff2b3, type: 3}
+--- !u!224 &1296877563891201531 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9185754462392474648, guid: 7c57e64e27f56c143925f8c47f6ff2b3,
+    type: 3}
+  m_PrefabInstance: {fileID: 7963828991800142307}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7727836457821266519 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 413203163870104500, guid: 7c57e64e27f56c143925f8c47f6ff2b3,
@@ -17947,12 +18097,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8dd0ccc8d8f0eaf4ea72f294d0786f56, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &1296877563891201531 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 9185754462392474648, guid: 7c57e64e27f56c143925f8c47f6ff2b3,
-    type: 3}
-  m_PrefabInstance: {fileID: 7963828991800142307}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8613126572797230412
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18169,12 +18313,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: da2354cb9f2fcf94fa1f36c9191a55c4, type: 3}
---- !u!224 &7115505017810700446 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1529151186128844242, guid: da2354cb9f2fcf94fa1f36c9191a55c4,
-    type: 3}
-  m_PrefabInstance: {fileID: 8613126572797230412}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5639468384418141104 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4162612922889301756, guid: da2354cb9f2fcf94fa1f36c9191a55c4,
@@ -18187,3 +18325,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9238eb31136005d41b21efa745def367, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &7115505017810700446 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1529151186128844242, guid: da2354cb9f2fcf94fa1f36c9191a55c4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8613126572797230412}
+  m_PrefabAsset: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/Common/NewProjectDetailsView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/Common/NewProjectDetailsView.prefab
@@ -1,0 +1,297 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5254037921470811559
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 609534503993898499, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_text
+      value: Welcome
+      objectReference: {fileID: 0}
+    - target: {fileID: 739407045391912289, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 739407045391912289, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 640
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419019480646106703, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419019480646106703, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419019480646106703, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419019480646106703, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 114.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1859515638817014026, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3114774194737841141, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_text
+      value: CREATE PROJECT
+      objectReference: {fileID: 0}
+    - target: {fileID: 5203811818029387293, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_Name
+      value: NewProjectDetailsView
+      objectReference: {fileID: 0}
+    - target: {fileID: 5203811818029387293, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5722261331957262047, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5722261331957262047, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5722261331957262047, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5722261331957262047, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -114.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6009670009004631957, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6009670009004631957, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -120
+      objectReference: {fileID: 0}
+    - target: {fileID: 6009670009004631957, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6009670009004631957, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -229
+      objectReference: {fileID: 0}
+    - target: {fileID: 6414112774583007673, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6414112774583007673, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -120
+      objectReference: {fileID: 0}
+    - target: {fileID: 6414112774583007673, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6414112774583007673, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -356
+      objectReference: {fileID: 0}
+    - target: {fileID: 7247179293299117378, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7247179293299117378, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -120
+      objectReference: {fileID: 0}
+    - target: {fileID: 7247179293299117378, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 7247179293299117378, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -320
+      objectReference: {fileID: 0}
+    - target: {fileID: 7740742457992419409, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7740742457992419409, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -122
+      objectReference: {fileID: 0}
+    - target: {fileID: 7740742457992419409, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806952891083010260, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -192
+      objectReference: {fileID: 0}
+    - target: {fileID: 8106884636979968880, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8106884636979968880, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -120
+      objectReference: {fileID: 0}
+    - target: {fileID: 8106884636979968880, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 8106884636979968880, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -193
+      objectReference: {fileID: 0}
+    - target: {fileID: 8806866615886706432, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_text
+      value: Welcome to the editor! Let's create a new Project! It allow you to automatically
+        save your changes until you are ready to publish your Scene to the world!
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9185754462392474648, guid: a667e4860d347ba44b17be7a83df9f51,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a667e4860d347ba44b17be7a83df9f51, type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/Common/NewProjectDetailsView.prefab.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Resources/Common/NewProjectDetailsView.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7db124fcb005be34f904b1366d8152cc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDInitializationModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDInitializationModel.cs
@@ -16,5 +16,6 @@ public class BuildModeHUDInitializationModel
     public ITopActionsButtonsController topActionsButtonsController;
     public IBuildModeConfirmationModalController buildModeConfirmationModalController;
     public ISaveHUDController saveHUDController;
+    public IPublicationDetailsController newProjectDetailsController;
     public IPublicationDetailsController publicationDetailsController;
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDView.cs
@@ -58,6 +58,7 @@ public class BuildModeHUDView : MonoBehaviour, IBuildModeHUDView
     [SerializeField] internal TopActionsButtonsView topActionsButtonsView;
     [SerializeField] internal BuildModeConfirmationModalView buildModeConfirmationModalView;
     [SerializeField] internal SaveHUDView saveView;
+    [SerializeField] internal PublicationDetailsView newProjectDetailsView;
     [SerializeField] internal PublicationDetailsView publicationDetailsView;
 
     private bool isDestroyed = false;
@@ -92,6 +93,7 @@ public class BuildModeHUDView : MonoBehaviour, IBuildModeHUDView
         this.controllers.buildModeConfirmationModalController.Initialize(buildModeConfirmationModalView);
         this.controllers.topActionsButtonsController.Initialize(topActionsButtonsView, this.controllers.tooltipController);
         this.controllers.saveHUDController.Initialize(saveView);
+        this.controllers.newProjectDetailsController.Initialize(newProjectDetailsView);
         this.controllers.publicationDetailsController.Initialize(publicationDetailsView);
     }
 
@@ -113,6 +115,7 @@ public class BuildModeHUDView : MonoBehaviour, IBuildModeHUDView
         controllers.buildModeConfirmationModalController.Dispose();
         controllers.topActionsButtonsController.Dispose();
         controllers.saveHUDController.Dispose();
+        controllers.newProjectDetailsController.Dispose();
         controllers.publicationDetailsController.Dispose();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/Common/PublicationDetailsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/Common/PublicationDetailsController.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 public interface IPublicationDetailsController
 {
     event Action OnCancel;
-    event Action<string, string> OnPublish;
+    event Action OnConfirm;
 
     void Initialize(IPublicationDetailsView publicationDetailsView);
     void Dispose();
@@ -23,7 +23,7 @@ public interface IPublicationDetailsController
 public class PublicationDetailsController : IPublicationDetailsController
 {
     public event Action OnCancel;
-    public event Action<string, string> OnPublish;
+    public event Action OnConfirm;
 
     internal const string DEFAULT_SCENE_NAME = "My new place";
     internal const string DEFAULT_SCENE_DESC = "";
@@ -64,7 +64,7 @@ public class PublicationDetailsController : IPublicationDetailsController
             return;
 
         SetActive(false);
-        OnPublish?.Invoke(sceneName, sceneDescription);
+        OnConfirm?.Invoke();
     }
 
     public void ValidatePublicationInfo(string sceneName)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDControllerShould.cs
@@ -31,6 +31,7 @@ namespace Tests.BuildModeHUDControllers
                 buildModeConfirmationModalController = Substitute.For<IBuildModeConfirmationModalController>(),
                 topActionsButtonsController = Substitute.For<ITopActionsButtonsController>(),
                 saveHUDController = Substitute.For<ISaveHUDController>(),
+                newProjectDetailsController = Substitute.For<IPublicationDetailsController>(),
                 publicationDetailsController = Substitute.For<IPublicationDetailsController>()
             };
 
@@ -60,6 +61,7 @@ namespace Tests.BuildModeHUDControllers
             buildModeHUDController.controllers.inspectorController = null;
             buildModeHUDController.controllers.topActionsButtonsController = null;
             buildModeHUDController.controllers.saveHUDController = null;
+            buildModeHUDController.controllers.newProjectDetailsController = null;
             buildModeHUDController.controllers.publicationDetailsController = null;
 
             // Act
@@ -80,6 +82,7 @@ namespace Tests.BuildModeHUDControllers
             Assert.NotNull(buildModeHUDController.controllers.inspectorController, "The inspectorController is null!");
             Assert.NotNull(buildModeHUDController.controllers.topActionsButtonsController, "The topActionsButtonsController is null!");
             Assert.NotNull(buildModeHUDController.controllers.saveHUDController, "The saveHUDController is null!");
+            Assert.NotNull(buildModeHUDController.controllers.newProjectDetailsController, "The newProjectDetailsController is null!");
             Assert.NotNull(buildModeHUDController.controllers.publicationDetailsController, "The publicationDetailsController is null!");
         }
 
@@ -110,9 +113,64 @@ namespace Tests.BuildModeHUDControllers
 
             // Assert
             if (!string.IsNullOrEmpty(projectName))
+            {
+                buildModeHUDController.controllers.newProjectDetailsController.Received(1).SetCustomPublicationInfo(projectName, testDesc);
                 buildModeHUDController.controllers.publicationDetailsController.Received(1).SetCustomPublicationInfo(projectName, testDesc);
+            }
             else
+            {
+                buildModeHUDController.controllers.newProjectDetailsController.Received(1).SetDefaultPublicationInfo();
                 buildModeHUDController.controllers.publicationDetailsController.Received(1).SetDefaultPublicationInfo();
+            }
+        }
+
+        [Test]
+        public void StartNewProjectFlowCorrectly()
+        {
+            // Arrange
+            Texture2D testScreenshot = new Texture2D(10, 10);
+
+            // Act
+            buildModeHUDController.NewProjectStart(testScreenshot);
+
+            // Assert
+            buildModeHUDController.controllers.newProjectDetailsController.Received(1).SetPublicationScreenshot(testScreenshot);
+
+            // TODO: This is temporal until we add the Welcome panel where the user will be able to edit the project info
+            //buildModeHUDController.controllers.newProjectDetailsController.Received(1).SetActive(true);
+        }
+
+        [Test]
+        public void ConfirmNewProjectDetailsCorrectly()
+        {
+            // Arrange
+            bool newProjectDetailsConfirmed = false;
+            buildModeHUDController.OnConfirmNewProjectAction += (name, desc, image) =>
+            {
+                newProjectDetailsConfirmed = true;
+            };
+
+            // Act
+            buildModeHUDController.ConfirmNewProjectDetails();
+
+            // Assert
+            buildModeHUDController.controllers.newProjectDetailsController.Received(1).GetSceneScreenshotTexture();
+            buildModeHUDController.controllers.newProjectDetailsController.Received(1).GetSceneName();
+            buildModeHUDController.controllers.newProjectDetailsController.Received(1).GetSceneDescription();
+            buildModeHUDController.controllers.publicationDetailsController.Received(1).SetCustomPublicationInfo(Arg.Any<string>(), Arg.Any<string>());
+            buildModeHUDController.controllers.newProjectDetailsController.Received(1).SetActive(false);
+            buildModeHUDController.controllers.buildModeConfirmationModalController.Received(1).SetActive(true, BuildModeModalType.PUBLISH);
+            Assert.IsTrue(newProjectDetailsConfirmed);
+        }
+
+        [Test]
+        public void CancelNewProjectDetailsCorrectly()
+        {
+            // Act
+            buildModeHUDController.CancelNewProjectDetails();
+
+            // Assert
+            buildModeHUDController.controllers.newProjectDetailsController.Received(1).SetActive(false);
         }
 
         [Test]
@@ -128,12 +186,8 @@ namespace Tests.BuildModeHUDControllers
         [Test]
         public void ConfirmPublicationDetailsCorrectly()
         {
-            // Arrange
-            string testName = "Test name";
-            string testDesc = "Test description";
-
             // Act
-            buildModeHUDController.ConfirmPublicationDetails(testName, testDesc);
+            buildModeHUDController.ConfirmPublicationDetails();
 
             // Assert
             buildModeHUDController.controllers.buildModeConfirmationModalController.Received(1)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDControllerShould.cs
@@ -145,13 +145,13 @@ namespace Tests.BuildModeHUDControllers
         {
             // Arrange
             bool newProjectDetailsConfirmed = false;
-            buildModeHUDController.OnConfirmNewProjectAction += (name, desc, image) =>
+            buildModeHUDController.OnSaveSceneInfoAction += (name, desc, image) =>
             {
                 newProjectDetailsConfirmed = true;
             };
 
             // Act
-            buildModeHUDController.ConfirmNewProjectDetails();
+            buildModeHUDController.SaveSceneInfo();
 
             // Assert
             buildModeHUDController.controllers.newProjectDetailsController.Received(1).GetSceneScreenshotTexture();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDControllerShould.cs
@@ -159,7 +159,6 @@ namespace Tests.BuildModeHUDControllers
             buildModeHUDController.controllers.newProjectDetailsController.Received(1).GetSceneDescription();
             buildModeHUDController.controllers.publicationDetailsController.Received(1).SetCustomPublicationInfo(Arg.Any<string>(), Arg.Any<string>());
             buildModeHUDController.controllers.newProjectDetailsController.Received(1).SetActive(false);
-            buildModeHUDController.controllers.buildModeConfirmationModalController.Received(1).SetActive(true, BuildModeModalType.PUBLISH);
             Assert.IsTrue(newProjectDetailsConfirmed);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDViewShould.cs
@@ -30,6 +30,7 @@ namespace Tests.BuildModeHUDViews
                 buildModeConfirmationModalController = Substitute.For<IBuildModeConfirmationModalController>(),
                 topActionsButtonsController = Substitute.For<ITopActionsButtonsController>(),
                 saveHUDController =  Substitute.For<ISaveHUDController>(),
+                newProjectDetailsController = Substitute.For<IPublicationDetailsController>(),
                 publicationDetailsController = Substitute.For<IPublicationDetailsController>()
             };
 
@@ -75,6 +76,8 @@ namespace Tests.BuildModeHUDViews
             testControllers.topActionsButtonsController.Received(1).Initialize(buildModeHUDView.topActionsButtonsView, testControllers.tooltipController);
             Assert.AreEqual(testControllers.saveHUDController, buildModeHUDView.controllers.saveHUDController, "The SaveHUDController does not match!");
             testControllers.saveHUDController.Received(1).Initialize(buildModeHUDView.saveView);
+            Assert.AreEqual(testControllers.newProjectDetailsController, buildModeHUDView.controllers.newProjectDetailsController, "The newProjectDetailsController does not match!");
+            testControllers.newProjectDetailsController.Received(1).Initialize(buildModeHUDView.newProjectDetailsView);
             Assert.AreEqual(testControllers.publicationDetailsController, buildModeHUDView.controllers.publicationDetailsController, "The publicationDetailsController does not match!");
             testControllers.publicationDetailsController.Received(1).Initialize(buildModeHUDView.publicationDetailsView);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/PublicationDetailsControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/PublicationDetailsControllerShould.cs
@@ -53,16 +53,9 @@ namespace Tests.BuildModeHUDControllers
             string testName = "Test name";
             string testDesc = "Test desc";
             publicationDetailsController.isValidated = isValidated;
-            string sceneNameReceived = "";
-            string sceneDescReceived = "";
 
             bool isPublishClicked = false;
-            publicationDetailsController.OnPublish += (sceneName, sceneDesc) =>
-            {
-                isPublishClicked = true;
-                sceneNameReceived = sceneName;
-                sceneDescReceived = sceneDesc;
-            };
+            publicationDetailsController.OnConfirm += () => isPublishClicked = true;
 
             // Act
             publicationDetailsController.Publish(testName, testDesc);
@@ -72,8 +65,6 @@ namespace Tests.BuildModeHUDControllers
             {
                 publicationDetailsController.publicationDetailsView.Received(1).SetActive(false);
                 Assert.IsTrue(isPublishClicked, "isPublishClicked is false!");
-                Assert.AreEqual(testName, sceneNameReceived, "The scene name does not match!");
-                Assert.AreEqual(testDesc, sceneDescReceived, "The scene description does not match!");
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/Protocol/ProtocolV2.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/Protocol/ProtocolV2.cs
@@ -162,9 +162,9 @@ public class ProtocolV2
     }
 
     [System.Serializable]
-    public class SaveSceneInfoEvent
+    public class SaveProjectInfoEvent
     {
-        public string type = "SaveSceneInfo";
+        public string type = "SaveProjectInfo";
         public BuilderProjectPayload payload = new BuilderProjectPayload();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/Protocol/ProtocolV2.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/Protocol/ProtocolV2.cs
@@ -162,11 +162,19 @@ public class ProtocolV2
     }
 
     [System.Serializable]
+    public class SaveSceneInfoEvent
+    {
+        public string type = "SaveSceneInfo";
+        public BuilderProjectPayload payload = new BuilderProjectPayload();
+    }
+
+    [System.Serializable]
     public class BuilderProjectPayload
     {
-        public string title;
-        public string description;
-        public string screenshot;
+        public string title = "";
+        public string description = "";
+        public string screenshot = "";
+        public bool isNewEmptyProject = false;
     }
 
     #endregion


### PR DESCRIPTION
## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
### Fixes #601 
BiW creates a Project in Builder, every time the Players edit a Scene that does not have a Project associated.

BiW must update the Project thumbnail of the project:
- [x] When the Project is created
- [x] When the player publishes the Scene
- [x] When the player exit the Scene without publishing changes

* Consider this last should only happen if there are unpublished changes
* Automatic screenshots will always be done using the reset camera view

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/branch/feat/BiW-should-update-Project-metadata-and-thumbnail-Kernel-side/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:feat/BiW-should-update-Project-metadata-and-thumbnail&ENV=zone&ENABLE_BUILDER_IN_WORLD&position=80,154
2. Press 'K' to open the Builer In World editor and test the 3 use cases.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md