### PR TITLE
fix: attach to first person camera

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
@@ -185,6 +185,11 @@ namespace DCL.Camera
 
         public Vector3 GetPosition() { return CinemachineCore.Instance.GetActiveBrain(0).ActiveVirtualCamera.State.FinalPosition; }
 
+        public UnityEngine.Camera GetCamera()
+        {
+            return camera;
+        }
+
         private void OnDestroy()
         {
             if (cachedModeToVirtualCamera != null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/FirstPersonCameraReference/FirstPersonCameraEntityReference.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/FirstPersonCameraReference/FirstPersonCameraEntityReference.cs
@@ -1,4 +1,3 @@
-using System;
 using DCL.Camera;
 using UnityEngine;
 
@@ -15,10 +14,11 @@ public class FirstPersonCameraEntityReference : MonoBehaviour
         if (cameraPosition != null)
         {
             transform.position = cameraPosition.position;
-            firstPersonParent = cameraPosition;
         }
 
         initialParent = transform.parent;
+        
+        firstPersonParent = cameraController.GetCamera().transform;
 
         // Listen to changes on the camera mode
         CommonScriptableObjects.cameraMode.OnChange += OnCameraModeChange;


### PR DESCRIPTION
reverted fix done here: https://github.com/decentraland/unity-renderer/pull/1716
added method `GetCamera` to `CameraController` and use it `Transform` as reference for parenting to first person camera

reason: since `GameObject` of `cameraPosition` was being disable, on camera mode changes, it was triggering GLTF animations when reparenting