### PR TITLE
chore: update comment bot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Decentraland Unity-Renderer Deployment Notification
     steps:
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@main
         with:
           message: |
             After the CI passes:


### PR DESCRIPTION
## What does this PR change?

The owner of `thollander/actions-comment-pull-request` changed the repo name from `master` to `main`. Just an update.