### PR TITLE
fix: GLTFParser exception crash

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/Serialization/GLTFParser.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/Serialization/GLTFParser.cs
@@ -39,6 +39,11 @@ namespace GLTF
 
         public static void ParseJson(Stream stream, out GLTFRoot gltfRoot, long startPosition = 0)
         {
+            if (stream == null)
+            {
+                throw new Exception("GLTFParser.ParseJson stream == null");
+            }
+            
             stream.Position = startPosition;
             bool isGLB = IsGLB(stream);
 


### PR DESCRIPTION
Fixes #1047 
Basically any fail on the GLTF web request could leave the GLTF stream as null making the GLTFParser crash the client
