### PR TITLE
feat: disable facial features based on distance to player

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -43,6 +43,7 @@ namespace DCL
 
         private Coroutine loadCoroutine;
         private List<string> wearablesInUse = new List<string>();
+        private bool facialFeaturesVisible = true;
 
         private void Awake()
         {
@@ -350,6 +351,7 @@ namespace DCL
             }
 
             bodyShapeController.SetActiveParts(unusedCategories.Contains(Categories.LOWER_BODY), unusedCategories.Contains(Categories.UPPER_BODY), unusedCategories.Contains(Categories.FEET));
+            bodyShapeController.SetFacialFeaturesVisible(facialFeaturesVisible);
             bodyShapeController.UpdateVisibility(hiddenList);
             foreach (WearableController wearableController in wearableControllers.Values)
             {
@@ -506,6 +508,16 @@ namespace DCL
             {
                 renderers[i].enabled = false;
             }
+        }
+
+        public void SetFacialFeaturesVisible(bool visible)
+        {
+            if (visible == facialFeaturesVisible)
+                return;
+            facialFeaturesVisible = visible;
+            if (bodyShapeController == null || !bodyShapeController.isReady)
+                return;
+            bodyShapeController.SetFacialFeaturesVisible(visible, true);
         }
 
         protected virtual void OnDestroy() { CleanupAvatar(); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
@@ -39,7 +39,8 @@
         "GUID:46cbc133d57a24117993396eb0fbbc5a",
         "GUID:750a3dd4b18d34b46a798e22b150fa10",
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
-        "GUID:c34e38f41494f834abff029ddf82af43"
+        "GUID:c34e38f41494f834abff029ddf82af43",
+        "GUID:3f4c1b4f55716479ea104c4254afe172"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -35,6 +35,7 @@ namespace DCL
         bool initializedPosition = false;
 
         private PlayerStatus playerStatus = null;
+        private Coroutine disableFacialFeatureRoutine = null;
 
         private void Awake()
         {
@@ -45,7 +46,13 @@ namespace DCL
         protected override void OnEnable()
         {
             base.OnEnable();
-            StartCoroutine(SetFacialFeaturesVisibleRoutine());
+
+            if (disableFacialFeatureRoutine != null)
+            {
+                StopCoroutine(disableFacialFeatureRoutine);
+                disableFacialFeatureRoutine = null;
+            }
+            disableFacialFeatureRoutine = StartCoroutine(SetFacialFeaturesVisibleRoutine());
         }
 
         private void PlayerClicked()
@@ -191,6 +198,12 @@ namespace DCL
         public override void Cleanup()
         {
             base.Cleanup();
+
+            if (disableFacialFeatureRoutine != null)
+            {
+                StopCoroutine(disableFacialFeatureRoutine);
+                disableFacialFeatureRoutine = null;
+            }
 
             if (playerStatus != null)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -13,6 +13,8 @@ namespace DCL
     public class AvatarShape : BaseComponent
     {
         private const string CURRENT_PLAYER_ID = "CurrentPlayerInfoCardId";
+        private const float DISABLE_FACIAL_FEATURES_DISTANCE_DELAY = 0.5f;
+        private const float DISABLE_FACIAL_FEATURES_DISTANCE = 15f;
 
         public static event Action<IDCLEntity, AvatarShape> OnAvatarShapeUpdated;
 
@@ -38,6 +40,12 @@ namespace DCL
         {
             model = new AvatarModel();
             currentPlayerInfoCardId = Resources.Load<StringVariable>(CURRENT_PLAYER_ID);
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            StartCoroutine(SetFacialFeaturesVisibleRoutine());
         }
 
         private void PlayerClicked()
@@ -205,6 +213,17 @@ namespace DCL
             {
                 entity.OnTransformChange = null;
                 entity = null;
+            }
+        }
+
+        private IEnumerator SetFacialFeaturesVisibleRoutine()
+        {
+            while (true)
+            {
+                yield return WaitForSecondsCache.Get(DISABLE_FACIAL_FEATURES_DISTANCE_DELAY);
+                Vector3 position = lastAvatarPosition ?? (entity.gameObject.transform.position + CommonScriptableObjects.worldOffset);
+                float distanceToPlayer = Vector3.Distance(CommonScriptableObjects.playerWorldPosition, position);
+                avatarRenderer.SetFacialFeaturesVisible(distanceToPlayer <= DISABLE_FACIAL_FEATURES_DISTANCE);
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
@@ -9,12 +9,15 @@ public interface IBodyShapeController
     void SetupEyes(Material material, Texture texture, Texture mask, Color color);
     void SetupEyebrows(Material material, Texture texture, Color color);
     void SetupMouth(Material material, Texture texture, Texture mask, Color color);
+    void SetFacialFeaturesVisible(bool visible, bool updateVisibility = false);
 }
 
 public class BodyShapeController : WearableController, IBodyShapeController
 {
     public string bodyShapeId => wearable.id;
     private Transform animationTarget;
+    private bool facialFeaturesVisible;
+    private HashSet<string> currentHiddenList = new HashSet<string>();
 
     public BodyShapeController(WearableItem wearableItem) : base(wearableItem) { }
 
@@ -117,6 +120,13 @@ public class BodyShapeController : WearableController, IBodyShapeController
             "mouth");
     }
 
+    public void SetFacialFeaturesVisible(bool visible, bool updateVisibility = false)
+    {
+        facialFeaturesVisible = visible;
+        if (updateVisibility)
+            UpdateVisibility(currentHiddenList);
+    }
+
     protected override void PrepareWearable(GameObject assetContainer)
     {
         Animation animation = null;
@@ -191,16 +201,17 @@ public class BodyShapeController : WearableController, IBodyShapeController
 
     public override void UpdateVisibility(HashSet<string> hiddenList)
     {
-        bool headIsVisible = !hiddenList.Contains(WearableLiterals.Misc.HEAD);
+        currentHiddenList = hiddenList;
+        bool headIsVisible = !currentHiddenList.Contains(WearableLiterals.Misc.HEAD);
 
         headRenderer.enabled = headIsVisible;
-        eyebrowsRenderer.enabled = headIsVisible;
-        eyesRenderer.enabled = headIsVisible;
-        mouthRenderer.enabled = headIsVisible;
+        eyebrowsRenderer.enabled = headIsVisible && facialFeaturesVisible;
+        eyesRenderer.enabled = headIsVisible && facialFeaturesVisible;
+        mouthRenderer.enabled = headIsVisible && facialFeaturesVisible;
 
-        feetRenderer.enabled = !hiddenList.Contains(WearableLiterals.Categories.FEET);
-        upperBodyRenderer.enabled = !hiddenList.Contains(WearableLiterals.Categories.UPPER_BODY);
-        lowerBodyRenderer.enabled = !hiddenList.Contains(WearableLiterals.Categories.LOWER_BODY);
+        feetRenderer.enabled = !currentHiddenList.Contains(WearableLiterals.Categories.FEET);
+        upperBodyRenderer.enabled = !currentHiddenList.Contains(WearableLiterals.Categories.UPPER_BODY);
+        lowerBodyRenderer.enabled = !currentHiddenList.Contains(WearableLiterals.Categories.LOWER_BODY);
     }
 
     private void InitializeAvatarAudioHandlers(GameObject container, Animation createdAnimation)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/BaseComponent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/BaseComponent.cs
@@ -43,7 +43,7 @@ namespace DCL.Components
 
         public abstract IEnumerator ApplyChanges(BaseModel model);
 
-        void OnEnable()
+        protected virtual void OnEnable()
         {
             if (updateHandler == null)
                 updateHandler = CreateUpdateHandler();


### PR DESCRIPTION
Fixes #826 

## How to test
It's easier to test this in Unity. Just lock the editor window to an avatar and either move the avatar away or move yourself away to see how the mouth, eyes and eyebros dissapear.

## Test coverage
All of our AvatarShape tests are disabled (it takes too long to load an Avatar) and there's an ongoing effort to first refactor AvatarShape/AvatarRenderer and then implement a proper test suite. Therefore I decided to not waste time on making a test that is going to be disabled.

## Implementation details
Instead of checking each time the player or the other avatars change position, I decided to have a routine running and performing the distance calculation.
I was worried of triggering a Distance calculation (expensive) each time (possibly multiple times).