### PR TITLE
chore: set AvatarShape layer to ViewportCullingIgnored

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 5523974814614327640}
   - component: {fileID: 122622683908687435}
   - component: {fileID: 1133411967100239370}
-  m_Layer: 0
+  m_Layer: 23
   m_Name: AvatarShape
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -69,6 +69,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b2e184f0ec373f4e807d927e1f8aef3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  movementLerpWait: 0
 --- !u!114 &1133411967100239370
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -98,7 +99,7 @@ GameObject:
   - component: {fileID: 6790643881566083082}
   - component: {fileID: 3298290865927950122}
   - component: {fileID: 4677808976097840642}
-  m_Layer: 0
+  m_Layer: 23
   m_Name: AvatarRenderer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -208,7 +209,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3553539495342899975}
-  m_Layer: 0
+  m_Layer: 23
   m_Name: Particles
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -240,7 +241,7 @@ GameObject:
   - component: {fileID: 4331657482804467835}
   - component: {fileID: 3865137627712764486}
   - component: {fileID: 1314168606903342224}
-  m_Layer: 9
+  m_Layer: 23
   m_Name: PointerEventCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -377,7 +378,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 58007861928506197}
-  m_Layer: 0
+  m_Layer: 23
   m_Name: GameObject
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -408,7 +409,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6301578636949877838}
   - component: {fileID: 7755590202629118220}
-  m_Layer: 21
+  m_Layer: 23
   m_Name: AvatarCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -453,6 +454,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: AvatarAudioHandlerRemote
+      objectReference: {fileID: 0}
+    - target: {fileID: 1933068967218137769, guid: 256ca49022c0ba84abc2a941931ee350,
+        type: 3}
+      propertyPath: m_Layer
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 3728983229202958758, guid: 256ca49022c0ba84abc2a941931ee350,
         type: 3}


### PR DESCRIPTION
Signed-off-by: Alejandro Jimenez <ajimenez@decentraland.org>

Culling controller were messing with our avatars optimizations, transitions and impostors. We ignore them from now on.

To test this PR just go to a crowded scene (or put some bots in) and check if small avatars in the distance get culled off if the setting is enabled. It shouldnt.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
