### PR TITLE
fix: only check for lands if the shortcut or panel is used

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWMainController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWMainController.cs
@@ -91,12 +91,6 @@ public class BIWMainController : PluginFeature
             builderInWorldBridge.OnBuilderProjectInfo -= BuilderProjectPanelInfo;
         }
 
-        userProfile = UserProfile.GetOwnUserProfile();
-        if (!string.IsNullOrEmpty(userProfile.userId))
-            updateLandsWithAcessCoroutine = CoroutineStarter.Start(CheckLandsAccess());
-        else
-            userProfile.OnUpdate += OnUserProfileUpdate;
-
         InitHUD();
 
         BIWTeleportAndEdit.OnTeleportEnd += OnPlayerTeleportedToEditScene;
@@ -304,6 +298,15 @@ public class BIWMainController : PluginFeature
         HUDController.i.builderInWorldMainHud.RefreshCatalogContent();
     }
 
+    private void ActivateLandAccessBackgroundChecker()
+    {
+        userProfile = UserProfile.GetOwnUserProfile();
+        if (!string.IsNullOrEmpty(userProfile.userId))
+            updateLandsWithAcessCoroutine = CoroutineStarter.Start(CheckLandsAccess());
+        else
+            userProfile.OnUpdate += OnUserProfileUpdate;
+    }
+
     private void BuilderProjectPanelInfo(string title, string description) { HUDController.i.builderInWorldMainHud.SetBuilderProjectInfo(title, description); }
 
     private void CatalogReceived(string catalogJson)
@@ -400,6 +403,9 @@ public class BIWMainController : PluginFeature
             HUDController.i.builderInWorldMainHud.ExitStart();
             return;
         }
+
+        if (landsWithAccess.Count == 0)
+            ActivateLandAccessBackgroundChecker();
 
         FindSceneToEdit();
 


### PR DESCRIPTION
## What does this PR change?

This PR is a defensive measure, if you have lots of lands the explorer will process a lot of information, this way we ensure to only process the information in case that you want to use builder-in-world

## How to test the changes?

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/release-defensive-fix&ENV=org
2. Try to use the biw shorcut ("K") in a land where you are operator
3. You shouldn't have access until the query is done, try again after some seconds
4. It should enter now

OR

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/release-defensive-fix&ENV=org
2. Enter with a land that have a lots of lands
3. Check that everything work as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
