### PR TITLE
chore: set min value for Max HQ Avatars to 25

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/MaxHQAvatarsControlConfiguration.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/MaxHQAvatarsControlConfiguration.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   flagsThatDeactivateMe:
   - {fileID: 11400000, guid: 5932aa2a572cf43a189edf2072b323d6, type: 2}
   isBeta: 0
-  sliderMinValue: 5
+  sliderMinValue: 25
   sliderMaxValue: 100
   storeValueAsNormalized: 0
   wholeNumbers: 1


### PR DESCRIPTION
Sets the min value for Max HQ Avatars setting to 25.

To test it go into an incognito mode an check the default value of that setting.