### PR TITLE
chore: remove test requirement to publish build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,5 +385,5 @@ workflows:
           requires:
             - build-unity
             - build-js-interface
-            - playmode-tests
+            # - playmode-tests
             # - editmode-tests


### PR DESCRIPTION
We need to be able to test builds regardless of the `playmode-tests` job.