### PR TITLE
fix: [Preview Mode] Add informative title about how to open/close the backpack and settings (TEMPORAL SOLUTION)

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/DebugController/Resources/DebugView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/DebugController/Resources/DebugView.prefab
@@ -52,6 +52,82 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   networkText: {fileID: 4562985737909129257}
   realmText: {fileID: 4067361348413919986}
+--- !u!1 &3012268900421929710
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5437722774046349002}
+  - component: {fileID: 4235893802883959605}
+  - component: {fileID: 7873853013833872189}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5437722774046349002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3012268900421929710}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 9118263488750823440}
+  m_Father: {fileID: 3936753532518245840}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1339.5454, y: -32.35}
+  m_SizeDelta: {x: 360, y: 34.7}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4235893802883959605
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3012268900421929710}
+  m_CullTransparentMesh: 1
+--- !u!114 &7873853013833872189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3012268900421929710}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.8}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4b1c9751d9ed642a190d2431fa02b5f8, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &470985736275968430
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -847,13 +923,13 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 3936753532518245840}
+  m_Father: {fileID: 5437722774046349002}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1476.6346, y: -17.349976}
-  m_SizeDelta: {x: 220, y: 34.7}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5827449074605025787
 CanvasRenderer:
@@ -890,7 +966,7 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 2
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 1
@@ -938,7 +1014,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 9118263488750823440}
+  - {fileID: 5437722774046349002}
   - {fileID: 8938636845429667942}
   m_Father: {fileID: 4003445959218808811}
   m_RootOrder: 2
@@ -962,8 +1038,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
-    m_Right: 10
-    m_Top: 0
+    m_Right: 80
+    m_Top: 15
     m_Bottom: 0
   m_ChildAlignment: 2
   m_Spacing: 10

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/FPSDisplay/FPSDisplay.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/FPSDisplay/FPSDisplay.cs
@@ -20,8 +20,8 @@ namespace DCL.FPSDisplay
         private CurrentRealmVariable currentRealm => DataStore.i.realm.playerRealm;
 
         private Promise<KernelConfigModel> kernelConfigPromise;
-        private string currentNetwork;
-        private string currentRealmValue;
+        private string currentNetwork = "";
+        private string currentRealmValue = "";
 
         private Vector2 minSize = Vector2.zero;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/FPSDisplay/FPSDisplay.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/FPSDisplay/FPSDisplay.cs
@@ -20,8 +20,8 @@ namespace DCL.FPSDisplay
         private CurrentRealmVariable currentRealm => DataStore.i.realm.playerRealm;
 
         private Promise<KernelConfigModel> kernelConfigPromise;
-        private string currentNetwork = "";
-        private string currentRealmValue = "";
+        private string currentNetwork = string.Empty;
+        private string currentRealmValue = string.Empty;
 
         private Vector2 minSize = Vector2.zero;
 
@@ -57,11 +57,11 @@ namespace DCL.FPSDisplay
         private void UpdateRealm(CurrentRealmModel current, CurrentRealmModel previous)
         {
             if (current == null) return;
-            currentRealmValue = current.serverName;
+            currentRealmValue = current.serverName ?? string.Empty;
         }
 
         private void OnKernelConfigChanged(KernelConfigModel current, KernelConfigModel previous) { OnKernelConfigChanged(current); }
-        private void OnKernelConfigChanged(KernelConfigModel kernelConfig) { currentNetwork = kernelConfig.network; }
+        private void OnKernelConfigChanged(KernelConfigModel kernelConfig) { currentNetwork = kernelConfig.network ?? string.Empty; }
 
         private void OnOtherPlayersModified(string playerName, Player player) { lastPlayerCount = otherPlayers.Count(); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/Panels/StatsPanelToggler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/Panels/StatsPanelToggler.cs
@@ -28,7 +28,7 @@ namespace DCL
         {
             UpdateDeepProfilingInput();
 
-            if (Input.GetKeyUp(KeyCode.P))
+            if (Input.GetKeyUp(KeyCode.Y))
             {
                 TogglePanel();
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/Panels/UserBenchmarkToggler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/Panels/UserBenchmarkToggler.cs
@@ -6,7 +6,7 @@ namespace DCL
 {
     public class UserBenchmarkToggler : MonoBehaviour
     {
-        const string SHORTCUT_TEXT = "P = Toggle Panel";
+        const string SHORTCUT_TEXT = "P = Toggle Panel | I = Toggle Backpack";
 
         public UserBenchmarkController userBenchmarkController;
         Text text;

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/Panels/UserBenchmarkToggler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/Panels/UserBenchmarkToggler.cs
@@ -6,7 +6,7 @@ namespace DCL
 {
     public class UserBenchmarkToggler : MonoBehaviour
     {
-        const string SHORTCUT_TEXT = "P = Toggle Panel | I = Toggle Backpack";
+        const string SHORTCUT_TEXT = "[Y] Debug Panel [P] Settings [I] Backpack";
 
         public UserBenchmarkController userBenchmarkController;
         Text text;
@@ -19,7 +19,7 @@ namespace DCL
 
         void Update()
         {
-            if (Input.GetKeyUp(KeyCode.P))
+            if (Input.GetKeyUp(KeyCode.Y))
             {
                 TogglePanel();
             }


### PR DESCRIPTION
## What does this PR change?
Add the title "**[Y] Debug Panel [P] Settings [I] Backpack**" on Preview Mode in order to inform the users how they can open/close the backpack.

![image](https://user-images.githubusercontent.com/64659061/148087777-0cc351e5-b2cd-438a-b2b5-a3bcab7fdd94.png)

**IMPORTANT:** This is a TEMPORAL solution while we adapt the new StartMenu to the PreviewMode flow. The idea will be that the StartMenu can be usable in PreviewMode in the same way as in the normal "world" flow.

## How to test?
1. Create a new empty scene
![image](https://user-images.githubusercontent.com/64659061/148089398-82a6f326-7428-455c-8b8b-1f342e7103c5.png)

2. Play it as preview mode
![image](https://user-images.githubusercontent.com/64659061/148089478-4ea0848f-b614-4af7-83e0-f006a24e1c6a.png)

3. Add in the url the url para: `&renderer-branch=fix/Backpack-not-available-on-preview-temporal-solution`
4. Notice the new informative panel is being showed by the user avatar profile.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
