### PR TITLE
chore: enable project settings that improve unity editor performance

### DIFF
--- a/unity-renderer/Assets/Scenes/InitialScene.unity
+++ b/unity-renderer/Assets/Scenes/InitialScene.unity
@@ -1110,6 +1110,7 @@ MonoBehaviour:
   baseUrlMode: 1
   baseUrlCustom: https://play.decentraland.zone/?
   environment: 4
+  realm: fenrir-amber
   startInCoords: {x: 0, y: 0}
   forceLocalComms: 0
   allWearables: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
@@ -124,8 +124,12 @@ namespace DCL
 
         public string baseUrlCustom;
 
+
         [Space(10)]
         public Environment environment;
+
+        [Tooltip("Set this field to force the realm (server). On the latin-american zone, recommended realms are fenrir-amber, baldr-amber and thor. Other realms can give problems to debug from Unity editor due to request certificate issues.\n\nFor auto selection leave this field blank.\n\nCheck out all the realms at https://catalyst-monitor.vercel.app/?includeDevServers")]
+        public string realm;
 
         public Vector2 startInCoords = new Vector2(-99, 109);
 
@@ -214,6 +218,11 @@ namespace DCL
                 if (builderInWorld)
                 {
                     debugString += "ENABLE_BUILDER_IN_WORLD&";
+                }
+
+                if ( !string.IsNullOrEmpty(realm))
+                {
+                    debugString += $"realm={realm}&";
                 }
 
                 string debugPanelString = "";

--- a/unity-renderer/ProjectSettings/EditorSettings.asset
+++ b/unity-renderer/ProjectSettings/EditorSettings.asset
@@ -3,8 +3,7 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
-  m_ExternalVersionControlSupport: Visible Meta Files
+  serializedVersion: 11
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 1
   m_DefaultBehaviorMode: 0
@@ -18,18 +17,24 @@ EditorSettings:
   m_EtcTextureBestCompressor: 4
   m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef;asmref
   m_ProjectGenerationRootNamespace: 
-  m_CollabEditorSettings:
-    inProgressEnabled: 1
   m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
   m_AsyncShaderCompilation: 1
-  m_EnterPlayModeOptionsEnabled: 0
-  m_EnterPlayModeOptions: 3
-  m_ShowLightmapResolutionOverlay: 1
+  m_CachingShaderPreprocessor: 1
+  m_PrefabModeAllowAutoSave: 1
+  m_EnterPlayModeOptionsEnabled: 1
+  m_EnterPlayModeOptions: 0
+  m_GameObjectNamingDigits: 1
+  m_GameObjectNamingScheme: 0
+  m_AssetNamingUsesSpace: 1
   m_UseLegacyProbeSampleCount: 1
+  m_SerializeInlineMappingsOnOneLine: 0
+  m_DisableCookiesInLightmapper: 1
   m_AssetPipelineMode: 1
   m_CacheServerMode: 0
   m_CacheServerEndpoint: 
   m_CacheServerNamespacePrefix: default
   m_CacheServerEnableDownload: 1
   m_CacheServerEnableUpload: 1
+  m_CacheServerEnableAuth: 0
+  m_CacheServerEnableTls: 0


### PR DESCRIPTION
## What does this PR change?

This PR changes two things:

### It enables the "Enter Play Mode Options" checkbox

This improves the editor performance by 1000%, at least in my case.

NOTE: Be aware that this setting can expose some null reference exceptions that are related to using the null-coalescing operator on unity objects.

![image](https://user-images.githubusercontent.com/6875814/129982442-95bef1de-fafc-4fef-9c77-4fc39ba169a3.png)


### It adds realm selection to `WSSController` to make debugging life easier
The `fenrir-amber` option is set by default as its acknowledged as stable by the contributors.

## How to test the changes?
You have to test the branch in editor mode to test them and try to go to play mode. 

Note that without the `Enter Play Mode Options` play mode may be delayed even by one full minute in some cases. 

With this option enabled, enter play mode only takes a few seconds and the client runs a lot smoother.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
