### PR TITLE
fix: name corrected assigned

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWMainController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWMainController.cs
@@ -95,7 +95,7 @@ public class BIWMainController : PluginFeature
         if (builderInWorldBridge != null)
         {
             builderInWorldBridge.OnCatalogHeadersReceived += CatalogHeadersReceived;
-            builderInWorldBridge.OnBuilderProjectInfo -= BuilderProjectPanelInfo;
+            builderInWorldBridge.OnBuilderProjectInfo += BuilderProjectPanelInfo;
         }
 
         InitHUD();


### PR DESCRIPTION
## What does this PR change?

Fix #902   
This PR fix the problem where scenes are not getting the details of the name and description

## How to test the changes?


1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/biw-name-twice
2. Enter builder in world
3. Publish an scene with a name
4. Go to another land or unpublish the scene
5. Enter again in builder in world
6. The names should be different

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
