### PR TITLE
fix: now memory manager is parametrizable and the memory threshhold i…

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/MemoryManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MemoryManager/MemoryManager.cs
@@ -7,20 +7,20 @@ namespace DCL
 {
     public class MemoryManager : IMemoryManager
     {
-        private const uint MAX_USED_MEMORY = 1300 * 1024 * 1024;
-        private const float TIME_FOR_NEW_MEMORY_CHECK = 1.0f;
+        private const long MAX_USED_MEMORY = 1300 * 1024 * 1024; // 1.3GB
+        private const float TIME_FOR_NEW_MEMORY_CHECK = 1.0f; // Each second
 
         private Coroutine autoCleanupCoroutine;
 
-        private uint memoryThresholdForCleanup = 0;
+        private long memoryThresholdForCleanup = 0;
         private float cleanupInterval;
 
         public event System.Action OnCriticalMemory;
 
-        public MemoryManager (uint memoryThresholdForCleanup, float cleanupInterval)
+        public MemoryManager (long memoryThresholdForCleanup, float cleanupInterval)
         {
-            this.memoryThresholdForCleanup = this.memoryThresholdForCleanup;
-            this.cleanupInterval = this.cleanupInterval;
+            this.memoryThresholdForCleanup = memoryThresholdForCleanup;
+            this.cleanupInterval = cleanupInterval;
             autoCleanupCoroutine = CoroutineStarter.Start(AutoCleanup());
         }
 
@@ -42,7 +42,7 @@ namespace DCL
         bool NeedsMemoryCleanup()
         {
             long usedMemory = Profiler.GetTotalAllocatedMemoryLong() + Profiler.GetMonoUsedSizeLong() + Profiler.GetAllocatedMemoryForGraphicsDriver();
-            return usedMemory >= MAX_USED_MEMORY;
+            return usedMemory >= this.memoryThresholdForCleanup;
         }
 
         IEnumerator AutoCleanup()
@@ -56,7 +56,7 @@ namespace DCL
                     Resources.UnloadUnusedAssets();
                 }
 
-                yield return new WaitForSecondsRealtime(TIME_FOR_NEW_MEMORY_CHECK);
+                yield return new WaitForSecondsRealtime(this.cleanupInterval);
             }
         }
 


### PR DESCRIPTION
…s a long variable

Related with #1459

## What does this PR change?

MemoryManager can be instantiated with two parameters, but those parameters weren't being taken into account. So this PR fixed that, and the variable was a `uint` and you couldn't set a memory larger than 4gb for clean up. So I changed it to `long` (64 bits variable).

This fix doesn't have any effect on `unity-renderer` but it's useful for `explorer-desktop`.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?renderer-branch={branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
