### PR TITLE
chore: fix `triggerPipeline` parameters order in publish.ts

### DIFF
--- a/browser-interface/scripts/publish.ts
+++ b/browser-interface/scripts/publish.ts
@@ -14,13 +14,13 @@ async function main() {
     throw new Error('GITLAB_PIPELINE_URL not present. Skipping CDN pipeline trigger')
   }
   
-  //if (process.env.CIRCLE_BRANCH == "master") {
-  await publish(["latest"], "public", DIST_ROOT)
-  // inform cdn-pipeline about new version
-  const version = await getVersion(DIST_ROOT)
-  const pkgName = (await execute(`npm info . name`, DIST_ROOT)).trim();
-  triggerPipeline(pkgName, `latest`, version)
-  //}
+  if (process.env.CIRCLE_BRANCH == "master") {
+    await publish(["latest"], "public", DIST_ROOT)
+    // inform cdn-pipeline about new version
+    const version = await getVersion(DIST_ROOT)
+    const pkgName = (await execute(`npm info . name`, DIST_ROOT)).trim();
+    triggerPipeline(pkgName, `latest`, version)
+  }
 }
 
 async function checkFiles() {

--- a/browser-interface/scripts/publish.ts
+++ b/browser-interface/scripts/publish.ts
@@ -19,7 +19,7 @@ async function main() {
     // inform cdn-pipeline about new version
     const version = await getVersion(DIST_ROOT)
     const pkgName = (await execute(`npm info . name`, DIST_ROOT)).trim();
-    triggerPipeline(pkgName, version, `latest`)
+    triggerPipeline(pkgName, `latest`, version)
   }
 }
 

--- a/browser-interface/scripts/publish.ts
+++ b/browser-interface/scripts/publish.ts
@@ -14,13 +14,13 @@ async function main() {
     throw new Error('GITLAB_PIPELINE_URL not present. Skipping CDN pipeline trigger')
   }
   
-  if (process.env.CIRCLE_BRANCH == "master") {
-    await publish(["latest"], "public", DIST_ROOT)
-    // inform cdn-pipeline about new version
-    const version = await getVersion(DIST_ROOT)
-    const pkgName = (await execute(`npm info . name`, DIST_ROOT)).trim();
-    triggerPipeline(pkgName, `latest`, version)
-  }
+  //if (process.env.CIRCLE_BRANCH == "master") {
+  await publish(["latest"], "public", DIST_ROOT)
+  // inform cdn-pipeline about new version
+  const version = await getVersion(DIST_ROOT)
+  const pkgName = (await execute(`npm info . name`, DIST_ROOT)).trim();
+  triggerPipeline(pkgName, `latest`, version)
+  //}
 }
 
 async function checkFiles() {


### PR DESCRIPTION
## What does this PR change?

Parameters in the `triggerPipeline` function weren't in the correct order

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
