### PR TITLE
fix: navmap parcel offset

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -228,7 +228,7 @@ namespace DCL
                 parcelHighlightImage.gameObject.SetActive(true);
 
             string previousText = highlightedParcelText.text;
-            parcelHighlightImage.transform.position = worldCoordsOriginInMap + cursorMapCoords * parcelSizeInMap + new Vector3(parcelSizeInMap, parcelSizeInMap, 0f) / 2;
+            parcelHighlightImage.rectTransform.anchoredPosition = MapUtils.GetTileToLocalPosition(cursorMapCoords.x, cursorMapCoords.y);
             highlightedParcelText.text = showCursorCoords ? $"{cursorMapCoords.x}, {cursorMapCoords.y}" : string.Empty;
 
             if (highlightedParcelText.text != previousText && !Input.GetMouseButton(0))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
@@ -445,9 +445,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1000, y: -1000}
+  m_AnchoredPosition: {x: -1009, y: -1007.2003}
   m_SizeDelta: {x: 18, y: 18}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 0.1}
 --- !u!222 &3409671240014069258
 CanvasRenderer:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?

`Closes #1511 `

- Modified the position calculation of map's parcel highlight object.
- Modified the anchor of the highlight object to match the visual position

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/map-parcel-offset
2. Press `M` to open the navmap
3. Move the mouse through the map, you should se its aligned with the visual parcels

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
