### PR TITLE
fix: added hitler into profanity words

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ProfanityFiltering/Resources/Profanity/badwords.json
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ProfanityFiltering/Resources/Profanity/badwords.json
@@ -205,6 +205,7 @@
     "hardcoresex",
     "handjob",
     "hentai",
+    "hitler",
     "homoerotic",
     "hooker",
     "howtokill",


### PR DESCRIPTION
## What does this PR change?

Adds `hitler` to profanity words filtering

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/filter-hitler
2. Go to settings menu and check profanity filtering is enabled
3. Write hitlerrrr123 on general chat it should be filtered
4. Change your user name to hitler and write something on general chat. Your name should be filtered

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
