### PR TITLE
refactor: settings persistence

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/IPlayerPrefsSettingsByKey.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/IPlayerPrefsSettingsByKey.cs
@@ -6,9 +6,11 @@
         bool GetBool(string fieldName, bool defaultValue);
         float GetFloat(string fieldName, float defaultValue);
         int GetInt(string fieldName, int defaultValue);
+        string GetString(string fieldName, string defaultValue);
         void SetBool(string fieldName, bool value);
         void SetFloat(string fieldName, float value);
         void SetEnum<T>(string fieldName, T value) where T : struct;
         void SetInt(string fieldName, int value);
+        void SetString(string fieldName, string value);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/IPlayerPrefsSettingsByKey.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/IPlayerPrefsSettingsByKey.cs
@@ -1,0 +1,14 @@
+﻿namespace DCL.SettingsCommon
+{
+    public interface IPlayerPrefsSettingsByKey
+    {
+        T GetEnum<T>(string fieldName, T defaultValue) where T : struct;
+        bool GetBool(string fieldName, bool defaultValue);
+        float GetFloat(string fieldName, float defaultValue);
+        int GetInt(string fieldName, int defaultValue);
+        void SetBool(string fieldName, bool value);
+        void SetFloat(string fieldName, float value);
+        void SetEnum<T>(string fieldName, T value) where T : struct;
+        void SetInt(string fieldName, int value);
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/IPlayerPrefsSettingsByKey.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/IPlayerPrefsSettingsByKey.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8c7cb5dfb7664712b1a3aa799e294efa
+timeCreated: 1637357216

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ISettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ISettingsRepository.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace DCL.SettingsCommon
+{
+    public interface ISettingsRepository<T> where T : struct
+    {
+        event Action<T> OnChanged;
+        T Data { get; }
+        void Apply(T settings);
+        void Reset();
+        void Save();
+        bool HasAnyData();
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ISettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ISettingsRepository.cs
@@ -2,7 +2,7 @@
 
 namespace DCL.SettingsCommon
 {
-    public interface ISettingsRepository<T> where T : struct
+    public interface ISettingsRepository<T>
     {
         event Action<T> OnChanged;
         T Data { get; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ISettingsRepository.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ISettingsRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 520112d2689803f4b8925dfac6ec3a49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsAudioSettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsAudioSettingsRepository.cs
@@ -5,6 +5,14 @@ namespace DCL.SettingsCommon
 {
     public class PlayerPrefsAudioSettingsRepository : ISettingsRepository<AudioSettings>
     {
+        private const string CHAT_SFX_ENABLED = "chatSFXEnabled";
+        private const string MASTER_VOLUME = "masterVolume";
+        private const string MUSIC_VOLUME = "musicVolume";
+        private const string VOICE_CHAT_VOLUME = "voiceChatVolume";
+        private const string AVATAR_SFX_VOLUME = "avatarSFXVolume";
+        private const string SCENE_SFX_VOLUME = "sceneSFXVolume";
+        private const string UI_SFX_VOLUME = "uiSFXVolume";
+
         private readonly IPlayerPrefsSettingsByKey settingsByKey;
         private readonly AudioSettings defaultSettings;
         private AudioSettings currentSettings;
@@ -36,13 +44,13 @@ namespace DCL.SettingsCommon
 
         public void Save()
         {
-            settingsByKey.SetBool("chatSFXEnabled", currentSettings.chatSFXEnabled);
-            settingsByKey.SetFloat("masterVolume", currentSettings.masterVolume);
-            settingsByKey.SetFloat("musicVolume", currentSettings.musicVolume);
-            settingsByKey.SetFloat("voiceChatVolume", currentSettings.voiceChatVolume);
-            settingsByKey.SetFloat("avatarSFXVolume", currentSettings.avatarSFXVolume);
-            settingsByKey.SetFloat("sceneSFXVolume", currentSettings.sceneSFXVolume);
-            settingsByKey.SetFloat("uiSFXVolume", currentSettings.uiSFXVolume);
+            settingsByKey.SetBool(CHAT_SFX_ENABLED, currentSettings.chatSFXEnabled);
+            settingsByKey.SetFloat(MASTER_VOLUME, currentSettings.masterVolume);
+            settingsByKey.SetFloat(MUSIC_VOLUME, currentSettings.musicVolume);
+            settingsByKey.SetFloat(VOICE_CHAT_VOLUME, currentSettings.voiceChatVolume);
+            settingsByKey.SetFloat(AVATAR_SFX_VOLUME, currentSettings.avatarSFXVolume);
+            settingsByKey.SetFloat(SCENE_SFX_VOLUME, currentSettings.sceneSFXVolume);
+            settingsByKey.SetFloat(UI_SFX_VOLUME, currentSettings.uiSFXVolume);
         }
 
         public bool HasAnyData() => !Data.Equals(defaultSettings);
@@ -53,13 +61,13 @@ namespace DCL.SettingsCommon
             
             try
             {
-                settings.chatSFXEnabled = settingsByKey.GetBool("chatSFXEnabled", defaultSettings.chatSFXEnabled);
-                settings.masterVolume = settingsByKey.GetFloat("masterVolume", defaultSettings.masterVolume);
-                settings.musicVolume = settingsByKey.GetFloat("musicVolume", defaultSettings.musicVolume);
-                settings.voiceChatVolume = settingsByKey.GetFloat("voiceChatVolume", defaultSettings.voiceChatVolume);
-                settings.avatarSFXVolume = settingsByKey.GetFloat("avatarSFXVolume", defaultSettings.avatarSFXVolume);
-                settings.sceneSFXVolume = settingsByKey.GetFloat("sceneSFXVolume", defaultSettings.sceneSFXVolume);
-                settings.uiSFXVolume = settingsByKey.GetFloat("uiSFXVolume", defaultSettings.uiSFXVolume);
+                settings.chatSFXEnabled = settingsByKey.GetBool(CHAT_SFX_ENABLED, defaultSettings.chatSFXEnabled);
+                settings.masterVolume = settingsByKey.GetFloat(MASTER_VOLUME, defaultSettings.masterVolume);
+                settings.musicVolume = settingsByKey.GetFloat(MUSIC_VOLUME, defaultSettings.musicVolume);
+                settings.voiceChatVolume = settingsByKey.GetFloat(VOICE_CHAT_VOLUME, defaultSettings.voiceChatVolume);
+                settings.avatarSFXVolume = settingsByKey.GetFloat(AVATAR_SFX_VOLUME, defaultSettings.avatarSFXVolume);
+                settings.sceneSFXVolume = settingsByKey.GetFloat(SCENE_SFX_VOLUME, defaultSettings.sceneSFXVolume);
+                settings.uiSFXVolume = settingsByKey.GetFloat(UI_SFX_VOLUME, defaultSettings.uiSFXVolume);
             }
             catch (Exception e)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsAudioSettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsAudioSettingsRepository.cs
@@ -63,7 +63,7 @@ namespace DCL.SettingsCommon
             }
             catch (Exception e)
             {
-                Debug.LogError(e.Message);
+                Debug.LogException(e);
             }
 
             return settings;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsAudioSettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsAudioSettingsRepository.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using UnityEngine;
+
+namespace DCL.SettingsCommon
+{
+    public class PlayerPrefsAudioSettingsRepository : ISettingsRepository<AudioSettings>
+    {
+        private readonly IPlayerPrefsSettingsByKey settingsByKey;
+        private readonly AudioSettings defaultSettings;
+        private AudioSettings currentSettings;
+        
+        public event Action<AudioSettings> OnChanged;
+
+        public PlayerPrefsAudioSettingsRepository(
+            IPlayerPrefsSettingsByKey settingsByKey,
+            AudioSettings defaultSettings)
+        {
+            this.settingsByKey = settingsByKey;
+            this.defaultSettings = defaultSettings;
+            currentSettings = Load();
+        }
+
+        public AudioSettings Data => currentSettings;
+
+        public void Apply(AudioSettings settings)
+        {
+            if (currentSettings.Equals(settings)) return;
+            currentSettings = settings;
+            OnChanged?.Invoke(currentSettings);
+        }
+
+        public void Reset()
+        {
+            Apply(defaultSettings);
+        }
+
+        public void Save()
+        {
+            settingsByKey.SetBool("chatSFXEnabled", currentSettings.chatSFXEnabled);
+            settingsByKey.SetFloat("masterVolume", currentSettings.masterVolume);
+            settingsByKey.SetFloat("musicVolume", currentSettings.musicVolume);
+            settingsByKey.SetFloat("voiceChatVolume", currentSettings.voiceChatVolume);
+            settingsByKey.SetFloat("avatarSFXVolume", currentSettings.avatarSFXVolume);
+            settingsByKey.SetFloat("sceneSFXVolume", currentSettings.sceneSFXVolume);
+            settingsByKey.SetFloat("uiSFXVolume", currentSettings.uiSFXVolume);
+        }
+
+        public bool HasAnyData() => !Data.Equals(defaultSettings);
+
+        private AudioSettings Load()
+        {
+            var settings = defaultSettings;
+            
+            try
+            {
+                settings.chatSFXEnabled = settingsByKey.GetBool("chatSFXEnabled", defaultSettings.chatSFXEnabled);
+                settings.masterVolume = settingsByKey.GetFloat("masterVolume", defaultSettings.masterVolume);
+                settings.musicVolume = settingsByKey.GetFloat("musicVolume", defaultSettings.musicVolume);
+                settings.voiceChatVolume = settingsByKey.GetFloat("voiceChatVolume", defaultSettings.voiceChatVolume);
+                settings.avatarSFXVolume = settingsByKey.GetFloat("avatarSFXVolume", defaultSettings.avatarSFXVolume);
+                settings.sceneSFXVolume = settingsByKey.GetFloat("sceneSFXVolume", defaultSettings.sceneSFXVolume);
+                settings.uiSFXVolume = settingsByKey.GetFloat("uiSFXVolume", defaultSettings.uiSFXVolume);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError(e.Message);
+            }
+
+            return settings;
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsAudioSettingsRepository.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsAudioSettingsRepository.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e74b6632061b409e9f026091ddda3c91
+timeCreated: 1637353971

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
@@ -68,7 +68,7 @@ namespace DCL.SettingsCommon
             }
             catch (Exception e)
             {
-                Debug.LogError(e.Message);
+                Debug.LogException(e);
             }
 
             return settings;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using UnityEngine;
+
+namespace DCL.SettingsCommon
+{
+    public class PlayerPrefsGeneralSettingsRepository : ISettingsRepository<GeneralSettings>
+    {
+        private readonly IPlayerPrefsSettingsByKey settingsByKey;
+        private readonly GeneralSettings defaultSettings;
+        private GeneralSettings currentSettings;
+        
+        public event Action<GeneralSettings> OnChanged;
+
+        public PlayerPrefsGeneralSettingsRepository(
+            IPlayerPrefsSettingsByKey settingsByKey,
+            GeneralSettings defaultSettings)
+        {
+            this.settingsByKey = settingsByKey;
+            this.defaultSettings = defaultSettings;
+            currentSettings = Load();
+        }
+
+        public GeneralSettings Data => currentSettings;
+
+        public void Apply(GeneralSettings settings)
+        {
+            if (currentSettings.Equals(settings)) return;
+            currentSettings = settings;
+            OnChanged?.Invoke(currentSettings);
+        }
+
+        public void Reset()
+        {
+            Apply(defaultSettings);
+        }
+
+        public void Save()
+        {
+            settingsByKey.SetBool("autoqualityOn", currentSettings.autoqualityOn);
+            settingsByKey.SetBool("profanityChatFiltering", currentSettings.profanityChatFiltering);
+            settingsByKey.SetFloat("mouseSensitivity", currentSettings.mouseSensitivity);
+            settingsByKey.SetFloat("namesOpacity", currentSettings.namesOpacity);
+            settingsByKey.SetFloat("scenesLoadRadius", currentSettings.scenesLoadRadius);
+            settingsByKey.SetFloat("voiceChatVolume", currentSettings.voiceChatVolume);
+            settingsByKey.SetFloat("avatarsLODDistance", currentSettings.avatarsLODDistance);
+            settingsByKey.SetFloat("maxNonLODAvatars", currentSettings.maxNonLODAvatars);
+            settingsByKey.SetEnum("voiceChatAllow", currentSettings.voiceChatAllow);
+        }
+
+        public bool HasAnyData() => !Data.Equals(defaultSettings);
+
+        private GeneralSettings Load()
+        {
+            var settings = defaultSettings;
+            
+            try
+            {
+                settings.autoqualityOn = settingsByKey.GetBool("autoqualityOn", defaultSettings.autoqualityOn);
+                settings.profanityChatFiltering = settingsByKey.GetBool("profanityChatFiltering",
+                    defaultSettings.profanityChatFiltering);
+                settings.mouseSensitivity = settingsByKey.GetFloat("mouseSensitivity", defaultSettings.mouseSensitivity);
+                settings.namesOpacity = settingsByKey.GetFloat("namesOpacity", defaultSettings.namesOpacity);
+                settings.scenesLoadRadius = settingsByKey.GetFloat("scenesLoadRadius", defaultSettings.scenesLoadRadius);
+                settings.voiceChatVolume = settingsByKey.GetFloat("voiceChatVolume", defaultSettings.voiceChatVolume);
+                settings.avatarsLODDistance = settingsByKey.GetFloat("avatarsLODDistance", defaultSettings.avatarsLODDistance);
+                settings.maxNonLODAvatars = settingsByKey.GetFloat("maxNonLODAvatars", defaultSettings.maxNonLODAvatars);
+                settings.voiceChatAllow = settingsByKey.GetEnum("voiceChatAllow", defaultSettings.voiceChatAllow);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError(e.Message);
+            }
+
+            return settings;
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
@@ -5,6 +5,16 @@ namespace DCL.SettingsCommon
 {
     public class PlayerPrefsGeneralSettingsRepository : ISettingsRepository<GeneralSettings>
     {
+        public const string AUTO_QUALITY_ON = "autoqualityOn";
+        public const string PROFANITY_CHAT_FILTERING = "profanityChatFiltering";
+        public const string MOUSE_SENSITIVITY = "mouseSensitivity";
+        public const string NAMES_OPACITY = "namesOpacity";
+        public const string SCENES_LOAD_RADIUS = "scenesLoadRadius";
+        public const string VOICE_CHAT_VOLUME = "voiceChatVolume";
+        public const string AVATARS_LOD_DISTANCE = "avatarsLODDistance";
+        public const string MAX_NON_LOAD_AVATARS = "maxNonLODAvatars";
+        public const string VOICE_CHAT_ALLOW = "voiceChatAllow";
+
         private readonly IPlayerPrefsSettingsByKey settingsByKey;
         private readonly GeneralSettings defaultSettings;
         private GeneralSettings currentSettings;
@@ -36,15 +46,15 @@ namespace DCL.SettingsCommon
 
         public void Save()
         {
-            settingsByKey.SetBool("autoqualityOn", currentSettings.autoqualityOn);
-            settingsByKey.SetBool("profanityChatFiltering", currentSettings.profanityChatFiltering);
-            settingsByKey.SetFloat("mouseSensitivity", currentSettings.mouseSensitivity);
-            settingsByKey.SetFloat("namesOpacity", currentSettings.namesOpacity);
-            settingsByKey.SetFloat("scenesLoadRadius", currentSettings.scenesLoadRadius);
-            settingsByKey.SetFloat("voiceChatVolume", currentSettings.voiceChatVolume);
-            settingsByKey.SetFloat("avatarsLODDistance", currentSettings.avatarsLODDistance);
-            settingsByKey.SetFloat("maxNonLODAvatars", currentSettings.maxNonLODAvatars);
-            settingsByKey.SetEnum("voiceChatAllow", currentSettings.voiceChatAllow);
+            settingsByKey.SetBool(AUTO_QUALITY_ON, currentSettings.autoqualityOn);
+            settingsByKey.SetBool(PROFANITY_CHAT_FILTERING, currentSettings.profanityChatFiltering);
+            settingsByKey.SetFloat(MOUSE_SENSITIVITY, currentSettings.mouseSensitivity);
+            settingsByKey.SetFloat(NAMES_OPACITY, currentSettings.namesOpacity);
+            settingsByKey.SetFloat(SCENES_LOAD_RADIUS, currentSettings.scenesLoadRadius);
+            settingsByKey.SetFloat(VOICE_CHAT_VOLUME, currentSettings.voiceChatVolume);
+            settingsByKey.SetFloat(AVATARS_LOD_DISTANCE, currentSettings.avatarsLODDistance);
+            settingsByKey.SetFloat(MAX_NON_LOAD_AVATARS, currentSettings.maxNonLODAvatars);
+            settingsByKey.SetEnum(VOICE_CHAT_ALLOW, currentSettings.voiceChatAllow);
         }
 
         public bool HasAnyData() => !Data.Equals(defaultSettings);
@@ -55,16 +65,16 @@ namespace DCL.SettingsCommon
             
             try
             {
-                settings.autoqualityOn = settingsByKey.GetBool("autoqualityOn", defaultSettings.autoqualityOn);
-                settings.profanityChatFiltering = settingsByKey.GetBool("profanityChatFiltering",
+                settings.autoqualityOn = settingsByKey.GetBool(AUTO_QUALITY_ON, defaultSettings.autoqualityOn);
+                settings.profanityChatFiltering = settingsByKey.GetBool(PROFANITY_CHAT_FILTERING,
                     defaultSettings.profanityChatFiltering);
-                settings.mouseSensitivity = settingsByKey.GetFloat("mouseSensitivity", defaultSettings.mouseSensitivity);
-                settings.namesOpacity = settingsByKey.GetFloat("namesOpacity", defaultSettings.namesOpacity);
-                settings.scenesLoadRadius = settingsByKey.GetFloat("scenesLoadRadius", defaultSettings.scenesLoadRadius);
-                settings.voiceChatVolume = settingsByKey.GetFloat("voiceChatVolume", defaultSettings.voiceChatVolume);
-                settings.avatarsLODDistance = settingsByKey.GetFloat("avatarsLODDistance", defaultSettings.avatarsLODDistance);
-                settings.maxNonLODAvatars = settingsByKey.GetFloat("maxNonLODAvatars", defaultSettings.maxNonLODAvatars);
-                settings.voiceChatAllow = settingsByKey.GetEnum("voiceChatAllow", defaultSettings.voiceChatAllow);
+                settings.mouseSensitivity = settingsByKey.GetFloat(MOUSE_SENSITIVITY, defaultSettings.mouseSensitivity);
+                settings.namesOpacity = settingsByKey.GetFloat(NAMES_OPACITY, defaultSettings.namesOpacity);
+                settings.scenesLoadRadius = settingsByKey.GetFloat(SCENES_LOAD_RADIUS, defaultSettings.scenesLoadRadius);
+                settings.voiceChatVolume = settingsByKey.GetFloat(VOICE_CHAT_VOLUME, defaultSettings.voiceChatVolume);
+                settings.avatarsLODDistance = settingsByKey.GetFloat(AVATARS_LOD_DISTANCE, defaultSettings.avatarsLODDistance);
+                settings.maxNonLODAvatars = settingsByKey.GetFloat(MAX_NON_LOAD_AVATARS, defaultSettings.maxNonLODAvatars);
+                settings.voiceChatAllow = settingsByKey.GetEnum(VOICE_CHAT_ALLOW, defaultSettings.voiceChatAllow);
             }
             catch (Exception e)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66c6fd333912f60449cbbdd841390319
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsQualitySettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsQualitySettingsRepository.cs
@@ -5,6 +5,23 @@ namespace DCL.SettingsCommon
 {
     public class PlayerPrefsQualitySettingsRepository : ISettingsRepository<QualitySettings>
     {
+        private const string DISPLAY_NAME = "displayName";
+        private const string BLOOM = "bloom";
+        private const string COLOR_GRADING = "colorGrading";
+        private const string FPS_CAP = "fpsCap";
+        private const string SOFT_SHADOWS = "softShadows";
+        private const string ENABLE_DETAIL_OBJECT_CULLING = "enableDetailObjectCulling";
+        private const string SHADOWS = "shadows";
+        private const string RENDER_SCALE = "renderScale";
+        private const string SHADOW_DISTANCE = "shadowDistance";
+        private const string CAMERA_DRAW_DISTANCE = "cameraDrawDistance";
+        private const string DETAIL_OBJECT_CULLING_LIMIT = "detailObjectCullingLimit";
+        private const string ANTI_ALIASING = "antiAliasing";
+        private const string BASE_RESOLUTION = "baseResolution";
+        private const string SHADOW_RESOLUTION = "shadowResolution";
+        private const string SSAO_QUALITY = "ssaoQuality";
+        private const string MAX_HQ_AVATARS = "maxHQAvatars";
+
         private readonly IPlayerPrefsSettingsByKey settingsByKey;
         private readonly QualitySettings defaultSettings;
         private QualitySettings currentSettings;
@@ -36,22 +53,22 @@ namespace DCL.SettingsCommon
 
         public void Save()
         {
-            settingsByKey.SetString("displayName", currentSettings.displayName);
-            settingsByKey.SetBool("bloom", currentSettings.bloom);
-            settingsByKey.SetBool("colorGrading", currentSettings.colorGrading);
-            settingsByKey.SetBool("fpsCap", currentSettings.fpsCap);
-            settingsByKey.SetBool("softShadows", currentSettings.softShadows);
-            settingsByKey.SetBool("enableDetailObjectCulling", currentSettings.enableDetailObjectCulling);
-            settingsByKey.SetBool("shadows", currentSettings.shadows);
-            settingsByKey.SetFloat("renderScale", currentSettings.renderScale);
-            settingsByKey.SetFloat("shadowDistance", currentSettings.shadowDistance);
-            settingsByKey.SetFloat("cameraDrawDistance", currentSettings.cameraDrawDistance);
-            settingsByKey.SetFloat("detailObjectCullingLimit", currentSettings.detailObjectCullingLimit);
-            settingsByKey.SetEnum("antiAliasing", currentSettings.antiAliasing);
-            settingsByKey.SetEnum("baseResolution", currentSettings.baseResolution);
-            settingsByKey.SetEnum("shadowResolution", currentSettings.shadowResolution);
-            settingsByKey.SetEnum("ssaoQuality", currentSettings.ssaoQuality);
-            settingsByKey.SetInt("maxHQAvatars", currentSettings.maxHQAvatars);
+            settingsByKey.SetString(DISPLAY_NAME, currentSettings.displayName);
+            settingsByKey.SetBool(BLOOM, currentSettings.bloom);
+            settingsByKey.SetBool(COLOR_GRADING, currentSettings.colorGrading);
+            settingsByKey.SetBool(FPS_CAP, currentSettings.fpsCap);
+            settingsByKey.SetBool(SOFT_SHADOWS, currentSettings.softShadows);
+            settingsByKey.SetBool(ENABLE_DETAIL_OBJECT_CULLING, currentSettings.enableDetailObjectCulling);
+            settingsByKey.SetBool(SHADOWS, currentSettings.shadows);
+            settingsByKey.SetFloat(RENDER_SCALE, currentSettings.renderScale);
+            settingsByKey.SetFloat(SHADOW_DISTANCE, currentSettings.shadowDistance);
+            settingsByKey.SetFloat(CAMERA_DRAW_DISTANCE, currentSettings.cameraDrawDistance);
+            settingsByKey.SetFloat(DETAIL_OBJECT_CULLING_LIMIT, currentSettings.detailObjectCullingLimit);
+            settingsByKey.SetEnum(ANTI_ALIASING, currentSettings.antiAliasing);
+            settingsByKey.SetEnum(BASE_RESOLUTION, currentSettings.baseResolution);
+            settingsByKey.SetEnum(SHADOW_RESOLUTION, currentSettings.shadowResolution);
+            settingsByKey.SetEnum(SSAO_QUALITY, currentSettings.ssaoQuality);
+            settingsByKey.SetInt(MAX_HQ_AVATARS, currentSettings.maxHQAvatars);
         }
 
         public bool HasAnyData() => !Data.Equals(defaultSettings);
@@ -62,22 +79,22 @@ namespace DCL.SettingsCommon
             
             try
             {
-                settings.displayName = settingsByKey.GetString("displayName", defaultSettings.displayName);
-                settings.bloom = settingsByKey.GetBool("bloom", defaultSettings.bloom);
-                settings.colorGrading = settingsByKey.GetBool("colorGrading", defaultSettings.colorGrading);
-                settings.fpsCap = settingsByKey.GetBool("fpsCap", defaultSettings.fpsCap);
-                settings.softShadows = settingsByKey.GetBool("softShadows", defaultSettings.softShadows);
-                settings.enableDetailObjectCulling = settingsByKey.GetBool("enableDetailObjectCulling", defaultSettings.enableDetailObjectCulling);
-                settings.shadows = settingsByKey.GetBool("shadows", defaultSettings.shadows);
-                settings.renderScale = settingsByKey.GetFloat("renderScale", defaultSettings.renderScale);
-                settings.shadowDistance = settingsByKey.GetFloat("shadowDistance", defaultSettings.shadowDistance);
-                settings.cameraDrawDistance = settingsByKey.GetFloat("cameraDrawDistance", defaultSettings.cameraDrawDistance);
-                settings.detailObjectCullingLimit = settingsByKey.GetFloat("detailObjectCullingLimit", defaultSettings.detailObjectCullingLimit);
-                settings.antiAliasing = settingsByKey.GetEnum("antiAliasing", defaultSettings.antiAliasing);
-                settings.baseResolution = settingsByKey.GetEnum("baseResolution", defaultSettings.baseResolution);
-                settings.shadowResolution = settingsByKey.GetEnum("shadowResolution", defaultSettings.shadowResolution);
-                settings.ssaoQuality = settingsByKey.GetEnum("ssaoQuality", defaultSettings.ssaoQuality);
-                settings.maxHQAvatars = settingsByKey.GetInt("maxHQAvatars", defaultSettings.maxHQAvatars);
+                settings.displayName = settingsByKey.GetString(DISPLAY_NAME, defaultSettings.displayName);
+                settings.bloom = settingsByKey.GetBool(BLOOM, defaultSettings.bloom);
+                settings.colorGrading = settingsByKey.GetBool(COLOR_GRADING, defaultSettings.colorGrading);
+                settings.fpsCap = settingsByKey.GetBool(FPS_CAP, defaultSettings.fpsCap);
+                settings.softShadows = settingsByKey.GetBool(SOFT_SHADOWS, defaultSettings.softShadows);
+                settings.enableDetailObjectCulling = settingsByKey.GetBool(ENABLE_DETAIL_OBJECT_CULLING, defaultSettings.enableDetailObjectCulling);
+                settings.shadows = settingsByKey.GetBool(SHADOWS, defaultSettings.shadows);
+                settings.renderScale = settingsByKey.GetFloat(RENDER_SCALE, defaultSettings.renderScale);
+                settings.shadowDistance = settingsByKey.GetFloat(SHADOW_DISTANCE, defaultSettings.shadowDistance);
+                settings.cameraDrawDistance = settingsByKey.GetFloat(CAMERA_DRAW_DISTANCE, defaultSettings.cameraDrawDistance);
+                settings.detailObjectCullingLimit = settingsByKey.GetFloat(DETAIL_OBJECT_CULLING_LIMIT, defaultSettings.detailObjectCullingLimit);
+                settings.antiAliasing = settingsByKey.GetEnum(ANTI_ALIASING, defaultSettings.antiAliasing);
+                settings.baseResolution = settingsByKey.GetEnum(BASE_RESOLUTION, defaultSettings.baseResolution);
+                settings.shadowResolution = settingsByKey.GetEnum(SHADOW_RESOLUTION, defaultSettings.shadowResolution);
+                settings.ssaoQuality = settingsByKey.GetEnum(SSAO_QUALITY, defaultSettings.ssaoQuality);
+                settings.maxHQAvatars = settingsByKey.GetInt(MAX_HQ_AVATARS, defaultSettings.maxHQAvatars);
             }
             catch (Exception e)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsQualitySettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsQualitySettingsRepository.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using UnityEngine;
+
+namespace DCL.SettingsCommon
+{
+    public class PlayerPrefsQualitySettingsRepository : ISettingsRepository<QualitySettings>
+    {
+        private readonly IPlayerPrefsSettingsByKey settingsByKey;
+        private readonly QualitySettings defaultSettings;
+        private QualitySettings currentSettings;
+        
+        public event Action<QualitySettings> OnChanged;
+
+        public PlayerPrefsQualitySettingsRepository(
+            IPlayerPrefsSettingsByKey settingsByKey,
+            QualitySettings defaultSettings)
+        {
+            this.settingsByKey = settingsByKey;
+            this.defaultSettings = defaultSettings;
+            currentSettings = Load();
+        }
+
+        public QualitySettings Data => currentSettings;
+
+        public void Apply(QualitySettings settings)
+        {
+            if (currentSettings.Equals(settings)) return;
+            currentSettings = settings;
+            OnChanged?.Invoke(currentSettings);
+        }
+
+        public void Reset()
+        {
+            Apply(defaultSettings);
+        }
+
+        public void Save()
+        {
+            settingsByKey.SetBool("bloom", currentSettings.bloom);
+            settingsByKey.SetBool("colorGrading", currentSettings.colorGrading);
+            settingsByKey.SetBool("fpsCap", currentSettings.fpsCap);
+            settingsByKey.SetBool("softShadows", currentSettings.softShadows);
+            settingsByKey.SetBool("enableDetailObjectCulling", currentSettings.enableDetailObjectCulling);
+            settingsByKey.SetBool("shadows", currentSettings.shadows);
+            settingsByKey.SetFloat("renderScale", currentSettings.renderScale);
+            settingsByKey.SetFloat("shadowDistance", currentSettings.shadowDistance);
+            settingsByKey.SetFloat("cameraDrawDistance", currentSettings.cameraDrawDistance);
+            settingsByKey.SetFloat("detailObjectCullingLimit", currentSettings.detailObjectCullingLimit);
+            settingsByKey.SetEnum("antiAliasing", currentSettings.antiAliasing);
+            settingsByKey.SetEnum("baseResolution", currentSettings.baseResolution);
+            settingsByKey.SetEnum("shadowResolution", currentSettings.shadowResolution);
+            settingsByKey.SetEnum("ssaoQuality", currentSettings.ssaoQuality);
+            settingsByKey.SetInt("maxHQAvatars", currentSettings.maxHQAvatars);
+        }
+
+        public bool HasAnyData() => !Data.Equals(defaultSettings);
+
+        private QualitySettings Load()
+        {
+            var settings = defaultSettings;
+            
+            try
+            {
+                settings.bloom = settingsByKey.GetBool("bloom", defaultSettings.bloom);
+                settings.colorGrading = settingsByKey.GetBool("colorGrading", defaultSettings.colorGrading);
+                settings.fpsCap = settingsByKey.GetBool("fpsCap", defaultSettings.fpsCap);
+                settings.softShadows = settingsByKey.GetBool("softShadows", defaultSettings.softShadows);
+                settings.enableDetailObjectCulling = settingsByKey.GetBool("enableDetailObjectCulling", defaultSettings.enableDetailObjectCulling);
+                settings.shadows = settingsByKey.GetBool("shadows", defaultSettings.shadows);
+                settings.renderScale = settingsByKey.GetFloat("renderScale", defaultSettings.renderScale);
+                settings.shadowDistance = settingsByKey.GetFloat("shadowDistance", defaultSettings.shadowDistance);
+                settings.cameraDrawDistance = settingsByKey.GetFloat("cameraDrawDistance", defaultSettings.cameraDrawDistance);
+                settings.detailObjectCullingLimit = settingsByKey.GetFloat("detailObjectCullingLimit", defaultSettings.detailObjectCullingLimit);
+                settings.antiAliasing = settingsByKey.GetEnum("antiAliasing", defaultSettings.antiAliasing);
+                settings.baseResolution = settingsByKey.GetEnum("baseResolution", defaultSettings.baseResolution);
+                settings.shadowResolution = settingsByKey.GetEnum("shadowResolution", defaultSettings.shadowResolution);
+                settings.ssaoQuality = settingsByKey.GetEnum("ssaoQuality", defaultSettings.ssaoQuality);
+                settings.maxHQAvatars = settingsByKey.GetInt("maxHQAvatars", defaultSettings.maxHQAvatars);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError(e.Message);
+            }
+
+            return settings;
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsQualitySettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsQualitySettingsRepository.cs
@@ -36,6 +36,7 @@ namespace DCL.SettingsCommon
 
         public void Save()
         {
+            settingsByKey.SetString("displayName", currentSettings.displayName);
             settingsByKey.SetBool("bloom", currentSettings.bloom);
             settingsByKey.SetBool("colorGrading", currentSettings.colorGrading);
             settingsByKey.SetBool("fpsCap", currentSettings.fpsCap);
@@ -61,6 +62,7 @@ namespace DCL.SettingsCommon
             
             try
             {
+                settings.displayName = settingsByKey.GetString("displayName", defaultSettings.displayName);
                 settings.bloom = settingsByKey.GetBool("bloom", defaultSettings.bloom);
                 settings.colorGrading = settingsByKey.GetBool("colorGrading", defaultSettings.colorGrading);
                 settings.fpsCap = settingsByKey.GetBool("fpsCap", defaultSettings.fpsCap);
@@ -79,7 +81,7 @@ namespace DCL.SettingsCommon
             }
             catch (Exception e)
             {
-                Debug.LogError(e.Message);
+                Debug.LogException(e);
             }
 
             return settings;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsQualitySettingsRepository.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsQualitySettingsRepository.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ab6229d3090142cbb3742c8646283c53
+timeCreated: 1637351902

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsSettingsByKey.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsSettingsByKey.cs
@@ -35,6 +35,11 @@ namespace DCL.SettingsCommon
             return PlayerPrefs.GetInt(GetFieldKey(fieldName), defaultValue);
         }
 
+        public string GetString(string fieldName, string defaultValue)
+        {
+            return PlayerPrefs.GetString(GetFieldKey(fieldName), defaultValue);
+        }
+
         public void SetBool(string fieldName, bool value)
         {
             PlayerPrefsUtils.SetBool(GetFieldKey(fieldName), value);
@@ -54,7 +59,12 @@ namespace DCL.SettingsCommon
         {
             PlayerPrefs.SetInt(GetFieldKey(fieldName), value);
         }
-        
+
+        public void SetString(string fieldName, string value)
+        {
+            PlayerPrefs.SetString(GetFieldKey(fieldName), value);
+        }
+
         private string GetFieldKey(string fieldName)
         {
             return $"{prefixPrefsKey}.{fieldName}";

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsSettingsByKey.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsSettingsByKey.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using DCL.Helpers;
+using UnityEngine;
+
+namespace DCL.SettingsCommon
+{
+    public class PlayerPrefsSettingsByKey : IPlayerPrefsSettingsByKey
+    {
+        private readonly string prefixPrefsKey;
+
+        public PlayerPrefsSettingsByKey(string prefixPrefsKey)
+        {
+            this.prefixPrefsKey = prefixPrefsKey;
+        }
+        
+        public T GetEnum<T>(string fieldName, T defaultValue) where T : struct
+        {
+            if (!Enum.TryParse<T>(PlayerPrefs.GetString(GetFieldKey(fieldName), ""), out var result))
+                return defaultValue;
+            return result;
+        }
+
+        public bool GetBool(string fieldName, bool defaultValue)
+        {
+            return PlayerPrefsUtils.GetBool(GetFieldKey(fieldName), defaultValue);
+        }
+
+        public float GetFloat(string fieldName, float defaultValue)
+        {
+            return PlayerPrefs.GetFloat(GetFieldKey(fieldName), defaultValue);
+        }
+        
+        public int GetInt(string fieldName, int defaultValue)
+        {
+            return PlayerPrefs.GetInt(GetFieldKey(fieldName), defaultValue);
+        }
+
+        public void SetBool(string fieldName, bool value)
+        {
+            PlayerPrefsUtils.SetBool(GetFieldKey(fieldName), value);
+        }
+
+        public void SetFloat(string fieldName, float value)
+        {
+            PlayerPrefs.SetFloat(GetFieldKey(fieldName), value);
+        }
+
+        public void SetEnum<T>(string fieldName, T value) where T : struct
+        {
+            PlayerPrefs.SetString(GetFieldKey(fieldName), value.ToString());
+        }
+
+        public void SetInt(string fieldName, int value)
+        {
+            PlayerPrefs.SetInt(GetFieldKey(fieldName), value);
+        }
+        
+        private string GetFieldKey(string fieldName)
+        {
+            return $"{prefixPrefsKey}.{fieldName}";
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsSettingsByKey.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsSettingsByKey.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6261f50c2b6e6c468779a1d499de8ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ProxySettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ProxySettingsRepository.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace DCL.SettingsCommon
+{
+    public class ProxySettingsRepository<T> : ISettingsRepository<T> where T : struct
+    {
+        private readonly ISettingsRepository<T> latestRepository;
+        private readonly ISettingsRepository<T> fallbackRepository;
+
+        public event Action<T> OnChanged
+        {
+            add => latestRepository.OnChanged += value;
+            remove => latestRepository.OnChanged -= value;
+        }
+
+        public T Data
+        {
+            get
+            {
+                if (!latestRepository.HasAnyData() && fallbackRepository.HasAnyData())
+                    latestRepository.Apply(fallbackRepository.Data);
+                return latestRepository.Data;
+            }
+        }
+
+        public ProxySettingsRepository(ISettingsRepository<T> latestRepository,
+            ISettingsRepository<T> fallbackRepository)
+        {
+            this.latestRepository = latestRepository;
+            this.fallbackRepository = fallbackRepository;
+        }
+
+        public void Apply(T settings) => latestRepository.Apply(settings);
+
+        public void Reset() => latestRepository.Reset();
+
+        public void Save() => latestRepository.Save();
+
+        public bool HasAnyData() => latestRepository.HasAnyData();
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ProxySettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ProxySettingsRepository.cs
@@ -5,7 +5,7 @@ namespace DCL.SettingsCommon
     public class ProxySettingsRepository<T> : ISettingsRepository<T> where T : struct
     {
         private readonly ISettingsRepository<T> latestRepository;
-        private readonly ISettingsRepository<T> fallbackRepository;
+        private readonly ISettingsRepository<T> recoveryRepository;
 
         public event Action<T> OnChanged
         {
@@ -17,17 +17,17 @@ namespace DCL.SettingsCommon
         {
             get
             {
-                if (!latestRepository.HasAnyData() && fallbackRepository.HasAnyData())
-                    latestRepository.Apply(fallbackRepository.Data);
+                if (!latestRepository.HasAnyData() && recoveryRepository.HasAnyData())
+                    latestRepository.Apply(recoveryRepository.Data);
                 return latestRepository.Data;
             }
         }
 
         public ProxySettingsRepository(ISettingsRepository<T> latestRepository,
-            ISettingsRepository<T> fallbackRepository)
+            ISettingsRepository<T> recoveryRepository)
         {
             this.latestRepository = latestRepository;
-            this.fallbackRepository = fallbackRepository;
+            this.recoveryRepository = recoveryRepository;
         }
 
         public void Apply(T settings) => latestRepository.Apply(settings);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ProxySettingsRepository.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/ProxySettingsRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6741e4e793a3a5d4cb0b944d3cd4308f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Settings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Settings.cs
@@ -14,9 +14,9 @@ namespace DCL.SettingsCommon
         public event Action OnResetAllSettings;
         public QualitySettingsData qualitySettingsPresets => qualitySettingsPreset;
 
-        public SettingsModule<QualitySettings> qualitySettings;
-        public SettingsModule<GeneralSettings> generalSettings;
-        public SettingsModule<AudioSettings> audioSettings;
+        public ISettingsRepository<QualitySettings> qualitySettings;
+        public ISettingsRepository<GeneralSettings> generalSettings;
+        public ISettingsRepository<AudioSettings> audioSettings;
 
         private static QualitySettingsData qualitySettingsPreset = null;
 
@@ -42,10 +42,27 @@ namespace DCL.SettingsCommon
             if (autosettingsEnabled == null)
                 autosettingsEnabled = Resources.Load<BooleanVariable>("ScriptableObjects/AutoQualityEnabled");
 
-
-            qualitySettings = new SettingsModule<QualitySettings>(QUALITY_SETTINGS_KEY, qualitySettingsPreset.defaultPreset);
-            generalSettings = new SettingsModule<GeneralSettings>(GENERAL_SETTINGS_KEY, GetDefaultGeneralSettings());
-            audioSettings = new SettingsModule<AudioSettings>(AUDIO_SETTINGS_KEY, GetDefaultAudioSettings());
+            qualitySettings = new ProxySettingsRepository<QualitySettings>(
+                new PlayerPrefsQualitySettingsRepository(
+                    new PlayerPrefsSettingsByKey(QUALITY_SETTINGS_KEY),
+                    qualitySettingsPreset.defaultPreset),
+                new SettingsModule<QualitySettings>(
+                    QUALITY_SETTINGS_KEY,
+                    qualitySettingsPreset.defaultPreset));
+            generalSettings = new ProxySettingsRepository<GeneralSettings>(
+                new PlayerPrefsGeneralSettingsRepository(
+                    new PlayerPrefsSettingsByKey(GENERAL_SETTINGS_KEY),
+                    GetDefaultGeneralSettings()),
+                new SettingsModule<GeneralSettings>(
+                    GENERAL_SETTINGS_KEY,
+                    GetDefaultGeneralSettings()));
+            audioSettings = new ProxySettingsRepository<AudioSettings>(
+                new PlayerPrefsAudioSettingsRepository(
+                    new PlayerPrefsSettingsByKey(AUDIO_SETTINGS_KEY),
+                    GetDefaultAudioSettings()),
+                new SettingsModule<AudioSettings>(
+                    AUDIO_SETTINGS_KEY,
+                    GetDefaultAudioSettings()));
 
             SubscribeToVirtualAudioMixerEvents();
             audioMixer = Resources.Load<AudioMixer>("AudioMixer");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/AudioSettings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/AudioSettings.cs
@@ -3,7 +3,7 @@ using System;
 namespace DCL.SettingsCommon
 {
     [Serializable]
-    public class AudioSettings : ICloneable
+    public struct AudioSettings
     {
         public float masterVolume;
         public float voiceChatVolume;
@@ -12,7 +12,5 @@ namespace DCL.SettingsCommon
         public float sceneSFXVolume; // Note(Mordi): Also known as "World SFX"
         public float musicVolume;
         public bool chatSFXEnabled;
-
-        public object Clone() => MemberwiseClone();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/GeneralSettings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/GeneralSettings.cs
@@ -3,7 +3,7 @@ using System;
 namespace DCL.SettingsCommon
 {
     [Serializable]
-    public class GeneralSettings : ICloneable
+    public struct GeneralSettings
     {
         public enum VoiceChatAllow { ALL_USERS, VERIFIED_ONLY, FRIENDS_ONLY }
 
@@ -16,7 +16,5 @@ namespace DCL.SettingsCommon
         public float maxNonLODAvatars;
         public float namesOpacity;
         public bool profanityChatFiltering;
-        
-        public object Clone() => MemberwiseClone();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/QualitySettings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/QualitySettings.cs
@@ -24,19 +24,21 @@ namespace DCL.SettingsCommon
 
         public string displayName;
 
-        [Tooltip("Base resolution level")]
-        public BaseResolution baseResolution;
+        [Tooltip("Base resolution level")] public BaseResolution baseResolution;
 
         [Tooltip("Controls the global anti aliasing setting")]
         public UnityEngine.Rendering.Universal.MsaaQuality antiAliasing;
 
-        [Tooltip("Scales the camera render target allowing the game to render at a resolution different than native resolution. UI is always rendered at native resolution")] [Range(0.5f, 1)]
+        [Tooltip(
+            "Scales the camera render target allowing the game to render at a resolution different than native resolution. UI is always rendered at native resolution")]
+        [Range(0.5f, 1)]
         public float renderScale;
 
         [Tooltip("If enabled the main light can be a shadow casting light")]
         public bool shadows;
 
-        [Tooltip("If enabled pipeline will perform shadow filterin. Otherwise all lights that cast shadows will fallback to perform a single shadow sample")]
+        [Tooltip(
+            "If enabled pipeline will perform shadow filterin. Otherwise all lights that cast shadows will fallback to perform a single shadow sample")]
         public bool softShadows;
 
         [Tooltip("Resolution of the main light shadowmap texture")]
@@ -45,8 +47,7 @@ namespace DCL.SettingsCommon
         [Tooltip("Camera Far")] [Range(40, 500)]
         public float cameraDrawDistance;
 
-        [Tooltip("Enable bloom post process")]
-        public bool bloom;
+        [Tooltip("Enable bloom post process")] public bool bloom;
 
         [Tooltip("Enable 30 FPS capping for more stable framerate")]
         public bool fpsCap;
@@ -60,11 +61,12 @@ namespace DCL.SettingsCommon
         [Tooltip("Enable culling for detail objects in the viewport.")]
         public bool enableDetailObjectCulling;
 
-        [Tooltip("If detail object culling is ON, this slider determines the relative size of culled objects from tiny to big. Bigger values gives better performance, but more objects will be hidden.")] [Range(0, 100)]
+        [Tooltip(
+            "If detail object culling is ON, this slider determines the relative size of culled objects from tiny to big. Bigger values gives better performance, but more objects will be hidden.")]
+        [Range(0, 100)]
         public float detailObjectCullingLimit;
 
-        [Tooltip("SSAO quality level")]
-        public SSAOQualityLevel ssaoQuality;
+        [Tooltip("SSAO quality level")] public SSAOQualityLevel ssaoQuality;
 
         [Tooltip("Amount of HQ Avatars visible at any time")]
         public int maxHQAvatars;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/QualitySettings.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsData/QualitySettings.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace DCL.SettingsCommon
 {
     [Serializable]
-    public class QualitySettings : ICloneable
+    public struct QualitySettings
     {
         public enum BaseResolution
         {
@@ -68,7 +68,5 @@ namespace DCL.SettingsCommon
 
         [Tooltip("Amount of HQ Avatars visible at any time")]
         public int maxHQAvatars;
-
-        public object Clone() => MemberwiseClone();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsModule.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsModule.cs
@@ -4,14 +4,14 @@ using UnityEngine;
 
 namespace DCL.SettingsCommon
 {
-    public class SettingsModule<T> where T : ICloneable
+    public class SettingsModule<T> : ISettingsRepository<T> where T : struct
     {
         public event Action<T> OnChanged;
 
         private readonly string playerPrefsKey;
         private readonly T defaultPreset;
 
-        public T Data => (T) dataValue?.Clone();
+        public T Data => dataValue;
         private T dataValue;
 
         public SettingsModule(string playerPrefsKey, T defaultPreset)
@@ -23,13 +23,13 @@ namespace DCL.SettingsCommon
 
         private void Preload()
         {
-            dataValue = (T) defaultPreset.Clone();
+            dataValue = defaultPreset;
             if (!PlayerPrefsUtils.HasKey(playerPrefsKey))
                 return;
 
             try
             {
-                JsonUtility.FromJsonOverwrite(PlayerPrefsUtils.GetString(playerPrefsKey), dataValue);
+                dataValue = JsonUtility.FromJson<T>(PlayerPrefsUtils.GetString(playerPrefsKey));
             }
             catch (Exception e)
             {
@@ -44,10 +44,12 @@ namespace DCL.SettingsCommon
             if (dataValue.Equals(newSettings))
                 return;
 
-            dataValue = (T) newSettings.Clone();
+            dataValue = newSettings;
             OnChanged?.Invoke(dataValue);
         }
 
         public void Save() { PlayerPrefsUtils.SetString(playerPrefsKey, JsonUtility.ToJson(dataValue)); }
+
+        public bool HasAnyData() => !Data.Equals(defaultPreset);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f45d02d479572bf4487d26d64ea6c680
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
@@ -72,6 +72,46 @@ namespace DCL.SettingsCommon.Tests
             Assert.AreEqual(latestEditedSettings, settings);
         }
 
+        [Test]
+        public void DefaultMissingAttributes()
+        {
+            var latestEditedSettings = new GeneralSettings
+            {
+                autoqualityOn = true,
+                namesOpacity = 0.75f,
+                voiceChatAllow = GeneralSettings.VoiceChatAllow.VERIFIED_ONLY
+            };
+            var settingsByKey = GivenDataStoredInPrefs(latestEditedSettings);
+            GivenMissingBoolAttribute(settingsByKey, "profanityChatFiltering");
+            GivenMissingFloatAttribute(settingsByKey, "scenesLoadRadius");
+            var defaultSettings = GetDefaultSettings();
+            var latestRepository = new PlayerPrefsGeneralSettingsRepository(
+                settingsByKey, defaultSettings);
+            var fallbackRepository = GivenSettingsRepositoryWithNoData();
+            var proxyRepository = new ProxySettingsRepository<GeneralSettings>(latestRepository,
+                fallbackRepository);
+            
+            var settings = proxyRepository.Data;
+            
+            Assert.AreEqual(latestEditedSettings.autoqualityOn, settings.autoqualityOn);
+            Assert.AreEqual(latestEditedSettings.namesOpacity, settings.namesOpacity);
+            Assert.AreEqual(latestEditedSettings.voiceChatAllow, settings.voiceChatAllow);
+            Assert.AreEqual(defaultSettings.profanityChatFiltering, settings.profanityChatFiltering);
+            Assert.AreEqual(defaultSettings.scenesLoadRadius, settings.scenesLoadRadius);
+        }
+
+        private void GivenMissingFloatAttribute(IPlayerPrefsSettingsByKey settingsByKey, string fieldName)
+        {
+            settingsByKey.GetFloat(fieldName, Arg.Any<float>())
+                .Returns(call => call[1]);
+        }
+
+        private void GivenMissingBoolAttribute(IPlayerPrefsSettingsByKey settingsByKey, string fieldName)
+        {
+            settingsByKey.GetBool(fieldName, Arg.Any<bool>())
+                .Returns(call => call[1]);
+        }
+
         private GeneralSettings GetDefaultSettings()
         {
             return new GeneralSettings

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
@@ -1,0 +1,137 @@
+﻿using NSubstitute;
+using NUnit.Framework;
+
+namespace DCL.SettingsCommon.Tests
+{
+    public class ProxySettingsRepositoryShould
+    {
+        [Test]
+        public void ReturnDefaultDataWhenRepositoriesHasNoData()
+        {
+            var latestRepository = GivenSettingsRepositoryWithNoData();
+            var fallbackRepository = GivenSettingsRepositoryWithNoData();
+            var proxyRepository = new ProxySettingsRepository<GeneralSettings>(latestRepository,
+                fallbackRepository);
+
+            var settings = proxyRepository.Data;
+            var latestRepositorySettings = latestRepository.Data;
+            
+            Assert.AreEqual(GetDefaultSettings(), settings);
+            ThenDataWasMigratedToLatestRepository(settings, latestRepositorySettings);
+        }
+
+        [Test]
+        public void ReturnFallbackDataWhenLatestRepositoryHasNoData()
+        {
+            var latestRepository = GivenSettingsRepositoryWithNoData();
+            var editedSettings = new GeneralSettings
+            {
+                autoqualityOn = true,
+                namesOpacity = 0.75f,
+                mouseSensitivity = 0.1f,
+                profanityChatFiltering = true,
+                scenesLoadRadius = 4
+            };
+            var fallbackRepository = GivenSettingsRepositoryWithDataStored(editedSettings);
+            var proxyRepository = new ProxySettingsRepository<GeneralSettings>(latestRepository,
+                fallbackRepository);
+
+            var settings = proxyRepository.Data;
+            var latestRepositorySettings = latestRepository.Data;
+            
+            Assert.AreEqual(editedSettings, settings);
+            ThenDataWasMigratedToLatestRepository(settings, latestRepositorySettings);
+        }
+
+        [Test]
+        public void ReturnLatestRepositoryDataWhenHasAnyDataStored()
+        {
+            var latestEditedSettings = new GeneralSettings
+            {
+                autoqualityOn = true,
+                namesOpacity = 0.75f,
+                mouseSensitivity = 0.1f,
+            };
+            var fallbackEditedSettings = new GeneralSettings
+            {
+                autoqualityOn = true,
+                namesOpacity = 0.23f,
+                mouseSensitivity = 0.7f,
+                profanityChatFiltering = false,
+                scenesLoadRadius = 1,
+                avatarsLODDistance = 0.6f,
+                voiceChatAllow = GeneralSettings.VoiceChatAllow.FRIENDS_ONLY
+            };
+            var latestRepository = GivenSettingsRepositoryWithDataStored(latestEditedSettings);
+            var fallbackRepository = GivenSettingsRepositoryWithDataStored(fallbackEditedSettings);
+            var proxyRepository = new ProxySettingsRepository<GeneralSettings>(latestRepository,
+                fallbackRepository);
+            
+            var settings = proxyRepository.Data;
+            
+            Assert.AreEqual(latestEditedSettings, settings);
+        }
+
+        private GeneralSettings GetDefaultSettings()
+        {
+            return new GeneralSettings
+            {
+                mouseSensitivity = 0.6f,
+                scenesLoadRadius = 4,
+                avatarsLODDistance = 16,
+                maxNonLODAvatars = 1,
+                voiceChatVolume = 1,
+                voiceChatAllow = GeneralSettings.VoiceChatAllow.ALL_USERS,
+                autoqualityOn = false,
+                namesOpacity = 0.5f,
+                profanityChatFiltering = true
+            };
+        }
+
+        private PlayerPrefsGeneralSettingsRepository GivenSettingsRepositoryWithDataStored(GeneralSettings settings)
+        {
+            return new PlayerPrefsGeneralSettingsRepository(GivenDataStoredInPrefs(settings),
+                GetDefaultSettings());
+        }
+
+        private PlayerPrefsGeneralSettingsRepository GivenSettingsRepositoryWithNoData()
+        {
+            var latestRepository = new PlayerPrefsGeneralSettingsRepository(GivenNoDataStoredInPrefs(),
+                GetDefaultSettings());
+            return latestRepository;
+        }
+
+        private IPlayerPrefsSettingsByKey GivenDataStoredInPrefs(GeneralSettings settings)
+        {
+            var prefsByKey = Substitute.For<IPlayerPrefsSettingsByKey>();
+            prefsByKey.GetBool("autoqualityOn", Arg.Any<bool>()).Returns(settings.autoqualityOn);
+            prefsByKey.GetBool("profanityChatFiltering", Arg.Any<bool>()).Returns(settings.profanityChatFiltering);
+            prefsByKey.GetFloat("mouseSensitivity", Arg.Any<float>()).Returns(settings.mouseSensitivity);
+            prefsByKey.GetFloat("namesOpacity", Arg.Any<float>()).Returns(settings.namesOpacity);
+            prefsByKey.GetFloat("scenesLoadRadius", Arg.Any<float>()).Returns(settings.scenesLoadRadius);
+            prefsByKey.GetFloat("voiceChatVolume", Arg.Any<float>()).Returns(settings.voiceChatVolume);
+            prefsByKey.GetFloat("avatarsLODDistance", Arg.Any<float>()).Returns(settings.avatarsLODDistance);
+            prefsByKey.GetFloat("maxNonLODAvatars", Arg.Any<float>()).Returns(settings.maxNonLODAvatars);
+            prefsByKey.GetEnum("voiceChatAllow", Arg.Any<GeneralSettings.VoiceChatAllow>())
+                .Returns(settings.voiceChatAllow);
+            return prefsByKey;
+        }
+
+        private IPlayerPrefsSettingsByKey GivenNoDataStoredInPrefs()
+        {
+            var prefsBykey = Substitute.For<IPlayerPrefsSettingsByKey>();
+            prefsBykey.GetBool(Arg.Any<string>(), Arg.Any<bool>()).Returns(info => info.Args()[1]);
+            prefsBykey.GetFloat(Arg.Any<string>(), Arg.Any<float>()).Returns(info => info.Args()[1]);
+            prefsBykey.GetInt(Arg.Any<string>(), Arg.Any<int>()).Returns(info => info.Args()[1]);
+            prefsBykey.GetEnum(Arg.Any<string>(), Arg.Any<GeneralSettings.VoiceChatAllow>())
+                .Returns(info => info.Args()[1]);
+            return prefsBykey;
+        }
+
+        private void ThenDataWasMigratedToLatestRepository(GeneralSettings settings,
+            GeneralSettings latestRepositorySettings)
+        {
+            Assert.AreEqual(settings, latestRepositorySettings);
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
@@ -82,8 +82,9 @@ namespace DCL.SettingsCommon.Tests
                 voiceChatAllow = GeneralSettings.VoiceChatAllow.VERIFIED_ONLY
             };
             var settingsByKey = GivenDataStoredInPrefs(latestEditedSettings);
-            GivenMissingBoolAttribute(settingsByKey, "profanityChatFiltering");
-            GivenMissingFloatAttribute(settingsByKey, "scenesLoadRadius");
+            
+            GivenMissingBoolAttribute(settingsByKey, PlayerPrefsGeneralSettingsRepository.PROFANITY_CHAT_FILTERING);
+            GivenMissingFloatAttribute(settingsByKey, PlayerPrefsGeneralSettingsRepository.SCENES_LOAD_RADIUS);
             var defaultSettings = GetDefaultSettings();
             var latestRepository = new PlayerPrefsGeneralSettingsRepository(
                 settingsByKey, defaultSettings);
@@ -144,16 +145,24 @@ namespace DCL.SettingsCommon.Tests
         private IPlayerPrefsSettingsByKey GivenDataStoredInPrefs(GeneralSettings settings)
         {
             var prefsByKey = Substitute.For<IPlayerPrefsSettingsByKey>();
-            prefsByKey.GetBool("autoqualityOn", Arg.Any<bool>()).Returns(settings.autoqualityOn);
-            prefsByKey.GetBool("profanityChatFiltering", Arg.Any<bool>()).Returns(settings.profanityChatFiltering);
-            prefsByKey.GetFloat("mouseSensitivity", Arg.Any<float>()).Returns(settings.mouseSensitivity);
-            prefsByKey.GetFloat("namesOpacity", Arg.Any<float>()).Returns(settings.namesOpacity);
-            prefsByKey.GetFloat("scenesLoadRadius", Arg.Any<float>()).Returns(settings.scenesLoadRadius);
-            prefsByKey.GetFloat("voiceChatVolume", Arg.Any<float>()).Returns(settings.voiceChatVolume);
-            prefsByKey.GetFloat("avatarsLODDistance", Arg.Any<float>()).Returns(settings.avatarsLODDistance);
-            prefsByKey.GetFloat("maxNonLODAvatars", Arg.Any<float>()).Returns(settings.maxNonLODAvatars);
-            prefsByKey.GetEnum("voiceChatAllow", Arg.Any<GeneralSettings.VoiceChatAllow>())
-                .Returns(settings.voiceChatAllow);
+            prefsByKey.GetBool(PlayerPrefsGeneralSettingsRepository.AUTO_QUALITY_ON,
+                Arg.Any<bool>()).Returns(settings.autoqualityOn);
+            prefsByKey.GetBool(PlayerPrefsGeneralSettingsRepository.PROFANITY_CHAT_FILTERING,
+                Arg.Any<bool>()).Returns(settings.profanityChatFiltering);
+            prefsByKey.GetFloat(PlayerPrefsGeneralSettingsRepository.MOUSE_SENSITIVITY,
+                Arg.Any<float>()).Returns(settings.mouseSensitivity);
+            prefsByKey.GetFloat(PlayerPrefsGeneralSettingsRepository.NAMES_OPACITY,
+                Arg.Any<float>()).Returns(settings.namesOpacity);
+            prefsByKey.GetFloat(PlayerPrefsGeneralSettingsRepository.SCENES_LOAD_RADIUS,
+                Arg.Any<float>()).Returns(settings.scenesLoadRadius);
+            prefsByKey.GetFloat(PlayerPrefsGeneralSettingsRepository.VOICE_CHAT_VOLUME,
+                Arg.Any<float>()).Returns(settings.voiceChatVolume);
+            prefsByKey.GetFloat(PlayerPrefsGeneralSettingsRepository.AVATARS_LOD_DISTANCE,
+                Arg.Any<float>()).Returns(settings.avatarsLODDistance);
+            prefsByKey.GetFloat(PlayerPrefsGeneralSettingsRepository.MAX_NON_LOAD_AVATARS,
+                Arg.Any<float>()).Returns(settings.maxNonLODAvatars);
+            prefsByKey.GetEnum(PlayerPrefsGeneralSettingsRepository.VOICE_CHAT_ALLOW,
+                    Arg.Any<GeneralSettings.VoiceChatAllow>()).Returns(settings.voiceChatAllow);
             return prefsByKey;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
@@ -160,6 +160,7 @@ namespace DCL.SettingsCommon.Tests
         private IPlayerPrefsSettingsByKey GivenNoDataStoredInPrefs()
         {
             var prefsBykey = Substitute.For<IPlayerPrefsSettingsByKey>();
+            prefsBykey.GetString(Arg.Any<string>(), Arg.Any<string>()).Returns(info => info.Args()[1]);
             prefsBykey.GetBool(Arg.Any<string>(), Arg.Any<bool>()).Returns(info => info.Args()[1]);
             prefsBykey.GetFloat(Arg.Any<string>(), Arg.Any<float>()).Returns(info => info.Args()[1]);
             prefsBykey.GetInt(Arg.Any<string>(), Arg.Any<int>()).Returns(info => info.Args()[1]);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acb8c6a456a69f04d87dd05e85ca85e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/SettingsTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/SettingsTests.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Tests",
+    "name": "SettingsTests",
     "rootNamespace": "",
     "references": [
         "UnityEngine.TestRunner",

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/SettingsTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/SettingsTests.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Settings"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "NSubstitute.dll",
+        "System.Threading.Tasks.Extensions.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/SettingsTests.asmdef.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/SettingsTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 44003f8e851dd144cb30832ac7450ebb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/PlayerPrefsUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/PlayerPrefsUtils.cs
@@ -7,6 +7,13 @@ namespace DCL.Helpers
         public static int GetInt(string key) { return PlayerPrefs.GetInt(key); }
 
         public static int GetInt(string key, int defaultValue) { return PlayerPrefs.GetInt(key, defaultValue); }
+        
+        public static bool GetBool(string key, bool defaultValue) => PlayerPrefs.GetInt(key, defaultValue ? 1 : 0) == 1;
+        
+        public static void SetBool(string key, bool value)
+        {
+            PlayerPrefs.SetInt(key, value ? 1 : 0);
+        }
 
         public static void SetInt(string key, int value)
         {


### PR DESCRIPTION
## What does this PR change?

`Closes #1482 `

Fixes the preset dropdown that was always showing `Custom` at quality settings menu.
Settings data structures were changed from classes to structs so that `equals` compares values instead of references.
A new persistence architecture was implemented to solve the problem of being unable to default a new/non-existent attribute of a user that already had any settings saved. It saves each setting's attribute into a new player prefs key. This architecture also holds retrocompatibility issues by migrating the previous settings saved to the new persistence schema.

## How to test the changes?

1. Go to: https://play.decentraland.org
2. Change your settings (general, quality & audio) to anything you'd like, preferably something different than default settings
3. Close the settings menu
4. Go to: https://play.decentraland.zone/?renderer-branch=refactor/settings-persistence
5. Open the settings menu, you should have the previous settings you changed (general, quality & audio)
6. Change any setting you like
7. Close the settings menu
8. Restart the app
9. You should have the previous settings
10. Go to quality settings then pick any preset from the dropdown (low, medium, high, ultra)
11. Restart the app
12. The preset dropdown should hold whatever preset you chose

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
