### PR TITLE
feat: add sdk event for avatar clicked

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -2,6 +2,7 @@ using System;
 using DCL.Components;
 using DCL.Interface;
 using System.Collections;
+using DCL.Configuration;
 using DCL.Models;
 using UnityEngine;
 
@@ -103,16 +104,6 @@ namespace DCL
 
             yield return new WaitUntil(() => avatarDone || avatarFailed);
 
-            onPointerDown.Initialize(
-                new OnPointerDown.Model()
-                {
-                    type = OnPointerDown.NAME,
-                    button = WebInterface.ACTION_BUTTON.POINTER.ToString(),
-                    hoverText = "view profile"
-                },
-                entity
-            );
-
             entity.OnTransformChange -= avatarMovementController.OnTransformChanged;
             entity.OnTransformChange += avatarMovementController.OnTransformChanged;
 
@@ -126,8 +117,17 @@ namespace DCL
             onPointerDown.OnPointerExitReport -= PlayerPointerExit;
             onPointerDown.OnPointerExitReport += PlayerPointerExit;
 
-
             UpdatePlayerStatus(model);
+            
+            onPointerDown.Initialize(
+                new OnPointerDown.Model()
+                {
+                    type = OnPointerDown.NAME,
+                    button = WebInterface.ACTION_BUTTON.POINTER.ToString(),
+                    hoverText = "view profile"
+                },
+                entity, player
+            );            
 
             avatarCollider.gameObject.SetActive(true);
 
@@ -135,6 +135,10 @@ namespace DCL
             OnAvatarShapeUpdated?.Invoke(entity, this);
 
             EnablePassport();
+
+            bool isAvatarGlobalScene = scene.sceneData.id == EnvironmentSettings.AVATAR_GLOBAL_SCENE_ID;
+            onPointerDown.SetColliderEnabled(isAvatarGlobalScene);
+            onPointerDown.SetOnClickReportEnabled(isAvatarGlobalScene);
 
             KernelConfig.i.EnsureConfigInitialized()
                 .Then(config =>
@@ -202,7 +206,7 @@ namespace DCL
             if (onPointerDown.collider == null)
                 return;
 
-            onPointerDown.SetColliderEnabled(false);
+            onPointerDown.SetPassportEnabled(false);
         }
 
         public void EnablePassport()
@@ -210,7 +214,7 @@ namespace DCL
             if (onPointerDown.collider == null)
                 return;
 
-            onPointerDown.SetColliderEnabled(true);
+            onPointerDown.SetPassportEnabled(true);
         }
 
         private void OnEntityTransformChanged(object newModel)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using DCL.Controllers;
 using DCL.Interface;
 using UnityEngine;
 using DCL.Helpers;
@@ -17,13 +19,17 @@ namespace DCL.Components
         public event System.Action OnPointerExitReport;
         private bool isHovering = false;
 
+        private bool passportEnabled = true;
+        private bool onClickReportEnabled = true;
+        private Player player;
+
         public WebInterface.ACTION_BUTTON GetActionButton() { return model.GetActionButton(); }
 
         public void SetHoverState(bool state)
         {
             bool isHoveringDirty = state != isHovering;
             isHovering = state;
-            eventHandler.SetFeedbackState(model.showFeedback, state, model.button, model.hoverText);
+            eventHandler.SetFeedbackState(model.showFeedback, state && passportEnabled, model.button, model.hoverText);
             if (!isHoveringDirty)
                 return;
             if (isHovering)
@@ -49,10 +55,11 @@ namespace DCL.Components
             CollidersManager.i.RemoveEntityCollider(entity, collider);
         }
 
