### PR TITLE
fix: custom quality settings label and performance issue

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/BaseControllers/SettingsControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/BaseControllers/SettingsControlController.cs
@@ -13,9 +13,9 @@ namespace DCL.SettingsCommon.SettingsControllers.BaseControllers
 
         public virtual void Initialize()
         {
-            currentGeneralSettings = Settings.i.generalSettings.Data.Clone() as GeneralSettings;
-            currentQualitySetting = Settings.i.qualitySettings.Data.Clone() as QualitySettings;
-            currentAudioSettings = Settings.i.audioSettings.Data.Clone() as AudioSettings;
+            currentGeneralSettings = Settings.i.generalSettings.Data;
+            currentQualitySetting = Settings.i.qualitySettings.Data;
+            currentAudioSettings = Settings.i.audioSettings.Data;
 
             Settings.i.generalSettings.OnChanged += OnGeneralSettingsChanged;
             Settings.i.qualitySettings.OnChanged += OnQualitySettingsChanged;
@@ -53,17 +53,17 @@ namespace DCL.SettingsCommon.SettingsControllers.BaseControllers
             Settings.i.audioSettings.Apply(currentAudioSettings);
         }
 
-        private void OnGeneralSettingsChanged(GeneralSettings newGeneralSettings) { currentGeneralSettings = (GeneralSettings)newGeneralSettings.Clone(); }
+        private void OnGeneralSettingsChanged(GeneralSettings newGeneralSettings) { currentGeneralSettings = newGeneralSettings; }
 
-        private void OnQualitySettingsChanged(QualitySettings newQualitySettings) { currentQualitySetting = (QualitySettings)newQualitySettings.Clone(); }
+        private void OnQualitySettingsChanged(QualitySettings newQualitySettings) { currentQualitySetting = newQualitySettings; }
 
