### PR TITLE
fix: solve a null reference edge case in quest controller

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/QuestsController/QuestsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/QuestsController/QuestsController.cs
@@ -157,10 +157,18 @@ namespace DCL.QuestsController
             {
                 QuestReward newReward = progressedQuest.rewards[index];
 
-                //Alex: Edge case. New quest reported contains a reward that was previously not contained.
-                // If it's completed, we call the RewardObtained event
-                bool oldRewardFound = oldQuest.TryGetReward(newReward.id, out QuestReward oldReward);
-                bool rewardObtained = (!oldRewardFound && newReward.status == QuestsLiterals.RewardStatus.OK) || ( newReward.status != oldReward.status && newReward.status == QuestsLiterals.RewardStatus.OK);
+                bool rewardObtained = false;
+                if (oldQuest.TryGetReward(newReward.id, out QuestReward oldReward))
+                {
+                    rewardObtained = newReward.status != oldReward.status && newReward.status == QuestsLiterals.RewardStatus.OK;
+                }
+                else
+                {
+                    //Alex: Edge case. New quest reported contains a reward that was previously not contained.
+                    // If it's completed, we call the RewardObtained event
+                    rewardObtained = newReward.status == QuestsLiterals.RewardStatus.OK;
+                }
+
                 if (rewardObtained)
                 {
                     OnRewardObtained?.Invoke(progressedQuest.id, newReward.id);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/QuestsController/Tests/QuestsControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/QuestsController/Tests/QuestsControllerShould.cs
@@ -114,6 +114,49 @@ namespace Tests.QuestsTrackerHUD
         }
 
         [Test]
+        public void UpdateQuestProgressUpdateQuest_NewReward()
+        {
+            quests.Add("0", new QuestModel
+            {
+                id = "0", status = QuestsLiterals.Status.NOT_STARTED,
+                sections = new [] { new QuestSection { id = "0_0", tasks = new [] { new QuestTask { id = "0_0_0" } } } },
+            });
+
+            QuestModel progressedQuest = new QuestModel
+            {
+                id = "0", status = QuestsLiterals.Status.NOT_STARTED,
+                sections = new [] { new QuestSection { id = "0_0", tasks = new [] { new QuestTask { id = "0_0_0" } } } },
+                rewards = new [] { new QuestReward { id = "reward0", status = QuestsLiterals.RewardStatus.NOT_GIVEN } }
+            };
+
+            bool newQuestReceived = false;
+            bool questUpdatedReceived = false;
+            bool rewardObtainedReceived = false;
+            questsController.OnNewQuest += (questId) => newQuestReceived = true;
+            questsController.OnQuestUpdated += (questId, hasProgressed) =>
+            {
+                questUpdatedReceived = true;
+            };
+            questsController.OnRewardObtained += (questId, rewardId) => rewardObtainedReceived = true;
+
+            questsController.UpdateQuestProgress(progressedQuest);
+
+            Assert.IsFalse(newQuestReceived);
+            Assert.IsTrue(questUpdatedReceived);
+            Assert.IsFalse(rewardObtainedReceived);
+
+            //Check progress flags are reverted
+            Assert.AreEqual(quests["0"].oldProgress, quests["0"].progress);
+            Assert.AreEqual(quests["0"].sections[0].tasks[0].oldProgress, quests["0"].sections[0].tasks[0].progress);
+            Assert.IsFalse(quests["0"].justProgressed);
+            Assert.IsFalse(quests["0"].sections[0].tasks[0].justProgressed);
+            Assert.IsFalse(quests["0"].sections[0].tasks[0].justUnlocked);
+            Assert.AreEqual(1, quests["0"].rewards.Length);
+            Assert.AreEqual("reward0", quests["0"].rewards[0].id);
+            Assert.AreEqual(QuestsLiterals.RewardStatus.NOT_GIVEN, quests["0"].rewards[0].status);
+        }
+
+        [Test]
         public void UpdateQuestProgressUpdateQuest()
         {
             quests.Add("0", new QuestModel


### PR DESCRIPTION
Fixes #1052 

Fixed an edge case in the `QuestController` due to a badly constructed logic operation.

It's easier to test this issue in UnityEditor, previously you would find an error in the console in the Genesis Plaza (with quests enabled), you should no longer see it.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
