### PR TITLE
fix: fixed bug of reload scenes when you don't have permission

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
@@ -339,6 +339,19 @@ public class BuilderInWorldController : MonoBehaviour
         if (isEnteringEditMode)
             return;
 
+        FindSceneToEdit();
+
+        if (!UserHasPermissionOnParcelScene(sceneToEdit))
+        {
+            ShowGenericNotification(BuilderInWorldSettings.LAND_EDITION_NOT_ALLOWED_BY_PERMISSIONS_MESSAGE);
+            return;
+        }
+        else if (IsParcelSceneDeployedFromSDK(sceneToEdit))
+        {
+            ShowGenericNotification(BuilderInWorldSettings.LAND_EDITION_NOT_ALLOWED_BY_SDK_LIMITATION_MESSAGE);
+            return;
+        }
+
         if (!isBuilderInWorldActivated)
         {
             GetCatalog();
@@ -450,6 +463,8 @@ public class BuilderInWorldController : MonoBehaviour
             EnterEditMode();
     }
 
+    private void CheckLandPermissions() { }
+
     public void TryStartEnterEditMode() { TryStartEnterEditMode(true, null); }
     public void TryStartEnterEditMode(IParcelScene targetScene) { TryStartEnterEditMode(true, targetScene); }
 
@@ -458,18 +473,7 @@ public class BuilderInWorldController : MonoBehaviour
         if (sceneToEditId != null)
             return;
 
-        if (targetScene != null)
-        {
-            var parcelSceneTarget = (ParcelScene)targetScene;
-            if (sceneToEdit != null && sceneToEdit != parcelSceneTarget)
-                actionController.Clear();
-
-            sceneToEdit = parcelSceneTarget;
-        }
-        else
-        {
-            FindSceneToEdit();
-        }
+        FindSceneToEdit(targetScene);
 
         if (!UserHasPermissionOnParcelScene(sceneToEdit))
         {
@@ -717,6 +721,22 @@ public class BuilderInWorldController : MonoBehaviour
     public void SetupNewScene() { biwFloorHandler.CreateDefaultFloor(); }
 
     void ExitAfterCharacterTeleport(DCLCharacterPosition position) { ExitEditMode(); }
+
+    public void FindSceneToEdit(IParcelScene targetScene)
+    {
+        if (targetScene != null)
+        {
+            var parcelSceneTarget = (ParcelScene)targetScene;
+            if (sceneToEdit != null && sceneToEdit != parcelSceneTarget)
+                actionController.Clear();
+
+            sceneToEdit = parcelSceneTarget;
+        }
+        else
+        {
+            FindSceneToEdit();
+        }
+    }
 
     public void FindSceneToEdit()
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
@@ -463,8 +463,6 @@ public class BuilderInWorldController : MonoBehaviour
             EnterEditMode();
     }
 
-    private void CheckLandPermissions() { }
-
     public void TryStartEnterEditMode() { TryStartEnterEditMode(true, null); }
     public void TryStartEnterEditMode(IParcelScene targetScene) { TryStartEnterEditMode(true, targetScene); }
 


### PR DESCRIPTION
## What this PR includes?

When an user tap on enter in builder in world in a land where the user don't have permission, the scene reloads.

This fix that issue

## How to test it?
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/biw-genesis-dissapear
2. Try to enter in a land where you don't have permissions ( like genesis plaza) and the world should stay

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md