### PR TITLE
chore: reduce body snapshot resolution

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
@@ -6,8 +6,8 @@ using UnityEngine;
 
 public class CharacterPreviewController : MonoBehaviour
 {
-    private const int SNAPSHOT_BODY_WIDTH_RES = 512;
-    private const int SNAPSHOT_BODY_HEIGHT_RES = 1024;
+    private const int SNAPSHOT_BODY_WIDTH_RES = 256;
+    private const int SNAPSHOT_BODY_HEIGHT_RES = 512;
 
     private const int SNAPSHOT_FACE_WIDTH_RES = 512;
     private const int SNAPSHOT_FACE_HEIGHT_RES = 512;


### PR DESCRIPTION
Fixes #1177 

Reduce the resolution of the body snapshot taken.

The only way to test it would be to save your avatar in the backpack and then retrieve your profile from https://peer.decentraland.org/lambdas/profile/{wallet}

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
