### PR TITLE
fix: relative paths for toon shader to work in `explorer-desktop`

### DIFF
--- a/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/How to generate this shader.md
+++ b/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/How to generate this shader.md
@@ -48,6 +48,21 @@ For the GPU skinning we need to do the same for the following passes:
 ```
 > NOTE: If this is not done, avatars aren't going to look toon.
 
+#### Replace the absolutes paths to relative paths
+
+Search
+```
+#include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+```
+
+and replace it for
+
+```
+#include "../ShaderGraph/Includes/SampleTexture.hlsl"
+```
+
+> NOTE: If this is not done, the shader will fail on the project `explorer-desktop`.
+
 ### You're done!.
 
 Yes, the project needs a tool for automating this.  

--- a/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/ToonShaderCompiled.shader
+++ b/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/ToonShaderCompiled.shader
@@ -604,7 +604,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -1981,7 +1981,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -3285,7 +3285,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -4571,7 +4571,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -5871,7 +5871,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -7159,7 +7159,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -8446,7 +8446,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -9817,7 +9817,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -11119,7 +11119,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -12404,7 +12404,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -13703,7 +13703,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -14991,7 +14991,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {
@@ -16279,7 +16279,7 @@
             }
 
             // a1a3e9b98a2a76cb13dae6c56d1d1a39
-            #include "Assets/Rendering/Shaders/Toon/ShaderGraph/Includes/SampleTexture.hlsl"
+            #include "../ShaderGraph/Includes/SampleTexture.hlsl"
 
             void Unity_ColorspaceConversion_RGB_Linear_float(float3 In, out float3 Out)
             {


### PR DESCRIPTION
## What does this PR change?

Fix #1154 

The Toon Shader had `absolute paths` to include other files, and when I imported it from `explorer-desktop` it fails. So I changed for `relative paths` to work correctly in `unity-renderer` and `explorer-desktop` and I added the step to do it on `How to generate this shader.md`

## How to test the changes?

1. Open `explorer-desktop` and check if the issue stopped happening
2. Then, go to https://play.decentraland.zone/?renderer-branch=fix/toon-shader-path-for-desktop and test if your character looks OK

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
