### PR TITLE
Caret position is moved to the end of the line when replying a whisper

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowHUDView.cs
@@ -77,7 +77,7 @@ public class WorldChatWindowHUDView : MonoBehaviour, IPointerClickHandler
         if (!string.IsNullOrEmpty(controller.lastPrivateMessageReceivedSender) && text == "/r ")
         {
             chatHudView.inputField.text = $"/w {controller.lastPrivateMessageReceivedSender} ";
-            chatHudView.inputField.caretPosition = chatHudView.inputField.text.Length;
+            chatHudView.inputField.MoveTextEnd(false);
         }
     }
 


### PR DESCRIPTION
## What does this PR change?

Fixes [#1117](https://github.com/decentraland/unity-renderer/issues/1117)

Caret position of chat input field is moved to the end of the line when replying a whisper

## How to test the changes?

1. Whisper a friend user typing _/w [friend] anything_ in chat
2. The friend user should reply typing _/r_ in chat
3. The chat should automatically write the name of the user you are replying positioning the caret at the end of the line

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
