### PR TITLE
fix: race conditions

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -46,7 +46,6 @@ namespace DCL
             }
 
             pluginSystem = new PluginSystem();
-            DCL.Interface.WebInterface.SendSystemInfoReport();
 
 #if !UNITY_EDITOR
             Debug.Log("DCL Unity Build Version: " + DCL.Configuration.ApplicationSettings.version);
@@ -59,6 +58,12 @@ namespace DCL
             // We should re-enable this later as produces a performance regression.
             if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
                 Environment.i.platform.cullingController.SetAnimationCulling(false);
+
+            // this event should be the last one to be executed after initialization
+            // it is used by the kernel to signal "EngineReady" or something like that
+            // to prevent race conditions like "SceneController is not an object",
+            // aka sending events before unity is ready
+            DCL.Interface.WebInterface.SendSystemInfoReport();
         }
 
         protected virtual void SetupEnvironment()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.cs
@@ -130,7 +130,7 @@ public class Catalyst : ICatalyst
         {
             string urlParams = "";
             urlParams = pointersGroupsToFetch[i].Aggregate(urlParams, (current, pointer) => current + $"&pointer={pointer}");
-            string url = $"{realmDomain}/content/entities/{entityType}?{urlParams}";
+            string url = $"{realmContentServerUrl}/entities/{entityType}?{urlParams}";
 
             splittedPromises[i] = Get(url);
             splittedPromises[i]


### PR DESCRIPTION
## What does this PR change?

The preview now loads so fast that unity doesn't finish loading itself before we start sending information about scenes to it.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:{branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
