### PR TITLE
fix: Streaming audio not changing when adjusting volume sliders

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Settings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Settings.cs
@@ -95,11 +95,28 @@ namespace DCL.SettingsCommon
             WebInterface.ApplySettings(calculatedVolume, (int)generalSettings.Data.voiceChatAllow);
         }
 
-        public void ApplyAvatarSFXVolume(float currentDataStoreVolume = 0f, float previousDataStoreVolume = 0f) { audioMixer.SetFloat("AvatarSFXBusVolume", Utils.ToAudioMixerGroupVolume(DataStore.i.virtualAudioMixer.avatarSFXVolume.Get() * audioSettings.Data.avatarSFXVolume)); }
+        public void ApplyAvatarSFXVolume(float currentDataStoreVolume = 0f, float previousDataStoreVolume = 0f)
+        {
+            audioMixer.SetFloat("AvatarSFXBusVolume", Utils.ToAudioMixerGroupVolume(DataStore.i.virtualAudioMixer.avatarSFXVolume.Get() * audioSettings.Data.avatarSFXVolume));
+        }
 
-        public void ApplyUISFXVolume(float currentDataStoreVolume = 0f, float previousDataStoreVolume = 0f) { audioMixer.SetFloat("UIBusVolume", Utils.ToAudioMixerGroupVolume(DataStore.i.virtualAudioMixer.uiSFXVolume.Get() * audioSettings.Data.uiSFXVolume)); }
+        public void ApplyUISFXVolume(float currentDataStoreVolume = 0f, float previousDataStoreVolume = 0f)
+        {
+            audioMixer.SetFloat("UIBusVolume", Utils.ToAudioMixerGroupVolume(DataStore.i.virtualAudioMixer.uiSFXVolume.Get() * audioSettings.Data.uiSFXVolume));
+        }
 
-        public void ApplyMusicVolume(float currentDataStoreVolume = 0f, float previousDataStoreVolume = 0f) { audioMixer.SetFloat("MusicBusVolume", Utils.ToAudioMixerGroupVolume(DataStore.i.virtualAudioMixer.uiSFXVolume.Get() * audioSettings.Data.musicVolume)); }
+        public void ApplyMusicVolume(float currentDataStoreVolume = 0f, float previousDataStoreVolume = 0f)
+        {
+            audioMixer.SetFloat("MusicBusVolume", Utils.ToAudioMixerGroupVolume(DataStore.i.virtualAudioMixer.uiSFXVolume.Get() * audioSettings.Data.musicVolume));
+        }
+
+        /// <summary>
+        /// This gets called by each UI slider directly. They also edit their own value inside of the audioSettings before calling this.
+        /// </summary>
+        public void ApplyAudioSettings()
+        {
+            audioSettings.Apply(audioSettings.Data);
+        }
 
         public void SaveSettings()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/AvatarSFXVolumeControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/AvatarSFXVolumeControlController.cs
@@ -11,6 +11,7 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
         public override void UpdateSetting(object newValue) {
             currentAudioSettings.avatarSFXVolume = (float)newValue * 0.01f;
             Settings.i.ApplyAvatarSFXVolume();
+            Settings.i.ApplyAudioSettings();
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/MasterVolumeControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/MasterVolumeControlController.cs
@@ -11,6 +11,7 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
         public override void UpdateSetting(object newValue) {
             currentAudioSettings.masterVolume = (float)newValue * 0.01f;
             Settings.i.ApplyMasterVolume();
+            Settings.i.ApplyAudioSettings();
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/MusicVolumeControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/MusicVolumeControlController.cs
@@ -11,6 +11,7 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
         public override void UpdateSetting(object newValue) {
             currentAudioSettings.musicVolume = (float)newValue * 0.01f;
             Settings.i.ApplyMusicVolume();
+            Settings.i.ApplyAudioSettings();
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/SceneSFXVolumeControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/SceneSFXVolumeControlController.cs
@@ -10,6 +10,7 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
 
         public override void UpdateSetting(object newValue) {
             currentAudioSettings.sceneSFXVolume = (float)newValue * 0.01f;
+            Settings.i.ApplyAudioSettings();
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/UISFXVolumeControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/UISFXVolumeControlController.cs
@@ -11,6 +11,7 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
         public override void UpdateSetting(object newValue) {
             currentAudioSettings.uiSFXVolume = (float)newValue * 0.01f;
             Settings.i.ApplyUISFXVolume();
+            Settings.i.ApplyAudioSettings();
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/VoiceChatVolumeControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/VoiceChatVolumeControlController.cs
@@ -12,6 +12,7 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
         {
             currentAudioSettings.voiceChatVolume = (float)newValue * 0.01f;
             Settings.i.ApplyVoiceChatSettings();
+            Settings.i.ApplyAudioSettings();
         }
     }
 }


### PR DESCRIPTION
Made it so each slider applies all volume changes, as the audioSettings.OnChanged action wasn't being invoked for some sliders.

## What does this PR change?

Fixes an issue where streaming audio volume would not get updated when using the volume sliders (Master volume and World SFX).

Reported by Shibu via Slack.

## How to test the changes?

1. Go to https://play.decentraland.org/
2. Jump into the hole and listen to the jukebox radio.
3. Go into settings and notice that the master volume slider doesn't affect the music volume.
4. Go to the playtest link of this branch.
5. Do steps 2 and 3, except notice this time that the master volume slider affects the volume of the music.
