### PR TITLE
fix: camera rotation on teleport or forced set

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Camera.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Camera.asmdef
@@ -9,7 +9,8 @@
         "GUID:e555144732b726c4cba5b0f6337fea75",
         "GUID:555c1f3c6d18648df910b7a1de75b424",
         "GUID:99cea83ca76dcd846abed7e61a8c90bd",
-        "GUID:4973650d2444c4561a15d50f24d91cd9"
+        "GUID:4973650d2444c4561a15d50f24d91cd9",
+        "GUID:28f74c468a54948bfa9f625c5d428f56"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraDampOnGroundType.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraDampOnGroundType.cs
@@ -5,6 +5,8 @@ namespace DCL.Camera
 {
     public class CameraDampOnGroundType
     {
+        private const float AFTER_TELEPORT_DAMP_TIME_MS = 50f;
+
         [System.Serializable]
         public class Settings
         {
@@ -19,18 +21,26 @@ namespace DCL.Camera
 
         private FollowWithDamping followWithDamping;
         public Settings settings;
+        private float zeroDampTime;
 
         public CameraDampOnGroundType (Settings settings, FollowWithDamping followWithDamping)
         {
             this.settings = settings;
             this.followWithDamping = followWithDamping;
+            DataStore.i.player.lastTeleportPosition.OnChange += OnTeleport;
         }
+        private void OnTeleport(Vector3 current, Vector3 previous) { zeroDampTime = AFTER_TELEPORT_DAMP_TIME_MS; }
 
         public void Update(bool hitGround, RaycastHit hitInfo)
         {
             if ( !settings.enabled )
                 return;
 
+            UpdateDamp(hitGround, hitInfo);
+            UpdateAfterTeleportDamp();
+        }
+        private void UpdateDamp(bool hitGround, RaycastHit hitInfo)
+        {
             bool isOnMovingPlatform = DCLCharacterController.i.isOnMovingPlatform;
 
             if ( hitGround )
@@ -39,6 +49,16 @@ namespace DCL.Camera
                     followWithDamping.damping.y = isOnMovingPlatform ? settings.dampingOnMovingPlatform : settings.dampingOnGround;
                 else
                     followWithDamping.damping.y = settings.dampingOnAir;
+            }
+        }
+        
+        // This avoids the "Camera clips through stuff" after teleporting to different heights
+        private void UpdateAfterTeleportDamp()
+        {
+            if (zeroDampTime > 0)
+            {
+                followWithDamping.damping.y = 0;
+                zeroDampTime -= Time.unscaledDeltaTime;
             }
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
@@ -60,15 +60,9 @@ namespace DCL.Camera
             base.Init(camera);
         }
 
-        private void OnEnable()
-        {
-            CommonScriptableObjects.playerIsOnMovingPlatform.OnChange += UpdateMovingPlatformCamera;
-        }
+        private void OnEnable() { CommonScriptableObjects.playerIsOnMovingPlatform.OnChange += UpdateMovingPlatformCamera; }
 
-        private void OnDisable()
-        {
-            CommonScriptableObjects.playerIsOnMovingPlatform.OnChange -= UpdateMovingPlatformCamera;
-        }
+        private void OnDisable() { CommonScriptableObjects.playerIsOnMovingPlatform.OnChange -= UpdateMovingPlatformCamera; }
 
         void UpdateMovingPlatformCamera(bool isOnMovingPlatform, bool wasOnMovingPlatform)
         {
@@ -179,11 +173,13 @@ namespace DCL.Camera
                 var dirToLook = (cameraTarget - newPos);
                 eulerDir = Quaternion.LookRotation(dirToLook).eulerAngles;
             }
-
+            
             defaultVirtualCameraAsFreeLook.m_XAxis.Value = eulerDir.y;
-            defaultVirtualCameraAsFreeLook.m_YAxis.Value = eulerDir.x;
+            
+            //value range 0 to 1, being 0 the bottom orbit and 1 the top orbit
+            var yValue = Mathf.InverseLerp(-90, 90, eulerDir.x);
+            defaultVirtualCameraAsFreeLook.m_YAxis.Value = yValue;
         }
-
         public override void OnBlock(bool blocked)
         {
             base.OnBlock(blocked);


### PR DESCRIPTION
## What does this PR change?

Fix #999 
...

## How to test the changes?

1 - `/goto 10,10` camera should point forward
2 - `/goto 0,0` camera should point forward and should not move through the floor

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