-        private void OnAudioSettingsChanged(AudioSettings newAudioSettings) { currentAudioSettings = (AudioSettings)newAudioSettings.Clone(); }
+        private void OnAudioSettingsChanged(AudioSettings newAudioSettings) { currentAudioSettings = newAudioSettings; }
 
         protected virtual void OnResetSettingsControl()
         {
-            currentGeneralSettings = Settings.i.generalSettings.Data.Clone() as GeneralSettings;
-            currentQualitySetting = Settings.i.qualitySettings.Data.Clone() as QualitySettings;
-            currentAudioSettings = Settings.i.audioSettings.Data.Clone() as AudioSettings;
+            currentGeneralSettings = Settings.i.generalSettings.Data;
+            currentQualitySetting = Settings.i.qualitySettings.Data;
+            currentAudioSettings = Settings.i.audioSettings.Data;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/AudioSettings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/AudioSettings.cs
@@ -3,7 +3,7 @@ using System;
 namespace DCL.SettingsCommon
 {
     [Serializable]
-    public class AudioSettings : ICloneable, IEquatable<AudioSettings>
+    public struct AudioSettings
     {
         public float masterVolume;
         public float voiceChatVolume;
@@ -12,25 +12,5 @@ namespace DCL.SettingsCommon
         public float sceneSFXVolume; // Note(Mordi): Also known as "World SFX"
         public float musicVolume;
         public bool chatSFXEnabled;
-
-        public object Clone() { return MemberwiseClone(); }
-        public bool Equals(AudioSettings other)
-        {
-            if (ReferenceEquals(null, other))
-                return false;
-            if (ReferenceEquals(this, other))
-                return true;
-            return masterVolume.Equals(other.masterVolume) && voiceChatVolume.Equals(other.voiceChatVolume) && avatarSFXVolume.Equals(other.avatarSFXVolume) && uiSFXVolume.Equals(other.uiSFXVolume) && sceneSFXVolume.Equals(other.sceneSFXVolume) && musicVolume.Equals(other.musicVolume) && chatSFXEnabled == other.chatSFXEnabled;
-        }
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != this.GetType())
-                return false;
-            return Equals((AudioSettings) obj);
-        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/GeneralSettings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/GeneralSettings.cs
@@ -3,7 +3,7 @@ using System;
 namespace DCL.SettingsCommon
 {
     [Serializable]
-    public class GeneralSettings : ICloneable, IEquatable<GeneralSettings>
+    public struct GeneralSettings
     {
         public enum VoiceChatAllow { ALL_USERS, VERIFIED_ONLY, FRIENDS_ONLY }
 
@@ -15,26 +15,5 @@ namespace DCL.SettingsCommon
         public float avatarsLODDistance;
         public float maxNonLODAvatars;
         public float namesOpacity;
-
-        public object Clone() { return (GeneralSettings)MemberwiseClone(); }
-
-        public bool Equals(GeneralSettings other)
-        {
-            if (ReferenceEquals(null, other))
-                return false;
-            if (ReferenceEquals(this, other))
-                return true;
-            return mouseSensitivity.Equals(other.mouseSensitivity) && voiceChatVolume.Equals(other.voiceChatVolume) && voiceChatAllow == other.voiceChatAllow && autoqualityOn == other.autoqualityOn && scenesLoadRadius.Equals(other.scenesLoadRadius) && avatarsLODDistance.Equals(other.avatarsLODDistance) && maxNonLODAvatars.Equals(other.maxNonLODAvatars) && namesOpacity.Equals(other.namesOpacity);
-        }
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != this.GetType())
-                return false;
-            return Equals((GeneralSettings) obj);
-        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/QualitySettings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/QualitySettings.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace DCL.SettingsCommon
 {
     [Serializable]
-    public class QualitySettings : ICloneable, IEquatable<QualitySettings>
+    public struct QualitySettings
     {
         public enum BaseResolution
         {
@@ -68,63 +68,5 @@ namespace DCL.SettingsCommon
 
         [Tooltip("Amount of HQ Avatars visible at any time")]
         public int maxHQAvatars;
-
-        
-        public object Clone() { return MemberwiseClone(); }
-        public bool Equals(QualitySettings otherSetting)
-        {
-            if (ReferenceEquals(null, otherSetting))
-                return false;
-            if (ReferenceEquals(this, otherSetting))
-                return true;
-            
-            // The precision is set to 1 because the wholeNumbers setting
-            // in the slider can clamp the values, thus we can have a 0 > n > 1 precision error.
-            const float comparePrecision = 1.0f;
-
-            if (baseResolution != otherSetting.baseResolution)
-                return false;
-            if (antiAliasing != otherSetting.antiAliasing)
-                return false;
-            if (Mathf.Abs(renderScale - otherSetting.renderScale) > 0.001f)
-                return false;
-            if (shadows != otherSetting.shadows)
-                return false;
-            if (softShadows != otherSetting.softShadows)
-                return false;
-            if (shadowResolution != otherSetting.shadowResolution)
-                return false;
-            if (!Utils.CompareFloats(cameraDrawDistance, otherSetting.cameraDrawDistance, comparePrecision))
-                return false;
-            if (bloom != otherSetting.bloom)
-                return false;
-            if (fpsCap != otherSetting.fpsCap)
-                return false;
-            if (colorGrading != otherSetting.colorGrading)
-                return false;
-            if (!Utils.CompareFloats(shadowDistance, otherSetting.shadowDistance, comparePrecision))
-                return false;
-            if (enableDetailObjectCulling != otherSetting.enableDetailObjectCulling)
-                return false;
-            if (!Utils.CompareFloats(detailObjectCullingLimit, otherSetting.detailObjectCullingLimit, comparePrecision))
-                return false;
-            if (ssaoQuality != otherSetting.ssaoQuality)
-                return false;
-            if (maxHQAvatars != otherSetting.maxHQAvatars)
-                return false;
-
-            return true;
-            
-        }
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != this.GetType())
-                return false;
-            return Equals((QualitySettings) obj);
-        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsModule.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsModule.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace DCL.SettingsCommon
 {
-    public class SettingsModule<T> where T : class, ICloneable, IEquatable<T>
+    public class SettingsModule<T> where T : struct
     {
         public event Action<T> OnChanged;
 
@@ -23,13 +23,13 @@ namespace DCL.SettingsCommon
 
         private void Preload()
         {
-            dataValue = (T)defaultPreset.Clone();
+            dataValue = defaultPreset;
             if (!PlayerPrefsUtils.HasKey(playerPrefsKey))
                 return;
 
             try
             {
-                JsonUtility.FromJsonOverwrite(PlayerPrefsUtils.GetString(playerPrefsKey), Data);
+                dataValue = JsonUtility.FromJson<T>(PlayerPrefsUtils.GetString(playerPrefsKey));
             }
             catch (Exception e)
             {
@@ -44,7 +44,7 @@ namespace DCL.SettingsCommon
             if (dataValue.Equals(newSettings))
                 return;
 
-            dataValue = (T)newSettings.Clone();
+            dataValue = newSettings;
             OnChanged?.Invoke(dataValue);
         }
 


### PR DESCRIPTION
## What does this PR change?
Fixes #1312 
Fixes the "Custom" label on Quality Preset dropdown when changing any quality setting.
Fixes a perfomance regression when changing the Quality Preset
...

## How to test the changes?

Change quality preset to any value then change any quality setting to another value, the quality preset label should change to Custom.

No hiccups when doing this

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
