### PR TITLE
chore: replace texSubImage2D with texImage2D in webVideoPlayer

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.cs
@@ -166,7 +166,8 @@ namespace DCL.Components.Video.Plugin
 
         private Texture2D CreateTexture(int width, int height)
         {
-            Texture2D tex = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            // We use RGBA instead of ARGB to avoid internal bit swapping in the Hls plugin that uses RGBA
+            Texture2D tex = new Texture2D(width, height, TextureFormat.RGBA32, false);
             tex.wrapMode = TextureWrapMode.Clamp;
             return tex;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -116,14 +116,28 @@ var WebVideoPlayer = {
         
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[texturePtr]);
         
-        GLctx.texImage2D(
-            GLctx.TEXTURE_2D,
-            0,
-            GLctx.RGBA,
-            GLctx.RGBA,
-            GLctx.UNSIGNED_BYTE,
-            videos[id].video
-        );
+        if (isWebGL1) {
+            GLctx.texImage2D(
+                GLctx.TEXTURE_2D,
+                0,
+                GLctx.RGBA,
+                GLctx.RGBA,
+                GLctx.UNSIGNED_BYTE,
+                videos[id].video
+            );
+        } else {
+            GLctx.texImage2D(
+                GLctx.TEXTURE_2D,
+                0,
+                GLctx.RGBA,
+                videos[id].video.videoWidth,
+                videos[id].video.videoHeight,
+                0,
+                GLctx.RGBA,
+                GLctx.UNSIGNED_BYTE,
+                videos[id].video
+            );
+        }
     },
 
     WebVideoPlayerPlay: function (videoId, startTime) {


### PR DESCRIPTION
Replaced texSubImage2D with texImage2D as it's reportedly more performant, as stated in https://github.com/decentraland/unity-renderer/issues/1349

**TESTING**
Test video streaming still works, there are several festival stages streaming all the time around -67, 86

https://play.decentraland.zone/?renderer-branch=chore/ReplaceTexSubImageInWebglVideoPlayer&position=-67%2C86