### PR TITLE
chore: add labels to differentiate webgl vs desktop

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/ReportBugButton.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/ReportBugButton.cs
@@ -37,9 +37,18 @@ namespace MainScripts.DCL.Controllers.HUD.TaskbarHUD
                          $"&ram={ram}" +
                          $"&gpu={gpu}" +
                          $"&nametag={nametag}" +
-                         $"&realm={realm}";
+                         $"&realm={realm}" + 
+                         $"&labels={GetLabels()}";
 
             WebInterface.OpenURL(url);
+        }
+        private string GetLabels()
+        {
+#if UNITY_WEBGL
+            return "explorer,new";
+#else
+            return "explorer-desktop,new";
+#endif
         }
         private string GetOSInfo()
         {


### PR DESCRIPTION
## What does this PR change?

Fix #1433 

## How to test the changes?

Press report a bug, the issue must have `explorer`/`explorer-desktop` and `new` labels

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
