### PR TITLE
feat: enable avatar merge cull optimization heuristic

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/CombineLayerUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/CombineLayerUtils.cs
@@ -13,7 +13,7 @@ namespace DCL
         // This heuristic forces double-sided opaque objects to have backface culling.
         // As many wearables are incorrectly modeled as double-sided, this greatly increases
         // the cases of avatars rendered with one draw call. Temporarily disabled until some wearables are fixed.
-        private static bool ENABLE_CULL_OPAQUE_HEURISTIC = false;
+        private static bool ENABLE_CULL_OPAQUE_HEURISTIC = true;
 
         private static bool VERBOSE = false;
         private const int MAX_TEXTURE_ID_COUNT = 12;


### PR DESCRIPTION
## What does this PR change?
This PR forces all the opaque wearables that use double-sided materials to use back-face instead. This greatly enhances the performance of avatar rendering given by the avatar mesh merging system. 

The performance improvement works because using back-face on all opaques will reduce the need to create new materials for render state change. So, avatars with far less submeshes will be produced, in most cases only taking a single submesh (and this means a single draw call/no gl pipeline flush).

## How to test the changes?
Wearables that use double-sided opaques should be tested. A clear example are the wearables of the `urn:decentraland:ethereum:collections-v1:tech_tribal_marc0matic` collection.

Those wearables are currently in process of being fixed. When the wearables are fixed, then this PR could be merged.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
