### PR TITLE
fix: gifs load cancellation memory crash

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromise.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromise.cs
@@ -155,14 +155,8 @@ namespace DCL
 
         public void Cleanup()
         {
-            if (state == AssetPromiseState.LOADING)
-            {
-                OnCancelLoading();
-                ClearEvents();
-            }
-
-            state = AssetPromiseState.IDLE_AND_EMPTY;
-
+            // Important: Asset destruction must be the first thing to happen here or else
+            // we risk leaking memory when the asset loading is canceled mid-loading
             if (asset != null)
             {
                 if (library.Contains(asset))
@@ -172,6 +166,14 @@ namespace DCL
 
                 asset = null;
             }
+            
+            if (state == AssetPromiseState.LOADING)
+            {
+                OnCancelLoading();
+                ClearEvents();
+            }
+
+            state = AssetPromiseState.IDLE_AND_EMPTY;
         }
 
         internal virtual void OnForget()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
@@ -28,8 +28,6 @@ namespace DCL
         protected override void OnCancelLoading()
         {
             CoroutineStarter.Stop(loadingRoutine);
-            
-            asset?.Dispose();
         }
 
         protected override bool AddToLibrary()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
@@ -29,7 +29,7 @@ namespace DCL
         {
             CoroutineStarter.Stop(loadingRoutine);
             
-            asset.Dispose();
+            asset?.Dispose();
         }
 
         protected override bool AddToLibrary()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
@@ -25,7 +25,12 @@ namespace DCL
                     }, OnFail));
         }
 
-        protected override void OnCancelLoading() { CoroutineStarter.Stop(loadingRoutine); }
+        protected override void OnCancelLoading()
+        {
+            CoroutineStarter.Stop(loadingRoutine);
+            
+            asset.Dispose();
+        }
 
         protected override bool AddToLibrary()
         {


### PR DESCRIPTION
Added missing asset disposing in OnCancelLoading().

All credit goes to @Suduck that found this issue.

https://play.decentraland.zone/?renderer-branch=fix/GifsLoadCancellationMemoryCrash&DISABLE_ASSET_BUNDLES