### PR TITLE
docs: add how to setup circleci

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ When the steps are followed, you will be able to run the local Unity build by go
 
 For more advanced topics, don't forget to check out our [Architecture Decisions Records](https://github.com/decentraland/adr) (ADR) repository.
 
+## Setup CircleCI
+
+[Setup CircleCI](docs/setup-circleci.md)
 ## Copyright info
 
 This repository is protected with a standard Apache 2 license. See the terms and conditions in

--- a/browser-interface/scripts/publish-artifacts.sh
+++ b/browser-interface/scripts/publish-artifacts.sh
@@ -13,7 +13,9 @@ npx @dcl/cdn-uploader@next \
   --local-folder "/tmp/workspace/unity-renderer/browser-interface/dist" \
   --bucket-folder "branch/${CIRCLE_BRANCH}"
 
-# Invalidate cache
-aws configure set preview.cloudfront true
-aws configure set preview.create-invalidation true
-aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_DISTRIBUTION}" --paths "/branch/${CIRCLE_BRANCH}/*"
+if [ -n "${CLOUDFRONT_DISTRIBUTION}" ];
+  # Invalidate cache
+  aws configure set preview.cloudfront true
+  aws configure set preview.create-invalidation true
+  aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_DISTRIBUTION}" --paths "/branch/${CIRCLE_BRANCH}/*"
+fi

--- a/browser-interface/scripts/publish-artifacts.sh
+++ b/browser-interface/scripts/publish-artifacts.sh
@@ -13,7 +13,9 @@ npx @dcl/cdn-uploader@next \
   --local-folder "/tmp/workspace/unity-renderer/browser-interface/dist" \
   --bucket-folder "branch/${CIRCLE_BRANCH}"
 
-if [ -n "${CLOUDFRONT_DISTRIBUTION}" ];
+set +u # unbound variables
+
+if [ -n "${CLOUDFRONT_DISTRIBUTION}" ]; then
   # Invalidate cache
   aws configure set preview.cloudfront true
   aws configure set preview.create-invalidation true

--- a/browser-interface/scripts/publish.ts
+++ b/browser-interface/scripts/publish.ts
@@ -11,7 +11,23 @@ async function main() {
   await checkFiles()
 
   if (!process.env.GITLAB_PIPELINE_URL) {
-    throw new Error("GITLAB_PIPELINE_URL not present. Skipping CDN pipeline trigger")
+    console.log("GITLAB_PIPELINE_URL not present. Skipping CDN pipeline trigger")
+    return;
+  }
+
+  if (!process.env.GITLAB_TOKEN) {
+    console.log("GITLAB_STATIC_PIPELINE_TOKEN not present. Skipping CDN pipeline trigger")
+    return;
+  }
+
+  if (!process.env.CIRCLE_SHA1) {
+    console.log("CIRCLE_SHA1 not present. Skipping CDN pipeline trigger")
+    return;
+  }
+
+  if (!process.env.NPM_TOKEN) {
+    console.log("NPM_TOKEN not present. Skipping CDN pipeline trigger")
+    return;
   }
 
   const { version, name } = await getPackageJson(DIST_ROOT)
@@ -38,21 +54,6 @@ async function getPackageJson(workingDirectory: string) {
 }
 
 async function triggerPipeline(packageName: string, packageVersion: string) {
-  const GITLAB_STATIC_PIPELINE_TOKEN = process.env.GITLAB_TOKEN
-  const GITLAB_STATIC_PIPELINE_URL = process.env.GITLAB_PIPELINE_URL
-
-  if (!GITLAB_STATIC_PIPELINE_URL) {
-    throw new Error("GITLAB_PIPELINE_URL not present. Skipping CDN pipeline trigger")
-  }
-
-  if (!GITLAB_STATIC_PIPELINE_TOKEN) {
-    throw new Error("GITLAB_STATIC_PIPELINE_TOKEN not present. Skipping CDN pipeline trigger")
-  }
-
-  if (!process.env.CIRCLE_SHA1) {
-    throw new Error("CIRCLE_SHA1 not present. Skipping CDN pipeline trigger")
-  }
-
   const body = new FormData()
   body.append("token", GITLAB_STATIC_PIPELINE_TOKEN)
   body.append("ref", "master")

--- a/browser-interface/scripts/publish.ts
+++ b/browser-interface/scripts/publish.ts
@@ -16,7 +16,7 @@ async function main() {
   }
 
   if (!process.env.GITLAB_TOKEN) {
-    console.log("GITLAB_STATIC_PIPELINE_TOKEN not present. Skipping CDN pipeline trigger")
+    console.log("GITLAB_TOKEN not present. Skipping CDN pipeline trigger")
     return;
   }
 
@@ -54,6 +54,9 @@ async function getPackageJson(workingDirectory: string) {
 }
 
 async function triggerPipeline(packageName: string, packageVersion: string) {
+  const GITLAB_STATIC_PIPELINE_TOKEN = process.env.GITLAB_TOKEN!
+  const GITLAB_STATIC_PIPELINE_URL = process.env.GITLAB_PIPELINE_URL!
+
   const body = new FormData()
   body.append("token", GITLAB_STATIC_PIPELINE_TOKEN)
   body.append("ref", "master")

--- a/docs/resources/circleci-unity-activation-file-v2020.3.0f1.alf
+++ b/docs/resources/circleci-unity-activation-file-v2020.3.0f1.alf
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <SystemInfo>
+        <IsoCode>C.UTF</IsoCode>
+        <UserName>(unset)</UserName>
+        <OperatingSystem>Linux 4.15 Ubuntu 18.04 64bit</OperatingSystem>
+        <OperatingSystemNumeric>415</OperatingSystemNumeric>
+        <ProcessorType>Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz</ProcessorType>
+        <ProcessorSpeed>3399</ProcessorSpeed>
+        <ProcessorCount>36</ProcessorCount>
+        <ProcessorCores>36</ProcessorCores>
+        <PhysicalMemoryMB>70340</PhysicalMemoryMB>
+        <ComputerName>45da78058f43</ComputerName>
+        <ComputerModel>PC</ComputerModel>
+        <UnityVersion>2020.3.0f1</UnityVersion>
+        <SupportedLicenseVersion>6.x</SupportedLicenseVersion>
+    </SystemInfo>
+    <License id="Terms">
+        <MachineID Value="D7nTUnjNAmtsUMcnoyrqkgIbYdM=" />
+        <MachineBindings>
+            <Binding Key="1" Value="576562626572264761624c65526f7578" />
+            <Binding Key="2" Value="576562626572264761624c65526f7578" />
+        </MachineBindings>
+        <UnityVersion Value="2020.3.0f1" />
+    </License>
+</root>

--- a/docs/setup-circleci.md
+++ b/docs/setup-circleci.md
@@ -47,17 +47,6 @@ After having the `circleci-unity-activation-file-v2020.3.0f1.alf` you must activ
 
 And you will be able to build with CircleCI.
 
-### Generate Unity License Content
-
-After having the `circleci-unity-activation-file-v2020.3.0f1.alf` you must activate it with the following steps:
-- Enter https://license.unity3d.com/manual with your Unity Credentials
-- Upload the `circleci-unity-activation-file-v2020.3.0f1.alf`
-- Download the `Unity_v2020.x.ulf`
-- Convert to base64, suggested command: `cat Unity_v2020.x.ulf | base64`
-- Create a CircleCI Environment Variable with the name of `DEVELOPERS_UNITY_LICENSE_CONTENT_2020_3_BASE64` and the base64 output
-
-And you will be able to build with CircleCI.
-
 ## AWS S3 Bucket
 
 Create an AWS S3 Bucket (with all public access, or you can use CloudFront)

--- a/docs/setup-circleci.md
+++ b/docs/setup-circleci.md
@@ -1,79 +1,65 @@
+
 # Setup CircleCI in your own repository
 
-To set up the CI, you will need:
+This guide helps you set up your own continuous integration system in your fork for running tests, as well as creating test builds for each of the commits that are made to the repository. 
 
-- Setup your project in CircleCI
-- Create the Environment Variable for the Unity License and an AWS S3 Bucket
-- `Performance Plan` in CircleCI because you need an `XLarge` computer to build Unity
+For this, you will need to perform the following steps:
+- Create your CircleCI account and set up the repository.
+- Create a Unity license
+- Set up your own S3 bucket to upload test versions and test coverage results. 
 
-## Setup your project in CircleCI
 
-Log in with your GitHub user in CircleCI.
+## 1) Setup your project in CircleCI
 
-Set up the `unity-renderer` project.
+Creating a CircleCI account is free, however the free plan machines are not powerful enough to run the full pipeline. 
+You will have to upgrade to at least the performance plan. The performance plan gives you 25,000 credits per $15, in addition to the 30,000 included in the base plan, which allows for ~70 builds per month. 
+Use your github account to login and set up a new project pointing to your `unity-renderer` fork.
 
-## Unity License Environment Variable
+## 2) Unity License Environment Variable
 
-To generate the unity license content, you need a `Unity Activation File`.
+To generate the Unity license content, you need a `Unity Activation File`. If you don't have an Unity account, you will need to create one first, and the go to the [manual license activation](https://license.unity3d.com/manual) to generate the license. 
+This requires an `.alf` file containing information of the computer that will run the CI. To obtain this file, you can either:
 
-This file must be created from the computer that will use Unity (in this case, the CI).
+A) Download [this pregenerated file](resources/circleci-unity-activation-file-v2020.3.0f1.alf) from the repo, as CircleCI uses the same Hardware ID for every run. 
 
-And then you must use that file to apply your Unity License (https://license.unity3d.com/manual)
-
-### Pre-created Activation File
-
-CircleCI uses the same Hardware ID for every run, so you can use the pre-created file: [resources/circleci-unity-activation-file-v2020.3.0f1.alf](resources/circleci-unity-activation-file-v2020.3.0f1.alf)
-
-### Create Activation File in CircleCI
-
-If you can not use the pre-created activation file, you should follow this step.
-
-Execute in a CircleCI Machine (Use `Rerun with SSH` in CircleCI) the following command:
-
+B) Create your own activation file, running in a CircleCI Machine (Use `Rerun with SSH` in CircleCI) the following command:
 ```
 bash -c '$UNITY_PATH/Editor/Unity -quit -nographics -logFile /tmp/unity-createManualActivationFile.log -batchmode -createManualActivationFile'
 ```
+Once you upload the file, the licensing system will ask you to define the type of license you want to generate. In this case, the free personal license is more than enough.
 
-And the generated file it's the activation file for the following step.
+The system will now generate an `.ulf` file containing your license. The content of this file must be converted to base64 (`cat Unity_v2020.x.ulf | base64` or you can also use [this site](https://www.base64encode.org/)) and add it to CircleCI as an environment variable of the project named `DEVELOPERS_UNITY_LICENSE_CONTENT_2020_3_BASE64`.
 
-### Generate Unity License Content
-
-After having the `circleci-unity-activation-file-v2020.3.0f1.alf` you must activate it with the following steps:
-- Enter https://license.unity3d.com/manual with your Unity Credentials
-- Upload the `circleci-unity-activation-file-v2020.3.0f1.alf`
-- Download the `Unity_v2020.x.ulf`
-- Convert to base64, suggested command: `cat Unity_v2020.x.ulf | base64`
-- Create a CircleCI Environment Variable with the name of `DEVELOPERS_UNITY_LICENSE_CONTENT_2020_3_BASE64` and the base64 output
-
-And you will be able to build with CircleCI.
-
-## AWS S3 Bucket
-
-Create an AWS S3 Bucket (with all public access, or you can use CloudFront)
-Create an IAM User with `Access key - Programmatic access` and the following policy:
-
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:*",
-                "s3-object-lambda:*"
-            ],
-            "Resource": [
-                "arn:aws:s3:::YOUR_BUCKET",
-                "arn:aws:s3:::YOUR_BUCKET/*"
-            ]
-        }
-    ]
-}
-```
-(replace YOUR_BUCKET with your bucket name)
+## 3) Setting up AWS S3 Bucket
+You will need to create a bucket in S3 with public privileges in order to upload the CI content. For that:
+1) Create an AWS S3 Bucket, with all public access.
+2) Create a new policy with the following content:
+	```
+	{
+	    "Version": "2012-10-17",
+	    "Statement": [
+	        {
+	            "Effect": "Allow",
+	            "Action": [
+	                "s3:*",
+	                "s3-object-lambda:*"
+	            ],
+	            "Resource": [
+	                "arn:aws:s3:::YOUR_BUCKET",
+	                "arn:aws:s3:::YOUR_BUCKET/*"
+	            ]
+	        }
+	    ]
+	}
+	```
+3) Create an IAM User with `Access key - Programmatic access` and attach the policy created before.
 
 Set up the following Environment Variables in CircleCI with the credentials generated above:
 
 - `AWS_ACCESS_KEY_ID`=IAM User generated key id
 - `AWS_SECRET_ACCESS_KEY`=IAM User generated secret access key
 - `S3_BUCKET`=S3 Bucket name
+
+## 4) Run the CI 
+After any commit to any of the branches in your fork, the CI will trigger. In order to test the builds successfully, you must inject the generated artifact using the `renderer` parameter as follows:
+https://play.decentraland.org/?renderer=S3_BUCKET_URL/BRANCH_NAME

--- a/docs/setup-circleci.md
+++ b/docs/setup-circleci.md
@@ -1,0 +1,83 @@
+# Setup CircleCI in your own repository
+
+To set up the CI, you will need:
+
+- Setup your project in CircleCI
+- Create the Environment Variable for the Unity License and an AWS S3 Bucket
+
+## Setup your project in CircleCI
+
+Log in with your user in CircleCI.
+
+## Unity License Environment Variable
+
+To generate the unity license content, you need a `Unity Activation File`.
+
+This file must be created from the computer that will use Unity (in this case, the CI).
+
+And then you must use that file to apply your Unity License (https://license.unity3d.com/manual)
+
+### Pre-created Activation File
+
+CircleCI uses the same Hardware ID for every run, so you can use the pre-created file: [resources/circleci-unity-activation-file-v2020.3.0f1.alf](resources/circleci-unity-activation-file-v2020.3.0f1.alf)
+
+### Create Activation File
+
+(TODO: Change the pipeline to detect when the UNITY LICENSE is empty and create this activation file)
+Execute in a CircleCI Machine the following command:
+
+```
+bash -c '$UNITY_PATH/Editor/Unity -quit -nographics -logFile /tmp/unity-createManualActivationFile.log -batchmode -createManualActivationFile'
+```
+
+### Generate Unity License Content
+
+After having the `circleci-unity-activation-file-v2020.3.0f1.alf` you must activate it with the following steps:
+- Enter https://license.unity3d.com/manual with your Unity Credentials
+- Upload the `circleci-unity-activation-file-v2020.3.0f1.alf`
+- Download the `Unity_v2020.x.ulf`
+- Convert to base64, suggested command: `cat Unity_v2020.x.ulf | base64`
+- Create a CircleCI Environment Variable with the name of `DEVELOPERS_UNITY_LICENSE_CONTENT_2020_3_BASE64` and the base64 output
+
+And you will be able to build with CircleCI.
+
+### Generate Unity License Content
+
+After having the `circleci-unity-activation-file-v2020.3.0f1.alf` you must activate it with the following steps:
+- Enter https://license.unity3d.com/manual with your Unity Credentials
+- Upload the `circleci-unity-activation-file-v2020.3.0f1.alf`
+- Download the `Unity_v2020.x.ulf`
+- Convert to base64, suggested command: `cat Unity_v2020.x.ulf | base64`
+- Create a CircleCI Environment Variable with the name of `DEVELOPERS_UNITY_LICENSE_CONTENT_2020_3_BASE64` and the base64 output
+
+And you will be able to build with CircleCI.
+
+## AWS S3 Bucket
+
+Create a AWS S3 Bucket (Public)
+Create a IAM User with `Access key - Programmatic access` and the following policy:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*",
+                "s3-object-lambda:*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::YOUR_BUCKET",
+                "arn:aws:s3:::YOUR_BUCKET/*"
+            ]
+        }
+    ]
+}
+```
+
+Set up the following Environment Variables in CircleCI with the credentials generated above:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `S3_BUCKET`

--- a/docs/setup-circleci.md
+++ b/docs/setup-circleci.md
@@ -4,6 +4,7 @@ To set up the CI, you will need:
 
 - Setup your project in CircleCI
 - Create the Environment Variable for the Unity License and an AWS S3 Bucket
+- `Performance Plan` in CircleCI because you need an `XLarge` computer to build Unity
 
 ## Setup your project in CircleCI
 

--- a/docs/setup-circleci.md
+++ b/docs/setup-circleci.md
@@ -7,7 +7,9 @@ To set up the CI, you will need:
 
 ## Setup your project in CircleCI
 
-Log in with your user in CircleCI.
+Log in with your GitHub user in CircleCI.
+
+Set up the `unity-renderer` project.
 
 ## Unity License Environment Variable
 
@@ -21,14 +23,17 @@ And then you must use that file to apply your Unity License (https://license.uni
 
 CircleCI uses the same Hardware ID for every run, so you can use the pre-created file: [resources/circleci-unity-activation-file-v2020.3.0f1.alf](resources/circleci-unity-activation-file-v2020.3.0f1.alf)
 
-### Create Activation File
+### Create Activation File in CircleCI
 
-(TODO: Change the pipeline to detect when the UNITY LICENSE is empty and create this activation file)
-Execute in a CircleCI Machine the following command:
+If you can not use the pre-created activation file, you should follow this step.
+
+Execute in a CircleCI Machine (Use `Rerun with SSH` in CircleCI) the following command:
 
 ```
 bash -c '$UNITY_PATH/Editor/Unity -quit -nographics -logFile /tmp/unity-createManualActivationFile.log -batchmode -createManualActivationFile'
 ```
+
+And the generated file it's the activation file for the following step.
 
 ### Generate Unity License Content
 
@@ -54,8 +59,8 @@ And you will be able to build with CircleCI.
 
 ## AWS S3 Bucket
 
-Create a AWS S3 Bucket (Public)
-Create a IAM User with `Access key - Programmatic access` and the following policy:
+Create an AWS S3 Bucket (with all public access, or you can use CloudFront)
+Create an IAM User with `Access key - Programmatic access` and the following policy:
 
 ```
 {
@@ -75,9 +80,10 @@ Create a IAM User with `Access key - Programmatic access` and the following poli
     ]
 }
 ```
+(replace YOUR_BUCKET with your bucket name)
 
 Set up the following Environment Variables in CircleCI with the credentials generated above:
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- `S3_BUCKET`
+- `AWS_ACCESS_KEY_ID`=IAM User generated key id
+- `AWS_SECRET_ACCESS_KEY`=IAM User generated secret access key
+- `S3_BUCKET`=S3 Bucket name


### PR DESCRIPTION
Fix #1591 

chore: update CI to work without CLOUDFRONT_DISTRIBUTION and without the publish tokens

Note: This is a PR from a forked unity-renderer!

## What does this PR change?

Add documentation to `unity-renderer` repo to know how to set up CircleCI

**Next steps:**
We need to configure the `GitHub Bot comment` to comment with the URL using the external S3 Bucket.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
