### PR TITLE
fix: builder and builder in world use the same metrics

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWMainController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWMainController.cs
@@ -457,6 +457,7 @@ public class BIWMainController : PluginFeature
         Environment.i.world.sceneController.OnNewSceneAdded -= NewSceneAdded;
 
         sceneToEdit = (ParcelScene)Environment.i.world.state.GetScene(sceneToEditId);
+        sceneToEdit.metricsController = new BIWSceneMetricsController(sceneToEdit);
         sceneToEdit.OnLoadingStateUpdated += UpdateSceneLoadingProgress;
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWSceneMetricsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWSceneMetricsController.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using DCL;
+using DCL.Controllers;
+using DCL.Models;
+using UnityEngine;
+
+public class BIWSceneMetricsController : SceneMetricsController
+{
+    public BIWSceneMetricsController(ParcelScene sceneOwner) : base(sceneOwner)
+    {
+        Enable();
+        isDirty = true;
+    }
+
+    protected override void OnEntityAdded(IDCLEntity e)
+    {
+        e.OnMeshesInfoUpdated += OnEntityMeshInfoUpdated;
+        e.OnMeshesInfoCleaned += OnEntityMeshInfoCleaned;
+    }
+
+    protected override void OnEntityRemoved(IDCLEntity e)
+    {
+        e.OnMeshesInfoUpdated -= OnEntityMeshInfoUpdated;
+        e.OnMeshesInfoCleaned -= OnEntityMeshInfoCleaned;
+
+        if (!e.components.ContainsKey(CLASS_ID_COMPONENT.SMART_ITEM))
+        {
+            SubstractMetrics(e);
+            model.entities = entitiesMetrics.Count;
+        }
+    }
+
+    protected override void OnEntityMeshInfoUpdated(IDCLEntity entity)
+    {
+        //builder should only check scene limits for not smart items entities
+        if (!entity.components.ContainsKey(CLASS_ID_COMPONENT.SMART_ITEM))
+        {
+            AddOrReplaceMetrics(entity);
+            model.entities = entitiesMetrics.Count;
+        }
+        else
+        {
+            SubstractMetrics(entity);
+            model.entities = entitiesMetrics.Count;
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWSceneMetricsController.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWSceneMetricsController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80a312f31d4858a4cac170f31b5c1cb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?

This PR Fixes: #750 

We this change builder and builder in world uses the same criteria for the scene limits

## How to test the changes?

1. Go to https://builder.decentraland.io/ and create a scene with smart items, then publish that scene
2. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/biw-scene-limit
2. Enter in the scene that you has been from builder
3. Check that both builders have the same criteria with the scene limits

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
