### PR TITLE
fix: add missing message `Reset`

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
@@ -193,6 +193,9 @@ public class WebSocketCommunication : IKernelCommunication
                             case "SendSceneMessage":
                                 DCL.Environment.i.world.sceneController.SendSceneMessage(msg.payload);
                                 break;
+                            case "Reset":
+                                DCL.Environment.i.world.sceneController.UnloadAllScenesQueued();
+                                break;
                             case "SetVoiceChatEnabledByScene":
                                 if (int.TryParse(msg.payload, out int value)) // The payload should be `string`, this will be changed in a `renderer-protocol` refactor
                                 {


### PR DESCRIPTION
## What does this PR change?

This message wasn't been handled with the `WebSocket` communication.

Maybe it will fix a bug of infinite loading. @Suduck, could you check it?

## How to test the changes?

1. Open `unity-renderer` from Unity Editor
2. Open with the following link: https://play.decentraland.zone/?renderer-branch=fix/missing-reset-message
3. You should not see in the Unity Editor log the following log:
```
SendMessage Reset has no receiver!
UnityEngine.GameObject:SendMessage 
```

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
