### PR TITLE
fix: add defines to only use native bridge on webgl, and only dump pe…

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -41,7 +41,7 @@ namespace DCL
 
             pluginSystem = new PluginSystem();
 
-#if !UNITY_EDITOR
+#if UNITY_WEBGL && !UNITY_EDITOR 
             Debug.Log("DCL Unity Build Version: " + DCL.Configuration.ApplicationSettings.version);
             Debug.unityLogger.logEnabled = false;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
@@ -249,7 +249,7 @@ namespace DCL
                                     + "\n "
                                     + "{\"frame-samples\": " + JsonConvert.SerializeObject(samples) + "}";
 
-#if !UNITY_WEBGL
+#if !UNITY_WEBGL && UNITY_EDITOR
             string targetFilePath = Application.persistentDataPath + "/PerformanceMeterRawFrames.txt";
             Log("Data report step 3 - Trying to dump raw samples JSON at: " + targetFilePath);
             System.IO.File.WriteAllText (targetFilePath, rawSamplesJSON);


### PR DESCRIPTION
…rformance metric on unity editor to use it on desktop

## What does this PR change?

On the WebSocketCommunication we're trying to use (Web)NativeCommunication instead of WebSocket.

And we're dumping some performance data when we are out of the UNITY_EDITOR that are not needed

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
