### PR TITLE
fix: tutorial robot is culled

### DIFF
--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/CullingControllerSettings.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/CullingControllerSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine;
 
 namespace DCL.Rendering
 {
@@ -17,7 +18,7 @@ namespace DCL.Rendering
 
         public float enableAnimationCullingDistance = 7.5f;
 
-        public int ignoredLayersMask = 0;
+        public int ignoredLayersMask = LayerMask.GetMask("Tutorial") | LayerMask.GetMask("CharacterPreview");
 
         public CullingControllerProfile rendererProfile =
             new CullingControllerProfile

--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/CullingControllerSettings.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/CullingControllerSettings.cs
@@ -18,7 +18,7 @@ namespace DCL.Rendering
 
         public float enableAnimationCullingDistance = 7.5f;
 
-        public int ignoredLayersMask = LayerMask.GetMask("Tutorial") | LayerMask.GetMask("CharacterPreview");
+        public int ignoredLayersMask = LayerMask.GetMask("Tutorial", "CharacterPreview");
 
         public CullingControllerProfile rendererProfile =
             new CullingControllerProfile

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
@@ -55,9 +55,6 @@ public class CharacterPreviewController : MonoBehaviour
             { CameraFocus.FaceSnapshot, faceSnapshotTemplate },
             { CameraFocus.BodySnapshot, bodySnapshotTemplate },
         };
-        var cullingSettings = DCL.Environment.i.platform.cullingController.GetSettingsCopy();
-        cullingSettings.ignoredLayersMask |= 1 << gameObject.layer;
-        DCL.Environment.i.platform.cullingController.SetSettings(cullingSettings);
     }
 
     public void UpdateModel(AvatarModel newModel, Action onDone) { updateModelRoutine = CoroutineStarter.Start(UpdateModelRoutine(newModel, onDone)); }

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
@@ -145,14 +145,11 @@ namespace DCL.Tutorial
         private Coroutine teacherMovementCoroutine;
         private Coroutine eagleEyeRotationCoroutine;
 
-        private int tutorialLayerMask;
-
         internal bool userAlreadyDidTheTutorial { get; set; }
 
         private void Awake()
         {
             i = this;
-            tutorialLayerMask = LayerMask.GetMask("Tutorial");
             ShowTeacher3DModel(false);
         }
 
@@ -236,8 +233,6 @@ namespace DCL.Tutorial
 
             WebInterface.SetDelightedSurveyEnabled(false);
 
-            ModifyCullingSettings();
-
             if (!CommonScriptableObjects.rendererState.Get())
                 CommonScriptableObjects.rendererState.OnChange += OnRenderingStateChanged;
             else
@@ -280,8 +275,6 @@ namespace DCL.Tutorial
             hudController?.taskbarHud?.ShowTutorialOption(true);
 
             CommonScriptableObjects.tutorialActive.Set(false);
-
-            RestoreCullingSettings();
 
             CommonScriptableObjects.rendererState.OnChange -= OnRenderingStateChanged;
 
@@ -667,20 +660,6 @@ namespace DCL.Tutorial
                 hudController?.minimapHud?.SetVisibility(true);
                 hudController?.profileHud?.SetVisibility(true);
             }
-        }
-
-        private void ModifyCullingSettings()
-        {
-            var cullingSettings = Environment.i.platform.cullingController.GetSettingsCopy();
-            cullingSettings.ignoredLayersMask |= tutorialLayerMask;
-            Environment.i.platform.cullingController.SetSettings(cullingSettings);
-        }
-
-        private void RestoreCullingSettings()
-        {
-            var cullingSettings = Environment.i.platform.cullingController.GetSettingsCopy();
-            cullingSettings.ignoredLayersMask &= ~tutorialLayerMask;
-            Environment.i.platform.cullingController.SetSettings(cullingSettings);
         }
     }
 }


### PR DESCRIPTION
The culling controller was culling the tutorial robot due to a race condition.
We fix it by having the robot disabled until needed (and the CullingController's ignore mask is ready as well).

#588 