### PR TITLE
chore: private to protected virtual methods to override those in `exp…

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -22,7 +22,7 @@ namespace DCL
 
         private PluginSystem pluginSystem;
 
-        void Awake()
+        protected virtual void Awake()
         {
             if (i != null)
             {
@@ -104,7 +104,7 @@ namespace DCL
             pluginSystem.LateUpdate();
         }
 
-        private void OnDestroy()
+        protected virtual void OnDestroy()
         {
             if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
                 Environment.Dispose();


### PR DESCRIPTION
…lorer-desktop`

## What does this PR change?

Unblock decentraland/explorer-desktop#10

Change `private` methods from `Main` to `protected virtual` to be overridable from `explorer-desktop`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
