### PR TITLE
fix: combined avatar mesh leak

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerHelper.cs
@@ -21,6 +21,8 @@ namespace DCL
         public GameObject container { get; private set; }
         public SkinnedMeshRenderer renderer { get; private set; }
 
+        private AvatarMeshCombiner.Output? lastOutput;
+
         public AvatarMeshCombinerHelper (GameObject container = null) { this.container = container; }
 
         /// <summary>
@@ -92,6 +94,7 @@ namespace DCL
                 renderer = container.AddComponent<SkinnedMeshRenderer>();
 
             UnloadAssets();
+            lastOutput = output;
 
             container.layer = bonesContainer.gameObject.layer;
             renderer.sharedMesh = output.mesh;
@@ -109,15 +112,15 @@ namespace DCL
 
         private void UnloadAssets()
         {
-            if (renderer == null)
+            if (!lastOutput.HasValue)
                 return;
 
-            if (renderer.sharedMesh != null)
-                Object.Destroy(renderer.sharedMesh);
+            if (lastOutput.Value.mesh != null)
+                Object.Destroy(lastOutput.Value.mesh);
 
-            if ( renderer.sharedMaterials != null)
+            if (lastOutput.Value.materials != null)
             {
-                foreach ( var material in renderer.sharedMaterials )
+                foreach ( var material in lastOutput.Value.materials )
                 {
                     Object.Destroy(material);
                 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -424,10 +424,6 @@ namespace DCL
             // TODO(Brian): Evaluate using UniTask<T> instead of this way.
             yield return new WaitUntil(() => bodyShapeController.isReady && wearableControllers.Values.All(x => x.isReady));
 
-            if ( eyesController == null || eyebrowsController == null || mouthController == null )
-            {
-            }
-
             eyesController.Load(bodyShapeController, model.eyeColor);
             eyebrowsController.Load(bodyShapeController, model.hairColor);
             mouthController.Load(bodyShapeController, model.skinColor);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -381,6 +381,15 @@ namespace DCL
                 }
             }
 
+            if ( eyesController == null && !unusedCategories.Contains(Categories.EYES))
+                unusedCategories.Add(Categories.EYES);
+
+            if ( mouthController == null && !unusedCategories.Contains(Categories.MOUTH))
+                unusedCategories.Add(Categories.MOUTH);
+
+            if ( eyebrowsController == null && !unusedCategories.Contains(Categories.EYEBROWS))
+                unusedCategories.Add(Categories.EYEBROWS);
+
             foreach (var category in unusedCategories)
             {
                 switch (category)
@@ -414,6 +423,10 @@ namespace DCL
 
             // TODO(Brian): Evaluate using UniTask<T> instead of this way.
             yield return new WaitUntil(() => bodyShapeController.isReady && wearableControllers.Values.All(x => x.isReady));
+
+            if ( eyesController == null || eyebrowsController == null || mouthController == null )
+            {
+            }
 
             eyesController.Load(bodyShapeController, model.eyeColor);
             eyebrowsController.Load(bodyShapeController, model.hairColor);
@@ -600,7 +613,7 @@ namespace DCL
 
             mainMeshRenderer.enabled = newVisibility;
         }
-        
+
         public void SetImpostorVisibility(bool impostorVisibility) { lodRenderer.gameObject.SetActive(impostorVisibility); }
 
         public void SetImpostorForward(Vector3 newForward) { lodRenderer.transform.forward = newForward; }


### PR DESCRIPTION
## What does this PR change?

* Combined avatar meshes were leaking because the renderer used to retrieve the mesh references for unload was being destroyed before the unload was called.
* Fix unhandled error when the face wearables can't be fetched from wearables endpoint.

## How to test the changes?

* Instance many avatars by using `clientDebug.InstantiateBotsAtCoords({ amount: 200 })`
* Clear the bots by using `clientDebug.ClearBots()`.

Notice that when doing this in `master` a lot of dangling meshes can be seen on Unity's profiler, incurring a leak of around 2.4 mb per avatar.

On the version of this PR, the meshes should be destroyed and the memory freed.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
