### PR TITLE
fix: open url from Unity instead of kernel for desktop

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -1259,7 +1259,11 @@ namespace DCL.Interface
 
         public static void OpenURL(string url)
         {
+#if UNITY_WEBGL
             SendMessage("OpenWebURL", new OpenURLPayload { url = url });
+#else
+            Application.OpenURL(url);
+#endif
         }
 
         public static void SendReportScene(string sceneID)


### PR DESCRIPTION
## What does this PR change?

Using `Application.OpenURL` instead of sending the message to the Kernel

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
