### PR TITLE
fix: TextMeshPro materials used by TextShape are not properly destroyed

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
@@ -62,8 +62,14 @@ namespace DCL.Components
         public TextMeshPro text;
         public RectTransform rectTransform;
         private Model cachedModel;
+        private Material cachedFontMaterial;
 
-        private void Awake() { model = new Model(); }
+        private void Awake()
+        {
+            model = new Model();
+            cachedFontMaterial = new Material(text.fontSharedMaterial);
+            text.fontSharedMaterial = cachedFontMaterial;
+        }
 
         public void Update()
         {
@@ -130,24 +136,24 @@ namespace DCL.Components
 
             if (model.shadowOffsetX != 0 || model.shadowOffsetY != 0)
             {
-                text.fontMaterial.EnableKeyword("UNDERLAY_ON");
-                text.fontMaterial.SetColor("_UnderlayColor", model.shadowColor);
-                text.fontMaterial.SetFloat("_UnderlaySoftness", model.shadowBlur);
+                text.fontSharedMaterial.EnableKeyword("UNDERLAY_ON");
+                text.fontSharedMaterial.SetColor("_UnderlayColor", model.shadowColor);
+                text.fontSharedMaterial.SetFloat("_UnderlaySoftness", model.shadowBlur);
             }
-            else if (text.fontMaterial.IsKeywordEnabled("UNDERLAY_ON"))
+            else if (text.fontSharedMaterial.IsKeywordEnabled("UNDERLAY_ON"))
             {
-                text.fontMaterial.DisableKeyword("UNDERLAY_ON");
+                text.fontSharedMaterial.DisableKeyword("UNDERLAY_ON");
             }
 
             if (model.outlineWidth > 0f)
             {
-                text.fontMaterial.EnableKeyword("OUTLINE_ON");
+                text.fontSharedMaterial.EnableKeyword("OUTLINE_ON");
                 text.outlineWidth = model.outlineWidth;
                 text.outlineColor = model.outlineColor;
             }
-            else if (text.fontMaterial.IsKeywordEnabled("OUTLINE_ON"))
+            else if (text.fontSharedMaterial.IsKeywordEnabled("OUTLINE_ON"))
             {
-                text.fontMaterial.DisableKeyword("OUTLINE_ON");
+                text.fontSharedMaterial.DisableKeyword("OUTLINE_ON");
             }
         }
 
@@ -217,5 +223,11 @@ namespace DCL.Components
         }
 
         public override int GetClassId() { return (int) CLASS_ID.UI_TEXT_SHAPE; }
+
+        private void OnDestroy()
+        {
+            base.Cleanup();
+            Object.Destroy(cachedFontMaterial);
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fix #772 

There were lots of mesh count related to TextMeshPro on unity's profiler.
We should analyze if the TextShape component is destroyed correctly

## Implemented solution
1. Each time a `TextShape` object is created, we store a copy of the shared material in a private variable.
2. Instead of using `text.fontMaterial...`, we use `text.fontSharedMaterial...` in order to not to provoke new copies of the material.
3. Once the `TextShape` object is destroyed, we destroy our stored material.

**NOTE:** Making different tests with the `TextShape` components loading isolated, I have not seen a huge memory saving (the most important issue that I've detected with the number of materials in the profiler has been telated to this other [ISSUE](https://github.com/decentraland/unity-renderer/issues/876)). Anyway, in order to avoid problems with the material handling, I think it is the best way to manage the cleaning of font materials.

## Test link
https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/TextShape-memory-leaks&ENV=org

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
