### PR TITLE
feat: biw save each 5 seconds

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldController.cs
@@ -641,12 +641,6 @@ public class BuilderInWorldController : MonoBehaviour
     {
         Environment.i.platform.cullingController.Start();
 
-        if (biwSaveController.numberOfSaves > 0)
-        {
-            HUDController.i.builderInWorldMainHud?.SaveSceneInfo();
-            biwSaveController.ResetNumberOfSaves();
-        }
-
         biwFloorHandler.OnAllParcelsFloorLoaded -= OnAllParcelsFloorLoaded;
         initialLoadingController.Hide(true);
         inputController.inputTypeMode = InputTypeMode.GENERAL;
@@ -677,6 +671,12 @@ public class BuilderInWorldController : MonoBehaviour
         Environment.i.world.blockersController.SetEnabled(true);
 
         ExitBiwControllers();
+
+        if (biwSaveController.numberOfSaves > 0)
+        {
+            HUDController.i.builderInWorldMainHud?.SaveSceneInfo();
+            biwSaveController.ResetNumberOfSaves();
+        }
 
         foreach (var groundVisual in groundVisualsGO)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWSaveController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWSaveController.cs
@@ -79,7 +79,6 @@ public class BIWSaveController : BIWController
 
         builderInWorldBridge.SaveSceneState(sceneToEdit);
         nextTimeToSave = DCLTime.realtimeSinceStartup + msBetweenSaves / 1000f;
-        Debug.Log("Scene Saved");
         HUDController.i.builderInWorldMainHud?.SceneSaved();
         numberOfSaves++;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWSaveController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWSaveController.cs
@@ -28,6 +28,12 @@ public class BIWSaveController : BIWController
         }
     }
 
+    public override void ExitEditMode()
+    {
+        ForceSave();
+        base.ExitEditMode();
+    }
+
     private void OnDestroy()
     {
         if (builderInWorldBridge != null)
@@ -73,6 +79,7 @@ public class BIWSaveController : BIWController
 
         builderInWorldBridge.SaveSceneState(sceneToEdit);
         nextTimeToSave = DCLTime.realtimeSinceStartup + msBetweenSaves / 1000f;
+        Debug.Log("Scene Saved");
         HUDController.i.builderInWorldMainHud?.SceneSaved();
         numberOfSaves++;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuilderInWorldGodMode.cs
@@ -189,7 +189,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         TransformActionEnd(selectedEntities[0].rootEntity, BuilderInWorldSettings.TRANSLATE_GIZMO_NAME);
         ActionFinish(BuildInWorldCompleteAction.ActionType.MOVE);
         builderInWorldEntityHandler.ReportTransform(true);
-        biwSaveController.ForceSave();
+        biwSaveController.TryToSave();
     }
 
     public void UpdateSelectionRotation(Vector3 rotation)
@@ -202,7 +202,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         TransformActionEnd(selectedEntities[0].rootEntity, BuilderInWorldSettings.ROTATE_GIZMO_NAME);
         ActionFinish(BuildInWorldCompleteAction.ActionType.ROTATE);
         builderInWorldEntityHandler.ReportTransform(true);
-        biwSaveController.ForceSave();
+        biwSaveController.TryToSave();
     }
 
     public void UpdateSelectionScale(Vector3 scale)
@@ -222,7 +222,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         TransformActionEnd(entityToUpdate.rootEntity, BuilderInWorldSettings.SCALE_GIZMO_NAME);
         ActionFinish(BuildInWorldCompleteAction.ActionType.SCALE);
         builderInWorldEntityHandler.ReportTransform(true);
-        biwSaveController.ForceSave();
+        biwSaveController.TryToSave();
     }
 
     public void UpdateGizmosToSelectedEntities()
@@ -259,7 +259,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         if (isPlacingNewObject)
         {
             builderInWorldEntityHandler.DeselectEntities();
-            biwSaveController.ForceSave();
+            biwSaveController.TryToSave();
             return;
         }
 
@@ -426,7 +426,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
         if (wasGizmosActive && !isPlacingNewObject)
         {
             gizmoManager.ShowGizmo();
-            biwSaveController.ForceSave();
+            biwSaveController.TryToSave();
         }
 
         wasGizmosActive = false;
@@ -531,7 +531,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
     public override void OnDeleteEntity(DCLBuilderInWorldEntity entity)
     {
         base.OnDeleteEntity(entity);
-        biwSaveController.ForceSave();
+        biwSaveController.TryToSave();
 
         if (selectedEntities.Count == 0)
             gizmoManager.HideGizmo();
@@ -769,7 +769,7 @@ public class BuilderInWorldGodMode : BuilderInWorldMode
                 break;
         }
 
-        biwSaveController.ForceSave();
+        biwSaveController.TryToSave();
     }
 
     #endregion


### PR DESCRIPTION
## What does this PR change?

This PR ensures that we are saving biw scenes each 5 seconds instead of each change, this will make the servers more stables

## How to test the changes?

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/biw-save-time
2. Enter builder in world
3. Check that the scene is not saved each time that you made a change

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
