### PR TITLE
fix: removed s.o.b & sh!+ as badwords due unexpected filtering

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ProfanityFiltering/Resources/Profanity/badwords.json
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ProfanityFiltering/Resources/Profanity/badwords.json
@@ -324,8 +324,6 @@
     "rustytrombone",
     "rimming",
     "shit",
-    "s.o.b.",
-    "sh!+",
     "sh!t",
     "slut",
     "s_h_i_t",


### PR DESCRIPTION
## What does this PR change?

Removed s.o.b & sh!+ from badwords due unexpected filtering for words like _snowball_

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/snowball-word-filter
2. Write `/emote` on chat
3. None of the emote words should be filtered

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
