### PR TITLE
chore: set "unprioritized" label to opened issues

### DIFF
--- a/.github/workflows/unprioritize-issues.yml
+++ b/.github/workflows/unprioritize-issues.yml
@@ -1,0 +1,16 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label issues
+        uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
+        with:
+          add-labels: "unprioritized"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix #754 
## What does this PR change?

Add GitHub Action to set "unprioritized" label to new issues.

## How to test the changes?

1. Go to https://github.com/kuruk-mm/unity-renderer/issues and open an issue (this fork it's exactly the same as this PR)
2. Wait some seconds, and it will be labelled as "unprioritized"

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
