### PR TITLE
fix: enable texture compression for gifs

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
@@ -20,6 +20,12 @@ namespace DCL
                 processor.Load(
                     frames =>
                     {
+                        for (int i = 0; i < frames.Length; i++)
+                        {
+                            GifFrameData frame = frames[i];
+                            frame.texture.Compress(false);
+                        }
+
                         asset.frames = frames;
                         OnSuccess?.Invoke();
                     }, OnFail));
@@ -34,6 +40,7 @@ namespace DCL
                 Debug.Log("add to library fail?");
                 return false;
             }
+
             asset = library.Get(asset.id);
             return true;
         }


### PR DESCRIPTION
## What does this PR change?

This PRs enable texture compression for gifs, making gifs take advantage of DXT compression. This should save around 25% of texture memory for gif NFT shapes.

## How to test the changes?

Go to any scene with a lot of gif NFTs and compare memory usage.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
