### PR TITLE
fix: GLTF's AsyncCoroutineHelper coroutine runner

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/Async/AsyncCoroutineHelper.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/Async/AsyncCoroutineHelper.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using DCL;
 using UnityEngine;
 
 namespace UnityGLTF
@@ -52,7 +53,7 @@ namespace UnityGLTF
                 if (coroutineInfo != null)
                 {
                     runningActions.Add(coroutineInfo);
-                    StartCoroutine(CallMethodOnMainThread(coroutineInfo));
+                    this.StartThrowingCoroutine(CallMethodOnMainThread(coroutineInfo), (exception => Debug.LogError(exception)));
                 }
             }
         }


### PR DESCRIPTION
For some mysterious reason using Unity's coroutine runner was leaving some GLTF in a state where they never finish loading.
Replacing `StartCoroutine` for `StartThrowingCoroutine` solved that issue.