### PR TITLE
fix: biw analytics improvements

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Analytics/BIWAnalytics.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Analytics/BIWAnalytics.cs
@@ -104,10 +104,12 @@ public static class BIWAnalytics
         SendEditorEvent("end_scene_publish", events);
     }
 
-    public static void SceneLimitsOverPassed(SceneMetricsModel sceneLimits)
+    public static void SceneLimitsOverPassed(SceneMetricsModel sceneUsage, SceneMetricsModel sceneLimits)
     {
         Dictionary<string, string> events = new Dictionary<string, string>();
+        events.Add("limits_passed", GetLimitsPassedArray(sceneUsage, sceneLimits));
         events.Add("scene_limits", JsonConvert.SerializeObject(ConvertSceneMetricsModelToDictionary(sceneLimits)));
+        events.Add("current_usage", JsonConvert.SerializeObject(ConvertSceneMetricsModelToDictionary(sceneUsage)));
         SendEditorEvent("scene_limits_over_passed", events);
     }
 
@@ -207,6 +209,28 @@ public static class BIWAnalytics
         sceneLimitsDictionary.Add("scene_height", sceneLimits.sceneHeight.ToString());
 
         return sceneLimitsDictionary;
+    }
+
+    private static string GetLimitsPassedArray(SceneMetricsModel sceneUsage, SceneMetricsModel sceneLimits)
+    {
+        string limitsPassed = "[";
+
+        if (sceneUsage.bodies >= sceneLimits.bodies)
+            limitsPassed += "bodies,";
+        if (sceneUsage.entities >= sceneLimits.entities)
+            limitsPassed += "entities,";
+        if (sceneUsage.textures >= sceneLimits.textures)
+            limitsPassed += "textures,";
+        if (sceneUsage.triangles >= sceneLimits.triangles)
+            limitsPassed += "triangles,";
+        if (sceneUsage.materials >= sceneLimits.materials)
+            limitsPassed += "materials,";
+        if (sceneUsage.meshes >= sceneLimits.meshes)
+            limitsPassed += "meshes,";
+
+        limitsPassed = limitsPassed.Substring(0, limitsPassed.Length - 1);
+        limitsPassed += "]";
+        return limitsPassed;
     }
 
     #endregion

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Analytics/BIWAnalytics.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Analytics/BIWAnalytics.cs
@@ -104,13 +104,13 @@ public static class BIWAnalytics
         SendEditorEvent("end_scene_publish", events);
     }
 
-    public static void SceneLimitsOverPassed(SceneMetricsModel sceneUsage, SceneMetricsModel sceneLimits)
+    public static void SceneLimitsExceeded(SceneMetricsModel sceneUsage, SceneMetricsModel sceneLimits)
     {
         Dictionary<string, string> events = new Dictionary<string, string>();
         events.Add("limits_passed", GetLimitsPassedArray(sceneUsage, sceneLimits));
         events.Add("scene_limits", JsonConvert.SerializeObject(ConvertSceneMetricsModelToDictionary(sceneLimits)));
         events.Add("current_usage", JsonConvert.SerializeObject(ConvertSceneMetricsModelToDictionary(sceneUsage)));
-        SendEditorEvent("scene_limits_over_passed", events);
+        SendEditorEvent("scene_limits_exceeded", events);
     }
 
     /// <summary>
@@ -211,7 +211,7 @@ public static class BIWAnalytics
         return sceneLimitsDictionary;
     }
 
