### PR TITLE
chore: replace old peer url

### DIFF
--- a/unity-renderer/Assets/ABConverter/Tests/ABConverterCoreShould.cs
+++ b/unity-renderer/Assets/ABConverter/Tests/ABConverterCoreShould.cs
@@ -39,7 +39,7 @@ namespace DCL.ABConverter.Tests
 
         string basePath = @"C:\test-path\";
         string hash1 = "QmHash1", hash2 = "QmHash2", hash3 = "QmHash3", hash4 = "QmHash4";
-        string baseUrl = @"https://peer.decentraland.org/lambdas/contentv2/contents/";
+        string baseUrl = @"https://peer-lb.decentraland.org/lambdas/contentv2/contents/";
         private string contentData1 = "TestContent1 - guid: 14e357df3f3b75940b5d59e1035255b1\n";
         private string contentData2 = "TestContent2 - guid: 14e357df3f3b75940b5d59e1035255b2\n";
         private string contentData3 = "TestContent3 - guid: 14e357df3f3b75940b5d59e1035255b3\n";

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/BuilderProjectsPanelController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/BuilderProjectsPanelController.cs
@@ -206,8 +206,8 @@ public class BuilderProjectsPanelController : IHUD
             tld = TESTING_TLD;
             DataStore.i.playerRealm.Set(new CurrentRealmModel()
             {
-                domain = $"https://peer.decentraland.{TESTING_TLD}",
-                contentServerUrl = $"https://peer.decentraland.{TESTING_TLD}/content",
+                domain = $"https://peer-lb.decentraland.{TESTING_TLD}",
+                contentServerUrl = $"https://peer-lb.decentraland.{TESTING_TLD}/content",
             });
         }
 #endif

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/ContentServerUtils/ContentServerUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/ContentServerUtils/ContentServerUtils.cs
@@ -73,7 +73,7 @@ namespace DCL
         public static string GetBaseUrl(ApiTLD tld)
         {
             if (tld != ApiTLD.NONE)
-                return $"https://peer.decentraland.{GetTldString(tld)}/lambdas/contentv2";
+                return $"https://peer-lb.decentraland.{GetTldString(tld)}/lambdas/contentv2";
 
             return customBaseUrl;
         }


### PR DESCRIPTION
Fixes #937 

Remove instances of old `peer.decentraland.org` link