### PR TITLE
fix: race condition null reference issue in BodyShapeController

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 public interface IBodyShapeController
 {
+    bool isReady { get; }
     string bodyShapeId { get; }
     void SetupEyes(Material material, Texture texture, Texture mask, Color color);
     void SetupEyebrows(Material material, Texture texture, Color color);
@@ -58,7 +59,7 @@ public class BodyShapeController : WearableController, IBodyShapeController
 
     public void SetupEyes(Material material, Texture texture, Texture mask, Color color)
     {
-        if (assetContainer != null && assetContainer.transform == null)
+        if (assetContainer == null || assetContainer.transform == null)
         {
             Debug.LogWarning("Tried to setup eyes when the asset not ready");
             return;
@@ -75,7 +76,7 @@ public class BodyShapeController : WearableController, IBodyShapeController
 
     public void SetupEyebrows(Material material, Texture texture, Color color)
     {
-        if (assetContainer != null && assetContainer.transform == null)
+        if (assetContainer == null || assetContainer.transform == null)
         {
             Debug.LogWarning("Tried to setup eyebrows when the asset not ready");
             return;
@@ -93,7 +94,7 @@ public class BodyShapeController : WearableController, IBodyShapeController
 
     public void SetupMouth(Material material, Texture texture, Texture mask, Color color)
     {
-        if (assetContainer != null && assetContainer.transform == null)
+        if (assetContainer == null || assetContainer.transform == null)
         {
             Debug.LogWarning("Tried to setup mouth when the asset not ready");
             return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/FacialFeatureController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/FacialFeatureController.cs
@@ -101,6 +101,7 @@ public class FacialFeatureController
 
         yield return mainTexturePromise;
         yield return maskTexturePromise;
+        yield return new DCL.WaitUntil( () => bodyShape.isReady );
 
         PrepareWearable();
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/FacialFeatureController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/FacialFeatureController.cs
@@ -20,6 +20,7 @@ public class FacialFeatureController
     private Color color;
     private IBodyShapeController bodyShape;
     internal Material baseMaterialCopy;
+    private Coroutine fetchTextureCoroutine;
 
     public FacialFeatureController(WearableItem wearableItem, Material baseMaterial)
     {
@@ -39,7 +40,7 @@ public class FacialFeatureController
         }
 
         this.bodyShape = loadedBody;
-        CoroutineStarter.Start(FetchTextures());
+        fetchTextureCoroutine = CoroutineStarter.Start(FetchTextures());
     }
 
     void PrepareWearable()
@@ -101,7 +102,6 @@ public class FacialFeatureController
 
         yield return mainTexturePromise;
         yield return maskTexturePromise;
-        yield return new DCL.WaitUntil( () => bodyShape.isReady );
 
         PrepareWearable();
     }
@@ -120,6 +120,10 @@ public class FacialFeatureController
             baseMaterialCopy = null;
         }
 
+        CoroutineStarter.Stop(fetchTextureCoroutine);
+
+        mainTexture = null;
+        maskTexture = null;
         isReady = false;
     }
 


### PR DESCRIPTION
## What does this PR change?

Many null references were detected on crowded places related to facial features controller trying to set colors before the body shape controller was ready. This PR fixes this issue.

## How to test the changes?

1. Go to WonderMine in editor mode
2. Note that in `master` we get a bunch of null references coming from `FacialFeatureController.PrepareWearable`.
3. This shouldn't happen anymore on this branch.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
