### PR TITLE
fix: UIInputText component events

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIInputText/UIInputText.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIInputText/UIInputText.cs
@@ -159,9 +159,9 @@ namespace DCL.Components
 
         public void OnSubmit(string call)
         {
-            bool validString = !string.IsNullOrEmpty(tmpText.text);
+            bool validString = !string.IsNullOrEmpty(call);
 
-            if (tmpText.text.Length == 1 && (byte) tmpText.text[0] == 11) //NOTE(Brian): Trim doesn't work. neither IsNullOrWhitespace.
+            if (call?.Length == 1 && (byte) call[0] == 11) //NOTE(Brian): Trim doesn't work. neither IsNullOrWhitespace.
             {
                 validString = false;
             }
@@ -169,8 +169,8 @@ namespace DCL.Components
             if (validString)
             {
                 // NOTE: we keep `ReportOnTextSubmitEvent` for backward compatibility (it won't be called for scenes using latest sdk)
-                Interface.WebInterface.ReportOnTextSubmitEvent(scene.sceneData.id, model.onTextSubmit, tmpText.text);
-                Interface.WebInterface.ReportOnTextInputChangedTextEvent(scene.sceneData.id, model.onTextChanged, tmpText.text, true);
+                Interface.WebInterface.ReportOnTextSubmitEvent(scene.sceneData.id, model.onTextSubmit, call);
+                Interface.WebInterface.ReportOnTextInputChangedTextEvent(scene.sceneData.id, model.onTextChanged, call, true);
             }
             else if (scene.isPersistent) // DCL UI Chat text input
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIInputText/UIInputText.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIInputText/UIInputText.cs
@@ -125,11 +125,13 @@ namespace DCL.Components
         public void OnChanged(string changedText)
         {
             // NOTE: OSX is adding the ESC character at the end of the string when ESC is pressed
+            #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
             if (changedText.Length > 0 && changedText[changedText.Length - 1] == 27)
             {
                 changedText = changedText.Substring(0, changedText.Length - 1);
                 inputField.SetTextWithoutNotify(changedText);
             }
+            #endif
 
             // NOTE: we keep `ReportOnTextInputChangedEvent` for backward compatibility (it won't be called for scenes using latest sdk)
             Interface.WebInterface.ReportOnTextInputChangedEvent(scene.sceneData.id, model.onChanged, changedText);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -170,6 +170,9 @@ namespace DCL.Interface
         private class OnTextInputChangeEvent : UUIDEvent<OnTextInputChangeEventPayload> { };
 
         [System.Serializable]
+        private class OnTextInputChangeTextEvent : UUIDEvent<OnTextInputChangeTextEventPayload> { };
+
+        [System.Serializable]
         private class OnScrollChangeEvent : UUIDEvent<OnScrollChangeEventPayload> { };
 
         [System.Serializable]
@@ -251,6 +254,18 @@ namespace DCL.Interface
         public class OnTextInputChangeEventPayload
         {
             public string value;
+        }
+        
+        [System.Serializable]
+        public class OnTextInputChangeTextEventPayload
+        {
+            [System.Serializable]
+            public class Payload
+            {
+                public string value;
+                public bool isSubmit;          
+            }
+            public Payload value = new Payload();
         }
 
         [System.Serializable]
@@ -690,6 +705,7 @@ namespace DCL.Interface
         private static OnPointerUpEvent onPointerUpEvent = new OnPointerUpEvent();
         private static OnTextSubmitEvent onTextSubmitEvent = new OnTextSubmitEvent();
         private static OnTextInputChangeEvent onTextInputChangeEvent = new OnTextInputChangeEvent();
+        private static OnTextInputChangeTextEvent onTextInputChangeTextEvent = new OnTextInputChangeTextEvent();
         private static OnScrollChangeEvent onScrollChangeEvent = new OnScrollChangeEvent();
         private static OnFocusEvent onFocusEvent = new OnFocusEvent();
         private static OnBlurEvent onBlurEvent = new OnBlurEvent();
@@ -894,6 +910,20 @@ namespace DCL.Interface
             onTextInputChangeEvent.payload.value = text;
 
             SendSceneEvent(sceneId, "uuidEvent", onTextInputChangeEvent);
+        }
+
+        public static void ReportOnTextInputChangedTextEvent(string sceneId, string uuid, string text, bool isSubmit)
+        {
+            if (string.IsNullOrEmpty(uuid))
+            {
+                return;
+            }
+
+            onTextInputChangeTextEvent.uuid = uuid;
+            onTextInputChangeTextEvent.payload.value.value = text;
+            onTextInputChangeTextEvent.payload.value.isSubmit = isSubmit;
+
+            SendSceneEvent(sceneId, "uuidEvent", onTextInputChangeTextEvent);
         }
 
         public static void ReportOnFocusEvent(string sceneId, string uuid)


### PR DESCRIPTION
* fix input field being clear and string value set to empty after submit: after submit an `onChanged` was triggered with and empty value
* fix input field adding an unknown character at the end of the string when ESC key was pressed (happening in OSX)
+ added a single event for text changes. kept old events to maintain compatibility with old scenes
