### PR TITLE
fix: disabled active since date label on player profile cards

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Resources/PlayerInfoCardHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Resources/PlayerInfoCardHUD.prefab
@@ -3865,7 +3865,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8009380997048099331
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?

`Fixes #1651 `
"Active since {Date}" has been disabled from player information cards.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/active-since-removal
2. Click on any user's avatar around you
3. The card should not display "Active since" label

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
