### PR TITLE
fix: prod rollout percentage

### DIFF
--- a/.github/workflows/set-rollout.yml
+++ b/.github/workflows/set-rollout.yml
@@ -59,4 +59,4 @@ jobs:
           # Rollout information
           deploymentDomain: "play.decentraland.org"
           deploymentName: "@dcl/unity-renderer"
-          percentage: 10
+          percentage: 50


### PR DESCRIPTION
## What does this PR change?

10% has proven to generate too much signal-noise ratio. Increasing to 50% to reduce falloff to prevent older versions to be selected in rollouts.

![Screen Shot 2021-08-17 at 19 28 48](https://user-images.githubusercontent.com/260114/129808983-4fdfac43-a719-4a3c-9358-bcd21daafb98.png)


## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:{branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
