### PR TITLE
fix: animation stuck fix

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
@@ -47,8 +47,8 @@ namespace DCL.Components
 
         public override IEnumerator ApplyChanges(BaseModel model)
         {
-            entity.OnShapeUpdated -= OnComponentUpdated;
-            entity.OnShapeUpdated += OnComponentUpdated;
+            entity.OnShapeLoaded -= OnComponentUpdated;
+            entity.OnShapeLoaded += OnComponentUpdated;
 
             UpdateAnimationState();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
@@ -62,6 +62,7 @@ namespace DCL.Components
             alreadyLoaded = true;
 
             entity.OnShapeUpdated?.Invoke(entity);
+            entity.OnShapeLoaded?.Invoke(entity);
         }
 
         void LoadAsset() { loaderController?.LoadAsset(assetUrl, true); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_OBJ.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_OBJ.cs
@@ -54,6 +54,7 @@ namespace DCL.Components
             {
                 entity.OnShapeUpdated.Invoke(entity);
             }
+            entity.OnShapeLoaded?.Invoke(entity);
 
             CollidersManager.i.ConfigureColliders(entity);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
@@ -263,6 +263,7 @@ namespace DCL.Components
             ConfigureColliders(entity);
 
             RaiseOnShapeUpdated(entity);
+            RaiseOnShapeLoaded(entity);
 
             OnFinishCallbacks?.Invoke(this);
             OnFinishCallbacks = null;
@@ -298,6 +299,14 @@ namespace DCL.Components
                 return;
 
             entity.OnShapeUpdated?.Invoke(entity);
+        }
+
+        private void RaiseOnShapeLoaded(IDCLEntity entity)
+        {
+            if (!isLoaded)
+                return;
+
+            entity.OnShapeLoaded?.Invoke(entity);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DecentralandEntity.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DecentralandEntity.cs
@@ -28,6 +28,7 @@ namespace DCL.Models
         public Renderer[] renderers => meshesInfo.renderers;
 
         public System.Action<IDCLEntity> OnShapeUpdated { get; set; }
+        public System.Action<IDCLEntity> OnShapeLoaded { get; set; }
         public System.Action<object> OnNameChange { get; set; }
         public System.Action<object> OnTransformChange { get; set; }
         public System.Action<IDCLEntity> OnRemoved { get; set; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IDCLEntity.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IDCLEntity.cs
@@ -41,6 +41,7 @@ namespace DCL.Models
         Dictionary<CLASS_ID_COMPONENT, IEntityComponent> components { get; }
         Dictionary<System.Type, ISharedComponent> sharedComponents { get; }
         Action<IDCLEntity> OnShapeUpdated { get; set; }
+        Action<IDCLEntity> OnShapeLoaded { get; set; }
         Action<IDCLEntity> OnRemoved { get; set; }
         Action<IDCLEntity> OnMeshesInfoUpdated { get; set; }
         Action<IDCLEntity> OnMeshesInfoCleaned { get; set; }


### PR DESCRIPTION
## What does this PR change?

Fixes #985  

The current animation system has a race condition where if you try to set the animation in the middle of the charge of a GLTF the animator component will say that the animation that you are trying to play is playing but it is not playing.

As the animator component will say that the animation is playing, the DCLAnimator component will ignore the message

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/animation-problem
2. Test several times that the octopus is doing the animation correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
