### PR TITLE
fix: Moving platforms now rotate character avatar and first person camera

### DIFF
--- a/unity-renderer/Assets/Resources/ScriptableObjects/MovingPlatformRotationDelta.asset
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/MovingPlatformRotationDelta.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ebfac2923d5248d09c85ae6b0b8a1df9, type: 3}
+  m_Name: GroundPlatformRotation
+  m_EditorClassIdentifier: 
+  value: {x: 0, y: 0, z: 0, w: 0}

--- a/unity-renderer/Assets/Resources/ScriptableObjects/MovingPlatformRotationDelta.asset.meta
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/MovingPlatformRotationDelta.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f22c7f72207994e6b91f4d3607f39f84
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateFPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateFPS.cs
@@ -18,6 +18,41 @@ namespace DCL.Camera
                 pov = vcamera.GetCinemachineComponent<CinemachinePOV>();
         }
 
+        public override void OnSelect()
+        {
+            base.OnSelect();
+            CommonScriptableObjects.playerIsOnMovingPlatform.OnChange += OnMovingPlatformStart;
+            if (CommonScriptableObjects.playerIsOnMovingPlatform.Get())
+                OnMovingPlatformStart(true, true);
+        }
+
+        public override void OnUnselect()
+        {
+            base.OnUnselect();
+            CommonScriptableObjects.playerIsOnMovingPlatform.OnChange -= OnMovingPlatformStart;
+            CommonScriptableObjects.movingPlatformRotationDelta.OnChange -= OnMovingPlatformRotate;
+        }
+        private void OnMovingPlatformStart(bool current, bool previous)
+        {
+            if (current)
+            {
+                CommonScriptableObjects.movingPlatformRotationDelta.OnChange += OnMovingPlatformRotate;
+            }
+            else
+            {
+                CommonScriptableObjects.movingPlatformRotationDelta.OnChange -= OnMovingPlatformRotate;
+            }
+        }
+        private void OnMovingPlatformRotate(Quaternion current, Quaternion previous)
+        {
+            Vector3 diff = current.eulerAngles;
+            if (pov != null)
+            {
+                pov.m_HorizontalAxis.Value += diff.y;
+                pov.m_VerticalAxis.Value += diff.x;
+            }
+        }
+
         public override void OnUpdate()
         {
             var xzPlaneForward = Vector3.Scale(cameraTransform.forward, new Vector3(1, 0, 1));

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -2,9 +2,7 @@ using DCL;
 using DCL.Configuration;
 using DCL.Helpers;
 using UnityEngine;
-using System.Collections;
 using Cinemachine;
-using UnityEngine.SceneManagement;
 
 public class DCLCharacterController : MonoBehaviour
 {
@@ -44,6 +42,10 @@ public class DCLCharacterController : MonoBehaviour
     float lastMovementReportTime;
     float originalGravity;
     Vector3 lastLocalGroundPosition;
+    
+    Vector3 lastCharacterRotation;
+    Vector3 lastGlobalCharacterRotation;
+    
     Vector3 velocity = Vector3.zero;
 
     public bool isWalking { get; private set; } = false;
@@ -97,7 +99,6 @@ public class DCLCharacterController : MonoBehaviour
 
     [System.NonSerialized]
     public float movingPlatformSpeed;
-
     public event System.Action OnJump;
     public event System.Action OnHitGround;
     public event System.Action<float> OnMoved;
@@ -139,6 +140,7 @@ public class DCLCharacterController : MonoBehaviour
 
         avatarReference = new DCL.Models.DecentralandEntity { gameObject = avatarGameObject };
         firstPersonCameraReference = new DCL.Models.DecentralandEntity { gameObject = firstPersonCameraGameObject };
+        
     }
 
     private void SubscribeToInput()
@@ -346,10 +348,20 @@ public class DCLCharacterController : MonoBehaviour
 
         if (isOnMovingPlatform)
         {
-            lastLocalGroundPosition = groundTransform.InverseTransformPoint(transform.position);
+            SaveLateUpdateGroundTransforms();
         }
 
         OnUpdateFinish?.Invoke(deltaTime);
+    }
+    private void SaveLateUpdateGroundTransforms()
+    {
+        lastLocalGroundPosition = groundTransform.InverseTransformPoint(transform.position);
+        
+        if (CommonScriptableObjects.characterForward.HasValue())
+        {
+            lastCharacterRotation = groundTransform.InverseTransformDirection(CommonScriptableObjects.characterForward.Get().Value);
+            lastGlobalCharacterRotation = CommonScriptableObjects.characterForward.Get().Value;
+        }
     }
 
     void Jump()
@@ -390,6 +402,16 @@ public class DCLCharacterController : MonoBehaviour
             Vector3 newGroundWorldPos = groundTransform.TransformPoint(lastLocalGroundPosition);
             movingPlatformSpeed = Vector3.Distance(newGroundWorldPos, transform.position);
             transform.position = newGroundWorldPos;
