### PR TITLE
fix: notify kernel that DebugBridge is ready

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/DebugController/DebugBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/DebugController/DebugBridge.cs
@@ -15,6 +15,7 @@ namespace DCL
         public void Setup(IDebugController debugController)
         {
             this.debugController = debugController;
+            WebInterface.SetDebugBridgeReady();
         }
         
         // Beware this SetDebug() may be called before Awake() somehow...

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -1298,5 +1298,10 @@ namespace DCL.Interface
 
             SendMessage("VideoProgressEvent", progressEvent);
         }
+
+        public static void SetDebugBridgeReady()
+        {
+            SendMessage("SetDebugBridgeReady");
+        }
     }
 }


### PR DESCRIPTION
`DebugBridge` is created at runtime. This means that kernel should wait for `DebugBridge` to be created before sending debug messages like those used when `PREVIEW` is initialized and/or using url params:
```
SetDebug()
SetSceneDebugPanel()
ShowFPSPanel()
SetEngineDebugPanel()
```