### PR TITLE
fix: asset bundle converter gives priority to albedo

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -224,6 +224,7 @@ namespace UnityGLTF
                     List<Texture2D> textures = new List<Texture2D>();
                     var texMaterialMap = new Dictionary<Texture2D, List<TexMaterialMap>>();
 
+                    HashSet<Texture2D> baseColor = new HashSet<Texture2D>();
                     HashSet<Texture2D> normals = new HashSet<Texture2D>();
                     HashSet<Texture2D> metallics = new HashSet<Texture2D>();
 
@@ -283,6 +284,10 @@ namespace UnityGLTF
                                                         }
 
                                                         materialMaps.Add(new TexMaterialMap(mat, propertyName, propertyName == "_BumpMap"));
+                                                        if (propertyName == "_BaseMap")
+                                                        {
+                                                            baseColor.Add(tex);
+                                                        }
                                                         if (propertyName == "_BumpMap")
                                                         {
                                                             normals.Add(tex);
@@ -423,7 +428,7 @@ namespace UnityGLTF
 
                                         if (isExternal)
                                         {
-                                            isNormalMap = normals.Contains(tex);
+                                            isNormalMap = !baseColor.Contains(tex) && normals.Contains(tex);
                                         }
 
                                         if (isNormalMap)


### PR DESCRIPTION
If the same texture is used as both BaseColor and Normal mapping now won't be marked as normal map.