### PR TITLE
fix: input spikes when changing lock states

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/InputSpikeFixer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/InputSpikeFixer.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace DCL.Camera
+{
+    public class InputSpikeFixer
+    {
+        private const float INPUT_SPIKE_TOLERANCE = 0.5f;
+
+        private CursorLockMode lastLockState;
+        private bool isLockStateDirty;
+
+        public InputSpikeFixer()
+        {
+            lastLockState = Cursor.lockState;
+            isLockStateDirty = false;
+        }
+
+        public float GetValue(float currentValue)
+        {
+            CheckLockState();
+
+            float absoluteValue = Mathf.Abs(currentValue);
+            
+            if (ShouldIgnoreInputValue(absoluteValue))
+            {
+                if (IsInputValueTolerable(absoluteValue)) 
+                    isLockStateDirty = false;
+                return 0;
+            }
+            
+            return currentValue;
+        }
+        private static bool IsInputValueTolerable(float value) { return value < INPUT_SPIKE_TOLERANCE; }
+        private bool ShouldIgnoreInputValue(float value) { return value > 0 && isLockStateDirty; }
+
+        private void CheckLockState()
+        {
+            var currentLockState = Cursor.lockState;
+
+            if (currentLockState != lastLockState)
+            {
+                isLockStateDirty = true;
+            }
+
+            lastLockState = currentLockState;
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/InputSpikeFixer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/InputSpikeFixer.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace DCL.Camera
@@ -5,16 +6,17 @@ namespace DCL.Camera
     public class InputSpikeFixer
     {
         private const float INPUT_SPIKE_TOLERANCE = 0.5f;
+        private readonly Func<CursorLockMode> getLockMode;
 
         private CursorLockMode lastLockState;
         private bool isLockStateDirty;
 
-        public InputSpikeFixer()
+        public InputSpikeFixer(Func<CursorLockMode> getLockMode)
         {
-            lastLockState = Cursor.lockState;
+            this.getLockMode = getLockMode;
+            lastLockState = getLockMode();
             isLockStateDirty = false;
         }
-
         public float GetValue(float currentValue)
         {
             CheckLockState();
@@ -35,7 +37,7 @@ namespace DCL.Camera
 
         private void CheckLockState()
         {
-            var currentLockState = Cursor.lockState;
+            var currentLockState = getLockMode();
 
             if (currentLockState != lastLockState)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/InputSpikeFixer.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/InputSpikeFixer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4cdce37c36964023ba5c9fd0513d233d
+timeCreated: 1631040792

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/OverrideCinemachineAxisInput.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/OverrideCinemachineAxisInput.cs
@@ -23,7 +23,7 @@ public class OverrideCinemachineAxisInput : MonoBehaviour
     {
         cachedAxisToMeasurableActions = axisToMeasurableActions.ToDictionary(x => x.axisName, x => x.measurableAction);
         CinemachineCore.GetInputAxis = OverrideGetAxis;
-        inputSpikeFixer = new InputSpikeFixer();
+        inputSpikeFixer = new InputSpikeFixer(() => Cursor.lockState);
     }
 
     private float OverrideGetAxis(string axisName)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/OverrideCinemachineAxisInput.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/OverrideCinemachineAxisInput.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Cinemachine;
+using DCL.Camera;
 using UnityEngine;
 
 public class OverrideCinemachineAxisInput : MonoBehaviour
 {
+
     [Serializable]
     public struct AxisToMeasurableAction
     {
@@ -15,18 +17,22 @@ public class OverrideCinemachineAxisInput : MonoBehaviour
 
     [SerializeField] private AxisToMeasurableAction[] axisToMeasurableActions;
     private Dictionary<string, InputAction_Measurable> cachedAxisToMeasurableActions;
+    private InputSpikeFixer inputSpikeFixer;
 
     private void Awake()
     {
         cachedAxisToMeasurableActions = axisToMeasurableActions.ToDictionary(x => x.axisName, x => x.measurableAction);
         CinemachineCore.GetInputAxis = OverrideGetAxis;
+        inputSpikeFixer = new InputSpikeFixer();
     }
 
     private float OverrideGetAxis(string axisName)
     {
         if (!cachedAxisToMeasurableActions.ContainsKey(axisName))
             return 0;
-
-        return cachedAxisToMeasurableActions[axisName].GetValue();
+        
+        float value = cachedAxisToMeasurableActions[axisName].GetValue();
+        return inputSpikeFixer.GetValue(value);
     }
+    
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/SmoothAxisProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/SmoothAxisProvider.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Cinemachine;
 using Cinemachine.Utility;
+using DCL.Camera;
 using UnityEngine;
 
 public class SmoothAxisProvider : MonoBehaviour, AxisState.IInputAxisProvider
@@ -13,7 +15,16 @@ public class SmoothAxisProvider : MonoBehaviour, AxisState.IInputAxisProvider
 
     public InputAction_Measurable axisX;
     public InputAction_Measurable axisY;
+    private InputSpikeFixer[] inputSpikeFixer;
 
+    private void Awake()
+    {
+        inputSpikeFixer = new []
+        {
+            new InputSpikeFixer(),
+            new InputSpikeFixer()
+        };
+    }
     void Update()
     {
         axisTarget[0] = axisX.GetValue();
@@ -23,6 +34,6 @@ public class SmoothAxisProvider : MonoBehaviour, AxisState.IInputAxisProvider
 
     public float GetAxisValue(int axis)
     {
-        return this.axis[axis];
+        return inputSpikeFixer[axis].GetValue(this.axis[axis]);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/SmoothAxisProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/SmoothAxisProvider.cs
@@ -21,8 +21,8 @@ public class SmoothAxisProvider : MonoBehaviour, AxisState.IInputAxisProvider
     {
         inputSpikeFixer = new []
         {
-            new InputSpikeFixer(),
-            new InputSpikeFixer()
+            new InputSpikeFixer(() => Cursor.lockState),
+            new InputSpikeFixer(() => Cursor.lockState)
         };
     }
     void Update()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
@@ -1,0 +1,62 @@
+using DCL.Camera;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CameraController_Test
+{
+    public class InputSpikeFixerShould
+    {
+        private CursorLockMode previousLockState;
+
+        [SetUp]
+        public void Setup()
+        {
+            previousLockState = Cursor.lockState;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Cursor.lockState = previousLockState;
+        }
+        
+        [TestCase(0, 0)]
+        [TestCase(10, 10)]
+        [TestCase(-10, -10)]
+        [TestCase(0.5f, 0.5f)]
+        public void WhenLockStateIsNotChangedValueWontChange(float inputValue, float expectedInputValue)
+        {
+            Cursor.lockState = CursorLockMode.Locked;
+            var inputSpikeFixer = new InputSpikeFixer();
+            var returnValue = inputSpikeFixer.GetValue(inputValue);
+            
+            Assert.AreEqual(expectedInputValue, returnValue);
+        }
+        
+        [Test]
+        public void WhenLockStateIsChangedAndValueIsHigherThanToleranceReturnValueIsZero()
+        {
+            Cursor.lockState = CursorLockMode.Locked;
+            var inputSpikeFixer = new InputSpikeFixer();
+            
+            Cursor.lockState = CursorLockMode.Confined;
+            var returnValue = inputSpikeFixer.GetValue(10);
+            
+            Assert.AreEqual(0, returnValue);
+        }
+        
+        [Test]
+        public void WhenLockStateIsChangedAndValueIsLowerThanToleranceReturnValueIsZeroJustOnce()
+        {
+            Cursor.lockState = CursorLockMode.Locked;
+            var inputSpikeFixer = new InputSpikeFixer();
+            
+            Cursor.lockState = CursorLockMode.Confined;
+            var returnValue = inputSpikeFixer.GetValue(0.4f);
+            Assert.AreEqual(0, returnValue);
+            
+            var returnValue2 = inputSpikeFixer.GetValue(0.4f);
+            Assert.AreEqual(0.4f, returnValue2);
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
@@ -45,7 +45,7 @@ namespace CameraController_Test
         }
         
         [Test]
-        public void WhenLockStateIsChangedAndValueIsLowerThanToleranceReturnValueIsZeroJustOnce()
+        public void ReturnZeroJustOnceWhenLockStateIsChangedAndValueIsLowerThanTolerance()
         {
             var lockState = CursorLockMode.Locked;
             var inputSpikeFixer = new InputSpikeFixer(() => lockState);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
@@ -24,7 +24,7 @@ namespace CameraController_Test
         [TestCase(10, 10)]
         [TestCase(-10, -10)]
         [TestCase(0.5f, 0.5f)]
-        public void WhenLockStateIsNotChangedValueWontChange(float inputValue, float expectedInputValue)
+        public void NotChangeValueWhenSameLockStateIsSetTwice(float inputValue, float expectedInputValue)
         {
             var inputSpikeFixer = new InputSpikeFixer(() => CursorLockMode.Locked);
             var returnValue = inputSpikeFixer.GetValue(inputValue);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
@@ -33,7 +33,7 @@ namespace CameraController_Test
         }
         
         [Test]
-        public void WhenLockStateIsChangedAndValueIsHigherThanToleranceReturnValueIsZero()
+        public void ReturnZeroWhenLockStateIsChangedAndValueIsHigherThanTolerance()
         {
             var lockState = CursorLockMode.Locked;
             var inputSpikeFixer = new InputSpikeFixer(() => lockState);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs
@@ -26,8 +26,7 @@ namespace CameraController_Test
         [TestCase(0.5f, 0.5f)]
         public void WhenLockStateIsNotChangedValueWontChange(float inputValue, float expectedInputValue)
         {
-            Cursor.lockState = CursorLockMode.Locked;
-            var inputSpikeFixer = new InputSpikeFixer();
+            var inputSpikeFixer = new InputSpikeFixer(() => CursorLockMode.Locked);
             var returnValue = inputSpikeFixer.GetValue(inputValue);
             
             Assert.AreEqual(expectedInputValue, returnValue);
@@ -36,10 +35,10 @@ namespace CameraController_Test
         [Test]
         public void WhenLockStateIsChangedAndValueIsHigherThanToleranceReturnValueIsZero()
         {
-            Cursor.lockState = CursorLockMode.Locked;
-            var inputSpikeFixer = new InputSpikeFixer();
+            var lockState = CursorLockMode.Locked;
+            var inputSpikeFixer = new InputSpikeFixer(() => lockState);
+            lockState = CursorLockMode.Confined;
             
-            Cursor.lockState = CursorLockMode.Confined;
             var returnValue = inputSpikeFixer.GetValue(10);
             
             Assert.AreEqual(0, returnValue);
@@ -48,10 +47,10 @@ namespace CameraController_Test
         [Test]
         public void WhenLockStateIsChangedAndValueIsLowerThanToleranceReturnValueIsZeroJustOnce()
         {
-            Cursor.lockState = CursorLockMode.Locked;
-            var inputSpikeFixer = new InputSpikeFixer();
+            var lockState = CursorLockMode.Locked;
+            var inputSpikeFixer = new InputSpikeFixer(() => lockState);
+            lockState = CursorLockMode.Confined;
             
-            Cursor.lockState = CursorLockMode.Confined;
             var returnValue = inputSpikeFixer.GetValue(0.4f);
             Assert.AreEqual(0, returnValue);
             

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/InputSpikeFixerShould.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3e318d46d94944008ff914b0039001f4
+timeCreated: 1631041363


### PR DESCRIPTION
## What does this PR change?

Fix #1104 

...

## How to test the changes?

Do random stuff on the world and change the focus state often ( pressing ESC and clicking on the screen over different points in the viewport).
Either when locking on or off, the camera shouldn't move abruptly.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
