### PR TITLE
fix: process queued messages on ws open

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -666,7 +666,10 @@ namespace DCL.Interface
             set
             {
                 OnMessage = value;
-                ProcessQueuedMessages();
+                if (OnMessage != null)
+                {
+                    ProcessQueuedMessages();
+                }
             } 
             get => OnMessage;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -22,17 +22,6 @@ namespace DCL.Interface
     {
         public static bool VERBOSE = false;
 
-        private static Action<string, string> OnMessage;
-        public static System.Action<string, string> OnMessageFromEngine
-        {
-            set
-            {
-                OnMessage = value;
-                ProcessQueuedMessages();
-            } 
-            get => OnMessage;
-        }
-
         [System.Serializable]
         private class ReportPositionPayload
         {
@@ -669,7 +658,20 @@ namespace DCL.Interface
     [DllImport("__Internal")] public static extern void MessageFromEngine(string type, string message);
     [DllImport("__Internal")] public static extern string GetGraphicCard();
     [DllImport("__Internal")] public static extern bool CheckURLParam(string targetParam);
+        
+    public static System.Action<string, string> OnMessageFromEngine;
 #else
+        public static Action<string, string> OnMessageFromEngine
+        {
+            set
+            {
+                OnMessage = value;
+                ProcessQueuedMessages();
+            } 
+            get => OnMessage;
+        }
+        private static Action<string, string> OnMessage;
+        
         private static bool hasQueuedMessages = false;
         private static List<(string, string)> queuedMessages = new List<(string, string)>();
         public static void StartDecentraland() { }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -21,7 +21,17 @@ namespace DCL.Interface
     public static class WebInterface
     {
         public static bool VERBOSE = false;
-        public static System.Action<string, string> OnMessageFromEngine;
+
+        private static Action<string, string> OnMessage;
+        public static System.Action<string, string> OnMessageFromEngine
+        {
+            set
+            {
+                OnMessage = value;
+                ProcessQueuedMessages();
+            } 
+            get => OnMessage;
+        }
 
         [System.Serializable]
         private class ReportPositionPayload


### PR DESCRIPTION
*fix: process enqueued messages on `OnMessageFromEngine` subscription.

Enqueued messages to kernel were only processed when trying to send a new message, sometimes leaving the initial messages in the queue without sending them and leaving kernel stalled, waiting for renderer's message that is ready.

test: connect using ws to this kernel version: `1.0.0-1537672436.commit-92098d5`
https://play.decentraland.org/?kernel-version=1.0.0-1537672436.commit-92098d5&ws=ws://localhost:5000/dcl