### PR TITLE
fix: AvatarModiferArea is only hiding own avatar (should hide all)

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarVisibility.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarVisibility.cs
@@ -40,10 +40,13 @@ namespace DCL
             OnSetVisibility?.Invoke(visibility);
         }
 
-        private void SetVisibilityForGameObjects(bool value)
+        internal void SetVisibilityForGameObjects(bool value)
         {
             foreach (GameObject gameObject in gameObjectsToToggle)
             {
+                if (gameObject == null)
+                    continue;
+
                 gameObject.SetActive(value);
             }
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarVisibilityTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarVisibilityTests.cs
@@ -1,10 +1,6 @@
-using AvatarShape_Tests;
 using DCL;
-using DCL.Helpers;
 using NUnit.Framework;
-using System.Collections;
 using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace Tests
 {
@@ -48,6 +44,32 @@ namespace Tests
 
             visibility.SetVisibility("Caller1", true);
             Assert.True(toggledGameObject.activeSelf);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetVisibilityForGameObjectsCorrectly(bool isVisible)
+        {
+            // Arrange
+            Object.Destroy(visibility.gameObjectsToToggle[0]);
+            visibility.gameObjectsToToggle = new[] { toggledGameObject, null };
+            visibility.gameObjectsToToggle[0].SetActive(!isVisible);
+
+            // Act
+            bool isFailed = false;
+            try
+            {
+                visibility.SetVisibilityForGameObjects(isVisible);
+            }
+            catch
+            {
+                isFailed = true;
+            }
+
+            // Assert
+            Assert.AreEqual(isVisible, visibility.gameObjectsToToggle[0].activeSelf);
+            Assert.IsFalse(isFailed, "The function call failed!");
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fixes #1089 

The AvatarModiferArea should hide every avatar that enters the area, and display every avatar that gets out of it.

Lastraum reported that currently this feature is bugged and only works for the own player and not the other avatars.

Let's create some tests to cover the correct functionality of the feature.

## Steps to reproduce (from preview mode)
1. Create a new scene with `dcl init` and paste this code:
```
const modArea = new Entity()
modArea.addComponent(
  new AvatarModifierArea({
    area: { box: new Vector3(16, 4, 16) },
    modifiers: [AvatarModifiers.HIDE_AVATARS],
  })
)
modArea.addComponent(
  new Transform({
    position: new Vector3(8, 0, 8),
  })
)
engine.addEntity(modArea)
```
2. Play the scene in preview mode (`dcl start`) and debug it from Unity (using this branch).
3. Open other browser in incognito mode with the same url in order to have a second user in the scene.
4. Enter and exit into the avatar modifier area with both avatars and notice they are dissapearing correctly.

## Test Link
https://play.decentraland.zone/?renderer-branch=fix/AvatarModiferArea-is-only-hiding-own-avatar

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
