### PR TITLE
chore: revert rollout, new rollout 0%

### DIFF
--- a/.github/workflows/set-rollout.yml
+++ b/.github/workflows/set-rollout.yml
@@ -59,4 +59,4 @@ jobs:
           # Rollout information
           deploymentDomain: "play.decentraland.org"
           deploymentName: "@dcl/unity-renderer"
-          percentage: 100
+          percentage: 0


### PR DESCRIPTION
Revert rollout to only use master as default branch