### PR TITLE
fix: asset bundles converter fatal errors

### DIFF
--- a/unity-renderer/Assets/ABConverter/VisualTests.cs
+++ b/unity-renderer/Assets/ABConverter/VisualTests.cs
@@ -84,15 +84,6 @@ namespace DCL.ABConverter
                 go.SetActive(false);
             }
 
-            foreach (GameObject go in gltfs)
-            {
-                go.SetActive(true);
-
-                yield return TakeObjectSnapshot(go, $"ABConverter_{go.name}.png");
-
-                go.SetActive(false);
-            }
-
             AssetBundlesVisualTestHelpers.generateBaseline = false;
 
             var abs = LoadAndInstantiateAllAssetBundles();

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -2104,10 +2104,17 @@ namespace UnityGLTF
                 yield return YieldOnTimeout();
             }
 
-            mesh.triangles = unityMeshData.Triangles;
-            if (ShouldYieldOnTimeout())
+            if (AreMeshTrianglesValid(unityMeshData.Triangles, vertexCount)) // Some scenes contain broken meshes that can trigger a fatal error
             {
-                yield return YieldOnTimeout();
+                mesh.triangles = unityMeshData.Triangles;
+                if (ShouldYieldOnTimeout())
+                {
+                    yield return YieldOnTimeout();
+                }
+            }
+            else
+            {
+                Debug.Log("GLTFSceneImporter - ERROR - ConstructUnityMesh - Couldn't assign triangles to mesh as there are indices pointing to vertices out of bounds");
             }
 
             mesh.tangents = unityMeshData.Tangents;
@@ -2151,6 +2158,23 @@ namespace UnityGLTF
                 Physics.BakeMesh(mesh.GetInstanceID(), false);
                 mesh.UploadMeshData(true);
             }
+        }
+
+        // This check is to avoid broken meshes fatal error "Failed setting triangles. Some indices are referencing out of bounds vertices."
+        private bool AreMeshTrianglesValid(int[] triangles, int vertexCount)
+        {
+            bool areValid = true;
+            
+            for (var i = 0; i < triangles.Length; i++)
+            {
+                if (triangles[i] > vertexCount)
+                {
+                    areValid = false;
+                    break;
+                }
+            }
+
+            return areValid;
         }
 
         protected virtual IEnumerator ConstructMaterial(GLTFMaterial def, int materialIndex)
@@ -2396,7 +2420,7 @@ namespace UnityGLTF
             else
             {
                 yield return ConstructImage(settings, image, sourceId);
-
+                
                 if (_assetCache.ImageCache[sourceId] == null)
                 {
                     Debug.Log($"GLTFSceneImporter - ConstructTexture - null tex detected for {sourceId} / {image.Uri} / {id}, applying invalid-tex texture...");

--- a/unity-renderer/Assets/UnityGLTF/Scripts/Loader/GLTFFileLoader.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/Loader/GLTFFileLoader.cs
@@ -25,7 +25,7 @@ namespace UnityGLTF.Loader
         {
             if (gltfFilePath == null)
             {
-                Debug.LogError("gltfFilePath is null!");
+                Debug.Log("GLTFSceneImporter - Error - gltfFilePath is null!");
                 yield break;
             }
 
@@ -38,7 +38,7 @@ namespace UnityGLTF.Loader
 
             if (!File.Exists(pathToLoad))
             {
-                Debug.LogError($"Buffer file not found ({pathToLoad}) -- {fileToLoad}");
+                Debug.Log($"GLTFSceneImporter - Error - Buffer file not found ({pathToLoad}) -- {fileToLoad}");
 
                 yield break;
             }
@@ -51,7 +51,7 @@ namespace UnityGLTF.Loader
         {
             if (gltfFilePath == null)
             {
-                Debug.LogError("gltfFilePath is null!");
+                Debug.Log("GLTFSceneImporter - Error - gltfFilePath is null!");
                 return;
             }
 
@@ -64,7 +64,7 @@ namespace UnityGLTF.Loader
 
             if (!File.Exists(pathToLoad))
             {
-                Debug.LogError("Buffer file not found -- " + fileToLoad);
+                Debug.Log("GLTFSceneImporter - Error - Buffer file not found -- " + fileToLoad);
 
                 return;
             }


### PR DESCRIPTION
* Added missing check for invalid meshes triangles that trigger a fatal error on mesh construction
* Updated some fatal errors to regular logs