### PR TITLE
chore: adjust presets for MaxHQAvatar

### DIFF
--- a/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
@@ -29,7 +29,7 @@ MonoBehaviour:
     enableDetailObjectCulling: 1
     detailObjectCullingLimit: 85
     ssaoQuality: 1
-    maxHQAvatars: 10
+    maxHQAvatars: 25
   - displayName: Medium
     baseResolution: 1
     antiAliasing: 1
@@ -45,7 +45,7 @@ MonoBehaviour:
     enableDetailObjectCulling: 1
     detailObjectCullingLimit: 50
     ssaoQuality: 2
-    maxHQAvatars: 20
+    maxHQAvatars: 40
   - displayName: High
     baseResolution: 1
     antiAliasing: 1


### PR DESCRIPTION
Basic, Medium presets had the value for MaxHQAvatar below the minimum for the setting.

## Test
Just check that you can set quality presets to Basic or Medium.