### PR TITLE
fix: camera mode change event

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -800,8 +800,20 @@ namespace DCL.Interface
 
         public static void ReportCameraChanged(CameraMode.ModeId cameraMode)
         {
+            ReportCameraChanged(cameraMode, null);
+        }
+        
+        public static void ReportCameraChanged(CameraMode.ModeId cameraMode, string targetSceneId)
+        {
             cameraModePayload.cameraMode = cameraMode;
-            SendAllScenesEvent("cameraModeChanged", cameraModePayload);
+            if (!string.IsNullOrEmpty(targetSceneId))
+            {
+                SendSceneEvent(targetSceneId, "cameraModeChanged", cameraModePayload);
+            }
+            else
+            {
+                SendAllScenesEvent("cameraModeChanged", cameraModePayload);
+            }
         }
 
         public static void ReportIdleStateChanged(bool isIdle)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -479,6 +479,7 @@ namespace DCL
             Environment.i.messaging.manager.SetSceneReady(sceneId);
 
             WebInterface.ReportControlEvent(new WebInterface.SceneReady(sceneId));
+            WebInterface.ReportCameraChanged(CommonScriptableObjects.cameraMode.Get(), sceneId);
 
             Environment.i.world.blockersController.SetupWorldBlockers();
 


### PR DESCRIPTION
fix: "camera mode" is only reported when mode changes, so scenes can't get the current "camera mode" unless user press `V` button