### PR TITLE
fix: biw publish photo is getting the correct camera

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/FreeCameraController/FreeCameraMovement.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/FreeCameraController/FreeCameraMovement.cs
@@ -592,7 +592,7 @@ namespace DCL.Camera
 
         private IEnumerator TakeSceneScreenshotCoroutine(IFreeCameraMovement.OnSnapshotsReady callback)
         {
-            UnityEngine.Camera camera = UnityEngine.Camera.current;
+            UnityEngine.Camera camera = UnityEngine.Camera.main;
             if (screenshotCamera != null)
                 camera = screenshotCamera;
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a rare situation where the camera to do the screenshots in builder in world is null

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/biw-publish-photo
2. Enter builder in world
3. Try to publish, you should see a photo of the scene

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
