### PR TITLE
fix: limit DCLTexture max size

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Textures/DCLTexture.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Textures/DCLTexture.cs
@@ -29,7 +29,7 @@ namespace DCL
             MIRROR
         }
 
-        AssetPromise_Texture texturePromise = null;
+        public AssetPromise_Texture texturePromise { private set; get; } = null;
 
         public TextureWrapMode unityWrap;
         public FilterMode unitySamplingMode;
@@ -136,7 +136,14 @@ namespace DCL
                         if (texturePromise != null)
                             AssetPromiseKeeper_Texture.i.Forget(texturePromise);
 
-                        texturePromise = new AssetPromise_Texture(contentsUrl, unityWrap, unitySamplingMode, storeDefaultTextureInAdvance: true);
+                        texturePromise = new AssetPromise_Texture(contentsUrl, new AssetPromise_Texture_Settings()
+                        {
+                            wrapMode = unityWrap,
+                            filterMode = unitySamplingMode,
+                            storeDefaultTextureInAdvance = true,
+                            storeTexAsNonReadable = true,
+                            limitTextureSize = true
+                        });
                         texturePromise.OnSuccessEvent += (x) => texture = x.texture;
                         texturePromise.OnFailEvent += (x) => { texture = null; };
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIImage/UIImage.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIImage/UIImage.cs
@@ -30,6 +30,8 @@ namespace DCL.Components
         public override string referencesContainerPrefabName => "UIImage";
 
         DCLTexture dclTexture = null;
+        private int originalWidth;
+        private int originalHeight;
 
         public UIImage() { model = new Model(); }
 
@@ -59,6 +61,15 @@ namespace DCL.Components
                     IEnumerator fetchIEnum = DCLTexture.FetchTextureComponent(scene, model.source, (downloadedTexture) =>
                     {
                         referencesContainer.image.texture = downloadedTexture.texture;
+                        originalWidth = downloadedTexture.texture.width;
+                        originalHeight = downloadedTexture.texture.height;
+
+                        if (downloadedTexture.texturePromise?.asset != null)
+                        {
+                            originalWidth = downloadedTexture.texturePromise.asset.originalWidth;
+                            originalHeight = downloadedTexture.texturePromise.asset.originalHeight;
+                        }
+
                         fetchRoutine = null;
                         dclTexture?.DetachFrom(this);
                         dclTexture = downloadedTexture;
@@ -99,14 +110,14 @@ namespace DCL.Components
 
             // Configure uv rect
             Vector2 normalizedSourceCoordinates = new Vector2(
-                model.sourceLeft / referencesContainer.image.texture.width,
-                -model.sourceTop / referencesContainer.image.texture.height);
+                model.sourceLeft / originalWidth,
+                -model.sourceTop / originalHeight);
 
             Vector2 normalizedSourceSize = new Vector2(
                 model.sourceWidth * (model.sizeInPixels ? 1f : parentRecTransform.rect.width) /
-                referencesContainer.image.texture.width,
+                originalWidth,
                 model.sourceHeight * (model.sizeInPixels ? 1f : parentRecTransform.rect.height) /
-                referencesContainer.image.texture.height);
+                originalHeight);
 
             referencesContainer.image.uvRect = new Rect(normalizedSourceCoordinates.x,
                 normalizedSourceCoordinates.y + (1 - normalizedSourceSize.y),

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromise_Texture_Settings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromise_Texture_Settings.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace DCL
+{
+    public class AssetPromise_Texture_Settings
+    {
+        public const TextureWrapMode DEFAULT_WRAP_MODE = TextureWrapMode.Clamp;
+        public const FilterMode DEFAULT_FILTER_MODE = FilterMode.Bilinear;
+        public const int ENFORCED_TEXTURE_MAX_SIZE = 1024;
+
+        public TextureWrapMode wrapMode = DEFAULT_WRAP_MODE;
+        public FilterMode filterMode = DEFAULT_FILTER_MODE;
+        public bool storeDefaultTextureInAdvance = false;
+        public bool storeTexAsNonReadable = true;
+        public bool limitTextureSize = false;
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromise_Texture_Settings.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromise_Texture_Settings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9d203c71a56a48f6ac865acbc95fb14d
+timeCreated: 1625592933

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/Asset_Texture.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/Asset_Texture.cs
@@ -11,6 +11,9 @@ namespace DCL
         public Texture2D texture { get; set; }
         public Asset_Texture dependencyAsset; // to store the default tex asset and release it accordingly
 
+        public int originalWidth { get; internal set; }
+        public int originalHeight { get; internal set; }
+
         public event System.Action OnCleanup;
 
         public void ConfigureTexture(TextureWrapMode textureWrapMode, FilterMode textureFilterMode, bool makeNoLongerReadable = true)


### PR DESCRIPTION
We notice lots of really really really large textures being loaded.
So we must resize them.

* pending: properly test UIImage when textures are used as an atlas
* pending: add visual test
* pending: figure out why when setting 512 as texture limit size the image on the right at coords 61,61 has some pixel lost when being resized
<img width="150" alt="Screen Shot 2021-07-07 at 11 26 45" src="https://user-images.githubusercontent.com/4195708/124777282-79c28d80-df16-11eb-81fa-18e3770bfa7c.png">
