### PR TITLE
chore: add date and commit hash to npm package version

### DIFF
--- a/browser-interface/scripts/build.ts
+++ b/browser-interface/scripts/build.ts
@@ -122,7 +122,7 @@ async function createPackageJson() {
     .replace(/([^\dT])/g, "")
     .replace("T", "")
 
-  const commitHash = git.short(__dirname)
+  const shortCommitHash = (process.env.CIRCLE_SHA1 as string).substring(0, 7)
 
   writeFileSync(
     path.resolve(DIST_PATH, "package.json"),
@@ -131,7 +131,7 @@ async function createPackageJson() {
         name: "@dcl/unity-renderer",
         main: "index.js",
         typings: "index.d.ts",
-        version: `1.0.${process.env.CIRCLE_BUILD_NUM || "0-development"}-${time}.commit-${commitHash}`,
+        version: `1.0.${process.env.CIRCLE_BUILD_NUM || "0-development"}-${time}.commit-${shortCommitHash}`,
         tag: process.env.CIRCLE_TAG,
         commit: process.env.CIRCLE_SHA1,
         branch: process.env.CIRCLE_BRANCH,

--- a/browser-interface/scripts/build.ts
+++ b/browser-interface/scripts/build.ts
@@ -111,7 +111,6 @@ declare var DclRenderer: typeof Renderer
   ensureFileExists(path.resolve(DIST_PATH, typingsRoot), "index.d.ts")
 }
 
-
 async function createPackageJson() {
   console.log("> writing package.json")
 

--- a/browser-interface/scripts/build.ts
+++ b/browser-interface/scripts/build.ts
@@ -122,7 +122,7 @@ async function createPackageJson() {
     .replace(/([^\dT])/g, "")
     .replace("T", "")
 
-  const commitHash = git.short(process.env.CIRCLE_SHA1 as string)
+  const commitHash = git.short(__dirname)
 
   writeFileSync(
     path.resolve(DIST_PATH, "package.json"),

--- a/browser-interface/scripts/build.ts
+++ b/browser-interface/scripts/build.ts
@@ -9,7 +9,7 @@ import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
 import rollupJson from "@rollup/plugin-json"
 import { generatedFiles } from "../package.json"
-import git = require("git-rev-sync");
+import git from "git-rev-sync"
 
 const PROD = !!process.env.CI
 

--- a/browser-interface/scripts/build.ts
+++ b/browser-interface/scripts/build.ts
@@ -9,7 +9,6 @@ import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
 import rollupJson from "@rollup/plugin-json"
 import { generatedFiles } from "../package.json"
-import git from "git-rev-sync"
 
 const PROD = !!process.env.CI
 

--- a/browser-interface/scripts/build.ts
+++ b/browser-interface/scripts/build.ts
@@ -111,8 +111,16 @@ declare var DclRenderer: typeof Renderer
   ensureFileExists(path.resolve(DIST_PATH, typingsRoot), "index.d.ts")
 }
 
+
 async function createPackageJson() {
   console.log("> writing package.json")
+
+  const time = new Date()
+    .toISOString()
+    .replace(/(\..*$)/g, "")
+    .replace(/([^\dT])/g, "")
+    .replace("T", "")
+
   writeFileSync(
     path.resolve(DIST_PATH, "package.json"),
     JSON.stringify(
@@ -120,7 +128,7 @@ async function createPackageJson() {
         name: "@dcl/unity-renderer",
         main: "index.js",
         typings: "index.d.ts",
-        version: `1.0.${process.env.CIRCLE_BUILD_NUM || "0-development"}`,
+        version: `1.0.${process.env.CIRCLE_BUILD_NUM || "0-development"}-${time}.commit-${process.env.CIRCLE_SHA1 as string}`,
         tag: process.env.CIRCLE_TAG,
         commit: process.env.CIRCLE_SHA1,
         branch: process.env.CIRCLE_BRANCH,

--- a/browser-interface/scripts/build.ts
+++ b/browser-interface/scripts/build.ts
@@ -9,6 +9,7 @@ import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
 import rollupJson from "@rollup/plugin-json"
 import { generatedFiles } from "../package.json"
+import git = require("git-rev-sync");
 
 const PROD = !!process.env.CI
 
@@ -121,6 +122,8 @@ async function createPackageJson() {
     .replace(/([^\dT])/g, "")
     .replace("T", "")
 
+  const commitHash = git.short(process.env.CIRCLE_SHA1 as string)
+
   writeFileSync(
     path.resolve(DIST_PATH, "package.json"),
     JSON.stringify(
@@ -128,7 +131,7 @@ async function createPackageJson() {
         name: "@dcl/unity-renderer",
         main: "index.js",
         typings: "index.d.ts",
-        version: `1.0.${process.env.CIRCLE_BUILD_NUM || "0-development"}-${time}.commit-${process.env.CIRCLE_SHA1 as string}`,
+        version: `1.0.${process.env.CIRCLE_BUILD_NUM || "0-development"}-${time}.commit-${commitHash}`,
         tag: process.env.CIRCLE_TAG,
         commit: process.env.CIRCLE_SHA1,
         branch: process.env.CIRCLE_BRANCH,


### PR DESCRIPTION
## What does this PR change?

Closes #1010

Change NPM format similar to `@dcl/explorer-website` and `@dcl/kernel` to:

`{major}-{minor}-{build}-{dateYYYYMMDDhhmmss).commit-{hash}`

## How to test the changes?

Open the CircleCI pipeline, in the `publish-renderer` stage, and the `npm run publish` step.

Check if the NPM version is in the correct format.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
