### PR TITLE
fix: Set transparent background in NFT prompts

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
@@ -309,7 +309,7 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
             }
             else if (!backgroundColorSet)
             {
-                SetSmartBackgroundColor(texture);
+                SetTransparentBackground();
             }
 
             SetNFTImageSize(texture);
@@ -365,11 +365,13 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
         return ret;
     }
 
-    private void SetSmartBackgroundColor(Texture2D texture)
+    private void SetTransparentBackground()
     {
-        //Note: we can't set the color like that because the texture is no readable even if it has been created from script
-        //imageNftBackground.color = texture.GetPixel(0, 0);
-        imageNftBackground.color = Color.white;
+        imageNftBackground.color = new Color(
+            imageNftBackground.color.r,
+            imageNftBackground.color.g,
+            imageNftBackground.color.b,
+            0f);
     }
 
     private void SetTokenSymbol(TextMeshProUGUI textToken, string symbol)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
@@ -147,7 +147,7 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
         if (fetchNFTImageRoutine != null)
             StopCoroutine(fetchNFTImageRoutine);
 
-        imageNftBackground.color = Color.white;
+        SetTransparentBackground();
 
         imageNft.gameObject.SetActive(false);
         textNftName.gameObject.SetActive(false);
@@ -178,7 +178,7 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
         nftContent.SetActive(true);
 
         nftTokenId = info.tokenId;
-        imageNftBackground.color = Color.white;
+        SetTransparentBackground();
         backgroundColorSet = info.backgroundColor != null;
         if (backgroundColorSet)
         {


### PR DESCRIPTION
## What does this PR change?
Fix #1414 

Set transparent background in NFT prompts.

![image](https://user-images.githubusercontent.com/64659061/140318921-23c21473-626c-448a-8a15-4db8d82a70d7.png)

![image](https://user-images.githubusercontent.com/64659061/140318953-eded4191-bab4-4d0b-97e5-bb48143ebc3c.png)

![image](https://user-images.githubusercontent.com/64659061/140319355-9283c5c5-88b6-49c3-bd80-af9165f0a4d0.png)

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/Set-transparent-background-in-NFT-prompt
2. Go to any place where there are NFT frames.
3. Click on one of these frames to open the NFT prompt.
4. Notice the image's background is transparent.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
