### PR TITLE
fix: gltf added to library more than once

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
@@ -37,7 +37,7 @@ namespace DCL
         HashSet<AssetPromiseType> blockedPromises = new HashSet<AssetPromiseType>();
 
         //NOTE(Brian): Master promise id -> blocked promises HashSet
-        Dictionary<object, HashSet<AssetPromiseType>> masterToBlockedPromises = new Dictionary<object, HashSet<AssetPromiseType>>(100);
+        protected Dictionary<object, HashSet<AssetPromiseType>> masterToBlockedPromises = new Dictionary<object, HashSet<AssetPromiseType>>(100);
 
         public bool useTimeBudget => CommonScriptableObjects.rendererState.Get();
 
@@ -111,7 +111,7 @@ namespace DCL
             return promise;
         }
 
-        public AssetPromiseType Forget(AssetPromiseType promise)
+        public virtual AssetPromiseType Forget(AssetPromiseType promise)
         {
             if (promise == null)
                 return null;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromiseKeeper_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromiseKeeper_GLTF.cs
@@ -33,7 +33,7 @@ namespace DCL
                     return base.Forget(promise);
                 }
 
-                if (promise.CanForget())
+                if (!isMasterPromise && promise.CanForget())
                 {
                     return base.Forget(promise);
                 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromiseKeeper_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromiseKeeper_GLTF.cs
@@ -4,9 +4,40 @@ namespace DCL
     {
         private static AssetPromiseKeeper_GLTF instance;
         public static AssetPromiseKeeper_GLTF i { get { return instance ??= new AssetPromiseKeeper_GLTF(); } }
-        
+
         public AssetPromiseKeeper_GLTF() : base(new AssetLibrary_GLTF()) { }
 
-        protected override void OnSilentForget(AssetPromise_GLTF promise) { promise.OnSilentForget(); }
+        protected override void OnSilentForget(AssetPromise_GLTF promise)
+        {
+            promise.OnSilentForget();
+        }
+
+        public override AssetPromise_GLTF Forget(AssetPromise_GLTF promise)
+        {
+            if (promise == null)
+                return null;
+
+            if (promise.state == AssetPromiseState.LOADING)
+            {
+                object id = promise.GetId();
+
+                bool isFirstPromise = masterPromiseById.ContainsKey(id) && masterPromiseById[id] == promise;
+                bool hasBlockedPromises = masterToBlockedPromises.ContainsKey(id) && masterToBlockedPromises[id].Count > 0;
+                bool isMasterPromise = isFirstPromise && hasBlockedPromises;
+
+                promise.OnForget();
+
+                if (!isMasterPromise && promise.IsCancellable())
+                {
+                    promise.Cancel();
+                    return base.Forget(promise);
+                }
+
+                promise.OnSilentForget();
+                return promise;
+            }
+
+            return base.Forget(promise);
+        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromiseKeeper_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromiseKeeper_GLTF.cs
@@ -27,9 +27,14 @@ namespace DCL
 
                 promise.OnForget();
 
-                if (!isMasterPromise && promise.IsCancellable())
+                if (!isMasterPromise && promise.CanCancel())
                 {
                     promise.Cancel();
+                    return base.Forget(promise);
+                }
+
+                if (promise.CanForget())
+                {
                     return base.Forget(promise);
                 }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -105,8 +105,11 @@ namespace DCL
 
         protected override bool AddToLibrary()
         {
-            if (!library.Add(asset))
-                return false;
+            if (!library.Contains(asset.id))
+            {
+                if (!library.Add(asset))
+                    return false;
+            }
 
             //NOTE(Brian): If the asset did load "in world" add it to library and then Get it immediately
             //             So it keeps being there. As master gltfs can't be in the world.
@@ -194,28 +197,22 @@ namespace DCL
         {
             asset = loadedAsset;
             waitingAssetLoad = false;
-            bool alreadyInLibrary = false;
-
-            if (success && asset != null)
-            {
-                alreadyInLibrary = library.Contains(asset);
-                if (alreadyInLibrary)
-                {
-                    asset.Cleanup();
-                    asset = null;
-                }
-                else
-                {
-                    AddToLibrary();
-                }
-            }
+            bool alreadyInLibrary = asset != null && library.Contains(asset);
 
             ClearEvents();
-            if (!alreadyInLibrary)
+
+            if (alreadyInLibrary)
             {
-                CallAndClearEvents(success);
+                asset.Cleanup();
+                asset = null;
+                return;
             }
-            Cleanup();
+            
+            if (success && asset != null)
+            {
+                library.Add(asset);
+                CallAndClearEvents();
+            }
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/BlockedAndMasterPromisesShould.cs
@@ -32,6 +32,8 @@ namespace AssetPromiseKeeper_GLTF_Tests
             keeper.Keep(prom);
             keeper.Keep(prom2);
             keeper.Keep(prom3);
+            
+            var asset = prom.asset;
 
             keeper.Forget(prom);
 
@@ -40,8 +42,6 @@ namespace AssetPromiseKeeper_GLTF_Tests
             Object.Destroy(parent);
 
             yield return prom;
-
-            var asset = prom.asset;
             
             yield return prom2;
             yield return prom3;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/GLTF_PromiseShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/GLTF_PromiseShould.cs
@@ -67,7 +67,7 @@ namespace AssetPromiseKeeper_GLTF_Tests
 
             var pool = PoolManager.i.GetPool(keeper.library.AssetIdToPoolId(promise1.GetId()));
             
-            Assert.AreEqual(1, pool.objectsCount);
+            Assert.AreEqual(2, pool.objectsCount);
             keeper.Cleanup();
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/GLTF_PromiseShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/GLTF_PromiseShould.cs
@@ -45,6 +45,31 @@ namespace AssetPromiseKeeper_GLTF_Tests
             Assert.AreEqual(cubeTexture, cylinderTexture);
             keeper.Cleanup();
         }
+        
+        [UnityTest]
+        public IEnumerator NotAddAssetToLibraryMoreThanOnce()
+        {
+            var keeper = new AssetPromiseKeeper_GLTF();
+            IWebRequestController webRequestController = WebRequestController.Create();
+            
+            string url = TestAssetsUtils.GetPath() + "/GLB/Trunk/Trunk.glb";
+            var provider = new ContentProvider_Dummy();
+            
+            AssetPromise_GLTF promise1 = new AssetPromise_GLTF(provider, url, webRequestController);
+            keeper.Keep(promise1);
+            keeper.Forget(promise1);
+            
+            AssetPromise_GLTF promise2 = new AssetPromise_GLTF(provider, url, webRequestController);
+            keeper.Keep(promise2);
+            
+            yield return promise2;
+            yield return promise1;
+
+            var pool = PoolManager.i.GetPool(keeper.library.AssetIdToPoolId(promise1.GetId()));
+            
+            Assert.AreEqual(1, pool.objectsCount);
+            keeper.Cleanup();
+        }
 
     }
 }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -359,13 +359,18 @@ namespace UnityGLTF
 
         public void CancelIfQueued()
         {
-            if (prioritizeDownload)
-                return;
-            
-            if (state == State.QUEUED || state == State.NONE)
+            if (IsInQueue())
             {
                 OnFail_Internal(null);
             }
+        }
+
+        public bool IsInQueue()
+        {
+            if (prioritizeDownload)
+                return false;
+            
+            return state == State.QUEUED || state == State.NONE;
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
related to PR https://github.com/decentraland/unity-renderer/pull/1194 (refactored changes done there)
related to issue #1196 

In some situations GLTFs were added more than once to the library sometimes leaving orphan GLTF and wasting memory unnecessarily 

also: closes #1205 by adding test coverage