### PR TITLE
fix: Noticeable hiccups when receiving a chat message and the chat history is long

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -5,7 +5,7 @@ using UnityEngine.Events;
 
 public class ChatHUDController : IDisposable
 {
-    public static int MAX_CHAT_ENTRIES { internal set; get; } = 100;
+    public static int MAX_CHAT_ENTRIES { internal set; get; } = 30;
 
     public ChatHUDView view;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -152,9 +152,7 @@ public class ChatHUDView : MonoBehaviour
 
         SortEntries();
 
-        Utils.ForceUpdateLayout(transform as RectTransform, delayed: false);
-
-        if (setScrollPositionToBottom)
+        if (setScrollPositionToBottom && scrollRect.verticalNormalizedPosition > 0)
             scrollRect.verticalNormalizedPosition = 0;
     }
 
@@ -188,7 +186,11 @@ public class ChatHUDView : MonoBehaviour
         int count = entries.Count;
         for (int i = 0; i < count; i++)
         {
-            entries[i].transform.SetSiblingIndex(i);
+            if (entries[i].transform.GetSiblingIndex() != i)
+            {
+                entries[i].transform.SetSiblingIndex(i);
+                Utils.ForceUpdateLayout(entries[i].transform as RectTransform, delayed: false);
+            }
         }
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -152,6 +152,8 @@ public class ChatHUDView : MonoBehaviour
 
         SortEntries();
 
+        Utils.ForceUpdateLayout(chatEntry.transform as RectTransform, delayed: false);
+
         if (setScrollPositionToBottom && scrollRect.verticalNormalizedPosition > 0)
             scrollRect.verticalNormalizedPosition = 0;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatHUDView.cs
@@ -24,7 +24,7 @@ public class PrivateChatHUDView : ChatHUDView
         entries.Add(chatEntry);
         Utils.ForceUpdateLayout(transform as RectTransform, delayed: false);
 
-        if (setScrollPositionToBottom)
+        if (setScrollPositionToBottom && scrollRect.verticalNormalizedPosition > 0)
             scrollRect.verticalNormalizedPosition = 0;
     }
 


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fix #123 

Seems to be that when the chat history gets quite long, every new chat message received takes some milliseconds in processing, and that causes noticeable hiccups

### Main cause of the hiccups
- Each time a message entered the chat, we was forcing to update **ALL** the existing entries layouts with `Utils.ForceUpdateLayout(transform as RectTransform, delayed: false)`, that had having a huge impact on the performance when the chat had accumulated a lot of messages.
- After a message entered the chat, we was setting the vertical position of the HUD scroll to 0 with `scrollRect.verticalNormalizedPosition = 0`, and it was affecting negatively to the performance.

### Implemented solutions
- [x] Now, instead of always update all the entries each time a new message entered the chat, we only update the new added entry and, if it is necessary, the entries whose position was changed during the re-ordering by timestamp.
- [x] Now, before setting the vertical position of the HUD scroll to 0, we check if the current position is grater that 0. In this way we will only apply this action when it is needed.
- [x] We have changed the maximum number of entries in the chat (`MAX_CHAT_ENTRIES`) from `100` to `30`. It will make the HUD lighter.

### Metrics obtained from the `AddEntry(...)` action hiccups
- **BEFORE**: Hiccups up to `~287.50ms` per each entry added in the chat.
- **NOW**: Hiccups up to `~3.45ms` per each entry added in the chat.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/Noticeable-hiccups-when-receiving-a-chat-message-and-the-chat-history-is-long
2. Test the world and private chats.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
