### PR TITLE
chore: avatar lod impostor snapshots V2

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -15,9 +15,9 @@ namespace DCL
             COUNT
         }
 
-        private readonly int LOD_TEXTURE_SHADER_VAR = Shader.PropertyToID("_BaseMap");
         private static Camera snapshotCamera;
 
+        private readonly int LOD_TEXTURE_SHADER_VAR = Shader.PropertyToID("_BaseMap");
         private readonly RenderTexture[] snapshotRenderTextures = new RenderTexture[(int)SnapshotDirections.COUNT];
 
         private Transform avatarTransform;
@@ -26,9 +26,6 @@ namespace DCL
         private List<Renderer> avatarRenderers;
         private Animation avatarAnimation;
         private SnapshotDirections currentCharacterRelativeDirection = SnapshotDirections.North;
-
-        public delegate void LODToggleEventDelegate(bool newValue);
-        public event LODToggleEventDelegate OnLODToggle;
 
         public AvatarLODController()
         {
@@ -57,6 +54,8 @@ namespace DCL
             this.avatarAnimation = avatarAnimation;
 
             InitializeSnapshots();
+
+            impostorMeshRenderer.material.SetTexture(LOD_TEXTURE_SHADER_VAR, snapshotRenderTextures[(int)currentCharacterRelativeDirection]);
         }
 
         // TODO: We should trigger this initialization again if a wearable is changed on the avatar

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -102,11 +102,13 @@ namespace DCL
 
         private void UpdateAvatarMeshes(int layer, bool enabledState)
         {
+            // TODO: We are ignoring the hidden-wearables list here
             int count = avatarRenderers.Count;
             for (var i = 0; i < count; i++)
             {
                 avatarRenderers[i].gameObject.layer = layer;
                 avatarRenderers[i].enabled = enabledState;
+                // avatarRenderers[i].forceRenderingOff = !enabledState; // shouldn't collide with CullintController as its in an ignored layer
             }
 
             avatarAnimation.enabled = enabledState;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -66,29 +66,29 @@ namespace DCL
 
             // Take N snapshot
             snapshotCamera.targetTexture = snapshotRenderTextures[(int)SnapshotDirections.North];
-            snapshotCamera.transform.position = impostorMeshRenderer.transform.position + Vector3.forward * 2;
-            snapshotCamera.transform.forward = impostorMeshRenderer.transform.position - snapshotCamera.transform.position;
+            snapshotCamera.transform.position = impostorMeshRenderer.transform.position + impostorMeshRenderer.transform.parent.forward * 2;
+            snapshotCamera.transform.forward = -impostorMeshRenderer.transform.parent.forward;
             snapshotCamera.Render();
             RenderTexture.active = snapshotCamera.targetTexture;
 
             // Take E snapshot
             snapshotCamera.targetTexture = snapshotRenderTextures[(int)SnapshotDirections.East];
-            snapshotCamera.transform.position = impostorMeshRenderer.transform.position + Vector3.right * 2;
-            snapshotCamera.transform.forward = impostorMeshRenderer.transform.position - snapshotCamera.transform.position;
+            snapshotCamera.transform.position = impostorMeshRenderer.transform.position + impostorMeshRenderer.transform.parent.right * 2;
+            snapshotCamera.transform.forward = -impostorMeshRenderer.transform.parent.right;
             snapshotCamera.Render();
             RenderTexture.active = snapshotCamera.targetTexture;
 
             // Take S snapshot
             snapshotCamera.targetTexture = snapshotRenderTextures[(int)SnapshotDirections.South];
-            snapshotCamera.transform.position = impostorMeshRenderer.transform.position + Vector3.back * 2;
-            snapshotCamera.transform.forward = impostorMeshRenderer.transform.position - snapshotCamera.transform.position;
+            snapshotCamera.transform.position = impostorMeshRenderer.transform.position - impostorMeshRenderer.transform.parent.forward * 2;
+            snapshotCamera.transform.forward = impostorMeshRenderer.transform.parent.forward;
             snapshotCamera.Render();
             RenderTexture.active = snapshotCamera.targetTexture;
 
             // Take W snapshot
             snapshotCamera.targetTexture = snapshotRenderTextures[(int)SnapshotDirections.West];
-            snapshotCamera.transform.position = impostorMeshRenderer.transform.position + Vector3.left * 2;
-            snapshotCamera.transform.forward = impostorMeshRenderer.transform.position - snapshotCamera.transform.position;
+            snapshotCamera.transform.position = impostorMeshRenderer.transform.position - impostorMeshRenderer.transform.parent.right * 2;
+            snapshotCamera.transform.forward = impostorMeshRenderer.transform.parent.right;
             snapshotCamera.Render();
             RenderTexture.active = snapshotCamera.targetTexture;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -138,7 +138,7 @@ namespace DCL
 
         private SnapshotDirections GetCharacterRelativeDirection(Vector3 mainCharacterPosition)
         {
-            Vector3 from = Vector3.forward;
+            Vector3 from = impostorMeshRenderer.transform.parent.forward;
             Vector3 to = (mainCharacterPosition - impostorMeshRenderer.transform.position).normalized;
             to.y = 0;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarsLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarsLODController.cs
@@ -5,8 +5,6 @@ namespace DCL
 {
     public class AvatarsLODController : IAvatarsLODController
     {
-        private const float SNAPSHOTS_FREQUENCY_IN_SECONDS = 2f;
-
         private List<AvatarLODController> avatarsList = new List<AvatarLODController>();
 
         public AvatarsLODController()
@@ -90,10 +88,7 @@ namespace DCL
 
                 if (isInLODDistance)
                 {
-                    // If distance is farther than 2 LODDistance, we decrease its snapshots frequency
-                    int distanceFrequencyMultiplier = distanceToPlayer < LODDistance * 2 ? 1 : 3;
-
-                    ToggleAvatarLOD(avatar, true, SNAPSHOTS_FREQUENCY_IN_SECONDS * distanceFrequencyMultiplier);
+                    ToggleAvatarLOD(avatar, true);
                 }
                 else
                 {
@@ -116,12 +111,10 @@ namespace DCL
             }
         }
 
-        private void ToggleAvatarLOD(AvatarLODController avatar, bool LODEnabled, float snapshotFrequency = SNAPSHOTS_FREQUENCY_IN_SECONDS)
+        private void ToggleAvatarLOD(AvatarLODController avatar, bool LODEnabled)
         {
-            bool shouldUpdateSnapshot = (Time.timeSinceLevelLoad - avatar.lastSnapshotsUpdateTime) >= SNAPSHOTS_FREQUENCY_IN_SECONDS;
-
-            if (LODEnabled && shouldUpdateSnapshot)
-                avatar.UpdateImpostorSnapshot();
+            if (LODEnabled)
+                avatar.UpdateImpostorSnapshot(DCLCharacterController.i.characterPosition.unityPosition);
 
             avatar.ToggleLOD(LODEnabled);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
@@ -144,12 +144,34 @@ namespace DCL
             currentPosition += delta;
         }
 
+        private const float LERP_UPDATE_SECONDS = 1.5f;
+        private float lastLerpTime = -1;
         void Update()
         {
             if (avatarTransformValue == null)
                 return;
 
-            UpdateLerp(Time.deltaTime);
+            float lerpDelta = Time.deltaTime;
+
+            float distanceToPlayer = Vector3.Distance(CommonScriptableObjects.playerUnityPosition.Get(), avatarTransform.position);
+            float LODDistance = DataStore.i.avatarsLOD.LODDistance.Get();
+            bool isInLODDistance = distanceToPlayer >= LODDistance;
+            if (isInLODDistance)
+            {
+                float timeDelta = Time.timeSinceLevelLoad - lastLerpTime;
+                if (timeDelta >= LERP_UPDATE_SECONDS )
+                {
+                    lastLerpTime = Time.timeSinceLevelLoad;
+                    lerpDelta = timeDelta;
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            // UpdateLerp(Time.deltaTime);
+            UpdateLerp(lerpDelta);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
@@ -47,7 +47,7 @@ namespace DCL.Components
         {
             DCLTransform.model = model as Model;
 
-            if (entity.OnTransformChange != null)
+            if (entity.OnTransformChange != null) // AvatarShape interpolation hack
             {
                 entity.OnTransformChange.Invoke(DCLTransform.model);
             }


### PR DESCRIPTION
* take snapshots on avatar loading
* switch between those snapshots instead of taking new ones later

### Testing with bots 
1. enter https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:chore/AvatarLODImpostorSnapshotsV2&ENV=zone&position=91,151&ENABLE_AVATAR_LODS
2. open browser console
3. run `clientDebug.InstantiateBotsAtCoords(100, 91.2, 151.2, 36, 50)` to instantiate 100 bot in the stadium. It may take a little while to load as the bots collections and wearables are being randomized and loaded.

### Testing with real users
1. enter https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:chore/AvatarLODImpostorSnapshotsV2&ENV=org&position=-27,60&ENABLE_AVATAR_LODS


