### PR TITLE
fix: BiW loading incorrect scene after teleport

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
@@ -427,14 +427,26 @@ public class BuilderInWorldController : MonoBehaviour
             EnterEditMode();
     }
 
-    public void TryStartEnterEditMode() { TryStartEnterEditMode(true); }
+    public void TryStartEnterEditMode() { TryStartEnterEditMode(true, null); }
+    public void TryStartEnterEditMode(IParcelScene targetScene) { TryStartEnterEditMode(true, targetScene); }
 
-    public void TryStartEnterEditMode(bool activateCamera)
+    public void TryStartEnterEditMode(bool activateCamera, IParcelScene targetScene = null)
     {
         if (sceneToEditId != null)
             return;
 
-        FindSceneToEdit();
+        if (targetScene != null)
+        {
+            var parcelSceneTarget = (ParcelScene)targetScene;
+            if (sceneToEdit != null && sceneToEdit != parcelSceneTarget)
+                actionController.Clear();
+
+            sceneToEdit = parcelSceneTarget;
+        }
+        else
+        {
+            FindSceneToEdit();
+        }
 
         if (!UserHasPermissionOnParcelScene(sceneToEdit))
         {
@@ -480,7 +492,7 @@ public class BuilderInWorldController : MonoBehaviour
         builderInWorldBridge.StartKernelEditMode(sceneToEdit);
     }
 
-    public void EnterEditMode()
+    private void EnterEditMode()
     {
         if (!initialLoadingController.isActive)
             return;
@@ -488,8 +500,6 @@ public class BuilderInWorldController : MonoBehaviour
         BuilderInWorldNFTController.i.ClearNFTs();
 
         ParcelSettings.VISUAL_LOADING_ENABLED = false;
-
-        FindSceneToEdit();
 
         sceneToEdit.SetEditMode(true);
         cursorGO.SetActive(false);
@@ -680,7 +690,9 @@ public class BuilderInWorldController : MonoBehaviour
     {
         if (activeFeature)
         {
-            TryStartEnterEditMode();
+            var targetScene = Environment.i.world.state.scenesSortedByDistance
+                                         .FirstOrDefault(scene => scene.sceneData.parcels.Contains(coords));
+            TryStartEnterEditMode(targetScene);
         }
     }
 


### PR DESCRIPTION
fixes #609

testing:
1- go to https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/609-biw-teleport-edit-correct-scene&ENABLE_BUILDER_IN_WORLD
2- open builder panel
3- choose to edit a scene next to a land where you are owner/operator
4- click on "editor" button
6- after loading screen, the correct scene should be loaded to edit.
