### PR TITLE
fix: set GPUOnly meshes dependant on a feature flag

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -15,14 +15,9 @@ namespace DCL
         AssetPromise_AB subPromise;
         Coroutine loadingCoroutine;
 
-        public AssetPromise_AB_GameObject(string contentUrl, string hash) : base(contentUrl, hash)
-        {
-        }
+        public AssetPromise_AB_GameObject(string contentUrl, string hash) : base(contentUrl, hash) { }
 
-        protected override void OnLoad(Action OnSuccess, Action OnFail)
-        {
-            loadingCoroutine = CoroutineStarter.Start(LoadingCoroutine(OnSuccess, OnFail));
-        }
+        protected override void OnLoad(Action OnSuccess, Action OnFail) { loadingCoroutine = CoroutineStarter.Start(LoadingCoroutine(OnSuccess, OnFail)); }
 
         protected override bool AddToLibrary()
         {
@@ -52,10 +47,7 @@ namespace DCL
             asset.Show(OnSuccess);
         }
 
-        protected override void OnAfterLoadOrReuse()
-        {
-            settings.ApplyAfterLoad(asset.container.transform);
-        }
+        protected override void OnAfterLoadOrReuse() { settings.ApplyAfterLoad(asset.container.transform); }
 
         protected override void OnBeforeLoadOrReuse()
         {
@@ -78,7 +70,6 @@ namespace DCL
 
             AssetPromiseKeeper_AB.i.Forget(subPromise);
         }
-
 
         public override string ToString()
         {
@@ -115,7 +106,6 @@ namespace DCL
                 OnFail?.Invoke();
             }
         }
-
 
         public IEnumerator InstantiateABGameObjects()
         {
@@ -170,15 +160,19 @@ namespace DCL
 
         private void UploadMeshesToGPU(List<Mesh> meshesList)
         {
+            var uploadToGPU = DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(FeatureFlag.GPU_ONLY_MESHES);
             foreach ( Mesh mesh in meshesList )
             {
                 if ( !mesh.isReadable )
                     continue;
 
-                Physics.BakeMesh(mesh.GetInstanceID(), false);
                 asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
                 asset.meshes.Add(mesh);
-                mesh.UploadMeshData(true);
+                if (uploadToGPU)
+                {
+                    Physics.BakeMesh(mesh.GetInstanceID(), false);
+                    mesh.UploadMeshData(true);
+                }
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetPromiseKeeper.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetPromiseKeeper.asmdef
@@ -21,7 +21,9 @@
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
         "GUID:38a8ee8544aa3d247917a7a4d70fdd8b",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:8af21c3a612af2645a9953d4b9b3f6d5"
+        "GUID:8af21c3a612af2645a9953d4b9b3f6d5",
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:2995626b54c60644988f134a69a77450"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/FeatureFlags/Data/FeatureFlag.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/FeatureFlags/Data/FeatureFlag.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class FeatureFlag
 {
+    public const string GPU_ONLY_MESHES = "use-gpu-only-meshes";
+
     public readonly Dictionary<string, bool> flags  = new Dictionary<string, bool>();
     public readonly Dictionary<string, FeatureFlagVariant> variants  = new Dictionary<string, FeatureFlagVariant>();
 

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -271,7 +271,7 @@ namespace UnityGLTF
                     sceneImporter.LoadingTextureMaterial = LoadingTextureMaterial;
                     sceneImporter.initialVisibility = initialVisibility;
                     sceneImporter.addMaterialsToPersistentCaching = addMaterialsToPersistentCaching;
-                    sceneImporter.forceGPUOnlyMesh = settings.forceGPUOnlyMesh;
+                    sceneImporter.forceGPUOnlyMesh = settings.forceGPUOnlyMesh && DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(FeatureFlag.GPU_ONLY_MESHES);
 
                     float time = Time.realtimeSinceStartup;
 
@@ -351,15 +351,9 @@ namespace UnityGLTF
             }
         }
 
-        public void Load(string url)
-        {
-            throw new NotImplementedException();
-        }
+        public void Load(string url) { throw new NotImplementedException(); }
 
-        public void SetPrioritized()
-        {
-            prioritizeDownload = true;
-        }
+        public void SetPrioritized() { prioritizeDownload = true; }
 
 #if UNITY_EDITOR
         // In production it will always be false
@@ -368,10 +362,7 @@ namespace UnityGLTF
         // We need to check if application is quitting in editor
         // to prevent the pool from releasing objects that are
         // being destroyed 
-        void Awake()
-        {
-            Application.quitting += OnIsQuitting;
-        }
+        void Awake() { Application.quitting += OnIsQuitting; }
 
         void OnIsQuitting()
         {
@@ -406,15 +397,9 @@ namespace UnityGLTF
             DecrementDownloadCount();
         }
 
-        bool IDownloadQueueElement.ShouldPrioritizeDownload()
-        {
-            return prioritizeDownload;
-        }
+        bool IDownloadQueueElement.ShouldPrioritizeDownload() { return prioritizeDownload; }
 
-        bool IDownloadQueueElement.ShouldForceDownload()
-        {
-            return mainCamera == null;
-        }
+        bool IDownloadQueueElement.ShouldForceDownload() { return mainCamera == null; }
 
         float IDownloadQueueElement.GetSqrDistance()
         {

--- a/unity-renderer/Assets/UnityGLTF/Scripts/UnityGLTFAssembly.asmdef
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/UnityGLTFAssembly.asmdef
@@ -13,7 +13,9 @@
         "GUID:ee6523961ef177343ad763fcd55c7c46",
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
         "GUID:dffbb581f2650ea4990781f603ac258a",
-        "GUID:0663fad624d836944b40ae27c3414652"
+        "GUID:0663fad624d836944b40ae27c3414652",
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:2995626b54c60644988f134a69a77450"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Fixes #1340 

Skewed scaling is breaking the GPUOnly meshes collision. We make the optimization dependan on a disabled feature flag until we decide how to handle this scenario.

You can use `ENABLE_USE-GPU-ONLY-MESHES` flag to enable the GPUOnlyMeshes and find the collision failing