### PR TITLE
fix: player minimap icon incorrect offset

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -43,7 +43,7 @@ namespace DCL
         public Transform overlayContainer;
         public Transform globalUserMarkerContainer;
 
-        public Image playerPositionIcon;
+        public RectTransform playerPositionIcon;
 
         // Used as a reference of the coordinates origin in-map and as a parcel width/height reference
         public RectTransform centeredReferenceParcel;
@@ -377,9 +377,9 @@ namespace DCL
             Vector3 f = CommonScriptableObjects.cameraForward.Get();
             Quaternion playerAngle = Quaternion.Euler(0, 0, Mathf.Atan2(-f.x, f.z) * Mathf.Rad2Deg);
 
-            var gridPosition = this.playerGridPosition;
-            playerPositionIcon.transform.localPosition = MapUtils.GetTileToLocalPosition(gridPosition.x, gridPosition.y);
-            playerPositionIcon.transform.rotation = playerAngle;
+            var gridPosition = playerGridPosition;
+            playerPositionIcon.anchoredPosition = MapUtils.GetTileToLocalPosition(gridPosition.x, gridPosition.y);
+            playerPositionIcon.rotation = playerAngle;
         }
 
         public Vector3 GetViewportCenter() { return atlas.viewport.TransformPoint(atlas.viewport.rect.center); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
@@ -235,7 +235,7 @@ MonoBehaviour:
   highlightedParcelText: {fileID: 7940259258301411768}
   overlayContainer: {fileID: 90597117798403300}
   globalUserMarkerContainer: {fileID: 3332934504654532118}
-  playerPositionIcon: {fileID: 7800080416519839540}
+  playerPositionIcon: {fileID: 1340394175305253205}
   centeredReferenceParcel: {fileID: 1025416073224921776}
   scenesOfInterestIconPrefab: {fileID: 4461918297282884638, guid: f7b91bf31609c8a43b5dbc0ae70e47ab,
     type: 3}
@@ -727,8 +727,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -510, y: -510}
-  m_SizeDelta: {x: 7130, y: 7130}
+  m_AnchoredPosition: {x: -500, y: -500}
+  m_SizeDelta: {x: 7140, y: 7140}
   m_Pivot: {x: 0, y: 0}
 --- !u!1001 &6431149015225084135
 PrefabInstance:


### PR DESCRIPTION
## What does this PR change?

`Closes #178 `
Fixes an incorrect offset of the player's icon in the minimap.
After several tests and approaches i went through the simplest solution i found.

## How to test the changes?

1. Go to: https://play.decentraland.org/?renderer-branch=fix/minimap-player-offset
2. Type `/goto 3,-17` (the roads acts as a reference where the player should be)
3. The player icon in the minimap should be perfectly positioned according to the map space
4. Press `M`. All the map icons should be correctly positioned
5. Go to any populated zone. Peer player icons should be correctly positioned in the minimap

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
