### PR TITLE
fix: animation play with reset flag as false

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
@@ -173,18 +173,15 @@ namespace DCL.Components
 
                     state.clipReference = unityState.clip;
 
+                    unityState.enabled = state.playing;
+
                     if (state.shouldReset)
                         ResetAnimation(state);
 
-                    if (state.playing)
+                    
+                    if (state.playing && !animComponent.IsPlaying(state.clip))
                     {
-                        if (!animComponent.IsPlaying(state.clip))
-                            animComponent.Play(state.clip);
-                    }
-                    else
-                    {
-                        if (animComponent.IsPlaying(state.clip))
-                            animComponent.Stop(state.clip);
+                        animComponent.Play(state.clip);
                     }
                 }
             }


### PR DESCRIPTION
address isssue: https://github.com/decentraland/sdk/issues/142
`animation.play(false)` resetting animation from start when it shouldn't