### PR TITLE
fix: rendereable incongruence

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -47,7 +47,11 @@ namespace DCL
             asset.Show(OnSuccess);
         }
 
-        protected override void OnAfterLoadOrReuse() { settings.ApplyAfterLoad(asset.container.transform); }
+        protected override void OnAfterLoadOrReuse()
+        {
+            asset.renderers = asset.container.GetComponentsInChildren<Renderer>(true).ToList();
+            settings.ApplyAfterLoad(asset.container.transform);
+        }
 
         protected override void OnBeforeLoadOrReuse()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -22,24 +22,16 @@ namespace DCL
         object id = null;
 
         public AssetPromise_GLTF(string url)
-            : this(new ContentProvider_Dummy(), url, null, Environment.i.platform.webRequest)
-        {
-        }
+            : this(new ContentProvider_Dummy(), url, null, Environment.i.platform.webRequest) { }
 
         public AssetPromise_GLTF(string url, IWebRequestController webRequestController)
-            : this(new ContentProvider_Dummy(), url, null, webRequestController)
-        {
-        }
+            : this(new ContentProvider_Dummy(), url, null, webRequestController) { }
 
         public AssetPromise_GLTF(ContentProvider provider, string url, string hash = null)
-            : this(provider, url, hash, Environment.i.platform.webRequest)
-        {
-        }
+            : this(provider, url, hash, Environment.i.platform.webRequest) { }
 
         public AssetPromise_GLTF(ContentProvider provider, string url, IWebRequestController webRequestController)
-            : this(provider, url, null, webRequestController)
-        {
-        }
+            : this(provider, url, null, webRequestController) { }
 
         public AssetPromise_GLTF(ContentProvider provider, string url, string hash, IWebRequestController webRequestController)
         {
@@ -64,6 +56,7 @@ namespace DCL
         {
             if (asset?.container != null)
             {
+                asset.renderers = asset.container.GetComponentsInChildren<Renderer>(true).ToList();
                 settings.ApplyAfterLoad(asset.container.transform);
             }
         }
@@ -105,7 +98,6 @@ namespace DCL
             asset.name = fileName;
         }
 
-
         private void RendererCreated(Renderer r)
         {
             Assert.IsTrue(r != null, "Renderer is null?");
@@ -129,10 +121,7 @@ namespace DCL
             asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
         }
 
-        bool FileToHash(string fileName, out string hash)
-        {
-            return provider.TryGetContentHash(assetDirectoryPath + fileName, out hash);
-        }
+        bool FileToHash(string fileName, out string hash) { return provider.TryGetContentHash(assetDirectoryPath + fileName, out hash); }
 
         protected override void OnReuse(Action OnSuccess)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/GLTF_PromiseShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/GLTF_PromiseShould.cs
@@ -70,5 +70,30 @@ namespace AssetPromiseKeeper_GLTF_Tests
             Assert.AreEqual(1, pool.objectsCount);
             keeper.Cleanup();
         }
+
+        [UnityTest]
+        public IEnumerator RefreshRenderers()
+        {
+            AssetPromiseKeeper_GLTF keeper = new AssetPromiseKeeper_GLTF();
+            IWebRequestController webRequestController = WebRequestController.Create();
+
+            string url = TestAssetsUtils.GetPath() + "/GLB/Trunk/Trunk.glb";
+            ContentProvider_Dummy provider = new ContentProvider_Dummy();
+
+            AssetPromise_GLTF promise = new AssetPromise_GLTF(provider, url, webRequestController);
+            GameObject holder1 = new GameObject("Test1");
+            promise.settings.parent = holder1.transform;
+            keeper.Keep(promise);
+
+            yield return promise;
+
+            Renderer[] renderers = promise.asset.container.GetComponentsInChildren<Renderer>(true);
+            Assert.AreEqual(renderers.Length, promise.asset.renderers.Count);
+            for (int i = 0; i < renderers.Length; i++)
+            {
+                Assert.AreEqual(renderers[i], promise.asset.renderers[i]);
+            }
+            Object.Destroy(holder1);
+        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -527,12 +527,5 @@ namespace DCL.Helpers
         /// <param name="volume">Linear volume (0 to 1)</param>
         /// <returns>Value for audio mixer group volume</returns>
         public static float ToAudioMixerGroupVolume(float volume) { return (ToVolumeCurve(volume) * 80f) - 80f; }
-
-        public static string GetHierarchyPath(this Transform transform)
-        {
-            if (transform.parent == null)
-                return transform.name;
-            return $"{transform.parent.GetHierarchyPath()}/{transform.name}";
-        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -213,10 +213,7 @@ namespace DCL.Helpers
         public static WebRequestAsyncOperation FetchTexture(string textureURL, bool isReadable, Action<Texture2D> OnSuccess, Action<IWebRequestAsyncOperation> OnFail = null)
         {
             //NOTE(Brian): This closure is called when the download is a success.
-            void SuccessInternal(IWebRequestAsyncOperation request)
-            {
-                OnSuccess?.Invoke(DownloadHandlerTexture.GetContent(request.webRequest));
-            }
+            void SuccessInternal(IWebRequestAsyncOperation request) { OnSuccess?.Invoke(DownloadHandlerTexture.GetContent(request.webRequest)); }
 
             var asyncOp = DCL.Environment.i.platform.webRequest.GetTexture(
                 url: textureURL,
@@ -530,5 +527,12 @@ namespace DCL.Helpers
         /// <param name="volume">Linear volume (0 to 1)</param>
         /// <returns>Value for audio mixer group volume</returns>
         public static float ToAudioMixerGroupVolume(float volume) { return (ToVolumeCurve(volume) * 80f) - 80f; }
+
+        public static string GetHierarchyPath(this Transform transform)
+        {
+            if (transform.parent == null)
+                return transform.name;
+            return $"{transform.parent.GetHierarchyPath()}/{transform.name}";
+        }
     }
 }


### PR DESCRIPTION
`AssetPromise` for GLTF and AB_GameObjects were not updating `asset.renderers` on certain cases when using the promise with a parent set.

This would end up in incongruences between `asset.container.GetComponentsInChildren<Renderer>()` and `asset.renderers`.