### PR TITLE
chore: release 100% rollout to .org

### DIFF
--- a/.github/workflows/set-rollout.yml
+++ b/.github/workflows/set-rollout.yml
@@ -59,4 +59,4 @@ jobs:
           # Rollout information
           deploymentDomain: "play.decentraland.org"
           deploymentName: "@dcl/unity-renderer"
-          percentage: 0
+          percentage: 100


### PR DESCRIPTION
We're going to use `master` as a release branch and `dev` as a development branch to create `hotfixes` for the festival.