### PR TITLE
fix: emotes now are working in unity editor/desktop, the websocket me…

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
@@ -134,7 +134,9 @@ public class WebSocketCommunication : IKernelCommunication
         messageTypeToBridgeName["UpdateBalanceOfMANA"] = "HUDController";
         messageTypeToBridgeName["SetPlayerTalking"] = "HUDController";
         messageTypeToBridgeName["SetVoiceChatEnabledByScene"] = "HUDController";
-
+        messageTypeToBridgeName["TriggerSelfUserExpression"] = "HUDController";
+        messageTypeToBridgeName["AirdroppingRequest"] = "HUDController";
+        
         messageTypeToBridgeName["GetMousePosition"] = "BuilderController";
         messageTypeToBridgeName["SelectGizmo"] = "BuilderController";
         messageTypeToBridgeName["ResetObject"] = "BuilderController";
@@ -152,8 +154,6 @@ public class WebSocketCommunication : IKernelCommunication
         messageTypeToBridgeName["GetCameraTargetBuilder"] = "BuilderController";
         messageTypeToBridgeName["PreloadFile"] = "BuilderController";
         messageTypeToBridgeName["SetBuilderConfiguration"] = "BuilderController";
-        messageTypeToBridgeName["TriggerSelfUserExpression"] = "BuilderController";
-        messageTypeToBridgeName["AirdroppingRequest"] = "BuilderController";
 
         messageTypeToBridgeName["SetTutorialEnabled"] = "TutorialController";
         messageTypeToBridgeName["SetTutorialEnabledForUsersThatAlreadyDidTheTutorial"] = "TutorialController";


### PR DESCRIPTION
…ssage was bridging it to an incorrect bridge

Fix #1249

## How to test the changes?

1. Open unity-renderer from the Unity Editor
2. Execute `/emote disco`
3. See if you're dancing

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
