### PR TITLE
fix: race condition leaving orphan gltf

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -194,10 +194,11 @@ namespace DCL
         {
             asset = loadedAsset;
             waitingAssetLoad = false;
+            bool alreadyInLibrary = false;
 
             if (success && asset != null)
             {
-                bool alreadyInLibrary = library.Contains(asset);
+                alreadyInLibrary = library.Contains(asset);
                 if (alreadyInLibrary)
                 {
                     asset.Cleanup();
@@ -210,7 +211,10 @@ namespace DCL
             }
 
             ClearEvents();
-            CallAndClearEvents(success);
+            if (!alreadyInLibrary)
+            {
+                CallAndClearEvents(success);
+            }
             Cleanup();
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -197,13 +197,20 @@ namespace DCL
 
             if (success && asset != null)
             {
-                bool alreadyInLibrary = library.Contains(loadedAsset);
-                AddToLibrary();
-                
+                bool alreadyInLibrary = library.Contains(asset);
                 if (alreadyInLibrary)
-                    loadedAsset.Cleanup();
+                {
+                    asset.Cleanup();
+                    asset = null;
+                }
+                else
+                {
+                    AddToLibrary();
+                }
             }
 
+            ClearEvents();
+            CallAndClearEvents(success);
             Cleanup();
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -193,14 +193,17 @@ namespace DCL
         private void OnLoadedAfterForget(bool success, Asset_GLTF loadedAsset)
         {
             asset = loadedAsset;
+            waitingAssetLoad = false;
 
             if (success && asset != null)
             {
+                bool alreadyInLibrary = library.Contains(loadedAsset);
                 AddToLibrary();
+                
+                if (alreadyInLibrary)
+                    loadedAsset.Cleanup();
             }
 
-            ClearEvents();
-            CallAndClearEvents(success);
             Cleanup();
         }
     }


### PR DESCRIPTION
The following scenario was leaving some GLTF orphan:
* keep `promiseA` for gltf asset `X`
* forget `promiseA`
* keep `promiseB` for gltf asset `X`
* 
if `promiseB` finish loading gltf `X` before `promiseA` (since we are waiting for gltf to finish loading) we will end up having an orphan gltf `X`

can be tested in [WonderMine `-26,59`](https://play.decentraland.zone/?renderer-branch=fix/orphan-gltfs&position=-26,59) when not using asset bundles
![image](https://user-images.githubusercontent.com/4195708/133336545-c852d1cc-4f90-431a-84bc-c90e8806ba59.png)
