### PR TITLE
fix: now asset promises are disposed properly in the NFTShapeLoader

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
@@ -208,6 +208,7 @@ public class NFTShapeLoaderController : MonoBehaviour
             yield return WrappedTextureUtils.Fetch(nftInfo.previewImageUrl, (promise) =>
             {
                 foundDCLImage = true;
+                assetPromise?.Forget();
                 this.assetPromise = promise;
                 FetchNFTInfoSuccess(promise.asset, nftInfo, true);
             });
@@ -220,6 +221,7 @@ public class NFTShapeLoaderController : MonoBehaviour
                 (promise) =>
                 {
                     foundDCLImage = true;
+                    assetPromise?.Forget();
                     this.assetPromise = promise;
                     FetchNFTInfoSuccess(promise.asset, nftInfo, false);
                 }, () => isError = true);


### PR DESCRIPTION
Fixes #1219 
NFTShapeLoader was not disposing asset promises properly.

It might translate to fewer memory crashes in place with lot of NFTShapes (as in -73,-33). You can test against that parcel and compare to master.

## How to test the changes?
NFTShapes should behave as before.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
