### PR TITLE
fix: entity attach to first person camera

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/FirstPersonCameraReference/FirstPersonCameraEntityReference.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/FirstPersonCameraReference/FirstPersonCameraEntityReference.cs
@@ -15,12 +15,10 @@ public class FirstPersonCameraEntityReference : MonoBehaviour
         if (cameraPosition != null)
         {
             transform.position = cameraPosition.position;
+            firstPersonParent = cameraPosition;
         }
 
         initialParent = transform.parent;
-
-        if (Camera.main != null)
-            firstPersonParent = Camera.main.transform;
 
         // Listen to changes on the camera mode
         CommonScriptableObjects.cameraMode.OnChange += OnCameraModeChange;


### PR DESCRIPTION
`Camera.main` was `null` on `Awake`
setting the `GameObject` as child of `firstPersonParent` was leaving it orphan.
`cameraPosition` is set, in the prefab, with the transform for the first person camera.
fixed using `cameraPosition` transform instead of `Camera.main.transform`