### PR TITLE
fix: now ABConverter processes internal textures properly

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -383,7 +383,17 @@ namespace UnityGLTF
                                     var materialMaps = texMaterialMap[tex];
                                     bool isExternal = cachedTextures.Contains(tex);
 
-                                    var texPath = AssetDatabase.GetAssetPath(tex);
+                                    string texPath;
+                                    if (isExternal)
+                                    {
+                                        texPath = AssetDatabase.GetAssetPath(tex);
+                                    }
+                                    else
+                                    {
+                                        var texturesRoot = string.Concat(folderName, "/", "Textures/");
+                                        var ext = _useJpgTextures ? ".jpg" : ".png";
+                                        texPath = string.Concat(texturesRoot, tex.name, ext);
+                                    }
                                     var importedTex = AssetDatabase.LoadAssetAtPath<Texture2D>(texPath);
                                     var importer = (TextureImporter) TextureImporter.GetAtPath(texPath);
 


### PR DESCRIPTION
Fixes #1406 

Embedded textures are referenced ni memory (altough they are imported to assets) and the `GetAssetPath` was failing.