### PR TITLE
fix: animation blending was firing all events at once

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -217,7 +217,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler
         }
         else
         {
-            animation.Blend(bb.expressionTriggerId, 1, 0.1f);
+            animation.Blend(bb.expressionTriggerId, 1, EXPRESSION_TRANSITION_TIME / 2f);
         }
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -215,6 +215,10 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler
 
             Update(bb.deltaTime);
         }
+        else
+        {
+            animation.Blend(bb.expressionTriggerId, 1, 0.1f);
+        }
     }
 
     public void SetExpressionValues(string expressionTriggerId, long expressionTriggerTimestamp)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickerAnimationListener.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickerAnimationListener.cs
@@ -7,5 +7,14 @@ public class StickerAnimationListener : MonoBehaviour
     private void Awake() { stickersController = GetComponentInParent<StickersController>(); }
 
     //It's going to be called through an AnimationEvent
-    private void PlaySticker(string id) { stickersController?.PlayEmote(id); }
+    private void PlaySticker(AnimationEvent animEvent)
+    {
+        if (string.IsNullOrEmpty(animEvent.stringParameter))
+            return;
+
+        if (animEvent.animationState.weight < 0.5f)
+            return;
+
+        stickersController?.PlayEmote(animEvent.stringParameter);
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickerAnimationListener.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickerAnimationListener.cs
@@ -2,6 +2,7 @@
 
 public class StickerAnimationListener : MonoBehaviour
 {
+    private const float WEIGHT_THRESHOLD = 0.5f;
     private StickersController stickersController;
 
     private void Awake() { stickersController = GetComponentInParent<StickersController>(); }
@@ -12,7 +13,7 @@ public class StickerAnimationListener : MonoBehaviour
         if (string.IsNullOrEmpty(animEvent.stringParameter))
             return;
 
-        if (animEvent.animationState.weight < 0.5f)
+        if (animEvent.animationState.weight < WEIGHT_THRESHOLD)
             return;
 
         stickersController?.PlayEmote(animEvent.stringParameter);


### PR DESCRIPTION
`Animation.Blend` was causing all the animation events to trigger at once when playing an Emote twice in a row. We fix it by setting the weight of the animation properly and using it to discard events in the transitions.

It's hard to implement a test for this because it's mostly due to how unity handles the animation. It would require the test to play an animation twice and count the events received.

## How to test the changes?
Just make sure that the emotes are triggering as usual and nothing is broken.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