-        public void Initialize(OnPointerEvent.Model model, IDCLEntity entity)
+        public void Initialize(OnPointerEvent.Model model, IDCLEntity entity, Player player)
         {
             this.model = model;
             this.entity = entity;
+            this.player = player;
 
             if (eventHandler == null)
                 eventHandler = new OnPointerEventHandler();
@@ -65,7 +72,7 @@ namespace DCL.Components
 
         public bool IsVisible() { return true; }
 
-        public bool ShouldReportEvent(WebInterface.ACTION_BUTTON buttonId, HitInfo hit)
+        public bool ShouldReportPassportInputEvent(WebInterface.ACTION_BUTTON buttonId, HitInfo hit)
         {
             return IsAtHoverDistance(hit.distance) &&
                    (model.button == "ANY" || buttonId.ToString() == model.button);
@@ -76,28 +83,18 @@ namespace DCL.Components
             if (!enabled)
                 return;
 
-            if (ShouldReportEvent(buttonId, hit))
+            if (passportEnabled && ShouldReportPassportInputEvent(buttonId, hit))
             {
-                string meshName = null;
-
-                if (hit.collider != null)
-                    meshName = eventHandler.GetMeshName(hit.collider);
-
-                WebInterface.ReportOnPointerDownEvent(
-                    buttonId,
-                    entity.scene.sceneData.id,
-                    model.uuid,
-                    entity.entityId,
-                    meshName,
-                    ray,
-                    hit.point,
-                    hit.normal,
-                    hit.distance);
-
                 eventHandler.SetFeedbackState(model.showFeedback, false, model.button, model.hoverText);
-                enabled = false;
+                passportEnabled = false;
 
                 OnPointerDownReport?.Invoke();
+            }
+
+            if (onClickReportEnabled && ShouldReportOnClickEvent(buttonId))
+            {
+                string playerSceneId = CommonScriptableObjects.sceneID.Get();
+                WebInterface.ReportAvatarClick(playerSceneId, player.id, ray, hit.distance);
             }
         }
 
@@ -105,20 +102,61 @@ namespace DCL.Components
 
         void ReEnableOnInfoCardClosed(bool newState, bool prevState)
         {
-            if (enabled || newState)
+            if (passportEnabled || newState)
                 return;
 
-            enabled = true;
+            passportEnabled = true;
         }
         public void SetColliderEnabled(bool newEnabledState)
         {
             collider.enabled = newEnabledState;
         }
+        
+        public void SetPassportEnabled(bool newEnabledState)
+        {
+            passportEnabled = newEnabledState;
+            eventHandler?.SetFeedbackState(model.showFeedback, false, model.button, model.hoverText);
+            isHovering = false;
+        }
+
+        public void SetOnClickReportEnabled(bool newEnabledState)
+        {
+            onClickReportEnabled = newEnabledState;
+        }        
 
         public Transform GetTransform() { return transform; }
 
-        public void OnPoolRelease() { eventHandler.Dispose(); }
+        public void OnPoolRelease()
+        {
+            eventHandler.Dispose();
+            player = null;
+        }
 
         public void OnPoolGet() { }
+        
+        private bool ShouldReportOnClickEvent(WebInterface.ACTION_BUTTON buttonId)
+        {
+            if (buttonId != WebInterface.ACTION_BUTTON.POINTER)
+            {
+                return false;
+            }
+            
+            if (player == null)
+            {
+                return false;
+            }
+
+            string playerSceneId = CommonScriptableObjects.sceneID.Get();
+
+            if (string.IsNullOrEmpty(playerSceneId))
+            {
+                return false;
+            }
+            
+            IParcelScene playerScene = Environment.i.world.state.GetScene(playerSceneId);
+            Vector2Int avatarCoords = Utils.WorldToGridPosition(CommonScriptableObjects.worldOffset + player.worldPosition);
+
+            return playerScene?.sceneData.parcels.Contains(avatarCoords) ?? false;
+        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -1535,11 +1535,11 @@ namespace DCL.Interface
             SendMessage("ReportAvatarState", avatarSceneChangedPayload);
         }
 
-        public static void ReportAvatarClick(string sceneId, string userId, Ray ray, float distance)
+        public static void ReportAvatarClick(string sceneId, string userId, Vector3 rayOrigin, Vector3 rayDirection, float distance)
         {
             avatarOnClickPayload.userId = userId;
-            avatarOnClickPayload.ray.origin = ray.origin;
-            avatarOnClickPayload.ray.direction = ray.direction;
+            avatarOnClickPayload.ray.origin = rayOrigin;
+            avatarOnClickPayload.ray.direction = rayDirection;
             avatarOnClickPayload.ray.distance = distance;
 
             SendSceneEvent(sceneId, "playerClicked", avatarOnClickPayload);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -649,6 +649,13 @@ namespace DCL.Interface
             public string sceneId;
         }
 
+        [System.Serializable]
+        public class AvatarOnClickPayload
+        {
+            public string userId;
+            public RayInfo ray = new RayInfo();
+        }
+
 #if UNITY_WEBGL && !UNITY_EDITOR
     /**
      * This method is called after the first render. It marks the loading of the
@@ -784,6 +791,7 @@ namespace DCL.Interface
         private static HeadersPayload headersPayload = new HeadersPayload();
         private static AvatarStateBase avatarStatePayload = new AvatarStateBase();
         private static AvatarStateSceneChanged avatarSceneChangedPayload = new AvatarStateSceneChanged();
+        public static AvatarOnClickPayload avatarOnClickPayload = new AvatarOnClickPayload();
 
         public static void SendSceneEvent<T>(string sceneId, string eventType, T payload)
         {
@@ -1517,6 +1525,7 @@ namespace DCL.Interface
             avatarStatePayload.avatarShapeId = avatarId;
             SendMessage("ReportAvatarState", avatarStatePayload);
         }
+
         public static void ReportAvatarSceneChanged(string entityId, string avatarId, string sceneId)
         {
             avatarSceneChangedPayload.type = "SceneChanged";
@@ -1524,6 +1533,16 @@ namespace DCL.Interface
             avatarSceneChangedPayload.avatarShapeId = avatarId;
             avatarSceneChangedPayload.sceneId = sceneId;
             SendMessage("ReportAvatarState", avatarSceneChangedPayload);
+        }
+
+        public static void ReportAvatarClick(string sceneId, string userId, Ray ray, float distance)
+        {
+            avatarOnClickPayload.userId = userId;
+            avatarOnClickPayload.ray.origin = ray.origin;
+            avatarOnClickPayload.ray.direction = ray.direction;
+            avatarOnClickPayload.ray.distance = distance;
+
+            SendSceneEvent(sceneId, "playerClicked", avatarOnClickPayload);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Utils/WorldStateUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Utils/WorldStateUtils.cs
@@ -115,7 +115,7 @@ namespace DCL
             return currentSceneAndPortableExperiencesIds;
         }
 
-        static IParcelScene GetCurrentScene()
+        public static IParcelScene GetCurrentScene()
         {
             var worldState = Environment.i.world.state;
             string currentSceneId = worldState.currentSceneId;

--- a/unity-renderer/Assets/Scripts/MainScripts/MainScripts.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/MainScripts.asmdef
@@ -91,8 +91,8 @@
         "GUID:4339091ce1655134b92fc0df855d2084",
         "GUID:85e616515af784fe2928e17f05a0b684",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
-        "GUID:18ee28afad71091499d9ebad494c995e",
-        "GUID:4934d1fdcdd394c76a501f04e1a15017"
+        "GUID:4934d1fdcdd394c76a501f04e1a15017",
+        "GUID:c34e38f41494f834abff029ddf82af43"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
issue: https://github.com/decentraland/sdk/issues/98
report to player's current scene click input on other players' avatar

*decoupled passport from onclick collider (collider was being disabled to avoid open passport interaction)
*removed old onclick uuid report since avatar onclick component is not actually an uuid component so it was not working
+report onclick when avatar is clicked in the same scene as the player is