+            
+            Vector3 newCharacterForward = groundTransform.TransformDirection(lastCharacterRotation);
+            Vector3 lastFrameDifference = Vector3.zero;
+            if (CommonScriptableObjects.characterForward.HasValue())
+            {
+                lastFrameDifference = CommonScriptableObjects.characterForward.Get().Value - lastGlobalCharacterRotation;
+            }
+            //NOTE(Kinerius) CameraStateTPS rotates the character between frames so we add the difference.
+            //               if we dont do this, the character wont rotate when moving, only when the platform rotates
+            CommonScriptableObjects.characterForward.Set(newCharacterForward + lastFrameDifference);
         }
 
         Transform transformHit = CastGroundCheckingRays();
@@ -406,12 +428,16 @@ public class DCLCharacterController : MonoBehaviour
                     isOnMovingPlatform = true;
                     CommonScriptableObjects.playerIsOnMovingPlatform.Set(true);
                     Physics.SyncTransforms();
-                    lastLocalGroundPosition = groundTransform.InverseTransformPoint(transform.position);
+                    SaveLateUpdateGroundTransforms();
+                    
+                    Quaternion deltaRotation = groundTransform.rotation * Quaternion.Inverse(groundLastRotation);
+                    CommonScriptableObjects.movingPlatformRotationDelta.Set(deltaRotation);
                 }
             }
             else
             {
                 groundTransform = transformHit;
+                CommonScriptableObjects.movingPlatformRotationDelta.Set(Quaternion.identity);
             }
         }
         else

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.cs
@@ -241,6 +241,7 @@ namespace Tests
 
             Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
 
+            var initialDirection = CommonScriptableObjects.characterForward.Get().Value;
             // Lerp the platform's rotation
             float lerpTime = 0f;
             float lerpSpeed = 1f;
@@ -271,6 +272,12 @@ namespace Tests
 
             UnityEngine.Assertions.Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.x, 11f, 1f);
             UnityEngine.Assertions.Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.z, 11f, 1f);
+
+            //test for rotation
+            var currentDirection = CommonScriptableObjects.characterForward.Get().Value;
+            var expectedDirection = Quaternion.AngleAxis(180, Vector3.up) * initialDirection;
+            var rotationIsExpected = Vector3.Distance(currentDirection, expectedDirection) <= 0.05f;
+            UnityEngine.Assertions.Assert.IsTrue(rotationIsExpected, "character is rotated");
 
             // remove platform and check character parent
             TestHelpers.RemoveSceneEntity(scene, platformEntityId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
@@ -120,6 +120,9 @@ public static class CommonScriptableObjects
     private static BooleanVariable playerIsOnMovingPlatformValue;
     public static BooleanVariable playerIsOnMovingPlatform => GetOrLoad(ref playerIsOnMovingPlatformValue, "ScriptableObjects/playerIsOnMovingPlatform");
 
+    private static QuaternionVariable movingPlatformRotationDeltaValue;
+    public static QuaternionVariable movingPlatformRotationDelta => GetOrLoad(ref movingPlatformRotationDeltaValue, "ScriptableObjects/MovingPlatformRotationDelta");
+
     private static StringVariable sceneIDValue;
     public static StringVariable sceneID => GetOrLoad(ref sceneIDValue, "ScriptableObjects/SceneID");
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/Variables/QuaternionVariable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/Variables/QuaternionVariable.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "QuaternionVariable", menuName = "Variables/QuaternionVariable")]
+public class QuaternionVariable : BaseVariableAsset<Quaternion>
+{
+    // Kinerius: euler angles comparison proved to be more reliable than comparing quaternion itself
+    public override bool Equals(Quaternion other) { return value.eulerAngles == other.eulerAngles; }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/Variables/QuaternionVariable.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/Variables/QuaternionVariable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ebfac2923d5248d09c85ae6b0b8a1df9
+timeCreated: 1628185288

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/Variables/Tests/VariableTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/Variables/Tests/VariableTests.cs
@@ -68,4 +68,13 @@ namespace VariableTests
         [NUnit.Framework.Test]
         public void VariableValueIsChangedProperly() { base.VariableValueIsChangedProperly(new Vector3(0, 0, 0), new Vector3(1, 1, 1)); }
     }
+
+    public class QuaternionVariableShould : BaseVariableTest<Quaternion, QuaternionVariable>
+    {
+        [NUnit.Framework.Test]
+        public void NotCallOnChangedWhenSameValueIsSet() { base.ShouldNotCallOnChangedWhenSameValueIsSet(new Quaternion(0, 0, 0, 0), new Quaternion(1, 1, 1, 1)); }
+
+        [NUnit.Framework.Test]
+        public void VariableValueIsChangedProperly() { base.VariableValueIsChangedProperly(new Quaternion(0, 0, 0, 0), new Quaternion(1, 1, 1, 1)); }
+    }
 }


### PR DESCRIPTION
Fixes #477 

How to test: 

- Go to Genesis Plaza flying tour carts or any moving platform that rotates
- On first person, the camera should rotate as the platform rotates
- On third person, the camera should stay still and the character should rotate as the platform rotates