### PR TITLE
fix: UIShape only refreshes itself if the user is on the scene

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
@@ -55,7 +55,7 @@ namespace DCL.Components
         where ModelType : UIShape.Model
     {
         public const float RAYCAST_ALPHA_THRESHOLD = 0.01f;
-        
+
         public UIShape() { }
 
         new public ModelType model { get { return base.model as ModelType; } set { base.model = value; } }
@@ -187,10 +187,7 @@ namespace DCL.Components
             }
         }
 
-        public override IEnumerator ApplyChanges(BaseModel newJson)
-        {
-            return null;
-        }
+        public override IEnumerator ApplyChanges(BaseModel newJson) { return null; }
 
         internal T InstantiateUIGameObject<T>(string prefabPath) where T : UIReferencesContainer
         {
@@ -241,6 +238,9 @@ namespace DCL.Components
                 yield return Application.isBatchMode ? null : new WaitForEndOfFrame();
 
                 if ( !isLayoutDirty )
+                    continue;
+
+                if (CommonScriptableObjects.sceneID.Get() != scene.sceneData.id)
                     continue;
 
                 RefreshAll();


### PR DESCRIPTION
#1437 
Now UIShapes are only refreshed when the user is on the scene. 

Pros:
A nearby scene with a heavy usage of the SDK UI and layouts (which kills performance) won't affect the performance of your scene.

Cons:
We no longer have prewarm of UIs as long as you walk around the world. When you enter the scene, your UI will be readjusted and it might take a frame for things to look correctly.