### PR TITLE
fix: model null ref in Gizmos component

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Gizmos/DCLGizmos.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Gizmos/DCLGizmos.cs
@@ -28,6 +28,8 @@ namespace DCL.Components
             public override BaseModel GetDataFromJSON(string json) { return Utils.SafeFromJson<Model>(json); }
         }
 
+        private void Awake() { model = new Model(); }
+        
         public override IEnumerator ApplyChanges(BaseModel baseModel) { return null; }
 
         public override int GetClassId() { return (int) CLASS_ID_COMPONENT.GIZMOS; }


### PR DESCRIPTION
not a relevant fix. 
does not happen in prod but it was crashing the client while running test-scene -102,102