### PR TITLE
fix: reimplemented websocket server search available port with try-ca…

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -104,6 +104,7 @@ namespace DCL
             if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
                 Environment.Dispose();
             pluginSystem?.OnDestroy();
+            kernelCommunication.Dispose();
         }
         private void OnGUI() { pluginSystem.OnGUI(); }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore.cs
@@ -103,11 +103,8 @@ namespace DCL
         public class DataStore_WSCommunication
         {
             [System.NonSerialized]
-            public string wssServerUrl = "ws://localhost:5000/";
-            
-            [System.NonSerialized]
-            public string wssServiceId = "dcl";
-            
+            public string url = "ws://localhost:5000/";
+
             public readonly BaseVariable<bool> communicationEstablished = new BaseVariable<bool>();
             public readonly BaseVariable<bool> communicationReady = new BaseVariable<bool>();
         }        

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/IKernelCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/IKernelCommunication.cs
@@ -1,8 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.PlayerLoop;
+using System;
 
-public interface IKernelCommunication
+public interface IKernelCommunication : IDisposable
 {
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/NativeBridgeCommunication/NativeBridgeCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/NativeBridgeCommunication/NativeBridgeCommunication.cs
@@ -54,6 +54,10 @@ public class NativeBridgeCommunication : IKernelCommunication
         SetCallback_Query(Query);
 #endif
     }
+    public void Dispose()
+    {
+        
+    }
 
     [MonoPInvokeCallback(typeof(JS_Delegate_VSSS))]
     internal static void OpenNftDialog(string contactAddress, string comment, string tokenId)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
@@ -60,6 +60,8 @@ public class WebSocketCommunication : IKernelCommunication
         DCL.DataStore.i.debugConfig.isWssDebugMode = true;
 
         string url = StartServer(5000, 5100);
+
+        Debug.Log("WebSocket Server URL: " + url);
         
         DataStore.i.wsCommunication.url = url;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
@@ -1,7 +1,7 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Net;
-using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using DCL;
 using UnityEngine;
 using WebSocketSharp.Server;
@@ -22,47 +22,34 @@ public class WebSocketCommunication : IKernelCommunication
     [System.NonSerialized]
     public static volatile bool queuedMessagesDirty;
 
-    public bool isServerReady { get { return ws.IsListening; } }
+    public bool isServerReady => ws.IsListening;
 
-    private bool CheckAvailableServerPort(int port)
+    private string StartServer(int port, int maxPort)
     {
-#if UNITY_EDITOR_OSX
-        return true;
-#else
-        bool isAvailable = true;
-
-        // Evaluate current system tcp connections. This is the same information provided
-        // by the netstat command line application, just in .Net strongly-typed object
-        // form.  We will look through the list, and if our port we would like to use
-        // in our TcpClient is occupied, we will set isAvailable to false.
-        IPGlobalProperties ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
-        IPEndPoint[] tcpConnInfoArray = ipGlobalProperties.GetActiveTcpListeners();
-
-        foreach (IPEndPoint endpoint in tcpConnInfoArray) {
-            if (endpoint.Port == port) {
-                isAvailable = false;
-                break;
-            }
-        }
-
-        return isAvailable;
-#endif
-    }
-
-    private int SearchUnusedPort()
-    {
-        const int minPort = 5000;
-        const int maxPort = 6000;
-
-        for (int i = minPort; i < maxPort; ++i)
+        if (port > maxPort)
         {
-            if (CheckAvailableServerPort(i))
-            {
-                return i;
-            }
+            throw new SocketException((int)SocketError.AddressAlreadyInUse);
         }
-        Debug.LogError("There are not unused ports.");
-        return minPort; // error
+        string wssServerUrl = $"ws://localhost:{port}/";
+        string wssServiceId = "dcl";
+        string wssUrl = wssServerUrl + wssServiceId; 
+        try
+        {
+            ws = new WebSocketServer(wssServerUrl);
+            ws.AddWebSocketService<DCLWebSocketService>("/" + wssServiceId);
+            ws.Start();
+        }
+        catch (InvalidOperationException e)
+        {
+            SocketException se = (SocketException)e.InnerException;
+            if (se is { SocketErrorCode: SocketError.AddressAlreadyInUse })
+            {
+                return StartServer(port + 1, maxPort);
+            }
+            throw new InvalidOperationException(e.Message, e.InnerException);
+        }
+
+        return wssUrl;
     }
 
     public WebSocketCommunication()
@@ -71,17 +58,9 @@ public class WebSocketCommunication : IKernelCommunication
 
         DCL.DataStore.i.debugConfig.isWssDebugMode = true;
 
-        int port = SearchUnusedPort();
-
-        string wssServerUrl = $"ws://localhost:{port}/";
-        string wssServiceId = "dcl";
-
-        DataStore.i.wsCommunication.wssServerUrl = wssServerUrl;
-        DataStore.i.wsCommunication.wssServiceId = wssServiceId;
-
-        ws = new WebSocketServer(wssServerUrl);
-        ws.AddWebSocketService<DCLWebSocketService>("/" + wssServiceId);
-        ws.Start();
+        string url = StartServer(5000, 5100);
+        
+        DataStore.i.wsCommunication.url = url;
 
         DataStore.i.wsCommunication.communicationReady.Set(true);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
@@ -41,6 +41,7 @@ public class WebSocketCommunication : IKernelCommunication
         }
         catch (InvalidOperationException e)
         {
+            ws.Stop();
             SocketException se = (SocketException)e.InnerException;
             if (se is { SocketErrorCode: SocketError.AddressAlreadyInUse })
             {
@@ -222,5 +223,9 @@ public class WebSocketCommunication : IKernelCommunication
             }
             yield return null;
         }
+    }
+    public void Dispose()
+    {
+        ws.Stop();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a07bf8f55c140984cadbd1d6d564dfb9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/DebugParameters/DebugConfigComponent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/DebugParameters/DebugConfigComponent.cs
@@ -184,7 +184,7 @@ namespace DCL
             }
 
             Application.OpenURL(
-                $"{baseUrl}{debugString}{debugPanelString}position={startInCoords.x}%2C{startInCoords.y}&ws={DataStore.i.wsCommunication.wssServerUrl}{DataStore.i.wsCommunication.wssServiceId}");
+                $"{baseUrl}{debugString}{debugPanelString}position={startInCoords.x}%2C{startInCoords.y}&ws={DataStore.i.wsCommunication.url}");
 #endif
         }
         


### PR DESCRIPTION
…tch to works on Mac

## What does this PR change?

Fix #1058

The implemented method didn't work on Mac. So in this PR, there is a new method to work cross-platform to search for an available port to listen to.

## How to test the changes?

1. Go to the local repo in the command line and change to `fix/search-port-mac` repo (you can execute `git fetch origin && git checkout origin/fix/search-port-mac`)
2. Create a process to listen port 5000 (ex: `npm install -g http-server && http-server . --port 5000`)
3. Execute the renderer from Unity Editor
4. It should open the web browser with DCL using wss url using port 5001

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
