### PR TITLE
fix: world sfx volume sliders

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
@@ -35,6 +35,7 @@ namespace DCL.Components
             audioSource = gameObject.GetOrCreateComponent<AudioSource>();
             model = new Model();
 
+            Settings.i.OnAudioSettingsChanged += OnAudioSettingsChanged;
             DataStore.i.virtualAudioMixer.sceneSFXVolume.OnChange += OnVirtualAudioMixerChangedValue;
         }
 
@@ -114,7 +115,13 @@ namespace DCL.Components
             }
         }
 
-        private void OnVirtualAudioMixerChangedValue(float currentValue, float previousValue) {
+        private void OnAudioSettingsChanged(SettingsData.AudioSettings settings)
+        {
+            UpdateAudioSourceVolume();
+        }
+
+        private void OnVirtualAudioMixerChangedValue(float currentValue, float previousValue)
+        {
             UpdateAudioSourceVolume();
         }
 
@@ -160,6 +167,7 @@ namespace DCL.Components
             //NOTE(Brian): Unsuscribe events.
             InitDCLAudioClip(null);
 
+            Settings.i.OnAudioSettingsChanged -= OnAudioSettingsChanged;
             DataStore.i.virtualAudioMixer.sceneSFXVolume.OnChange -= OnVirtualAudioMixerChangedValue;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/SceneSFXVolumeControlConfiguration.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/SceneSFXVolumeControlConfiguration.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 060c1aa63ccfe124aa3cd640f9286a0b, type: 3}
   m_Name: SceneSFXVolumeControlConfiguration
   m_EditorClassIdentifier: 
-  title: SCENE SFX
+  title: WORLD SFX
   controlPrefab: {fileID: 3572563192424337713, guid: 9c69fdd3db1d73140bfff48c5a2f72dd,
     type: 3}
   controlController: {fileID: 11400000, guid: c3c02538f9379304d90d5e2e48b3bb5b, type: 2}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Settings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Settings.cs
@@ -300,7 +300,7 @@ namespace DCL.SettingsData
         public float voiceChatVolume;
         public float avatarSFXVolume;
         public float uiSFXVolume;
-        public float sceneSFXVolume;
+        public float sceneSFXVolume; // Note(Mordi): Also known as "World SFX"
         public float musicVolume;
         public bool chatSFXEnabled;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -218,14 +218,8 @@ namespace DCL.Helpers
                 {
                     if (OnSuccess != null)
                     {
-                        bool supported = true;
-#if UNITY_EDITOR
-                        supported = audioType != AudioType.MPEG;
-#endif
                         AudioClip ac = null;
-
-                        if (supported)
-                            ac = DownloadHandlerAudioClip.GetContent(request);
+                        ac = DownloadHandlerAudioClip.GetContent(request);
 
                         OnSuccess.Invoke(ac);
                     }


### PR DESCRIPTION
## What does this PR change?

Fixes issue #1005, where scene SFX (aka world SFX) would not adhere to the "Master" or "World SFX" sliders.
I also included a fix for scene SFX not playing while testing in the editor, since this was needed for testing.
Additionally, I changed the "Scene SFX" slider title into "World SFX", as requested by Alvaro.

## How to test the changes?

1. Go to the playtest link: https://play.decentraland.zone/?renderer-branch=fix/world-sfx-volume-sliders
2. In the Genesis Plaza, listen to the waterfall and the birds.
3. Open settings and notice that the "World SFX" and the "Master" sliders are affecting the aforementioned sounds.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
