### PR TITLE
fix: use desambiguated content server

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.cs
@@ -130,7 +130,7 @@ public class Catalyst : ICatalyst
         {
             string urlParams = "";
             urlParams = pointersGroupsToFetch[i].Aggregate(urlParams, (current, pointer) => current + $"&pointer={pointer}");
-            string url = $"{realmDomain}/content/entities/{entityType}?{urlParams}";
+            string url = $"{realmContentServerUrl}/entities/{entityType}?{urlParams}";
 
             splittedPromises[i] = Get(url);
             splittedPromises[i]


### PR DESCRIPTION
## What does this PR change?
Content server is desambiguated from realm domain, _must_ use the content server URL to resolve content.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:{branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
