### PR TITLE
fix: avoid start menu during on-boarding flow

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -156,11 +156,7 @@ public class HUDController : IHUDController
                 break;
             case HUDElementID.AVATAR_EDITOR:
                 CreateHudElement(configuration, hudElementId);
-                if (avatarEditorHud != null)
-                {
-                    avatarEditorHud.Initialize(ownUserProfile, wearableCatalog);
-                }
-
+                avatarEditorHud?.Initialize(ownUserProfile, wearableCatalog);
                 break;
             case HUDElementID.SETTINGS_PANEL:
                 CreateHudElement(configuration, hudElementId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Shortcuts/ShortcutsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Shortcuts/ShortcutsController.cs
@@ -66,9 +66,7 @@ public class ShortcutsController : IDisposable
     private void ToggleStartMenuTriggered(DCLAction_Trigger action)
     {
         bool value = !DataStore.i.exploreV2.isOpen.Get();
-        var isOnTutorialFlow = DataStore.i.common.isTutorialRunning.Get()
-                               | DataStore.i.common.isSignUpFlow.Get();
-        if (isOnTutorialFlow) return;
+        if (DataStore.i.common.isSignUpFlow.Get()) return;
 
         if (value)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Shortcuts/ShortcutsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Shortcuts/ShortcutsController.cs
@@ -66,6 +66,9 @@ public class ShortcutsController : IDisposable
     private void ToggleStartMenuTriggered(DCLAction_Trigger action)
     {
         bool value = !DataStore.i.exploreV2.isOpen.Get();
+        var isOnTutorialFlow = DataStore.i.common.isTutorialRunning.Get()
+                               | DataStore.i.common.isSignUpFlow.Get();
+        if (isOnTutorialFlow) return;
 
         if (value)
         {


### PR DESCRIPTION
## What does this PR change?

`Fixes #1688 `
Prevents the user to open start menu by pressing TAB key during the avatar creation on signup flow.

## How to test the changes?

1. Open an incognito tab
2. Go to: https://play.decentraland.zone/?renderer-branch=fix/avoid-start-menu-during-onboarding
3. Enter as a guest
4. On first avatar edition press TAB, it should not open the start menu
5. Confirm your avatar and follow the tutorial
6. When time comes to open the start menu press TAB, it should open as expected
7. Finish the tutorial, press TAB and the start menu should open as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
