### PR TITLE
fix: avatar lod transition performance

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -6,6 +6,13 @@ namespace DCL
 {
     public class AvatarLODController : IDisposable
     {
+        private enum LODState
+        {
+            LOD0,
+            LOD1,
+            LOD2
+        }
+
         private const float TRANSITION_DURATION = 0.25f;
         private Player player;
 
@@ -16,6 +23,7 @@ namespace DCL
 
         private bool SSAOEnabled;
         private bool facialFeaturesEnabled;
+        private LODState currentState = LODState.LOD0;
 
         private Coroutine currentTransition = null;
 
@@ -34,8 +42,10 @@ namespace DCL
 
         public void SetAvatarState()
         {
-            if (player?.renderer == null)
+            if (player?.renderer == null || currentState == LODState.LOD0)
                 return;
+
+            currentState = LODState.LOD0;
 
             SetAvatarFeatures(true, true);
             StartTransition(1, 0);
@@ -43,8 +53,10 @@ namespace DCL
 
         public void SetSimpleAvatar()
         {
-            if (player?.renderer == null)
+            if (player?.renderer == null || currentState == LODState.LOD1)
                 return;
+
+            currentState = LODState.LOD1;
 
             SetAvatarFeatures(false, false);
             StartTransition(1, 0);
@@ -52,8 +64,10 @@ namespace DCL
 
         public void SetImpostorState()
         {
-            if (player?.renderer == null)
+            if (player?.renderer == null || currentState == LODState.LOD2)
                 return;
+
+            currentState = LODState.LOD2;
 
             SetAvatarFeatures(false, false);
             StartTransition(0, 1);
@@ -61,7 +75,7 @@ namespace DCL
 
         private void StartTransition(float newTargetAvatarFade, float newTargetImpostorFade)
         {
-            if (currentTransition != null && Mathf.Approximately(targetAvatarFade, newTargetAvatarFade) && Mathf.Approximately(targetImpostorFade, newTargetImpostorFade))
+            if (Mathf.Approximately(targetAvatarFade, newTargetAvatarFade) && Mathf.Approximately(targetImpostorFade, newTargetImpostorFade))
                 return;
 
             targetAvatarFade = newTargetAvatarFade;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -42,7 +42,7 @@ namespace DCL
 
         public void SetAvatarState()
         {
-            if (player?.renderer == null || currentState == LODState.LOD0)
+            if (currentState == LODState.LOD0 || player?.renderer == null)
                 return;
 
             currentState = LODState.LOD0;
@@ -53,7 +53,7 @@ namespace DCL
 
         public void SetSimpleAvatar()
         {
-            if (player?.renderer == null || currentState == LODState.LOD1)
+            if (currentState == LODState.LOD1 || player?.renderer == null)
                 return;
 
             currentState = LODState.LOD1;
@@ -64,7 +64,7 @@ namespace DCL
 
         public void SetImpostorState()
         {
-            if (player?.renderer == null || currentState == LODState.LOD2)
+            if (currentState == LODState.LOD2 || player?.renderer == null)
                 return;
 
             currentState = LODState.LOD2;


### PR DESCRIPTION
* We are constantly telling every avatar which state they should be in
* We were already checking if the new state values correspond to the "current transition" values, the problem here is that we also checked if the coroutine was not null to escape, removing this check (and leaving the `Mathf.Approximately()` checks) **already fixes the performance issue**:
![Screen Shot 2021-08-11 at 15 53 12](https://user-images.githubusercontent.com/1031741/129088454-d175bd46-2338-432d-b3f3-1f773af037b5.png)
(`AvatarsLODController.UpdateAllLODs()` average CPU usage with 200 bots: ~1.55ms)

* However, the 2 `Mathf.Approximately()` checks have a bit of performance cost as well, even though it's not much, the `AvatarsLODController.UpdateAllLODs()` ends up consuming 50% more CPU. By introducing a "state" `enum` and using that  to escape before calling the `StartTransition()` method we can lower the `AvatarsLODController.UpdateAllLODs()` average CPU usage with 200 bots to ~1ms
![Screen Shot 2021-08-11 at 15 57 23](https://user-images.githubusercontent.com/1031741/129088809-a5919a11-b326-4761-8c75-53907f3495d8.png)

### Testing with bots 
1. enter https://play.decentraland.zone/index.html?renderer-branch=fix/AvatarLODTransitionPerformance&ENV=zone&position=91,151&ENABLE_AVATAR_LODS
2. open browser console
3. run `clientDebug.InstantiateBotsAtCoords(100, 91.2, 151.2, 36, 50)` to instantiate 100 bot in the stadium. It may take a little while to load as the bots collections and wearables are being randomized and loaded.

### Testing with real users
1. enter https://play.decentraland.zone/index.html?renderer-branch=fix/AvatarLODTransitionPerformance&ENV=org&position=-27,60&ENABLE_AVATAR_LODS