### PR TITLE
fix: initialization time with impostors material gpu instancing

### DIFF
--- a/unity-renderer/Assets/Materials/AvatarLOD.mat
+++ b/unity-renderer/Assets/Materials/AvatarLOD.mat
@@ -24,7 +24,7 @@ Material:
   m_Shader: {fileID: 4800000, guid: 861f58cc229a5f449b2494095122257f, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 1
+  m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 1
   m_CustomRenderQueue: 3000
   stringTagMap:


### PR DESCRIPTION
Apparently this property affects our shader variants prewarm (that happens on initialization time), making the app block the main thread for too long.

* Disabled GPU instancing for the avatar impostors material
* Tested with 100 bots comparing using that property ON and OFF and didn't notice any performance change.