-    private static string GetLimitsPassedArray(SceneMetricsModel sceneUsage, SceneMetricsModel sceneLimits)
+    public static string GetLimitsPassedArray(SceneMetricsModel sceneUsage, SceneMetricsModel sceneLimits)
     {
         string limitsPassed = "[";
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWSceneMetricsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWSceneMetricsController.cs
@@ -7,6 +7,8 @@ using UnityEngine;
 
 public class BIWSceneMetricsController : SceneMetricsController
 {
+    private string currentOverpassLimitTypes = "";
+
     public BIWSceneMetricsController(ParcelScene sceneOwner) : base(sceneOwner)
     {
         Enable();
@@ -29,6 +31,7 @@ public class BIWSceneMetricsController : SceneMetricsController
             SubstractMetrics(e);
             model.entities = entitiesMetrics.Count;
         }
+        CheckSceneLimitOverPassedAnalaytics();
     }
 
     protected override void OnEntityMeshInfoUpdated(IDCLEntity entity)
@@ -43,6 +46,25 @@ public class BIWSceneMetricsController : SceneMetricsController
         {
             SubstractMetrics(entity);
             model.entities = entitiesMetrics.Count;
+        }
+        CheckSceneLimitOverPassedAnalaytics();
+    }
+
+    private void CheckSceneLimitOverPassedAnalaytics()
+    {
+        if (!IsInsideTheLimits())
+        {
+            string overpassLimit = BIWAnalytics.GetLimitsPassedArray(scene.metricsController.GetModel(), scene.metricsController.GetLimits());
+            if (overpassLimit != currentOverpassLimitTypes)
+            {
+                BIWAnalytics.SceneLimitsExceeded(scene.metricsController.GetModel(), scene.metricsController.GetLimits());
+                currentOverpassLimitTypes = overpassLimit;
+                Debug.Log("Send overpass limit" + currentOverpassLimitTypes);
+            }
+        }
+        else
+        {
+            currentOverpassLimitTypes = "";
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWSceneMetricsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BIWSceneMetricsController.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 public class BIWSceneMetricsController : SceneMetricsController
 {
-    private string currentOverpassLimitTypes = "";
+    private string currentExceededLimitTypes = "";
 
     public BIWSceneMetricsController(ParcelScene sceneOwner) : base(sceneOwner)
     {
@@ -31,7 +31,7 @@ public class BIWSceneMetricsController : SceneMetricsController
             SubstractMetrics(e);
             model.entities = entitiesMetrics.Count;
         }
-        CheckSceneLimitOverPassedAnalaytics();
+        CheckSceneLimitExceededAnalaytics();
     }
 
     protected override void OnEntityMeshInfoUpdated(IDCLEntity entity)
@@ -47,24 +47,23 @@ public class BIWSceneMetricsController : SceneMetricsController
             SubstractMetrics(entity);
             model.entities = entitiesMetrics.Count;
         }
-        CheckSceneLimitOverPassedAnalaytics();
+        CheckSceneLimitExceededAnalaytics();
     }
 
