### PR TITLE
fix: biw new way to sign the calls

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldEditor.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderInWorldEditor.cs
@@ -134,7 +134,7 @@ public class BuilderInWorldEditor : IBIWEditor
     {
         string ethAddress =  string.IsNullOrEmpty(userProfile.ethAddress) ? "default" : userProfile.ethAddress;
         areCatalogHeadersAsked = true;
-        builderInWorldBridge.AskKernelForCatalogHeadersWithParams("get", "/assetPacks?owner=" + ethAddress);
+        builderInWorldBridge.AskKernelForCatalogHeadersWithParams("get", "/assetPacks"); 
     }
 
     public void InitReferences(InitialSceneReferences.Data sceneReferences)


### PR DESCRIPTION
## What does this PR change?

This PR fixes biw, right now it is not working because the builder API has changed the way we sign the headers

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/biw-api
2. Check that builder in world work as intendeed

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
