### PR TITLE
fix: Connect to the next best realm if the Explore JumpIn fails (II)

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExploreHUD/Scripts/HighlightScenes/HotSceneCellView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExploreHUD/Scripts/HighlightScenes/HotSceneCellView.cs
@@ -148,11 +148,15 @@ internal class HotSceneCellView : MonoBehaviour
             RealmsInfoBridge.OnRealmConnectionFailed += OnRealmConnectionFailed;
         }
 
-        lastJumpInTried.gridPosition = hotSceneInfo.baseCoords;
-        lastJumpInTried.realm.serverName = realm.serverName;
-        lastJumpInTried.realm.layer = realm.layer;
-
+        SetLastJumpInTried(hotSceneInfo.baseCoords, realm.serverName, realm.layer);
         OnJumpIn?.Invoke(hotSceneInfo.baseCoords, realm.serverName, realm.layer);
+    }
+
+    private void SetLastJumpInTried(Vector2 position, string serverName, string layer)
+    {
+        lastJumpInTried.gridPosition = position;
+        lastJumpInTried.realm.serverName = serverName;
+        lastJumpInTried.realm.layer = layer;
     }
 
     private void OnRealmConnectionSuccess(JumpInPayload successRealm)
@@ -181,6 +185,7 @@ internal class HotSceneCellView : MonoBehaviour
         {
             WebInterface.NotifyStatusThroughChat("Trying to connect to the next more populated realm...");
             HotScenesController.HotSceneInfo.Realm nextRealmToTry = nextMostPopulatedRealms.Dequeue();
+            SetLastJumpInTried(hotSceneInfo.baseCoords, nextRealmToTry.serverName, nextRealmToTry.layer);
             OnJumpIn?.Invoke(hotSceneInfo.baseCoords, nextRealmToTry.serverName, nextRealmToTry.layer);
         }
         else


### PR DESCRIPTION
## What does this PR fix?
Fix #244

It is a second part of the previous PR (https://github.com/decentraland/unity-renderer/pull/781). We found an issue when we tried to re-joinning to the next best realms that was making it always failed. This PR fix it!

## How to test the changes?
1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/JumpIns-from-Explore-don't-work-correctly&ENV=org
2. Open the Explore window.
3. Select different scenes to jump in.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
