### PR TITLE
fix: incorrect cursor locking during loading and avatar creation

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesHUD/EmotesHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesHUD/EmotesHUDController.cs
@@ -40,6 +40,8 @@ public class EmotesHUDController : IHUD
         }
         else
         {
+            // Avoid locking cursor. It produces undesired mouse locking the first time you gain focus in the window
+            // during loading screen or first avatar creation
             //DCL.Helpers.Utils.LockCursor();
             ownUserProfile.snapshotObserver.RemoveListener(view.UpdateAvatarSprite);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesHUD/EmotesHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesHUD/EmotesHUDController.cs
@@ -40,7 +40,7 @@ public class EmotesHUDController : IHUD
         }
         else
         {
-            DCL.Helpers.Utils.LockCursor();
+            //DCL.Helpers.Utils.LockCursor();
             ownUserProfile.snapshotObserver.RemoveListener(view.UpdateAvatarSprite);
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
@@ -44,9 +44,9 @@ namespace DCL
             if (!renderingEnabled || DataStore.i.common.isSignUpFlow.Get() || DataStore.i.HUDs.loadingHUD.visible.Get())
                 return;
 
-            Utils.LockCursor();
+            //Utils.LockCursor();
 #if !WEB_PLATFORM
-            OnMouseLock?.Invoke();
+            //OnMouseLock?.Invoke();
 #endif
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
@@ -41,7 +41,7 @@ namespace DCL
 
         public void LockCursor()
         {
-            if (!renderingEnabled || DataStore.i.common.isSignUpFlow.Get())
+            if (!renderingEnabled || DataStore.i.common.isSignUpFlow.Get() || DataStore.i.HUDs.loadingHUD.visible.Get())
                 return;
 
             Utils.LockCursor();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
@@ -44,9 +44,9 @@ namespace DCL
             if (!renderingEnabled || DataStore.i.common.isSignUpFlow.Get() || DataStore.i.HUDs.loadingHUD.visible.Get())
                 return;
 
-            //Utils.LockCursor();
+            Utils.LockCursor();
 #if !WEB_PLATFORM
-            //OnMouseLock?.Invoke();
+            OnMouseLock?.Invoke();
 #endif
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -357,6 +357,7 @@ namespace DCL.Helpers
 
         public static void LockCursor()
         {
+            /*
 #if WEB_PLATFORM
             //TODO(Brian): Encapsulate all this mechanism to a new MouseLockController and branch
             //             behaviour using strategy pattern instead of this.
@@ -376,7 +377,7 @@ namespace DCL.Helpers
             Cursor.lockState = CursorLockMode.Locked;
             lockedInFrame = Time.frameCount;
 
-            EventSystem.current?.SetSelectedGameObject(null);
+            EventSystem.current?.SetSelectedGameObject(null);*/
         }
 
         public static void UnlockCursor()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -357,7 +357,6 @@ namespace DCL.Helpers
 
         public static void LockCursor()
         {
-            /*
 #if WEB_PLATFORM
             //TODO(Brian): Encapsulate all this mechanism to a new MouseLockController and branch
             //             behaviour using strategy pattern instead of this.
@@ -377,7 +376,7 @@ namespace DCL.Helpers
             Cursor.lockState = CursorLockMode.Locked;
             lockedInFrame = Time.frameCount;
 
-            EventSystem.current?.SetSelectedGameObject(null);*/
+            EventSystem.current?.SetSelectedGameObject(null);
         }
 
         public static void UnlockCursor()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -412,7 +412,7 @@ namespace DCL.Helpers
         // NOTE: This should come from browser's pointerlockchange callback
         public static void BrowserSetCursorState(bool locked)
         {
-            if (!locked && !requestedUnlock)
+            /*if (!locked && !requestedUnlock)
             {
                 Cursor.lockState = CursorLockMode.None;
             }
@@ -420,7 +420,7 @@ namespace DCL.Helpers
             isCursorLocked = locked;
             Cursor.visible = !locked;
             requestedUnlock = false;
-            requestedLock = false;
+            requestedLock = false;*/
         }
 
         #endregion

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -413,7 +413,7 @@ namespace DCL.Helpers
         // NOTE: This should come from browser's pointerlockchange callback
         public static void BrowserSetCursorState(bool locked)
         {
-            /*if (!locked && !requestedUnlock)
+            if (!locked && !requestedUnlock)
             {
                 Cursor.lockState = CursorLockMode.None;
             }
@@ -421,7 +421,7 @@ namespace DCL.Helpers
             isCursorLocked = locked;
             Cursor.visible = !locked;
             requestedUnlock = false;
-            requestedLock = false;*/
+            requestedLock = false;
         }
 
         #endregion


### PR DESCRIPTION
## What does this PR change?

Disables cursor locking that was occuring on `EmotesHUDController` which caused the locking during the first loading or the first time you create an avatar as a guest.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/incorrect-mouse-locking
2. Enter as a guest from a clean session
3. While the app is loading, click anywhere on the screen. The cursor should not be locked
4. Enter into the avatar creation flow. Click anywhere on the screen. The cursor should not be locked
5. Enter the metaverse. Press `B` to open Emotes HUD. Everything should work as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
