### PR TITLE
feat: correct biw flow with the shortcut

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -78,6 +78,7 @@ namespace DCL.Configuration
         //Others
         public const float RAYCAST_MAX_DISTANCE = 10000f;
         public const string LAND_EDITION_NOT_ALLOWED_BY_PERMISSIONS_MESSAGE = "This land does not belong to you, nor have you been granted operating permits by its owner.";
+        public const string LAND_EDITION_WAITING_FOR_PERMISSIONS_MESSAGE = "Checking if you have permission to edit this land";
         public const string LAND_EDITION_NOT_ALLOWED_BY_SDK_LIMITATION_MESSAGE = "This place was created with the SDK and can not be edited in-world.";
         public const float CACHE_TIME_LAND = 5 * 60;
         public const float CACHE_TIME_SCENES = 1 * 60;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -84,6 +84,7 @@ namespace DCL.Configuration
         public const float CACHE_TIME_SCENES = 1 * 60;
         public const float REFRESH_LANDS_WITH_ACCESS_INTERVAL = 2 * 60;
         public const float LAND_NOTIFICATIONS_TIMER = 10f;
+        public const float LAND_CHECK_MESSAGE_TIMER = 5f;
     }
 
     public static class ApplicationSettings


### PR DESCRIPTION
## What does this PR change?

Fixes #896

Entering in builder in world by the shortcut is not working correctly. This PR changes that adding a message and trying to edit the land after the permissions of the lands has been checked if the shortcut has been pressed

## How to test the changes?

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/biw-shorcut-flow
2. Try to enter in your land with the shortcut "K" without opening the builder in world panel
3. Restart the session and try to enter in a land where you don't have permissions

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
