### PR TITLE
fix: avatar names outside frustrum are now hidden

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarNamesHUD/AvatarNamesTracker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarNamesHUD/AvatarNamesTracker.cs
@@ -78,23 +78,31 @@ namespace AvatarNamesHUD
             float startingFade = lodDistance * 0.75f;
             float alpha = Mathf.Lerp(1, 0, (screenPoint.z - startingFade) / (lodDistance - startingFade)); //Lerp just at the last quarter of distance
 
+            if (screenPoint.z > 0)
+            {
+                screenPoint.Scale(canvasRect.rect.size);
+                name.rectTransform.anchoredPosition = screenPoint;
+                background.rectTransform.anchoredPosition = screenPoint;
+                background.rectTransform.sizeDelta = new Vector2(name.textBounds.extents.x * 2.5f, 30);
+                Vector2 voiceChatOffset = -Vector2.Scale(Vector2.right, background.rectTransform.sizeDelta) * 0.5f;
+                (voiceChatCanvasGroup.transform as RectTransform).anchoredPosition = background.rectTransform.anchoredPosition + voiceChatOffset;
 
-            screenPoint.Scale(canvasRect.rect.size);
-            name.rectTransform.anchoredPosition = screenPoint;
-            background.rectTransform.anchoredPosition = screenPoint;
-            background.rectTransform.sizeDelta = new Vector2(name.textBounds.extents.x * 2.5f, 30);
-            Vector2 voiceChatOffset = -Vector2.Scale(Vector2.right, background.rectTransform.sizeDelta) * 0.5f;
-            (voiceChatCanvasGroup.transform as RectTransform).anchoredPosition = background.rectTransform.anchoredPosition + voiceChatOffset;
+                voiceChatCanvasGroup.alpha = alpha;
+                name.color = new Color(name.color.r, name.color.g, name.color.b, alpha);
+                backgroundCanvasGroup.alpha = alpha;
+                voiceChatCanvasGroup?.gameObject.SetActive(visibility && (player?.isTalking ?? false));
+                voiceChatAnimator.SetBool(VOICE_CHAT_ANIMATOR_TALKING, player.isTalking);
 
-            voiceChatCanvasGroup.alpha = alpha;
-            name.color = new Color(name.color.r, name.color.g, name.color.b, alpha);
-            backgroundCanvasGroup.alpha = alpha;
-            voiceChatCanvasGroup?.gameObject.SetActive(visibility && (player?.isTalking ?? false));
-            voiceChatAnimator.SetBool(VOICE_CHAT_ANIMATOR_TALKING, player.isTalking);
-
-            background.gameObject.SetActive(visibility);
-            name.gameObject.SetActive(visibility);
-            voiceChatCanvasGroup.gameObject.SetActive(visibility && (player?.isTalking ?? false));
+                background.gameObject.SetActive(visibility);
+                name.gameObject.SetActive(visibility);
+                voiceChatCanvasGroup.gameObject.SetActive(visibility && (player?.isTalking ?? false));
+            }
+            else
+            {
+                background.gameObject.SetActive(false);
+                name.gameObject.SetActive(false);
+                voiceChatCanvasGroup.gameObject.SetActive(false);
+            }
         }
 
         public void DestroyUIElements()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarNamesHUD/Tests/AvatarNamesHUDViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarNamesHUD/Tests/AvatarNamesHUDViewShould.cs
@@ -50,6 +50,28 @@ namespace Tests.AvatarNamesHUD
         }
 
         [Test]
+        public void HideNamesOutsideFrustrum()
+        {
+            var camera = new GameObject().AddComponent<Camera>();
+            camera.tag = "MainCamera";
+
+            Player user0 = new Player { id = "user0", name = "user0", isTalking = false, worldPosition = (Camera.main.transform.position - Camera.main.transform.forward) };
+            hudView.TrackPlayer(user0);
+
+            AvatarNamesTracker tracker = hudView.trackers["user0"];
+            Assert.AreEqual(user0, tracker.player);
+            Assert.NotNull(tracker);
+
+            tracker.UpdatePosition();
+
+            Assert.False(tracker.background.gameObject.activeSelf);
+            Assert.False(tracker.name.gameObject.activeSelf);
+            Assert.False(tracker.voiceChatCanvasGroup.gameObject.activeSelf);
+
+            Object.Destroy(camera.gameObject);
+        }
+
+        [Test]
         public void UntrackPlayer()
         {
             Player user0 = new Player { id = "user0", name = "user0" };


### PR DESCRIPTION
Fixes #1136 

The AvatarLODs controller introduced an optimization that allows us to remove one of the checks for the AvatarNames. Sadly it made the feature to stop working properly with LODs disabled. Be sure to test this with `DISABLE_AVATAR_LODS` or in `.org`.