### PR TITLE
fix: remove loading feedback message when the loading view is not visisible

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/LoadingFeedbackController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/LoadingFeedbackController.cs
@@ -95,6 +95,9 @@ public class LoadingFeedbackController : MonoBehaviour
 
     private void RefreshFeedbackMessage()
     {
+        if (!DataStore.i.HUDs.loadingHUD.visible.Get())
+            return;
+
         string loadingText = string.Empty;
         string secondLoadingText = string.Empty;
         DCL.Interface.WebInterface.LoadingFeedbackMessage messageToSend = new WebInterface.LoadingFeedbackMessage();


### PR DESCRIPTION
## What does this PR change?

Fixes #1001 

This PR removes the loading feedback message sent to kernel if the loading view is not visible

## How to test the changes?

1. Go to unity editor and download the branch
2. Debug the messages send to kernel and check that the messages are not sent anymore

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
