### PR TITLE
chore: upload code coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,9 +129,6 @@ jobs:
       - store_artifacts:
           name: Store test results
           path: ./unity-renderer/editmode-results.xml
-      - store_artifacts:
-          name: Store test coverage
-          path: ./unity-renderer/CodeCoverage
       - store_test_results:
           path: ./unity-renderer/test-results
       - save_cache: &SAVE_CHECKSUM_CACHE_EDITMODE
@@ -173,9 +170,6 @@ jobs:
       - store_artifacts:
           name: Store test results
           path: ./unity-renderer/playmode-results.xml
-      - store_artifacts:
-          name: Store test coverage
-          path: ./unity-renderer/CodeCoverage
       - persist_to_workspace:
           root: *working_directory
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,10 @@ jobs:
       - store_artifacts:
           name: Store test coverage
           path: ./unity-renderer/CodeCoverage
+      - persist_to_workspace:
+          root: *working_directory
+          paths:
+            - ./unity-renderer/CodeCoverage
       - save_cache:
           name: Store test cache
           key: unity-playmode-2020-3-{{ checksum "../.unitysources-checksum" }}
@@ -313,7 +317,11 @@ jobs:
           working_directory: *node_workspace
           name: npm run test
           command: npm run test
-
+      - run:
+          working_directory: *node_workspace
+          name: prepare code coverage
+          command: |
+            cp -r /tmp/workspace/unity-renderer/unity-renderer/CodeCoverage/Report/ /tmp/workspace/unity-renderer/browser-interface/dist/code-coverage/
       - run: sudo apt-get -y -qq install awscli
       - run:
           working_directory: *node_workspace
@@ -377,6 +385,7 @@ workflows:
           <<: *all_branches_and_tags
           requires:
             - build-unity
+            - playmode-tests
 
       - publish-renderer:
           filters:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,6 @@ jobs:
 
             - This branch can be previewed at [https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:${{ github.head_ref }}](https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:${{ github.head_ref }}&ENV=org)
 
+            - Code coverage report: [https://renderer-artifacts.decentraland.org/branch/${{ github.head_ref }}/code-coverage](https://renderer-artifacts.decentraland.org/branch/${{ github.head_ref }}/code-coverage)
+
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci-playmode-test.sh
+++ b/ci-playmode-test.sh
@@ -13,7 +13,7 @@ xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' $UNITY_PATH/Edito
   -testResults "$PROJECT_PATH/playmode-results.xml" \
   -enableCodeCoverage \
   -coverageResultsPath "$PROJECT_PATH/CodeCoverage" \
-  -coverageOptions "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport"
+  -coverageOptions "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-Protocol,-WebSocketSharp,-UnityGLTFAssembly"
 
 # Catch exit code
 UNITY_EXIT_CODE=$?

--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -16,6 +16,7 @@
     "com.unity.shadergraph": "10.3.2",
     "com.unity.test-framework": "1.1.22",
     "com.unity.test-framework.performance": "1.3.3-preview",
+    "com.unity.testtools.codecoverage": "1.1.0",
     "com.unity.textmeshpro": "3.0.4",
     "com.unity.timeline": "1.4.6",
     "com.unity.ugui": "1.0.0",

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -138,6 +138,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.settings-manager": {
+      "version": "1.0.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.shadergraph": {
       "version": "10.4.0",
       "depth": 1,
@@ -166,6 +173,16 @@
       "dependencies": {
         "com.unity.test-framework": "1.1.0",
         "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.testtools.codecoverage": {
+      "version": "1.1.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.0.16",
+        "com.unity.settings-manager": "1.0.1"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
Fix #700
## What does this PR change?

- Add code coverage package to Unity
- Upload code coverage report to S3
- Now GitHub Bot to comment the link of the report

Maybe this would be an intermediate step to upload the code coverage to a service like http://coveralls.io/.

## How to test the changes?

1. Go to the bot comment on this PR (https://github.com/decentraland/unity-renderer/pull/777#issuecomment-875648113)
2. See if it reported the code coverage and if you can see it well.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
