### PR TITLE
fix: revert "fix: navmap parcel offset (#1538)"

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -228,7 +228,7 @@ namespace DCL
                 parcelHighlightImage.gameObject.SetActive(true);
 
             string previousText = highlightedParcelText.text;
-            parcelHighlightImage.rectTransform.anchoredPosition = MapUtils.GetTileToLocalPosition(cursorMapCoords.x, cursorMapCoords.y);
+            parcelHighlightImage.transform.position = worldCoordsOriginInMap + cursorMapCoords * parcelSizeInMap + new Vector3(parcelSizeInMap, parcelSizeInMap, 0f) / 2;
             highlightedParcelText.text = showCursorCoords ? $"{cursorMapCoords.x}, {cursorMapCoords.y}" : string.Empty;
 
             if (highlightedParcelText.text != previousText && !Input.GetMouseButton(0))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
@@ -445,9 +445,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1009, y: -1007.2003}
+  m_AnchoredPosition: {x: -1000, y: -1000}
   m_SizeDelta: {x: 18, y: 18}
-  m_Pivot: {x: 0, y: 0.1}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3409671240014069258
 CanvasRenderer:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This reverts commit cde4e90c95d6e5adef5945e9d4e2e2fcf9027764.

## What does this PR change?

Reverts the fix of the navmap parcel offset since it its inaccurate when you scroll the map from the center.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/revert-navmap-parcel-offset
2. Press `M` to open the navmap
3. Scroll it and move the mouse around it
4. The parcel highlighting should be on your mouse position

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
