### PR TITLE
fix: name renderer behind the canvas

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarName/AvatarName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarName/AvatarName.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class AvatarName : MonoBehaviour
 {
+    private const int AVATAR_NAME_SORTING_ORDER = -2;
     const float NAME_VANISHING_POINT_DISTANCE = 20.0f;
     readonly int VOICE_CHAT_ANIMATOR_TALKING = Animator.StringToHash("Talking");
 
@@ -50,6 +51,7 @@ public class AvatarName : MonoBehaviour
     private void Awake()
     {
         canvas = GetComponentInParent<Canvas>();
+        canvas.sortingOrder = AVATAR_NAME_SORTING_ORDER;
         canvasRect = (RectTransform)canvas.transform;
         talkingAnimator?.gameObject.SetActive(false);
     }


### PR DESCRIPTION
## What does this PR change?

Fixes #491. Now the Avatar name is renderer behind the scene UI

## How to test the changes?

1. Go to: https://play.decentraland.org/?ENABLE_BUILDER_IN_WORLD&ENV=org&position=-118%2C136&realm=unicorn-blue&ws=ws%3A%2F%2Flocalhost%3A4999%2Fdcl
2. Try to put an avatar name on top of the scene UI

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
