### PR TITLE
fix: flatten materials hiccup

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
@@ -42,9 +42,9 @@ namespace DCL
     public class FlattenedMaterialsData
     {
         public List<Material> materials = new List<Material>();
-        public List<Vector3> texturePointers = new List<Vector3>();
-        public List<Vector4> colors = new List<Vector4>();
-        public List<Vector4> emissionColors = new List<Vector4>();
+        public Vector3[] texturePointers;
+        public Vector4[] colors;
+        public Vector4[] emissionColors;
     }
 
     /// <summary>
@@ -131,7 +131,7 @@ namespace DCL
             finalMesh.SetUVs(EMISSION_COLORS_UV_CHANNEL_INDEX, flattenedMaterialsData.emissionColors);
             finalMesh.SetUVs(TEXTURE_POINTERS_UV_CHANNEL_INDEX, flattenedMaterialsData.texturePointers);
 
-            var tempArray = new NativeArray<Vector4>(flattenedMaterialsData.colors.Count, Allocator.Temp);
+            var tempArray = new NativeArray<Vector4>(flattenedMaterialsData.colors.Length, Allocator.Temp);
             tempArray.CopyFrom(flattenedMaterialsData.colors.ToArray());
             finalMesh.SetColors(tempArray);
             tempArray.Dispose();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
@@ -183,17 +183,22 @@ public class AvatarMeshCombinerUtilsCan
 
         // Assert
         FlattenedMaterialsData expected = new FlattenedMaterialsData();
-        expected.colors = new List<Vector4>();
-        expected.texturePointers = new List<Vector3>();
-        expected.emissionColors = new List<Vector4>();
 
-        expected.colors.AddRange(Enumerable.Repeat((Vector4)Color.blue, 24));
-        expected.emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.yellow, 24));
-        expected.texturePointers.AddRange(Enumerable.Repeat(new Vector3(6, 11, 0.5f), 24));
+        var colors = new List<Vector4>();
+        var texturePointers = new List<Vector3>();
+        var emissionColors = new List<Vector4>();
 
-        expected.colors.AddRange(Enumerable.Repeat((Vector4)Color.red, 24));
-        expected.emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.white, 24));
-        expected.texturePointers.AddRange(Enumerable.Repeat(new Vector3(4, 10, 0.5f), 24));
+        colors.AddRange(Enumerable.Repeat((Vector4)Color.blue, 24));
+        emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.yellow, 24));
+        texturePointers.AddRange(Enumerable.Repeat(new Vector3(6, 11, 0.5f), 24));
+
+        colors.AddRange(Enumerable.Repeat((Vector4)Color.red, 24));
+        emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.white, 24));
+        texturePointers.AddRange(Enumerable.Repeat(new Vector3(4, 10, 0.5f), 24));
+
+        expected.colors = colors.ToArray();
+        expected.emissionColors = emissionColors.ToArray();
+        expected.texturePointers = texturePointers.ToArray();
 
         CollectionAssert.AreEquivalent(expected.colors, result.colors);
         CollectionAssert.AreEquivalent(expected.texturePointers, result.texturePointers);
@@ -219,17 +224,22 @@ public class AvatarMeshCombinerUtilsCan
 
         // Assert
         FlattenedMaterialsData expected = new FlattenedMaterialsData();
-        expected.colors = new List<Vector4>();
-        expected.texturePointers = new List<Vector3>();
-        expected.emissionColors = new List<Vector4>();
 
-        expected.colors.AddRange(Enumerable.Repeat((Vector4)Color.blue, 24));
-        expected.emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.yellow, 24));
-        expected.texturePointers.AddRange(Enumerable.Repeat(new Vector3(6, 11, 0.5f), 24));
+        var colors = new List<Vector4>();
+        var texturePointers = new List<Vector3>();
+        var emissionColors = new List<Vector4>();
 
-        expected.colors.AddRange(Enumerable.Repeat((Vector4)Color.red, 24));
-        expected.emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.white, 24));
-        expected.texturePointers.AddRange(Enumerable.Repeat(new Vector3(4, 10, 0.5f), 24));
+        colors.AddRange(Enumerable.Repeat((Vector4)Color.blue, 24));
+        emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.yellow, 24));
+        texturePointers.AddRange(Enumerable.Repeat(new Vector3(6, 11, 0.5f), 24));
+
+        colors.AddRange(Enumerable.Repeat((Vector4)Color.red, 24));
+        emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.white, 24));
+        texturePointers.AddRange(Enumerable.Repeat(new Vector3(4, 10, 0.5f), 24));
+
+        expected.colors = colors.ToArray();
+        expected.emissionColors = emissionColors.ToArray();
+        expected.texturePointers = texturePointers.ToArray();
 
         CollectionAssert.AreEquivalent(expected.colors, result.colors);
         CollectionAssert.AreEquivalent(expected.texturePointers, result.texturePointers);


### PR DESCRIPTION
## What does this PR change?

This PR improves the performance of the `FlattenMaterials` method. This method was identified as a source of hiccups on this document: https://www.notion.so/decentraland/Hiccup-Profiling-14-10-2021-e8d8ff74e20d42c6a206f3824ba6dfa4

Sources used for inspiration:
[https://stackoverflow.com/questions/11672149/fill-a-multidimensional-array-with-same-values-c-sharp](https://stackoverflow.com/questions/11672149/fill-a-multidimensional-array-with-same-values-c-sharp)

[https://stackoverflow.com/questions/54096317/performance-difference-between-c-sharp-for-loop-and-array-fill](https://stackoverflow.com/questions/54096317/performance-difference-between-c-sharp-for-loop-and-array-fill)

Technical details:
- `List.Add` `List.AddRange` `List.ctor` and `List.EnsureCapacity` were a source of unwanted performance cost. So moved everything to normal pre-allocated arrays instead.
- `Enumerator.Repeat` was a source of unwanted performance cost. Removed its usage.
- Removed conversion of List to Arrays as now is everything an array.

Before:
![image](https://user-images.githubusercontent.com/6875814/137530867-953bcf18-29c9-4e72-9d91-fd7888ac6657.png)

After:
![image](https://user-images.githubusercontent.com/6875814/137530816-f9c4c423-c1a6-4506-8092-2e8c3493224d.png)

## How to test the changes?
You'd have to profile the method.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
