### PR TITLE
fix: Some scenes bug the character controller gravity

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -442,10 +442,7 @@ public class DCLCharacterController : MonoBehaviour
         return null;
     }
 
-    public bool CastGroundCheckingRays(float extraDistance, float scale, out RaycastHit hitInfo)
-    {
-        return CastGroundCheckingRays(transform, collider, extraDistance, scale, groundLayers, out hitInfo);
-    }
+    public bool CastGroundCheckingRays(float extraDistance, float scale, out RaycastHit hitInfo) { return CastGroundCheckingRays(transform, collider, extraDistance, scale, groundLayers, out hitInfo); }
 
     public bool CastGroundCheckingRay(float extraDistance, out RaycastHit hitInfo)
     {
@@ -463,7 +460,7 @@ public class DCLCharacterController : MonoBehaviour
         float rayMagnitude = (bounds.extents.y + extraDistance);
         float originScale = scale * bounds.extents.x;
 
-        if (!CastGroundCheckingRay(Vector3.zero, out hitInfo, rayMagnitude, groundLayers) // center
+        if (!CastGroundCheckingRay(transform.position, out hitInfo, rayMagnitude, groundLayers) // center
             && !CastGroundCheckingRay( transform.position + transform.forward * originScale, out hitInfo, rayMagnitude, groundLayers) // forward
             && !CastGroundCheckingRay( transform.position + transform.right * originScale, out hitInfo, rayMagnitude, groundLayers) // right
             && !CastGroundCheckingRay( transform.position + -transform.forward * originScale, out hitInfo, rayMagnitude, groundLayers) // back


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fix #799 

Some scenes are breaking the character controller gravity when jumping, letting us to make infinite jumps. See this [video](https://decentralandteam.slack.com/files/UB4ENQ750/F027WJJ3NBX/screen_recording_2021-07-13_at_22.30.20.mov).

![image](https://user-images.githubusercontent.com/64659061/126472209-84a51226-6581-4f59-90f6-10bfc4dbaeef.png)

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/A-deployed-scene-bugs-the-character-controller-gravity&ENV=org&position=50,75
2. Try to jump multiples times.
3. Notice the avatar is only able to make a single jump and not inifinites as before.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
