### PR TITLE
feat: [BiW Editor] Confirmation dialog while exiting the editor

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -64,6 +64,9 @@ namespace DCL.Configuration
         public const string EXIT_MODAL_SUBTITLE = "Are you sure you want to exit Builder mode?";
         public const string EXIT_MODAL_CONFIRM_BUTTON = "EXIT";
         public const string EXIT_MODAL_CANCEL_BUTTON = "CANCEL";
+        public const string EXIT_WITHOUT_PUBLISH_MODAL_SUBTITLE = "There are unpublished changes in this project. But don't worry, next time you enter the editor you will be able to continue where you left off!";
+        public const string EXIT_WITHOUT_PUBLISH_MODAL_CONFIRM_BUTTON = "GOT IT!";
+        public const string EXIT_WITHOUT_PUBLISH_MODAL_CANCEL_BUTTON = "BACK";
 
         //Others
         public const float RAYCAST_MAX_DISTANCE = 10000f;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
@@ -606,7 +606,23 @@ public class BuilderInWorldController : MonoBehaviour
     public void StartExitMode()
     {
         if (biwSaveController.numberOfSaves > 0)
+        {
             editorMode.TakeSceneScreenshotForExit();
+
+            HUDController.i.builderInWorldMainHud.ConfigureConfirmationModal(
+                BuilderInWorldSettings.EXIT_MODAL_TITLE,
+                BuilderInWorldSettings.EXIT_WITHOUT_PUBLISH_MODAL_SUBTITLE,
+                BuilderInWorldSettings.EXIT_WITHOUT_PUBLISH_MODAL_CANCEL_BUTTON,
+                BuilderInWorldSettings.EXIT_WITHOUT_PUBLISH_MODAL_CONFIRM_BUTTON);
+        }
+        else
+        {
+            HUDController.i.builderInWorldMainHud.ConfigureConfirmationModal(
+                BuilderInWorldSettings.EXIT_MODAL_TITLE,
+                BuilderInWorldSettings.EXIT_MODAL_SUBTITLE,
+                BuilderInWorldSettings.EXIT_MODAL_CANCEL_BUTTON,
+                BuilderInWorldSettings.EXIT_MODAL_CONFIRM_BUTTON);
+        }
     }
 
     public void ExitEditMode()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/BuildModeHUDController.cs
@@ -255,6 +255,15 @@ public class BuildModeHUDController : IHUD
 
     public void PublishStart() { controllers.publicationDetailsController.SetActive(true); }
 
+    public void ConfigureConfirmationModal(string title, string subTitle, string cancelButtonText, string confirmButtonText)
+    {
+        controllers.buildModeConfirmationModalController.Configure(
+            title,
+            subTitle,
+            cancelButtonText,
+            confirmButtonText);
+    }
+
     internal void ConfirmPublicationDetails()
     {
         UnsubscribeConfirmationModal();
@@ -262,11 +271,12 @@ public class BuildModeHUDController : IHUD
         controllers.buildModeConfirmationModalController.OnCancelExit += CancelPublishModal;
         controllers.buildModeConfirmationModalController.OnConfirmExit += ConfirmPublishModal;
 
-        controllers.buildModeConfirmationModalController.Configure(
+        ConfigureConfirmationModal(
             BuilderInWorldSettings.PUBLISH_MODAL_TITLE,
             BuilderInWorldSettings.PUBLISH_MODAL_SUBTITLE,
             BuilderInWorldSettings.PUBLISH_MODAL_CANCEL_BUTTON,
             BuilderInWorldSettings.PUBLISH_MODAL_CONFIRM_BUTTON);
+
         controllers.buildModeConfirmationModalController.SetActive(true, BuildModeModalType.PUBLISH);
         controllers.publicationDetailsController.SetActive(false);
     }
@@ -333,11 +343,6 @@ public class BuildModeHUDController : IHUD
         controllers.buildModeConfirmationModalController.OnCancelExit += CancelExitModal;
         controllers.buildModeConfirmationModalController.OnConfirmExit += ConfirmExitModal;
 
-        controllers.buildModeConfirmationModalController.Configure(
-            BuilderInWorldSettings.EXIT_MODAL_TITLE,
-            BuilderInWorldSettings.EXIT_MODAL_SUBTITLE,
-            BuilderInWorldSettings.EXIT_MODAL_CANCEL_BUTTON,
-            BuilderInWorldSettings.EXIT_MODAL_CONFIRM_BUTTON);
         controllers.buildModeConfirmationModalController.SetActive(true, BuildModeModalType.EXIT);
 
         OnStartExitAction?.Invoke();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Tests/BuildModeHUDControllerShould.cs
@@ -241,12 +241,6 @@ namespace Tests.BuildModeHUDControllers
             buildModeHUDController.ExitStart();
 
             // Assert
-            buildModeHUDController.controllers.buildModeConfirmationModalController.Received(1)
-                                  .Configure(
-                                      Arg.Any<string>(),
-                                      Arg.Any<string>(),
-                                      Arg.Any<string>(),
-                                      Arg.Any<string>());
             buildModeHUDController.controllers.buildModeConfirmationModalController.Received(1).SetActive(true, BuildModeModalType.EXIT);
         }
 
@@ -583,6 +577,22 @@ namespace Tests.BuildModeHUDControllers
             // Assert
             Assert.AreEqual(isVisible, buildModeHUDController.isEntityListVisible);
             buildModeHUDController.view.Received(1).SetVisibilityOfInspector(isVisible);
+        }
+
+        [Test]
+        public void ConfigureConfirmationModalCorrectly()
+        {
+            // Arrange
+            string testTitle = "test title";
+            string testSubTitle = "test subTitle";
+            string testCancelText = "test cancel";
+            string testConfirmText = "test confirm";
+
+            // Act
+            buildModeHUDController.ConfigureConfirmationModal(testTitle, testSubTitle, testCancelText, testConfirmText);
+
+            // Assert
+            buildModeHUDController.controllers.buildModeConfirmationModalController.Received(1).Configure(testTitle, testSubTitle, testCancelText, testConfirmText);
         }
     }
 }


### PR DESCRIPTION
## What this PR includes?
<!-- 
Explain what this PR implements:
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a brief description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
### Fixes #602 
While editing a Scene, the Player may decide to exit without publishing the changes. This does not mean the player loose the Project done so far, but they will need to be reminded:

- [x] When the player exit the editor with unpublished changes, a prompt must appear warning:
"There are unpublished changes in this project. But don't worry, next time you enter the editor you will be able to continue where you left off!" 
A "Got it!" button will allow you to exit the editor. 
A "Back" button will cancel the Exit action

![image](https://user-images.githubusercontent.com/64659061/123621850-ec8f8280-d80b-11eb-9679-db5e777b0849.png)

- [x] Otherwise, the current exit confirmation dialog will be promtped

![image](https://user-images.githubusercontent.com/64659061/123621949-fdd88f00-d80b-11eb-9f0c-d6f773da6138.png)

## How to test it?
<!-- 
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:feat/BiW-confirmation-dialog-while-exiting-the-editor&ENV=zone&position=80,154
2. Press 'K' to open the Builder In World editor.
3. Make any change in the scene.
4. Exit from the editor.
5. Notice the modal message.

## Annotations
Finally I had not have to use the new implemented class `SettingsPanelDataStore` for this issue, but I would like to keep it in the project because I think it is something useful that we're going to use in the future. This data store class let us to change any setting control from any place of our code without the necessity to go and click fisically in the control inside the SettingsPanelHUD.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md