### PR TITLE
fix: gpu skinning on Metal graphics API

### DIFF
--- a/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/GPUSkinning.hlsl
+++ b/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/GPUSkinning.hlsl
@@ -1,6 +1,10 @@
 #ifndef DCL_GPU_SKINNING_INCLUDED
 #define DCL_GPU_SKINNING_INCLUDED
+
+#if defined(SHADER_API_METAL)
 #define UNITY_ENABLE_CBUFFER
+#endif
+
 #include <HLSLSupport.cginc>
 
 CBUFFER_START(UnityPerMaterial)
@@ -8,7 +12,6 @@ float4x4 _WorldInverse;
 float4x4 _Matrices[100];
 float4x4 _BindPoses[100];
 CBUFFER_END
-
 
 float4x4 inverse(float4x4 input)
 {

--- a/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/GPUSkinning.hlsl
+++ b/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/GPUSkinning.hlsl
@@ -1,6 +1,5 @@
 #ifndef DCL_GPU_SKINNING_INCLUDED
 #define DCL_GPU_SKINNING_INCLUDED
-#include <HLSLSupport.cginc>
 
 CBUFFER_START(UnityPerMaterial)
 float4x4 _WorldInverse;

--- a/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/GPUSkinning.hlsl
+++ b/unity-renderer/Assets/Rendering/Shaders/Toon/Compiled/GPUSkinning.hlsl
@@ -1,11 +1,14 @@
 #ifndef DCL_GPU_SKINNING_INCLUDED
 #define DCL_GPU_SKINNING_INCLUDED
+#define UNITY_ENABLE_CBUFFER
+#include <HLSLSupport.cginc>
 
 CBUFFER_START(UnityPerMaterial)
 float4x4 _WorldInverse;
 float4x4 _Matrices[100];
 float4x4 _BindPoses[100];
 CBUFFER_END
+
 
 float4x4 inverse(float4x4 input)
 {


### PR DESCRIPTION
## What does this PR change?

Fixes GPU skinning on Metal-based graphic API platforms
Shadows are still broken

Fix #1144 

## How to test the changes?

Run on `Editor` or [Desktop](https://github.com/decentraland/explorer-desktop/pull/29) build while on `MacOS` the "Flashmob" error should be gone

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
