### PR TITLE
fix: skip `CheckAvailableServerPort` for Mac OS in Unity Editor (temp…

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
@@ -26,6 +26,9 @@ public class WebSocketCommunication : IKernelCommunication
 
     private bool CheckAvailableServerPort(int port)
     {
+#if UNITY_EDITOR_OSX
+        return true;
+#else
         bool isAvailable = true;
 
         // Evaluate current system tcp connections. This is the same information provided
@@ -43,6 +46,7 @@ public class WebSocketCommunication : IKernelCommunication
         }
 
         return isAvailable;
+#endif
     }
 
     private int SearchUnusedPort()


### PR DESCRIPTION
…oral fix)

Temporal fix for #1058 

## What does this PR change?

Skip `CheckAvailableServerPort` for Mac OS in Unity Editor

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
