### PR TITLE
fix: biw bug fixing

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Analytics/BIWAnalytics.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Analytics/BIWAnalytics.cs
@@ -234,9 +234,5 @@ public static class BIWAnalytics
         SendEvent(eventName, events);
     }
 
-    private static void SendEvent(string eventName, Dictionary<string, string> events)
-    {
-        Debug.Log("Event " + eventName + " message: " + events.ToString());
-        Analytics.i.SendAnalytic(eventName, events);
-    }
+    private static void SendEvent(string eventName, Dictionary<string, string> events) { Analytics.i.SendAnalytic(eventName, events); }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldInputWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldInputWrapper.cs
@@ -14,6 +14,7 @@ public class BuilderInWorldInputWrapper : MonoBehaviour
     public static event Action<int, Vector3> OnMouseClickOnUI;
     public static event Action<int, Vector3> OnMouseDown;
     public static event Action<int, Vector3> OnMouseUp;
+    public static event Action<int, Vector3> OnMouseUpOnUI;
 
     public static event Action<float> OnMouseWheel;
 
@@ -71,6 +72,8 @@ public class BuilderInWorldInputWrapper : MonoBehaviour
                 return;
             OnMouseClick?.Invoke(buttonId, mousePosition);
         }
+        else
+            OnMouseUpOnUI?.Invoke(buttonId, mousePosition);
     }
 
     private void MouseDown(int buttonId, Vector3 mousePosition)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BuilderInWorldEntityHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BuilderInWorldEntityHandler.cs
