### PR TITLE
Default wearable for missing upper body and lower body parts

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -436,7 +436,7 @@ namespace DCL
             Action<Exception> error,
             Action<List<WearableItem>> completed)
         {
-            var missingClothesReplacements = new [] {Categories.LOWER_BODY, Categories.UPPER_BODY, Categories.FEET}
+            var missingClothesReplacements = new [] {Categories.LOWER_BODY, Categories.UPPER_BODY}
                 .Except(wearables.Select(wearable => wearable.data.category))
                 .Select(RequestWearableReplacement);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -251,7 +251,6 @@ namespace DCL
 
             if (bodyShapeError != null)
             {
-                Debug.LogError(bodyShapeError);
                 isLoading = false;
                 OnFailEvent?.Invoke(true);
                 yield break;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -435,8 +435,14 @@ namespace DCL
             Action<Exception> error,
             Action<List<WearableItem>> completed)
         {
+            var wearedAndReplacedCategories = wearables.SelectMany(wearable =>
+                {
+                    var replacedByWearable = wearable.GetReplacesList(model.bodyShape) ?? new string[0];
+                    return new[] {wearable.data.category}.Concat(replacedByWearable);
+                })
+                .Distinct();
             var missingClothesReplacements = new [] {Categories.LOWER_BODY, Categories.UPPER_BODY}
-                .Except(wearables.Select(wearable => wearable.data.category))
+                .Except(wearedAndReplacedCategories)
                 .Select(RequestWearableReplacement);
 
             yield return LoadWearables(missingClothesReplacements, error, completed);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
@@ -235,6 +235,18 @@ public class CatalogController : MonoBehaviour
         }
     }
 
+    public static void AddWearableUsage(string wearableId)
+    {
+        if (!wearablesInUseCounters.ContainsKey(wearableId))
+            wearablesInUseCounters.Add(wearableId, 0);
+        wearablesInUseCounters[wearableId]++;
+    }
+
+    public static void OverrideWearableRequestResult(string wearableId, Promise<WearableItem> promise)
+    {
+        awaitingWearablePromises[wearableId] = promise;
+    }
+
     private void ResolvePendingWearablePromise(string wearableId, WearableItem newWearableAddedIntoCatalog = null, string errorMessage = "")
     {
         if (awaitingWearablePromises.TryGetValue(wearableId, out Promise<WearableItem> promise))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/Tests/Helpers/AvatarAssetsTestHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/Tests/Helpers/AvatarAssetsTestHelpers.cs
@@ -41,6 +41,7 @@ public static class AvatarAssetsTestHelpers
         foreach (var item in dummyWereables)
         {
             CatalogController.wearableCatalog.Add(item.Key, item.Value);
+            CatalogController.AddWearableUsage(item.Key);
         }
 
         return CatalogController.wearableCatalog;


### PR DESCRIPTION
## What does this PR change?

- Adds a default wearable to upper body and/or lower body if its missing due fetching errors.
- Added an exception when there is a wearable that replaces any of this body parts.
- Minor refactor for retrieving wearables at `AvatarRenderer`.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/naked-avatars
2. Go to any populated area. You should not see any naked avatar, unless is using a wearable that hides or replaces upper body or lower body parts.
3. Open your backpack and use wearables that replaces or hides the upper body or the lower body. You should see your avatar correctly rendered according to the wearable.
4. Use any other wearable that do not hide or replace upper body or lower body parts. You should see your avatar correctly rendered.
5. If any error occurs on loading the wearable, you should see a default wearable: `urn:decentraland:off-chain:base-avatars:green_hoodie`, `urn:decentraland:off-chain:base-avatars:brown_pants` for males. `urn:decentraland:off-chain:base-avatars:f_sweater`,  `urn:decentraland:off-chain:base-avatars:f_jeans` for females.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