-    private void CheckSceneLimitOverPassedAnalaytics()
+    private void CheckSceneLimitExceededAnalaytics()
     {
         if (!IsInsideTheLimits())
         {
-            string overpassLimit = BIWAnalytics.GetLimitsPassedArray(scene.metricsController.GetModel(), scene.metricsController.GetLimits());
-            if (overpassLimit != currentOverpassLimitTypes)
+            string exceededLimits = BIWAnalytics.GetLimitsPassedArray(scene.metricsController.GetModel(), scene.metricsController.GetLimits());
+            if (exceededLimits != currentExceededLimitTypes)
             {
                 BIWAnalytics.SceneLimitsExceeded(scene.metricsController.GetModel(), scene.metricsController.GetLimits());
-                currentOverpassLimitTypes = overpassLimit;
-                Debug.Log("Send overpass limit" + currentOverpassLimitTypes);
+                currentExceededLimitTypes = exceededLimits;
             }
         }
         else
         {
-            currentOverpassLimitTypes = "";
+            currentExceededLimitTypes = "";
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWPublishController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWPublishController.cs
@@ -104,7 +104,7 @@ public class BIWPublishController : BIWController, IBIWPublishController
             feedbackMessage = FEEDBACK_MESSAGE_TOO_MANY_ENTITIES;
             if (reportSceneLimitsOverpassedAnalytic)
             {
-                BIWAnalytics.SceneLimitsOverPassed(sceneToEdit.metricsController.GetModel());
+                BIWAnalytics.SceneLimitsOverPassed(sceneToEdit.metricsController.GetModel(), sceneToEdit.metricsController.GetLimits());
                 reportSceneLimitsOverpassedAnalytic = false;
             }
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWPublishController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWPublishController.cs
@@ -17,7 +17,6 @@ public class BIWPublishController : BIWController, IBIWPublishController
     private const string FEEDBACK_MESSAGE_OUTSIDE_BOUNDARIES = "Some entities are outside of the Scene boundaries.";
     private const string FEEDBACK_MESSAGE_TOO_MANY_ENTITIES = "Too many entities in the scene. Check scene limits.";
 
-    private bool reportSceneLimitsOverpassedAnalytic = true;
     private float startPublishingTimestamp = 0;
 
     public override void Init(BIWContext context)
@@ -77,7 +76,6 @@ public class BIWPublishController : BIWController, IBIWPublishController
         if (!entityHandler.AreAllEntitiesInsideBoundaries())
             return false;
 
-        reportSceneLimitsOverpassedAnalytic = true;
         return true;
     }
 
@@ -102,11 +100,6 @@ public class BIWPublishController : BIWController, IBIWPublishController
         else if (!sceneToEdit.metricsController.IsInsideTheLimits())
         {
             feedbackMessage = FEEDBACK_MESSAGE_TOO_MANY_ENTITIES;
-            if (reportSceneLimitsOverpassedAnalytic)
-            {
-                BIWAnalytics.SceneLimitsOverPassed(sceneToEdit.metricsController.GetModel(), sceneToEdit.metricsController.GetLimits());
-                reportSceneLimitsOverpassedAnalytic = false;
-            }
         }
 
         HUDController.i.builderInWorldMainHud?.SetPublishBtnAvailability(CanPublish(), feedbackMessage);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Tests/BIWCommonShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Tests/BIWCommonShould.cs
@@ -10,11 +10,14 @@ using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using DCL.Controllers;
 using UnityEngine;
 using UnityEngine.TestTools;
 
 public class BIWCommonShould : IntegrationTestSuite_Legacy
 {
+    private GameObject mockedGameObject;
+
     [Test]
     public void SettingsCorrectLayers()
     {
@@ -96,8 +99,84 @@ public class BIWCommonShould : IntegrationTestSuite_Legacy
         Assert.AreEqual(biwEntity.isLocked, isLocked);
     }
 
+    [Test]
+    public void GetCorrectSceneSize()
+    {
+        mockedGameObject = new GameObject("SceneSize");
+
+        //Arrange
+        var firstScene = CreateParcelSceneForSizeTest(new []
+        {
+            new Vector2Int(140, 140)
+        });
+
+        var secondScene = CreateParcelSceneForSizeTest(new []
+        {
+            new Vector2Int(140, 140),
+            new Vector2Int(140, 141)
+        });
+
+        var thirdScene = CreateParcelSceneForSizeTest(new []
+        {
+            new Vector2Int(140, 140),
+            new Vector2Int(141, 140)
+        });
+
+        var fourScene = CreateParcelSceneForSizeTest(new []
+        {
+            new Vector2Int(140, 140),
+            new Vector2Int(141, 140),
+            new Vector2Int(141, 141)
+
+        });
+
+        var fiveScene = CreateParcelSceneForSizeTest(new []
+        {
+            new Vector2Int(140, 140),
+            new Vector2Int(139, 140),
+            new Vector2Int(138, 140)
+
+        });
+
+        var sixScene = CreateParcelSceneForSizeTest(new []
+        {
+            new Vector2Int(140, 140),
+            new Vector2Int(140, 139),
+            new Vector2Int(140, 138)
+
+        });
+
+        //Act
+        var firstResult = BIWUtils.GetSceneSize(firstScene);
+        var secondResult = BIWUtils.GetSceneSize(secondScene);
+        var thirdResult = BIWUtils.GetSceneSize(thirdScene);
+        var fourResult = BIWUtils.GetSceneSize(fourScene);
+        var fiveResult = BIWUtils.GetSceneSize(fiveScene);
+        var sixResult = BIWUtils.GetSceneSize(sixScene);
+
+        //Assert
+        Assert.AreEqual(firstResult, new Vector2Int(1, 1));
+        Assert.AreEqual(secondResult, new Vector2Int(1, 2));
+        Assert.AreEqual(thirdResult, new Vector2Int(2, 1));
+        Assert.AreEqual(fourResult, new Vector2Int(2, 2));
+        Assert.AreEqual(fiveResult, new Vector2Int(3, 1));
+        Assert.AreEqual(sixResult, new Vector2Int(1, 3));
+
+    }
+
+    private ParcelScene CreateParcelSceneForSizeTest(Vector2Int[] parcels)
+    {
+        ParcelScene scene = mockedGameObject.AddComponent<ParcelScene>();
+        var data = new LoadParcelScenesMessage.UnityParcelScene();
+        data.parcels = parcels;
+        scene.SetData(data);
+        return scene;
+    }
+
     protected override IEnumerator TearDown()
     {
+        if (mockedGameObject != null)
+            GameObject.Destroy(mockedGameObject);
         AssetCatalogBridge.i.ClearCatalog();
         BIWCatalogManager.ClearCatalog();
         yield return base.TearDown();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Utils/BIWUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Utils/BIWUtils.cs
@@ -63,22 +63,27 @@ public static partial class BIWUtils
 
     public static Vector2Int GetSceneSize(ParcelScene parcelScene)
     {
-        Vector2Int size = new Vector2Int(0, 0);
-        int lastXCoordinate = 0;
-        int lastYCoordinate = 0;
+        int minX = Int32.MaxValue;
+        int maxX = Int32.MinValue;
+        int minY = Int32.MaxValue;
+        int maxY = Int32.MinValue;
 
         foreach (var parcel in parcelScene.sceneData.parcels)
         {
-            if (parcel.x == lastXCoordinate)
-                size.y++;
-            else
-                size.x++;
+            if (parcel.x > maxX)
+                maxX = parcel.x;
+            if (parcel.x < minX)
+                minX = parcel.x;
 
-            lastXCoordinate = parcel.x;
-            lastYCoordinate = parcel.y;
+            if (parcel.y > maxY)
+                maxY = parcel.y;
+            if (parcel.y < minY)
+                minY = parcel.y;
         }
 
-        return size;
+        int sizeX = maxX - minX + 1;
+        int sizeY = maxY - minY + 1;
+        return new Vector2Int(sizeX, sizeY);
     }
 
     public static Vector3 CalculateUnityMiddlePoint(IParcelScene parcelScene)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/BuilderProjectsPanelController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuilderProjectsPanel/Scripts/BuilderProjectsPanelController.cs
@@ -133,7 +133,10 @@ public class BuilderProjectsPanelController : IHUD
 
         if (isVisible)
         {
-            sendPlayerOpenPanelEvent = true;
+            if (DataStore.i.builderInWorld.landsWithAccess != null)
+                PanelOpenEvent(DataStore.i.builderInWorld.landsWithAccess.Get());
+            else
+                sendPlayerOpenPanelEvent = true;
 
             FetchLandsAndScenes();
             StartFetchInterval();
@@ -229,7 +232,8 @@ public class BuilderProjectsPanelController : IHUD
                                       .Aggregate((i, j) => i.Concat(j))
                                       .ToArray();
 
-                    PanelOpenEvent(lands);
+                    if (sendPlayerOpenPanelEvent)
+                        PanelOpenEvent(lands);
                     landsController.SetLands(lands);
                     scenesViewController.SetScenes(scenes);
                 }


### PR DESCRIPTION
## What does this PR change?

Fix #919

This PR fix some biw analytics that werent' send correctly and improve the scene limits event

Analytics fixed: 
-"Player Open Builder in world Panel" now the event is sent correctly
-Scene size value of all events is now correct

## How to test the changes?

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:fix/biw-analytics
2. Open de builder in world panel
3. Check in the network tab that the scene is send correctly
4. Enter builder in world
5. Check that the scene size is sent correctly
6. Overpass the scene limits
7. Check that the the event now includes the scene limit and an array with the limit overpass

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
