### PR TITLE
fix: biw exit correctly with an entity outside scene 

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsFeedbackStyle_BIW.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsFeedbackStyle_BIW.cs
@@ -52,9 +52,9 @@ public class SceneBoundsFeedbackStyle_BIW : ISceneBoundsFeedbackStyle
 
     public void CleanFeedback()
     {
-        foreach (var meshInfo in currentMeshesInvalidated)
+        for (int i = 0; i < currentMeshesInvalidated.Count; i++)
         {
-            RemoveInvalidMeshEffect(meshInfo);
+            RemoveInvalidMeshEffect(currentMeshesInvalidated[i]);
         }
 
         currentMeshesInvalidated.Clear();


### PR DESCRIPTION
## What does this PR change?

This PR fixes #795 , If you exit from builder in world with an entity outside the parcel, the explorer will end in a unexpected state and you won't be able to do anything

## How to test the changes?

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/biw-feedback
2. Enter builder in world
3. Put an entity outside the parcel
4. Exit from builder in world

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
