### PR TITLE
chore: test to ensure culling controller ignores AvatarShape

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShapeTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShapeTests.cs
@@ -29,6 +29,14 @@ namespace Tests
             }
         }
 
+        [Test]
+        public void IgnoresCullingController()
+        {
+            AvatarAssetsTestHelpers.CreateTestCatalogLocal();
+            AvatarShape avatar = AvatarShapeTestHelpers.CreateAvatarShape(scene, "Abortit", "TestAvatar.json");
+            Assert.AreEqual(avatar.gameObject.layer, LayerMask.NameToLayer("ViewportCullingIgnored"));
+        }
+
         [UnityTest]
         public IEnumerator DestroyWhileLoading()
         {


### PR DESCRIPTION
## What does this PR change?
Added a test to ensure that the culling controller is ignoring the avatars

## How to test the changes?
You cant =D

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
