### PR TITLE
fix: set AvatarCollider and PointerEventCollider layers properly

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -18,7 +18,7 @@ namespace DCL
         public AvatarMovementController avatarMovementController;
 
         [SerializeField]
-        private AvatarOnPointerDown onPointerDown;
+        internal AvatarOnPointerDown onPointerDown;
 
         private StringVariable currentPlayerInfoCardId;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -241,7 +241,7 @@ GameObject:
   - component: {fileID: 4331657482804467835}
   - component: {fileID: 3865137627712764486}
   - component: {fileID: 1314168606903342224}
-  m_Layer: 23
+  m_Layer: 9
   m_Name: PointerEventCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -409,7 +409,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6301578636949877838}
   - component: {fileID: 7755590202629118220}
-  m_Layer: 23
+  m_Layer: 21
   m_Name: AvatarCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShapeTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShapeTests.cs
@@ -30,11 +30,13 @@ namespace Tests
         }
 
         [Test]
-        public void IgnoresCullingController()
+        public void SetLayersProperly()
         {
             AvatarAssetsTestHelpers.CreateTestCatalogLocal();
             AvatarShape avatar = AvatarShapeTestHelpers.CreateAvatarShape(scene, "Abortit", "TestAvatar.json");
             Assert.AreEqual(avatar.gameObject.layer, LayerMask.NameToLayer("ViewportCullingIgnored"));
+            Assert.AreEqual(avatar.avatarCollider.gameObject.layer, LayerMask.NameToLayer("AvatarTriggerDetection"));
+            Assert.AreEqual(avatar.onPointerDown.gameObject.layer, LayerMask.NameToLayer("OnPointerEvent"));
         }
 
         [UnityTest]


### PR DESCRIPTION
This should fix the issue with the Passport and probably avatar trigger area issues.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
