### PR TITLE
fix: ensure capacity hiccup

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
@@ -124,19 +124,15 @@ namespace DCL
 
             finalMesh.bindposes = bindPoses;
 
-            //var boneWeights = AvatarMeshCombinerUtils.ComputeBoneWeightsV2( layers );
-            //finalMesh.boneWeights = boneWeights;
-
             var boneWeights = AvatarMeshCombinerUtils.ComputeBoneWeights( layers );
-            finalMesh.boneWeights = boneWeights.ToArray();
-
+            finalMesh.boneWeights = boneWeights;
 
             var flattenedMaterialsData = AvatarMeshCombinerUtils.FlattenMaterials( layers, materialAsset );
             finalMesh.SetUVs(EMISSION_COLORS_UV_CHANNEL_INDEX, flattenedMaterialsData.emissionColors);
             finalMesh.SetUVs(TEXTURE_POINTERS_UV_CHANNEL_INDEX, flattenedMaterialsData.texturePointers);
 
             var tempArray = new NativeArray<Vector4>(flattenedMaterialsData.colors.Length, Allocator.Temp);
-            tempArray.CopyFrom(flattenedMaterialsData.colors.ToArray());
+            tempArray.CopyFrom(flattenedMaterialsData.colors);
             finalMesh.SetColors(tempArray);
             tempArray.Dispose();
             // Each layer corresponds with a subMesh. This is to take advantage of the sharedMaterials array.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
@@ -124,8 +124,12 @@ namespace DCL
 
             finalMesh.bindposes = bindPoses;
 
+            //var boneWeights = AvatarMeshCombinerUtils.ComputeBoneWeightsV2( layers );
+            //finalMesh.boneWeights = boneWeights;
+
             var boneWeights = AvatarMeshCombinerUtils.ComputeBoneWeights( layers );
             finalMesh.boneWeights = boneWeights.ToArray();
+
 
             var flattenedMaterialsData = AvatarMeshCombinerUtils.FlattenMaterials( layers, materialAsset );
             finalMesh.SetUVs(EMISSION_COLORS_UV_CHANNEL_INDEX, flattenedMaterialsData.emissionColors);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerUtils.cs
@@ -68,6 +68,53 @@ namespace DCL
             return result;
         }
 
+
+        /// <summary>
+        /// This method iterates over all the renderers contained in the given CombineLayer list, and
+        /// outputs an array of all the BoneWeights of the renderers in order.
+        ///
+        /// This is needed because Mesh.CombineMeshes don't calculate boneWeights correctly.
+        /// When using Mesh.CombineMeshes, the boneWeights returned correspond to indexes of skeleton copies,
+        /// not the same skeleton.
+        /// </summary>
+        /// <param name="layers">A CombineLayer list. You can generate this array using CombineLayerUtils.Slice().</param>
+        /// <returns>A list of BoneWeights that share the same skeleton.</returns>
+        public static BoneWeight[] ComputeBoneWeightsV2( List<CombineLayer> layers )
+        {
+            int layersCount = layers.Count;
+
+            int resultSize = 0;
+
+            List<BoneWeight[]> boneWeightArrays = new List<BoneWeight[]>(10);
+
+            for (int layerIndex = 0; layerIndex < layersCount; layerIndex++)
+            {
+                CombineLayer layer = layers[layerIndex];
+                var layerRenderers = layer.renderers;
+
+                int layerRenderersCount = layerRenderers.Count;
+
+                for (int i = 0; i < layerRenderersCount; i++)
+                {
+                    var boneWeights = layerRenderers[i].sharedMesh.boneWeights;
+                    boneWeightArrays.Add(boneWeights);
+                    resultSize += boneWeights.Length;
+                }
+            }
+
+            BoneWeight[] result = new BoneWeight[resultSize];
+
+            int copyOffset = 0;
+            for ( int i = 0; i < boneWeightArrays.Count; i++ )
+            {
+                Array.Copy(boneWeightArrays[i], result, copyOffset);
+                copyOffset += boneWeightArrays[i].Length;
+            }
+
+            return result;
+        }
+
+
         /// <summary>
         /// FlattenMaterials take a CombineLayer list and returns a FlattenedMaterialsData object.
         /// 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerUtils.cs
@@ -42,44 +42,7 @@ namespace DCL
         /// </summary>
         /// <param name="layers">A CombineLayer list. You can generate this array using CombineLayerUtils.Slice().</param>
         /// <returns>A list of BoneWeights that share the same skeleton.</returns>
-        public static List<BoneWeight> ComputeBoneWeights( List<CombineLayer> layers )
-        {
-            List<BoneWeight> result = new List<BoneWeight>();
-            int layersCount = layers.Count;
-
-            for (int layerIndex = 0; layerIndex < layersCount; layerIndex++)
-            {
-                CombineLayer layer = layers[layerIndex];
-                var layerRenderers = layer.renderers;
-
-                int layerRenderersCount = layerRenderers.Count;
-
-                for (int i = 0; i < layerRenderersCount; i++)
-                {
-                    var renderer = layerRenderers[i];
-
-                    // Bone Weights
-                    var sharedMesh = renderer.sharedMesh;
-                    var meshBoneWeights = sharedMesh.boneWeights;
-                    result.AddRange(meshBoneWeights);
-                }
-            }
-
-            return result;
-        }
-
-
-        /// <summary>
-        /// This method iterates over all the renderers contained in the given CombineLayer list, and
-        /// outputs an array of all the BoneWeights of the renderers in order.
-        ///
-        /// This is needed because Mesh.CombineMeshes don't calculate boneWeights correctly.
-        /// When using Mesh.CombineMeshes, the boneWeights returned correspond to indexes of skeleton copies,
-        /// not the same skeleton.
-        /// </summary>
-        /// <param name="layers">A CombineLayer list. You can generate this array using CombineLayerUtils.Slice().</param>
-        /// <returns>A list of BoneWeights that share the same skeleton.</returns>
-        public static BoneWeight[] ComputeBoneWeightsV2( List<CombineLayer> layers )
+        public static BoneWeight[] ComputeBoneWeights( List<CombineLayer> layers )
         {
             int layersCount = layers.Count;
 
@@ -107,7 +70,7 @@ namespace DCL
             int copyOffset = 0;
             for ( int i = 0; i < boneWeightArrays.Count; i++ )
             {
-                Array.Copy(boneWeightArrays[i], result, copyOffset);
+                Array.Copy(boneWeightArrays[i], 0, result, copyOffset, boneWeightArrays[i].Length);
                 copyOffset += boneWeightArrays[i].Length;
             }
 


### PR DESCRIPTION
## What does this PR change?

This PR attempts to fix the hiccups caused by `ComputeBoneWeights` function when an avatar is loaded.

Before:
![image](https://user-images.githubusercontent.com/6875814/142277061-3563c861-8ef3-4dc2-9917-42c45eed95de.png)

After:
![image](https://user-images.githubusercontent.com/6875814/142275195-54e20e82-c603-4566-93a4-926f5018c818.png)

Note that:
* Most of the overhead the `List<T>` capacity setting went away due to use of arrays
* Very high GC overhead almost was almost wiped
* In the shown case, the ms cost went from 4.51ms to 0.10ms with the improvement enabled

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
