### PR TITLE
fix: invisible UI container blocking raycast

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/UIContainerRect.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/UIContainerRect.cs
@@ -38,6 +38,7 @@ namespace DCL.Components
         public override IEnumerator ApplyChanges(BaseModel newModel)
         {
             referencesContainer.image.color = new Color(model.color.r, model.color.g, model.color.b, model.color.a);
+            referencesContainer.image.raycastTarget = model.color.a >= RAYCAST_ALPHA_THRESHOLD;
 
             Outline outline = referencesContainer.image.GetComponent<Outline>();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/UIContainerStack.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/UIContainerStack.cs
@@ -50,6 +50,7 @@ namespace DCL.Components
         public override IEnumerator ApplyChanges(BaseModel newModel)
         {
             referencesContainer.image.color = new Color(model.color.r, model.color.g, model.color.b, model.color.a);
+            referencesContainer.image.raycastTarget = model.color.a >= RAYCAST_ALPHA_THRESHOLD;
 
             if (model.stackOrientation == StackOrientation.VERTICAL && !(layoutGroup is VerticalLayoutGroup))
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
@@ -54,7 +54,7 @@ namespace DCL.Components
         where ReferencesContainerType : UIReferencesContainer
         where ModelType : UIShape.Model
     {
-        public const float RAYCAST_ALPHA_THRESHOLD = 0.02f;
+        public const float RAYCAST_ALPHA_THRESHOLD = 0.01f;
         
         public UIShape() { }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
@@ -54,6 +54,8 @@ namespace DCL.Components
         where ReferencesContainerType : UIReferencesContainer
         where ModelType : UIShape.Model
     {
+        public const float RAYCAST_ALPHA_THRESHOLD = 0.02f;
+        
         public UIShape() { }
 
         new public ModelType model { get { return base.model as ModelType; } set { base.model = value; } }

--- a/unity-renderer/Assets/Scripts/Tests/CursorControllerTests/CursorControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/Tests/CursorControllerTests/CursorControllerTests.cs
@@ -276,7 +276,7 @@ namespace Tests
 
             UIContainerRect uiContainerRectShape =
                 TestHelpers.SharedComponentCreate<UIContainerRect, UIContainerRect.Model>(scene,
-                    CLASS_ID.UI_CONTAINER_RECT);
+                    CLASS_ID.UI_CONTAINER_RECT, new UIContainerRect.Model() { color = Color.white });
             yield return uiContainerRectShape.routine;
 
             yield return null;
@@ -286,5 +286,66 @@ namespace Tests
 
             DCLCharacterController.i.ResumeGravity();
         }
+        
+        [UnityTest]
+        public IEnumerator OnPointerHoverFeedbackIsNotBlockedByFullyAplhaUIContainer()
+        {
+            IDCLEntity entity;
+            BoxShape shape;
+
+            shape = TestHelpers.InstantiateEntityWithShape<BoxShape, BoxShape.Model>(
+                scene,
+                DCL.Models.CLASS_ID.BOX_SHAPE,
+                Vector3.zero,
+                out entity,
+                new BoxShape.Model() { });
+
+            TestHelpers.SetEntityTransform(scene, entity, new Vector3(8, 2, 10), Quaternion.identity, new Vector3(3, 3, 3));
+            yield return shape.routine;
+
+            var onPointerDownModel = new OnPointerDown.Model()
+            {
+                type = OnPointerDown.NAME,
+                uuid = "pointerevent-1"
+            };
+            var component = TestHelpers.EntityComponentCreate<OnPointerDown, OnPointerDown.Model>(scene, entity,
+                onPointerDownModel, CLASS_ID_COMPONENT.UUID_CALLBACK);
+            Assert.IsTrue(component != null);
+
+            yield return null;
+
+            DCLCharacterController.i.SetPosition(new Vector3(8, 1, 7f));
+
+            var cameraController = GameObject.FindObjectOfType<CameraController>();
+
+            // Rotate camera towards the interactive object
+            cameraController.SetRotation(45, 0, 0);
+
+            yield return null;
+
+            var hoverCanvasController = InteractionHoverCanvasController.i;
+            Assert.IsNotNull(hoverCanvasController);
+
+            // Check hover feedback is enabled
+            Assert.IsTrue(hoverCanvasController.canvas.enabled);
+
+            // Put UI in the middle
+            UIScreenSpace screenSpaceShape =
+                TestHelpers.SharedComponentCreate<UIScreenSpace, UIScreenSpace.Model>(scene,
+                    CLASS_ID.UI_SCREEN_SPACE_SHAPE);
+            yield return screenSpaceShape.routine;
+
+            UIContainerRect uiContainerRectShape =
+                TestHelpers.SharedComponentCreate<UIContainerRect, UIContainerRect.Model>(scene,
+                    CLASS_ID.UI_CONTAINER_RECT, new UIContainerRect.Model() { color = Color.clear });
+            yield return uiContainerRectShape.routine;
+
+            yield return null;
+
+            // Check hover feedback is still enabled
+            Assert.IsTrue(hoverCanvasController.canvas.enabled);
+
+            DCLCharacterController.i.ResumeGravity();
+        }        
     }
 }

--- a/unity-renderer/Assets/Scripts/Tests/CursorControllerTests/CursorControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/Tests/CursorControllerTests/CursorControllerTests.cs
@@ -288,7 +288,7 @@ namespace Tests
         }
         
         [UnityTest]
-        public IEnumerator OnPointerHoverFeedbackIsNotBlockedByFullyAplhaUIContainer()
+        public IEnumerator OnPointerHoverFeedbackIsNotBlockedByFullyAlphaUIContainer()
         {
             IDCLEntity entity;
             BoxShape shape;


### PR DESCRIPTION
related to https://github.com/decentraland/sdk/issues/75

It's not uncommon for scenes developers to leave UIContainers on screen since by default it alpha is 0 so they don't see it.
This generate issues like hover feedback not being display or not being able to lock the mouse.
So I've added an alpha tolerance to decide if a UIContainer should be a target for raycast or not.

issue can be reproduced here: https://play.decentraland.zone/?position=-29,55 trying to lock the mouse on the bottom-right corner of the screen is impossible cause an invisible UIContainer is blocking it
test issue is fixed here: https://play.decentraland.zone/?renderer-branch=fix/invisible-ui-container-blocking-raycast&position=-29,55