### PR TITLE
Fix: builder dropdown menu position

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Resources/BuilderProjectsPanel.prefab
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Resources/BuilderProjectsPanel.prefab
@@ -7278,7 +7278,7 @@ PrefabInstance:
     - target: {fileID: 998314802997577610, guid: cfa10a3fc421146919bdccb6f63fb116,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 575
+      value: 586
       objectReference: {fileID: 0}
     - target: {fileID: 998314802997577610, guid: cfa10a3fc421146919bdccb6f63fb116,
         type: 3}


### PR DESCRIPTION
Go to the Builder section in the manu and check the X alignment of the dropdown menu opened in comparison with its button.

Before
<img width="218" alt="Screen Shot 2021-12-17 at 14 08 41" src="https://user-images.githubusercontent.com/51088292/146582632-9517c374-1bd9-429b-a4b8-9439d54f88ac.png">

Now
<img width="323" alt="Screen Shot 2021-12-17 at 14 15 52" src="https://user-images.githubusercontent.com/51088292/146582709-9969b325-27a0-4ffc-b41e-1dbd6c6ae07c.png">



Test link: https://play.decentraland.zone/?renderer-branch=fix/BuilderDropdownMenu

