### PR TITLE
fix: restore deleted code from `auth from explorer-desktop` feature to use it on explorer-desktop

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
@@ -11,7 +11,7 @@ namespace DCL
 {
     public class DCLWebSocketService : WebSocketBehavior
     {
-        // TODO(Mateo): Refactor https://github.com/decentraland/unity-renderer/issues/585
+        public static bool enterAsAGuest = false; // TODO(Mateo): Refactor https://github.com/decentraland/unity-renderer/issues/585
         static bool VERBOSE = false;
 
         private void SendMessageToWeb(string type, string message)
@@ -61,6 +61,8 @@ namespace DCL
             base.OnOpen();
             WebInterface.OnMessageFromEngine += SendMessageToWeb;
             Send("{\"welcome\": true}");
+            if (enterAsAGuest)
+                WebInterface.SendAuthentication(WebInterface.RendererAuthenticationType.Guest);
         }
     }
 


### PR DESCRIPTION
…o use it on unity-desktop

## What does this PR change?

This code was deleted here: https://github.com/decentraland/unity-renderer/commit/9031228244c37aa6298f1affcfd85f60ab654620#diff-2a171cfb86bcc979ce96b8c8bb2809ebb910c4903bd65bb30a73a23859fe58a4

And it was implemented here: https://github.com/decentraland/unity-renderer/pull/611

This code is used by explorer-desktop to login as a guest and in the future with wallet connect

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
