### PR TITLE
fix: special rotating platforms going full helicopter

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateFPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateFPS.cs
@@ -17,44 +17,7 @@ namespace DCL.Camera
             if (defaultVirtualCamera is CinemachineVirtualCamera vcamera)
                 pov = vcamera.GetCinemachineComponent<CinemachinePOV>();
         }
-
-        public override void OnSelect()
-        {
-            base.OnSelect();
-            CommonScriptableObjects.playerIsOnMovingPlatform.OnChange += OnMovingPlatformStart;
-            if (CommonScriptableObjects.playerIsOnMovingPlatform.Get())
-                OnMovingPlatformStart(true, true);
-        }
-
-        public override void OnUnselect()
-        {
-            base.OnUnselect();
-            CommonScriptableObjects.playerIsOnMovingPlatform.OnChange -= OnMovingPlatformStart;
-            CommonScriptableObjects.movingPlatformRotationDelta.OnChange -= OnMovingPlatformRotate;
-        }
-        private void OnMovingPlatformStart(bool current, bool previous)
-        {
-            if (current)
-            {
-                CommonScriptableObjects.movingPlatformRotationDelta.OnChange += OnMovingPlatformRotate;
-            }
-            else
-            {
-                CommonScriptableObjects.movingPlatformRotationDelta.OnChange -= OnMovingPlatformRotate;
-            }
-        }
-        private void OnMovingPlatformRotate(Quaternion current, Quaternion previous)
-        {
-            // Disabled camera rotation on moving platforms because this was causing issues for some scenes
-            return;
-            Vector3 diff = current.eulerAngles;
-            if (pov != null)
-            {
-                pov.m_HorizontalAxis.Value += diff.y;
-                pov.m_VerticalAxis.Value += diff.x;
-            }
-        }
-
+        
         public override void OnUpdate()
         {
             var xzPlaneForward = Vector3.Scale(cameraTransform.forward, new Vector3(1, 0, 1));

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateFPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateFPS.cs
@@ -45,6 +45,8 @@ namespace DCL.Camera
         }
         private void OnMovingPlatformRotate(Quaternion current, Quaternion previous)
         {
+            // Disabled camera rotation on moving platforms because this was causing issues for some scenes
+            return;
             Vector3 diff = current.eulerAngles;
             if (pov != null)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -522,7 +522,7 @@ public class DCLCharacterController : MonoBehaviour
         float height = 0.875f;
 
         var reportPosition = characterPosition.worldPosition + (Vector3.up * height);
-        var compositeRotation = Quaternion.LookRotation(characterForward.HasValue() ? characterForward.Get().Value : cameraForward.Get());
+        var compositeRotation = Quaternion.LookRotation(cameraForward.Get());
         var playerHeight = height + (characterController.height / 2);
 
         //NOTE(Brian): We have to wait for a Teleport before sending the ReportPosition, because if not ReportPosition events will be sent


### PR DESCRIPTION
## What does this PR change?

Disabled camera rotation when platforms rotate on First Person camera.
Player rotation report is now based on camera rotation only.

Fixes #1122 

## How to test the changes?

Go to Dragon Rush, get on the dragon and smash F, neither FPS or TPS cameras should go helicopter mode.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
