### PR TITLE
fix: removed tit from badwords

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ProfanityFiltering/Resources/Profanity/badwords.json
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ProfanityFiltering/Resources/Profanity/badwords.json
@@ -376,7 +376,6 @@
     "twink",
     "twinkie",
     "twogirlsonecup",
-    "tit",
     "twat",
     "tw4t",
     "v14gra",


### PR DESCRIPTION
## What does this PR change?

Word "tit" removed from profanity filtering due there are problems with words like "competitive"

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/tit-filter
2. Write tit in chat, it shouldnt be filtered

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
