### PR TITLE
fix: shadow resolution on Ultra is now 4096

### DIFF
--- a/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
@@ -65,7 +65,7 @@ MonoBehaviour:
     renderScale: 1
     shadows: 1
     softShadows: 1
-    shadowResolution: 1024
+    shadowResolution: 4096
     cameraDrawDistance: 100
     bloom: 1
     fpsCap: 0


### PR DESCRIPTION
Fixes #803

How to test:
- Run the game
- Set graphics preset to Ultra
- Shadow resolution should be 4096