### PR TITLE
fix: cardinal points visibility in the minimap

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/Resources/MinimapHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/Resources/MinimapHUD.prefab
@@ -584,7 +584,7 @@ RectTransform:
   - {fileID: 1347496358759656025}
   - {fileID: 7368721439090438775}
   m_Father: {fileID: 487610079711947160}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -805,8 +805,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4773941053877397113}
-  - {fileID: 678636146031537704}
   - {fileID: 5111283870554404647}
+  - {fileID: 678636146031537704}
   - {fileID: 3093613561795223592}
   m_Father: {fileID: 6238993295414465396}
   m_RootOrder: 0
@@ -858,7 +858,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -87.4, y: 8.299978}
+  m_AnchoredPosition: {x: -87.2, y: 8.299978}
   m_SizeDelta: {x: 14, y: 14}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &3079489998825435303
@@ -2176,7 +2176,7 @@ RectTransform:
   - {fileID: 5352573081592215779}
   - {fileID: 3738486534253400336}
   m_Father: {fileID: 487610079711947160}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}


### PR DESCRIPTION
## What does this PR change?
The map rendering was overlapping the cardinal points references. Now they are visible again.

Before
<img width="166" alt="Screen Shot 2021-12-22 at 18 12 54" src="https://user-images.githubusercontent.com/51088292/147155814-a08cd665-1467-4f63-aa88-55afb94dab88.png">

After
<img width="205" alt="Screen Shot 2021-12-22 at 18 14 21" src="https://user-images.githubusercontent.com/51088292/147155962-447259a8-2efc-4fb9-92f3-1d6bf779af89.png">


Test link: https://play.decentraland.zone/?renderer-branch=fix/CardinalPointsVisibility