### PR TITLE
chore: remove invalid triangles check in gltfsceneimporter

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -2104,17 +2104,10 @@ namespace UnityGLTF
                 yield return YieldOnTimeout();
             }
 
-            if (AreMeshTrianglesValid(unityMeshData.Triangles, vertexCount)) // Some scenes contain broken meshes that can trigger a fatal error
+            mesh.triangles = unityMeshData.Triangles;
+            if (ShouldYieldOnTimeout())
             {
-                mesh.triangles = unityMeshData.Triangles;
-                if (ShouldYieldOnTimeout())
-                {
-                    yield return YieldOnTimeout();
-                }
-            }
-            else
-            {
-                Debug.Log("GLTFSceneImporter - ERROR - ConstructUnityMesh - Couldn't assign triangles to mesh as there are indices pointing to vertices out of bounds");
+                yield return YieldOnTimeout();
             }
 
             mesh.tangents = unityMeshData.Tangents;


### PR DESCRIPTION
this check was introduced when debugging the AB converter, as this check affects performance in runtime, we are removing it.

https://play.decentraland.zone/?renderer-branch=chore/RemoveInvalidVerticesCheckInGLTFSceneImporter&DISABLE_ASSET_BUNDLES