### PR TITLE
fix: map parcel highlight due map scrolling

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -228,6 +228,7 @@ namespace DCL
                 parcelHighlightImage.gameObject.SetActive(true);
 
             string previousText = highlightedParcelText.text;
+            parcelHighlightImage.rectTransform.SetAsLastSibling();
             parcelHighlightImage.rectTransform.anchoredPosition = MapUtils.GetTileToLocalPosition(cursorMapCoords.x, cursorMapCoords.y);
             highlightedParcelText.text = showCursorCoords ? $"{cursorMapCoords.x}, {cursorMapCoords.y}" : string.Empty;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
@@ -272,6 +272,7 @@ RectTransform:
   m_Children:
   - {fileID: 3332934504654532118}
   - {fileID: 1340394175305253205}
+  - {fileID: 6083578241133350518}
   m_Father: {fileID: 2249193035634569280}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -440,7 +441,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2624566956026777839}
-  m_Father: {fileID: 2249193035634569280}
+  m_Father: {fileID: 90597117798403300}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -556,7 +557,6 @@ RectTransform:
   m_Children:
   - {fileID: 8867674413542430443}
   - {fileID: 90597117798403300}
-  - {fileID: 6083578241133350518}
   m_Father: {fileID: 6584822353056061070}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
## What does this PR change?

Fixes an the offset of the highlighted parcel when scrolling the map.
The highlighted object `ParcelHighlight` was childed into `Map Renderer/Container/Overlay Layer` root in prefab hierarchy.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/map-parcel-offset
2. Press `M` to open the navmap
3. Move the mouse around the map. The highlighted parcel should fit respectly to the map reference
4. Scroll the map. Move the mouse around the map. The highlighted parcel should fit respectly to the map reference

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
