### PR TITLE
Fix: pools instantiating additional objects when renderer was turned off

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
@@ -39,6 +39,7 @@ namespace DCL
         private readonly LinkedList<PoolableObject> usedObjects = new LinkedList<PoolableObject>();
 
         private int maxPrewarmCount = 0;
+        private bool isInitialized;
 
         public float lastGetTime { get; private set; }
 
@@ -73,8 +74,9 @@ namespace DCL
         public PoolableObject Get()
         {
             // These extra instantiations during initialization are to populate pools that will be used a lot later  
-            if (PoolManager.i.initializing)
+            if (PoolManager.i.initializing && !isInitialized)
             {
+                isInitialized = true;
                 int count = usedObjectsCount;
 
                 for (int i = unusedObjectsCount; i < Mathf.Min(count * PREWARM_ACTIVE_MULTIPLIER, maxPrewarmCount); i++)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Tests/PoolManagerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Tests/PoolManagerTests.cs
@@ -107,5 +107,23 @@ namespace Tests
 
             Assert.IsFalse(PoolManager.i.ContainsPool(id), "Pool shouldn't exist after disposal");
         }
+
+        [Test]
+        public void PoolIsNotBeingInitializedAgainAfterRendererWasToggled()
+        {
+            PooledObjectInstantiator instantiator = new PooledObjectInstantiator();
+            GameObject original = new GameObject("Original");
+
+            Pool pool = PoolManager.i.AddPool("totallyNewPoolID", original, instantiator);
+            Assert.IsNotNull(pool, "Pool instance shouldn't be null.");
+
+            // When teleporting this is false
+            CommonScriptableObjects.rendererState.Set(false);
+            
+            pool.Get().Release();
+            pool.Get().Release();
+            
+            UnityEngine.Assertions.Assert.AreEqual(1, pool.unusedObjectsCount, "Unused objects pool");
+        }
     }
 }


### PR DESCRIPTION
Fixes #876 
When teleporting, the renderer is being turned off and every pool instantiates new objects instead of using the unused ones.

I'm not sure if this is the best fix for this issue