### PR TITLE
feat: [Explore V2] Signed requests to Events API (Unity side)

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/Bridges.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/Bridges.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 7701290377581287658}
   - component: {fileID: 8242017988712305001}
   - component: {fileID: 6402082374581292810}
+  - component: {fileID: 5085020541334580736}
   m_Layer: 0
   m_Name: Bridges
   m_TagString: Untagged
@@ -132,5 +133,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7ab929cd616fbde4fa9b696c94c91e6e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5085020541334580736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6401575379531892522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99dbd659999d37440b2927cb7cc3c20f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/ExploreV2Bridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/ExploreV2Bridge.cs
@@ -1,0 +1,9 @@
+using System;
+using UnityEngine;
+
+public class ExploreV2Bridge : MonoBehaviour
+{
+    public static event Action<string> OnDCLEventsReceived;
+
+    public void DCLEvents(string payload) { OnDCLEventsReceived?.Invoke(payload); }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/ExploreV2Bridge.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/ExploreV2Bridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99dbd659999d37440b2927cb7cc3c20f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsAPIModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsAPIModel.cs
@@ -8,6 +8,12 @@ public class EventListFromAPIModel
     public List<EventFromAPIModel> data;
 }
 
+public class EventListFromAPISignedModel
+{
+    public bool ok;
+    public string data;
+}
+
 [Serializable]
 public class EventFromAPIModel
 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
@@ -108,7 +108,8 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
 
     internal void RequestAllEventsFromAPI()
     {
-        eventsAPIApiController.GetAllEvents(
+        // First try with signed request
+        eventsAPIApiController.GetAllEventsSigned(
             (eventList) =>
             {
                 eventsFromAPI = eventList;
@@ -116,7 +117,19 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
             },
             (error) =>
             {
-                Debug.LogError($"Error receiving events from the API: {error}");
+                Debug.LogError($"Error receiving events from the API (with signed request): {error}");
+
+                // If the signed request fails, tries with non-signed one (this is temporal)
+                eventsAPIApiController.GetAllEvents(
+                    (eventList) =>
+                    {
+                        eventsFromAPI = eventList;
+                        OnEventsFromAPIUpdated?.Invoke();
+                    },
+                    (error) =>
+                    {
+                        Debug.LogError($"Error receiving events from the API (with non-signed request): {error}");
+                    });
             });
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventsSubSectionComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventsSubSectionComponentControllerTests.cs
@@ -84,7 +84,7 @@ public class EventsSubSectionComponentControllerTests
         eventsSubSectionComponentView.Received().SetUpcomingEventsAsLoading(true);
         eventsSubSectionComponentView.Received().SetShowMoreUpcomingEventsButtonActive(false);
         eventsSubSectionComponentView.Received().SetGoingEventsAsLoading(true);
-        eventsAPIController.Received().GetAllEvents(Arg.Any<Action<List<EventFromAPIModel>>>(), Arg.Any<Action<string>>());
+        eventsAPIController.Received().GetAllEventsSigned(Arg.Any<Action<List<EventFromAPIModel>>>(), Arg.Any<Action<string>>());
         Assert.IsFalse(eventsSubSectionComponentController.reloadEvents);
     }
 
@@ -95,7 +95,7 @@ public class EventsSubSectionComponentControllerTests
         eventsSubSectionComponentController.RequestAllEventsFromAPI();
 
         // Assert
-        eventsAPIController.Received().GetAllEvents(Arg.Any<Action<List<EventFromAPIModel>>>(), Arg.Any<Action<string>>());
+        eventsAPIController.Received().GetAllEventsSigned(Arg.Any<Action<List<EventFromAPIModel>>>(), Arg.Any<Action<string>>());
     }
 
     [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -1030,16 +1030,13 @@ namespace DCL.Interface
         {
             public string newUnverifiedName;
         }
-        
+
         [System.Serializable]
         public class SendSaveUserDescriptionPayload
         {
             public string description;
 
-            public SendSaveUserDescriptionPayload(string description)
-            {
-                this.description = description;
-            }
+            public SendSaveUserDescriptionPayload(string description) { this.description = description; }
         }
 
         [Serializable]
@@ -1082,11 +1079,8 @@ namespace DCL.Interface
 
             SendMessage("SaveUserUnverifiedName", payload);
         }
-        
-        public static void SendSaveUserDescription(string about)
-        {
-            SendMessage("SaveUserDescription", new SendSaveUserDescriptionPayload(about));
-        }
+
+        public static void SendSaveUserDescription(string about) { SendMessage("SaveUserDescription", new SendSaveUserDescriptionPayload(about)); }
 
         public static void SendUserAcceptedCollectibles(string airdropId) { SendMessage("UserAcceptedCollectibles", new UserAcceptedCollectiblesPayload { id = airdropId }); }
 
@@ -1338,6 +1332,12 @@ namespace DCL.Interface
             };
 
             SendMessage("VideoProgressEvent", progressEvent);
+        }
+
+        public static void RequestDCLEvents(string url)
+        {
+            stringPayload.value = url;
+            SendMessage("RequestDCLEvents", stringPayload);
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?
Fixes #1297 

Make signed requests (through `signedFetch`) to the Events API.

Once the new version of the Events API is available, we will need to sign the requests in order to be able to obtain custom user fields like `attending`  that will inform us if out user is subscribed to an event or not.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=feat/ExploreV2-Signed-requests-to-events-API-Unity-side&kernel-branch=feat/ExploreV2-Signed-requests-to-events-API
2. Open Explore.
3. Open the Events sub-section.
4. Notice everything loads corretcly.

## PR dependencies
This PR should not be merged until this other kernel PR is merged: https://github.com/decentraland/kernel/pull/98

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
