### PR TITLE
fix: onpointerevent colliders renderer missing null check

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEventColliders.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEventColliders.cs
@@ -55,6 +55,8 @@ namespace DCL.Components
 
             for (int i = 0; i < colliders.Length; i++)
             {
+                if (rendererList[i] == null)
+                    continue;
                 colliders[i] = CreateCollider(rendererList[i]);
             }
         }


### PR DESCRIPTION
There is a renderer turning into null at some point in the meshesinfo given certain circumstances and that interrupts the scene logic for example when entering (walking from outside) the etheremon wolves scene at [-138, -123](https://play.decentraland.org?position=-138%2C-122). The error can be seen in the browser console.

When the OnPointerEvent colliders are initialized on those entities, 1 renderer in the meshesinfo collection is null for some reason. I found out that we already had placed nullchecks for this case in other places in the OnPointerEvent pipeline, so I added the missing nullcheck now and created [this other issue](https://github.com/decentraland/unity-renderer/issues/1654) to some day get in the rabbit hole and find out why some renderers turn to null at some point.