### PR TITLE
chore: use peer-lb to load balance requests to catalysts

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Wearables/WearablesFetchingHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Wearables/WearablesFetchingHelper.cs
@@ -9,8 +9,8 @@ namespace DCL.Helpers
 {
     public static class WearablesFetchingHelper
     {
-        public const string WEARABLES_FETCH_URL = "https://peer.decentraland.org/lambdas/collections/wearables?";
-        private const string COLLECTIONS_FETCH_URL = "https://peer.decentraland.org/lambdas/collections";
+        public const string WEARABLES_FETCH_URL = "https://peer-lb.decentraland.org/lambdas/collections/wearables?";
+        private const string COLLECTIONS_FETCH_URL = "https://peer-lb.decentraland.org/lambdas/collections";
         private const string BASE_WEARABLES_COLLECTION_ID = "urn:decentraland:off-chain:base-avatars";
 
         private static Collection[] collections;


### PR DESCRIPTION
## What does this PR change?
Use a load balanced catalyst. It picks a catalyst based on health rules and regional distance.

In every hardcoded case tho, it should use the content-server provided by the Kernel.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:{branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
