### PR TITLE
fix: deformed avatar when backpack interrupts "head explode" emote

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -222,6 +222,9 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler
         if (animation == null)
             return;
 
+        if (string.IsNullOrEmpty(expressionTriggerId))
+            return;
+
         var mustTriggerAnimation = !string.IsNullOrEmpty(expressionTriggerId) && blackboard.expressionTriggerTimestamp != expressionTriggerTimestamp;
 
         blackboard.expressionTriggerId = expressionTriggerId;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -61,10 +61,23 @@ namespace DCL
 
         public void ApplyModel(AvatarModel model, Action onSuccess, Action onFail)
         {
-            if (this.model != null && model != null && this.model.Equals(model))
+            if ( this.model != null )
             {
-                onSuccess?.Invoke();
-                return;
+                if (model != null && this.model.Equals(model))
+                {
+                    onSuccess?.Invoke();
+                    return;
+                }
+
+                bool wearablesChanged = !this.model.HaveSameWearablesAndColors(model);
+                bool expressionsChanged = !this.model.HaveSameExpressions(model);
+
+                if (!wearablesChanged && expressionsChanged)
+                {
+                    UpdateExpression();
+                    onSuccess?.Invoke();
+                    return;
+                }
             }
 
             this.model = new AvatarModel();
@@ -429,15 +442,7 @@ namespace DCL
             SetWearableBones();
 
             // TODO(Brian): Expression and sticker update shouldn't be part of avatar loading code!!!! Refactor me please.
-            UpdateExpressions(model.expressionTriggerId, model.expressionTriggerTimestamp);
-
-            if (lastStickerTimestamp != model.stickerTriggerTimestamp && model.stickerTriggerId != null)
-            {
-                lastStickerTimestamp = model.stickerTriggerTimestamp;
-
-                if ( stickersController != null )
-                    stickersController.PlayEmote(model.stickerTriggerId);
-            }
+            UpdateExpression();
 
             bool mergeSuccess = MergeAvatar();
 
@@ -502,7 +507,20 @@ namespace DCL
             }
         }
 
-        public void UpdateExpressions(string id, long timestamp)
+        private void UpdateExpression()
+        {
+            SetExpression(model.expressionTriggerId, model.expressionTriggerTimestamp);
+
+            if (lastStickerTimestamp != model.stickerTriggerTimestamp && model.stickerTriggerId != null)
+            {
+                lastStickerTimestamp = model.stickerTriggerTimestamp;
+
+                if ( stickersController != null )
+                    stickersController.PlayEmote(model.stickerTriggerId);
+            }
+        }
+
+        public void SetExpression(string id, long timestamp)
         {
             model.expressionTriggerId = id;
             model.expressionTriggerTimestamp = timestamp;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRendererInterface/IAvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRendererInterface/IAvatarRenderer.cs
@@ -14,7 +14,7 @@ namespace DCL
         bool isReady { get; }
         event Action<VisualCue> OnVisualCue;
         void CleanupAvatar();
-        void UpdateExpressions(string id, long timestamp);
+        void SetExpression(string id, long timestamp);
         void SetVisibility(bool newVisibility);
         void SetImpostorVisibility(bool impostorVisibility);
         void SetImpostorForward(Vector3 newForward);
@@ -23,5 +23,4 @@ namespace DCL
         void SetFacialFeaturesVisible(bool visible);
         void SetSSAOEnabled(bool enabled);
     }
-
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
@@ -108,7 +108,7 @@ public class PlayerAvatarController : MonoBehaviour
         userProfile.OnAvatarExpressionSet += OnAvatarExpression;
     }
 
-    private void OnAvatarExpression(string id, long timestamp) { avatarRenderer.UpdateExpressions(id, timestamp); }
+    private void OnAvatarExpression(string id, long timestamp) { avatarRenderer.SetExpression(id, timestamp); }
 
     private void OnUserProfileOnUpdate(UserProfile profile) { avatarRenderer.ApplyModel(profile.avatar, null, null); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
@@ -19,6 +19,25 @@ public class AvatarModel : BaseModel
     public long stickerTriggerTimestamp = -1;
     public bool talking = false;
 
+    public bool HaveSameWearablesAndColors(AvatarModel other)
+    {
+        bool wearablesAreEqual = wearables.All(other.wearables.Contains) && wearables.Count == other.wearables.Count;
+
+        return bodyShape == other.bodyShape &&
+               skinColor == other.skinColor &&
+               hairColor == other.hairColor &&
+               eyeColor == other.eyeColor &&
+               wearablesAreEqual;
+    }
+
+    public bool HaveSameExpressions(AvatarModel other)
+    {
+        return expressionTriggerId == other.expressionTriggerId &&
+               expressionTriggerTimestamp == other.expressionTriggerTimestamp &&
+               stickerTriggerTimestamp == other.stickerTriggerTimestamp;
+    }
+
+
     public bool Equals(AvatarModel other)
     {
         bool wearablesAreEqual = wearables.All(other.wearables.Contains) && wearables.Count == other.wearables.Count;


### PR DESCRIPTION
## What does this PR change?

Fixes #1009 
Also should fix #1019 

![image](https://user-images.githubusercontent.com/6875814/130259977-a77ed097-d0af-4048-912e-a68e46f5919a.png)

## How to test the changes?

* Write `/emote headexplode` in the chatbox 
* Enter the backpack before the animation ends
* When getting back from backpack, the avatar should look correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
