### PR TITLE
fix: revert gif compression to see it correctly

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Gif/AssetPromise_Gif.cs
@@ -22,12 +22,6 @@ namespace DCL
                     {
                         asset.frames = frames;
 
-                        foreach ( var frame in asset.frames )
-                        {
-                            frame.texture.Compress(false);
-                            frame.texture.Apply(true, true);
-                        }
-
                         OnSuccess?.Invoke();
                     }, OnFail));
         }


### PR DESCRIPTION
## What does this PR change?

Fix gif compression error

Before:
![image](https://user-images.githubusercontent.com/12563266/138954081-b845085a-b481-4d47-aecf-babd0a81b804.png)


After:
![image](https://user-images.githubusercontent.com/12563266/138954135-7698cf1d-c5e6-40c5-91fb-ec5274b05a01.png)


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
