### PR TITLE
fix: AssetPromiseKeeper singleton

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromiseKeeper_AB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromiseKeeper_AB.cs
@@ -2,6 +2,9 @@ namespace DCL
 {
     public class AssetPromiseKeeper_AB : AssetPromiseKeeper<Asset_AB, AssetLibrary_AB, AssetPromise_AB>
     {
+        private static AssetPromiseKeeper_AB instance;
+        public static AssetPromiseKeeper_AB i { get { return instance ??= new AssetPromiseKeeper_AB(); } }
+
         public AssetPromiseKeeper_AB() : base(new AssetLibrary_AB()) { }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromiseKeeper_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromiseKeeper_AB_GameObject.cs
@@ -1,17 +1,16 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AssetPromiseKeeper_AssetBundleModelTests")]
+
 namespace DCL
 {
     public class AssetPromiseKeeper_AB_GameObject : AssetPromiseKeeper<Asset_AB_GameObject, AssetLibrary_AB_GameObject, AssetPromise_AB_GameObject>
     {
-        public AssetPromiseKeeper_AB_GameObject() : base(new AssetLibrary_AB_GameObject())
-        {
-        }
-        protected override void OnSilentForget(AssetPromise_AB_GameObject promise)
-        {
-            promise.asset.Hide();
-        }
+        private static AssetPromiseKeeper_AB_GameObject instance;
+        public static AssetPromiseKeeper_AB_GameObject i { get { return instance ??= new AssetPromiseKeeper_AB_GameObject(); } }
+
+        public AssetPromiseKeeper_AB_GameObject() : base(new AssetLibrary_AB_GameObject()) { }
+        protected override void OnSilentForget(AssetPromise_AB_GameObject promise) { promise.asset.Hide(); }
 
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
@@ -24,21 +24,6 @@ namespace DCL
         where AssetLibraryType : AssetLibrary<AssetType>, new()
         where AssetPromiseType : AssetPromise<AssetType>
     {
-        private static AssetPromiseKeeper<AssetType, AssetLibraryType, AssetPromiseType> instance;
-
-        public static AssetPromiseKeeper<AssetType, AssetLibraryType, AssetPromiseType> i
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    instance = new AssetPromiseKeeper<AssetType, AssetLibraryType, AssetPromiseType>(new AssetLibraryType());
-                }
-
-                return instance;
-            }
-        }
-
         public AssetLibraryType library;
 
         //NOTE(Brian): All waiting promises. Only used for cleanup and to keep count.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromiseKeeper_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromiseKeeper_GLTF.cs
@@ -2,6 +2,9 @@ namespace DCL
 {
     public class AssetPromiseKeeper_GLTF : AssetPromiseKeeper<Asset_GLTF, AssetLibrary_GLTF, AssetPromise_GLTF>
     {
+        private static AssetPromiseKeeper_GLTF instance;
+        public static AssetPromiseKeeper_GLTF i { get { return instance ??= new AssetPromiseKeeper_GLTF(); } }
+        
         public AssetPromiseKeeper_GLTF() : base(new AssetLibrary_GLTF()) { }
 
         protected override void OnSilentForget(AssetPromise_GLTF promise) { promise.asset.Hide(); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromiseKeeper_Gif.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromiseKeeper_Gif.cs
@@ -2,6 +2,9 @@ namespace DCL
 {
     public class AssetPromiseKeeper_Gif : AssetPromiseKeeper<Asset_Gif, AssetLibrary_RefCounted<Asset_Gif>, AssetPromise_Gif>
     {
+        private static AssetPromiseKeeper_Gif instance;
+        public static AssetPromiseKeeper_Gif i { get { return instance ??= new AssetPromiseKeeper_Gif(); } }
+
         public AssetPromiseKeeper_Gif() : base(new AssetLibrary_RefCounted<Asset_Gif>()) { }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Material/AssetPromiseKeeper_Material.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Material/AssetPromiseKeeper_Material.cs
@@ -1,22 +1,28 @@
+using System;
+
 namespace DCL
 {
     public class AssetLibrary_Material : AssetLibrary<Asset_Material>
     {
-        public override bool Add(Asset_Material asset) { throw new System.NotImplementedException(); }
+        public override bool Add(Asset_Material asset) { throw new NotImplementedException(); }
 
-        public override void Cleanup() { throw new System.NotImplementedException(); }
+        public override void Cleanup() { throw new NotImplementedException(); }
 
-        public override bool Contains(object id) { throw new System.NotImplementedException(); }
+        public override bool Contains(object id) { throw new NotImplementedException(); }
 
-        public override bool Contains(Asset_Material asset) { throw new System.NotImplementedException(); }
+        public override bool Contains(Asset_Material asset) { throw new NotImplementedException(); }
 
-        public override Asset_Material Get(object id) { throw new System.NotImplementedException(); }
+        public override Asset_Material Get(object id) { throw new NotImplementedException(); }
 
-        public override void Release(Asset_Material asset) { throw new System.NotImplementedException(); }
+        public override void Release(Asset_Material asset) { throw new NotImplementedException(); }
     }
 
     public class AssetPromiseKeeper_Material : AssetPromiseKeeper<Asset_Material, AssetLibrary_Material, AssetPromise_Material>
     {
+        private static AssetPromiseKeeper_Material instance;
+        public static AssetPromiseKeeper_Material i { get { return instance ??= new AssetPromiseKeeper_Material(); } }
+        
+        public AssetPromiseKeeper_Material() : base(new AssetLibrary_Material()) { }
         public AssetPromiseKeeper_Material(AssetLibrary_Material library) : base(library) { }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromiseKeeper_Texture.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromiseKeeper_Texture.cs
@@ -2,6 +2,9 @@ namespace DCL
 {
     public class AssetPromiseKeeper_Texture : AssetPromiseKeeper<Asset_Texture, AssetLibrary_Texture, AssetPromise_Texture>
     {
+        private static AssetPromiseKeeper_Texture instance;
+        public static AssetPromiseKeeper_Texture i { get { return instance ??= new AssetPromiseKeeper_Texture(); } }
+
         public AssetPromiseKeeper_Texture() : base(new AssetLibrary_Texture()) { }
     }
 }


### PR DESCRIPTION
Due to the implementation of the singleton pattern in `AssetPromiseKeeper` overridden methods for classes that extends it (like `AssetPromiseKeeper_GLTF` `OnSilentForget`) were not being called.