### PR TITLE
fix: teleport memory handling

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/Tests/AnimatorTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/Tests/AnimatorTests.cs
@@ -28,7 +28,7 @@ namespace Tests
 
             DCLAnimator.Model animatorModel = new DCLAnimator.Model
             {
-                states = new DCLAnimator.Model.DCLAnimationState[]
+                states = new []
                 {
                     new DCLAnimator.Model.DCLAnimationState
                     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerHelperShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerHelperShould.cs
@@ -40,7 +40,7 @@ public class AvatarMeshCombinerHelperShould
         keeper.Forget(promise);
         webRequestController.Dispose();
         Object.Destroy(materialAsset);
-        PoolManager.i.Cleanup();
+        PoolManager.i.Dispose();
         yield break;
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/Tests/GLTFImporterTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/Tests/GLTFImporterTests.cs
@@ -140,7 +140,7 @@ public class GLTFImporterTests : IntegrationTestSuite_Legacy
 
         UnityEngine.Assertions.Assert.AreEqual(1, PersistentAssetCache.ImageCacheByUri.Count);
         scene.RemoveEntity(entity.entityId);
-        PoolManager.i.Cleanup();
+        PoolManager.i.Dispose();
 
         yield return null;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Tests/APKWithPoolableAssetShouldWorkWhen_Base.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Tests/APKWithPoolableAssetShouldWorkWhen_Base.cs
@@ -86,7 +86,7 @@ namespace AssetPromiseKeeper_Tests
             Assert.IsTrue(keeper.library.Contains(loadedAsset.id), "Asset should be still in library, it only should be removed from library when the Pool is cleaned by the MemoryManager");
             Assert.AreEqual(1, keeper.library.masterAssets.Count, "Asset should be still in library, it only should be removed from library when the Pool is cleaned by the MemoryManager");
 
-            yield return Environment.i.platform.memoryManager.CleanPoolManager(true);
+            yield return PoolManager.i.CleanupAsync(false, false);
 
             Assert.AreEqual(0, keeper.library.masterAssets.Count, "After MemoryManager clear the pools, the asset should be removed from the library");
             Assert.IsTrue(!keeper.library.Contains(loadedAsset.id), "After MemoryManager clear the pools, the asset should be removed from the library");
@@ -141,7 +141,7 @@ namespace AssetPromiseKeeper_Tests
 
             keeper.Forget(prom2);
 
-            yield return Environment.i.platform.memoryManager.CleanPoolManager(true);
+            yield return PoolManager.i.CleanupAsync(false, false);
 
             Assert.IsTrue(asset.container == null);
             Assert.IsTrue(!keeper.library.Contains(asset));

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Tests/APKWithPoolableAssetShouldWorkWhen_Base.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Tests/APKWithPoolableAssetShouldWorkWhen_Base.cs
@@ -86,7 +86,7 @@ namespace AssetPromiseKeeper_Tests
             Assert.IsTrue(keeper.library.Contains(loadedAsset.id), "Asset should be still in library, it only should be removed from library when the Pool is cleaned by the MemoryManager");
             Assert.AreEqual(1, keeper.library.masterAssets.Count, "Asset should be still in library, it only should be removed from library when the Pool is cleaned by the MemoryManager");
 
-            yield return Environment.i.platform.memoryManager.CleanupPoolsIfNeeded(true);
+            yield return Environment.i.platform.memoryManager.CleanPoolManager(true);
 
             Assert.AreEqual(0, keeper.library.masterAssets.Count, "After MemoryManager clear the pools, the asset should be removed from the library");
             Assert.IsTrue(!keeper.library.Contains(loadedAsset.id), "After MemoryManager clear the pools, the asset should be removed from the library");
@@ -141,7 +141,7 @@ namespace AssetPromiseKeeper_Tests
 
             keeper.Forget(prom2);
 
-            yield return Environment.i.platform.memoryManager.CleanupPoolsIfNeeded(true);
+            yield return Environment.i.platform.memoryManager.CleanPoolManager(true);
 
             Assert.IsTrue(asset.container == null);
             Assert.IsTrue(!keeper.library.Contains(asset));

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Tests/AssetLibrary_Poolable_Should.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Tests/AssetLibrary_Poolable_Should.cs
@@ -35,7 +35,7 @@ namespace AssetPromiseKeeper_Tests
 
             assetGltf.Cleanup();
             assetAbGameObject.Cleanup();
-            PoolManager.i.Cleanup();
+            PoolManager.i.Dispose();
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Tests/BIWNftsShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Tests/BIWNftsShould.cs
@@ -82,6 +82,6 @@ public class BIWNftsShould : IntegrationTestSuite
         BIWCatalogManager.ClearCatalog();
         BIWNFTController.i.ClearNFTs();
         yield return base.TearDown();
-        PoolManager.i.Cleanup();
+        PoolManager.i.Dispose();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/Interfaces/IMemoryManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/Interfaces/IMemoryManager.cs
@@ -5,6 +5,6 @@ namespace DCL
 {
     public interface IMemoryManager : IDisposable
     {
-        IEnumerator CleanPoolManager(bool forceCleanup = false, bool immediate = false);
+        public event System.Action OnCriticalMemory;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/Interfaces/IMemoryManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/Interfaces/IMemoryManager.cs
@@ -5,7 +5,6 @@ namespace DCL
 {
     public interface IMemoryManager : IDisposable
     {
-        void Initialize(IParcelScenesCleaner parcelScenesCleaner);
-        IEnumerator CleanupPoolsIfNeeded(bool forceCleanup = false, bool immediate = false);
+        IEnumerator CleanPoolManager(bool forceCleanup = false, bool immediate = false);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/MemoryManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/MemoryManager.cs
@@ -33,8 +33,6 @@ namespace DCL
 
         public void Dispose()
         {
-            PoolManager.i.Cleanup();
-
             if (autoCleanupCoroutine != null)
                 CoroutineStarter.Stop(autoCleanupCoroutine);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/MemoryManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/MemoryManager.cs
@@ -15,6 +15,8 @@ namespace DCL
         private uint memoryThresholdForCleanup = 0;
         private float cleanupInterval;
 
+        public event System.Action OnCriticalMemory;
+
         public MemoryManager (uint memoryThresholdForCleanup, float cleanupInterval)
         {
             this.memoryThresholdForCleanup = this.memoryThresholdForCleanup;
@@ -37,20 +39,7 @@ namespace DCL
                 CoroutineStarter.Stop(autoCleanupCoroutine);
 
             autoCleanupCoroutine = null;
-
-            // CommonScriptableObjects.rendererState.OnChange -= OnRendererStateChange;
         }
-
-        // public MemoryManager() { CommonScriptableObjects.rendererState.OnChange += OnRendererStateChange; }
-        //
-        // private void OnRendererStateChange(bool isEnable, bool prevState)
-        // {
-        //     if (!isEnable)
-        //     {
-        //         parcelScenesCleaner?.ForceCleanup();
-        //         Resources.UnloadUnusedAssets();
-        //     }
-        // }
 
         bool NeedsMemoryCleanup()
         {
@@ -64,7 +53,9 @@ namespace DCL
             {
                 if (NeedsMemoryCleanup())
                 {
+                    OnCriticalMemory?.Invoke();
                     yield return CleanPoolManager();
+                    Resources.UnloadUnusedAssets();
                 }
 
                 yield return new WaitForSecondsRealtime(TIME_FOR_NEW_MEMORY_CHECK);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/MemoryManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/MemoryManager.cs
@@ -75,7 +75,7 @@ namespace DCL
 
             if ( immediate )
             {
-                PoolManager.i.CleanupAsync(unusedOnly, nonPersistentOnly, true);
+                PoolManager.i.Cleanup(unusedOnly, nonPersistentOnly);
             }
             else
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
@@ -119,7 +119,7 @@ namespace DCL
 
         public GameObject InstantiateAsOriginal()
         {
-            Assert.IsTrue(original != null, "Original should never be null here");
+            Assert.IsTrue(original != null, $"Original should never be null here ({id})");
 
             GameObject gameObject = null;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/PoolManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/PoolManager.cs
@@ -228,7 +228,7 @@ namespace DCL
                 while (iterator.MoveNext())
                 {
                     Pool pool = iterator.Current.Value;
-                    bool unusedPool = pool.usedObjectsCount == 0 && pool.unusedObjectsCount > 0;
+                    bool unusedPool = pool.usedObjectsCount == 0; // && pool.unusedObjectsCount > 0;
                     bool isNonPersistent = !pool.persistent;
 
                     if (!unusedOnly) unusedPool = true;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/PoolManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/PoolManager.cs
@@ -219,7 +219,7 @@ namespace DCL
             return pool.Get();
         }
 
-        public IEnumerator CleanupAsync(bool unusedOnly = false, bool nonPersistentOnly = false, bool immediate = false)
+        public IEnumerator CleanupAsync(bool unusedOnly = true, bool nonPersistentOnly = true, bool immediate = false)
         {
             List<object> idsToRemove = new List<object>(pools.Count);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/PoolManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/PoolManager.cs
@@ -250,13 +250,12 @@ namespace DCL
             }
         }
 
-        public void Cleanup()
+        public void Cleanup( bool unusedOnly = false, bool nonPersistentOnly = false )
         {
             if (pools == null)
                 return;
 
-            // The immediate mode doesn't return a IEnumerator, so yield is not needed.
-            CleanupAsync( unusedOnly: false, nonPersistentOnly: false, immediate: true );
+            CleanupAsync( unusedOnly: unusedOnly, nonPersistentOnly: nonPersistentOnly, immediate: true ).MoveNext();
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Tests/PoolManagerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Tests/PoolManagerShould.cs
@@ -11,7 +11,7 @@ using UnityEngine.TestTools;
 
 namespace Tests
 {
-    public class PoolManagerTests : IntegrationTestSuite_Legacy
+    public class PoolManagerShould
     {
         public class PooledObjectInstantiator : IPooledObjectInstantiator
         {
@@ -21,14 +21,14 @@ namespace Tests
         }
 
         [Test]
-        public void PoolManagerShouldHandleNullArgsGracefully()
+        public void HandleNullArgsGracefully()
         {
             var thisShouldBeNull = PoolManager.i.GetPoolable(null);
             Assert.IsTrue(thisShouldBeNull == null);
         }
 
         [UnityTest]
-        public IEnumerator PooledGameObjectDestroyed()
+        public IEnumerator CountUsedAndUnusedObjectsWhenGetAndReleaseIsCalled()
         {
             PooledObjectInstantiator instantiator = new PooledObjectInstantiator();
 
@@ -63,14 +63,14 @@ namespace Tests
             Assert.AreEqual(1, pool.usedObjectsCount, "Alive objects count should be 1");
             Assert.AreEqual(1, pool.unusedObjectsCount, "Inactive objects count should be 1");
 
-            PoolManager.i.Cleanup();
+            PoolManager.i.Dispose();
 
             Assert.AreEqual(0, pool.usedObjectsCount, "Alive objects count should be 0");
             Assert.AreEqual(0, pool.unusedObjectsCount, "Inactive objects count should be 0");
         }
 
         [Test]
-        public void GetPoolableObject()
+        public void GetPoolableObjectsWhenGetIsCalled()
         {
             PooledObjectInstantiator instantiator = new PooledObjectInstantiator();
 
@@ -109,7 +109,7 @@ namespace Tests
         }
 
         [Test]
-        public void PoolIsNotBeingInitializedAgainAfterRendererWasToggled()
+        public void InitializeOnlyOnceAfterRendererIsToggled()
         {
             PooledObjectInstantiator instantiator = new PooledObjectInstantiator();
             GameObject original = new GameObject("Original");
@@ -119,10 +119,10 @@ namespace Tests
 
             // When teleporting this is false
             CommonScriptableObjects.rendererState.Set(false);
-            
+
             pool.Get().Release();
             pool.Get().Release();
-            
+
             UnityEngine.Assertions.Assert.AreEqual(1, pool.unusedObjectsCount, "Unused objects pool");
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Tests/PoolManagerShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Tests/PoolManagerShould.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b06e5f151e1a0c34faba34afd1086e6e
+guid: b44ae311cdcf5fb4ba39ff4d7947f66b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Environment.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Environment.cs
@@ -58,7 +58,6 @@ namespace DCL
 
             // Platform systems
             model.platform.parcelScenesCleaner.Start();
-            model.platform.memoryManager.Initialize(model.platform.parcelScenesCleaner);
             model.platform.cullingController.Start();
 
             // World context systems
@@ -69,7 +68,7 @@ namespace DCL
                 model.world.state, model.platform.cullingController);
             model.world.sceneBoundsChecker.Start();
             model.world.componentFactory.Initialize();
-            
+
             // HUD context system
             model.hud.controller.Initialize(model.hud.factory);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Environment.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Environment.cs
@@ -57,8 +57,8 @@ namespace DCL
             model.messaging.manager.Initialize(i.world.sceneController);
 
             // Platform systems
-            model.platform.parcelScenesCleaner.Start();
             model.platform.cullingController.Start();
+            model.platform.parcelScenesCleaner.Initialize();
 
             // World context systems
             model.world.sceneController.Initialize();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -144,7 +144,7 @@ namespace DCL.Controllers
             if (immediate) //!CommonScriptableObjects.rendererState.Get())
             {
                 RemoveAllEntitiesImmediate();
-                PoolManager.i.CleanupAsync(true, true, true);
+                PoolManager.i.Cleanup(true, true);
             }
             else
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -144,7 +144,7 @@ namespace DCL.Controllers
             if (immediate) //!CommonScriptableObjects.rendererState.Get())
             {
                 RemoveAllEntitiesImmediate();
-                Environment.i.platform.memoryManager.CleanPoolManager(false, true);
+                PoolManager.i.CleanupAsync(true, true, true);
             }
             else
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -144,6 +144,7 @@ namespace DCL.Controllers
             if (immediate) //!CommonScriptableObjects.rendererState.Get())
             {
                 RemoveAllEntitiesImmediate();
+                Environment.i.platform.memoryManager.CleanPoolManager(false, true);
             }
             else
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScenesCleaner/Interfaces/IParcelScenesCleaner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScenesCleaner/Interfaces/IParcelScenesCleaner.cs
@@ -6,8 +6,7 @@ namespace DCL
 {
     public interface IParcelScenesCleaner : IDisposable
     {
-        void Start();
-        void Stop();
+        void Initialize();
         void MarkForCleanup(IDCLEntity entity);
         void MarkRootEntityForCleanup(IParcelScene scene, IDCLEntity entity);
         void MarkDisposableComponentForCleanup(IParcelScene scene, string componentId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScenesCleaner/Interfaces/IParcelScenesCleaner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScenesCleaner/Interfaces/IParcelScenesCleaner.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using DCL.Controllers;
 using DCL.Models;
 
@@ -10,6 +12,7 @@ namespace DCL
         void MarkForCleanup(IDCLEntity entity);
         void MarkRootEntityForCleanup(IParcelScene scene, IDCLEntity entity);
         void MarkDisposableComponentForCleanup(IParcelScene scene, string componentId);
-        void ForceCleanup();
+        void CleanMarkedEntities();
+        public IEnumerator CleanMarkedEntitiesAsync(bool immediate = false);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
@@ -35,7 +35,7 @@ namespace SceneBoundariesCheckerTests
 
             TestHelpers.RemoveSceneEntity(scene, entity2.entityId);
 
-            Environment.i.platform.parcelScenesCleaner.ForceCleanup();
+            Environment.i.platform.parcelScenesCleaner.CleanMarkedEntities();
 
             Assert.AreEqual(0, scene.entities.Count, "entity count should be zero");
             Assert.AreEqual(0, Environment.i.world.sceneBoundsChecker.entitiesToCheckCount, "entities to check should be zero!");
@@ -158,7 +158,7 @@ namespace SceneBoundariesCheckerTests
             nftInfo.previewImageUrl = localAsset;
 
             nftFetcher.When((x) => x.FetchNFTImage(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<NFTInfo>>(), Arg.Any<Action>()))
-                      .Do(info => info.Arg<Action<NFTInfo>>().Invoke(nftInfo));
+                .Do(info => info.Arg<Action<NFTInfo>>().Invoke(nftInfo));
 
             wrapperNFT.loaderController.LoadAsset(model.src, true);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -106,7 +106,7 @@ namespace SceneBoundariesCheckerTests
             TestHelpers.RemoveSceneEntity(scene, entity2.entityId);
             TestHelpers.RemoveSceneEntity(scene, entity3.entityId);
 
-            Environment.i.platform.parcelScenesCleaner.ForceCleanup();
+            Environment.i.platform.parcelScenesCleaner.CleanMarkedEntities();
 
             Assert.AreEqual(0, Environment.i.world.sceneBoundsChecker.highPrioEntitiesToCheckCount, "entities to check should be zero!");
         }
@@ -133,7 +133,7 @@ namespace SceneBoundariesCheckerTests
             TestHelpers.RemoveSceneEntity(scene, entity2.entityId);
             TestHelpers.RemoveSceneEntity(scene, entity3.entityId);
 
-            Environment.i.platform.parcelScenesCleaner.ForceCleanup();
+            Environment.i.platform.parcelScenesCleaner.CleanMarkedEntities();
 
             Assert.AreEqual(0, Environment.i.world.sceneBoundsChecker.highPrioEntitiesToCheckCount, "entities to check should be zero!");
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests_DebugMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests_DebugMode.cs
@@ -54,7 +54,7 @@ namespace SceneBoundariesCheckerTests
 
             TestHelpers.RemoveSceneEntity(scene, entity.entityId);
 
-            Environment.i.platform.parcelScenesCleaner.ForceCleanup();
+            Environment.i.platform.parcelScenesCleaner.CleanMarkedEntities();
 
             yield return null;
 

--- a/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite/IntegrationTestSuite.cs
+++ b/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite/IntegrationTestSuite.cs
@@ -31,7 +31,7 @@ namespace Tests
         protected virtual IEnumerator TearDown()
         {
             Environment.Dispose();
-            PoolManager.i?.Cleanup();
+            PoolManager.i?.Dispose();
             yield break;
         }
     }

--- a/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
+++ b/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
@@ -106,7 +106,7 @@ public class IntegrationTestSuite_Legacy
     protected virtual IEnumerator TearDown()
     {
         yield return null;
-        
+
         if (runtimeGameObjectsRoot != null)
             Object.Destroy(runtimeGameObjectsRoot.gameObject);
 
@@ -141,10 +141,10 @@ public class IntegrationTestSuite_Legacy
         TearDown_PromiseKeepers();
 
         if (Environment.i.platform.memoryManager != null)
-            yield return Environment.i.platform.memoryManager.CleanupPoolsIfNeeded(true);
+            yield return Environment.i.platform.memoryManager.CleanPoolManager(true);
 
         if (PoolManager.i != null)
-            PoolManager.i.Cleanup();
+            PoolManager.i.Dispose();
 
         Caching.ClearCache();
         Resources.UnloadUnusedAssets();

--- a/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
+++ b/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
@@ -119,9 +119,9 @@ public class IntegrationTestSuite_Legacy
                 DCLCharacterController.i.characterController.enabled = true;
         }
 
-        Environment.Dispose();
-
         TearDown_Memory();
+
+        Environment.Dispose();
 
         if (MapRenderer.i != null)
             MapRenderer.i.Cleanup();

--- a/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
+++ b/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
@@ -119,9 +119,9 @@ public class IntegrationTestSuite_Legacy
                 DCLCharacterController.i.characterController.enabled = true;
         }
 
-        TearDown_Memory();
-
         Environment.Dispose();
+
+        TearDown_Memory();
 
         if (MapRenderer.i != null)
             MapRenderer.i.Cleanup();
@@ -252,13 +252,7 @@ public class IntegrationTestSuite_Legacy
         }
     }
 
-    protected IEnumerator WaitForUICanvasUpdate() { yield break; }
-
-    public static T Reflection_GetStaticField<T>(System.Type baseType, string fieldName) { return (T) baseType.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static).GetValue(null); }
-
     public static T Reflection_GetField<T>(object instance, string fieldName) { return (T) instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance).GetValue(instance); }
-
-    public static void Reflection_SetField<T>(object instance, string fieldName, T newValue) { instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance).SetValue(instance, newValue); }
 
     protected GameObject CreateTestGameObject(string name) { return CreateTestGameObject(name, Vector3.zero); }
 

--- a/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
+++ b/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
@@ -121,7 +121,7 @@ public class IntegrationTestSuite_Legacy
 
         Environment.Dispose();
 
-        yield return TearDown_Memory();
+        TearDown_Memory();
 
         if (MapRenderer.i != null)
             MapRenderer.i.Cleanup();
@@ -136,12 +136,9 @@ public class IntegrationTestSuite_Legacy
         AssetPromiseKeeper_AB.i?.Cleanup();
     }
 
-    protected IEnumerator TearDown_Memory()
+    protected void TearDown_Memory()
     {
         TearDown_PromiseKeepers();
-
-        if (Environment.i.platform.memoryManager != null)
-            yield return Environment.i.platform.memoryManager.CleanPoolManager(true);
 
         if (PoolManager.i != null)
             PoolManager.i.Dispose();

--- a/unity-renderer/Assets/Scripts/Tests/TestHelpers.asmdef
+++ b/unity-renderer/Assets/Scripts/Tests/TestHelpers.asmdef
@@ -37,7 +37,8 @@
         "GUID:9aa18dd7d97b0419e933b45b56d4ccca",
         "GUID:2eaa9b64aed3308028df3c2f56a3a471",
         "GUID:c27391cd3f3b5aeb4b4c45372ede8043",
-        "GUID:28f74c468a54948bfa9f625c5d428f56"
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:4bca15ec88eae72498e62f9a5c04bcf1"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?

This PR add small tweaks to how we free memory when teleporting.

* When clearing entities in "immediate mode" now the pool is cleaned up.
* When the rendering is deactivated to start a teleport, `ParcelScenesCleaner` pending entities are cleaned up and `Resources.UnloadUnusedAssets` is called. (before this happened when the rendering was **activated**, leading to potential unwanted memory spikes)
* Added a few refactors to improve `MemoryManager` and `ParcelScenesCleaner` encapsulation. `MemoryManager` now just exposes a `OnCriticalMemory` event. `MemoryManager` responsibility was simplified, and now it doesn't uses `ParcelScenesCleaner` anymore. The `MemoryManager` responsibility of cleaning pools is still in place, but the pool cleaning code was moved to `PoolManager`.

These changes shouldn't fix the recurring memory out of bounds situation. The memory issue is a combination of many issues that are going to be addressed in subsequent PRs. Those PR are going to take advantage of the changes presented on this one.

## How to test the changes?

- Try to teleport a few times around the world.
- As this PR introduced a more aggresive unloading on teleports, we should ensure loading times don't increase very much.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
