### PR TITLE
fix: set AvatarCollider to the correct layer to detect the collisions…

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
@@ -233,7 +233,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4710899382381041556}
   - component: {fileID: 7115442889188564318}
-  m_Layer: 16
+  m_Layer: 21
   m_Name: AvatarCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}


### PR DESCRIPTION
… with BoxTriggerArea for AvatarModifierArea

## What this PR includes?
Fix #557

The AvatarCollider was in an incorrect layer, so it wasn't detecting an Avatar entering a Trigger Area. And the side-effect is #557.

## How to test it?
Go to one of the following position:
- https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/trigger-collider-layer&position=-24,22&ENV=org
- https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/trigger-collider-layer&position=-46,-99&ENV=org
- https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/trigger-collider-layer&position=150,63&ENV=org

And check if you're avatar hide properly.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md