@@ -509,8 +509,9 @@ public class BuilderInWorldEntityHandler : BIWController
     public DCLBuilderInWorldEntity DuplicateEntity(DCLBuilderInWorldEntity entityToDuplicate)
     {
         IDCLEntity entity = SceneUtils.DuplicateEntity(sceneToEdit, entityToDuplicate.rootEntity);
-        //Note: If the entity contains the name component, we don't want to copy the name
+        //Note: If the entity contains the name component or DCLLockedOnEdit, we don't want to copy them 
         entity.RemoveSharedComponent(typeof(DCLName), false);
+        entity.RemoveSharedComponent(typeof(DCLLockedOnEdit), false);
 
         BuilderInWorldUtils.CopyGameObjectStatus(entityToDuplicate.gameObject, entity.gameObject, false, false);
         DCLBuilderInWorldEntity convertedEntity = SetupEntityToEdit(entity);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -47,8 +47,6 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
     private bool mouseSecondaryBtnPressed = false;
     private bool isSquareMultiSelectionInputActive = false;
     private bool isMouseDragging = false;
-    private bool isTypeOfBoundSelectionSelected = false;
-    private bool isVoxelBoundMultiSelection = false;
     private bool changeSnapTemporaryButtonPressed = false;
 
     private bool wasGizmosActive = false;
@@ -69,6 +67,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
 
         BuilderInWorldInputWrapper.OnMouseDown += OnInputMouseDown;
         BuilderInWorldInputWrapper.OnMouseUp += OnInputMouseUp;
+        BuilderInWorldInputWrapper.OnMouseUpOnUI += OnInputMouseUpOnUi;
         BuilderInWorldInputWrapper.OnMouseDrag += OnInputMouseDrag;
 
         focusOnSelectedEntitiesInputAction.OnTriggered += (o) => FocusOnSelectedEntitiesInput();
@@ -86,6 +85,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
 
         BuilderInWorldInputWrapper.OnMouseDown -= OnInputMouseDown;
         BuilderInWorldInputWrapper.OnMouseUp -= OnInputMouseUp;
+        BuilderInWorldInputWrapper.OnMouseUpOnUI -= OnInputMouseUpOnUi;
         BuilderInWorldInputWrapper.OnMouseDrag -= OnInputMouseDrag;
 
         gizmoManager.OnChangeTransformValue -= EntitiesTransfromByGizmos;
@@ -115,26 +115,16 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         else if (isSquareMultiSelectionInputActive && isMouseDragging)
         {
             List<DCLBuilderInWorldEntity> allEntities = null;
-            if (!isTypeOfBoundSelectionSelected || !isVoxelBoundMultiSelection)
-                allEntities = builderInWorldEntityHandler.GetAllEntitiesFromCurrentScene();
-            else if (isVoxelBoundMultiSelection)
-                allEntities = builderInWorldEntityHandler.GetAllVoxelsEntities();
+
+            allEntities = builderInWorldEntityHandler.GetAllEntitiesFromCurrentScene();
 
             foreach (DCLBuilderInWorldEntity entity in allEntities)
             {
-                if (entity.isVoxel && !isVoxelBoundMultiSelection && isTypeOfBoundSelectionSelected)
-                    continue;
                 if (!entity.rootEntity.meshRootGameObject || entity.rootEntity.meshesInfo.renderers.Length <= 0)
                     continue;
 
                 if (BuilderInWorldUtils.IsWithInSelectionBounds(entity.rootEntity.meshesInfo.mergedBounds.center, lastMousePosition, Input.mousePosition))
                 {
-                    if (!isTypeOfBoundSelectionSelected && !entity.IsLocked)
-                    {
-                        isVoxelBoundMultiSelection = entity.isVoxel;
-                        isTypeOfBoundSelectionSelected = true;
-                    }
-
                     outlinerController.OutlineEntity(entity);
                 }
                 else
@@ -307,6 +297,21 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         return position;
     }
 
+    private void OnInputMouseUpOnUi(int buttonID, Vector3 position)
+    {
+        if (buttonID == 1)
+        {
+            mouseSecondaryBtnPressed = false;
+            freeCameraController.StopDetectingMovement();
+        }
+
+        if (buttonID != 0)
+            return;
+
+        CheckEndBoundMultiselection(position);
+        isMouseDragging = false;
+    }
+
     private void OnInputMouseUp(int buttonID, Vector3 position)
     {
         if (buttonID == 1)
@@ -323,14 +328,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
 
         EndDraggingSelectedEntities();
 
-        if (isSquareMultiSelectionInputActive && mouseMainBtnPressed )
-        {
-            if (Vector3.Distance(lastMousePosition, position) >= BuilderInWorldSettings.MOUSE_THRESHOLD_FOR_DRAG)
-                EndBoundMultiSelection();
-
-            isSquareMultiSelectionInputActive = false;
-            mouseMainBtnPressed = false;
-        }
+        CheckEndBoundMultiselection(position);
 
         outlinerController.SetOutlineCheckActive(true);
 
@@ -367,8 +365,6 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
             && !BuilderInWorldUtils.IsPointerOverMaskElement(layerToStopClick))
         {
             isSquareMultiSelectionInputActive = true;
-            isTypeOfBoundSelectionSelected = false;
-            isVoxelBoundMultiSelection = false;
             outlinerController.SetOutlineCheckActive(false);
         }
 
@@ -377,6 +373,18 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
     }
 
     #endregion
+
+    private void CheckEndBoundMultiselection(Vector3 position)
+    {
+        if (isSquareMultiSelectionInputActive && mouseMainBtnPressed )
+        {
+            if (Vector3.Distance(lastMousePosition, position) >= BuilderInWorldSettings.MOUSE_THRESHOLD_FOR_DRAG)
+                EndBoundMultiSelection();
+
+            isSquareMultiSelectionInputActive = false;
+            mouseMainBtnPressed = false;
+        }
+    }
 
     private bool CanCancelAction(Vector3 currentMousePosition) { return Vector3.Distance(lastMousePosition, currentMousePosition) <= BuilderInWorldSettings.MOUSE_THRESHOLD_FOR_DRAG && !freeCameraController.HasBeenMovement; }
 
@@ -419,10 +427,8 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
     {
         freeCameraController.SetCameraCanMove(true);
         List<DCLBuilderInWorldEntity> allEntities = null;
-        if (!isVoxelBoundMultiSelection)
-            allEntities = builderInWorldEntityHandler.GetAllEntitiesFromCurrentScene();
-        else
-            allEntities = builderInWorldEntityHandler.GetAllVoxelsEntities();
+
+        allEntities = builderInWorldEntityHandler.GetAllEntitiesFromCurrentScene();
 
         List<DCLBuilderInWorldEntity> selectedInsideBoundsEntities = new List<DCLBuilderInWorldEntity>();
         int alreadySelectedEntities = 0;
@@ -432,10 +438,6 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
 
         foreach (DCLBuilderInWorldEntity entity in allEntities)
         {
-            if ((entity.isVoxel && !isVoxelBoundMultiSelection) ||
-                !entity.IsVisible)
-                continue;
-
             if (entity.rootEntity.meshRootGameObject && entity.rootEntity.meshesInfo.renderers.Length > 0)
             {
                 if (BuilderInWorldUtils.IsWithInSelectionBounds(entity.rootEntity.meshesInfo.mergedBounds.center, lastMousePosition, Input.mousePosition)
@@ -617,7 +619,8 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
     public override void EntityDoubleClick(DCLBuilderInWorldEntity entity)
     {
         base.EntityDoubleClick(entity);
-        LookAtEntity(entity.rootEntity);
+        if (!entity.IsLocked)
+            LookAtEntity(entity.rootEntity);
     }
 
     private void UpdateActionsInteractable()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/Views/SceneCardView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/Views/SceneCardView.cs
@@ -106,14 +106,14 @@ internal class SceneCardView : MonoBehaviour, ISceneCardView
 
     private void JumpInButtonPressed()
     {
-        BIWAnalytics.PlayerJumpOrEdit("Scene", "JumpIn", sceneData.coords, "Scene Owner");
         OnJumpInPressed?.Invoke(sceneData.coords);
+        BIWAnalytics.PlayerJumpOrEdit("Scene", "JumpIn", sceneData.coords, "Scene Owner");
     }
 
     private void EditorButtonPressed()
     {
+        OnEditorPressed?.Invoke(sceneData.coords);
         BIWAnalytics.PlayerJumpOrEdit("Scene", "Editor", sceneData.coords, "Scene Owner");
-        OnJumpInPressed?.Invoke(sceneData.coords);
     }
 
     private void OnEnable() { loadingAnimator.SetBool(isLoadingAnimation, isLoadingThumbnail); }


### PR DESCRIPTION
## What does this PR change?
Fixes #721 

 - Scene editor button is working as jump in

 - Square multi selection is not released if you do it on top of a UI

 - Double click on a locked entity will focus on it

 - if you duplicate and entity, and then you lock it, the original entities are locked as well

 - Voxel and other objects are selected differently

 - After playing around in the biw, I wasn't able to select the rotation or scale tool by UI, I needed to use the shorcut, after using the shorcut everything worked as expected

## How to test the changes?


1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/big-bug-fixing-4
2. Enter builder in world
3. Check if the bug are correctly fixed

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
