### PR TITLE
feat: Integrate StartMenu into PreviewMode

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/DebugController/Resources/DebugView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/DebugController/Resources/DebugView.prefab
@@ -87,8 +87,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1339.5454, y: -32.35}
-  m_SizeDelta: {x: 360, y: 34.7}
+  m_AnchoredPosition: {x: 1439.7731, y: -32.35}
+  m_SizeDelta: {x: 160, y: 34.7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4235893802883959605
 CanvasRenderer:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
@@ -1870,7 +1870,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d8b939b5bedb9494b806609faeda7d8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hideOnEnable: 0
+  hideOnEnable: 1
   animSpeedFactor: 1
   disableAfterFadeOut: 0
   visibleParam: visible

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
@@ -7448,12 +7448,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 17c845a92d1948c4783ccac4b36e7c7f, type: 3}
---- !u!224 &2036364358663740187 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3337524177640211239, guid: 17c845a92d1948c4783ccac4b36e7c7f,
-    type: 3}
-  m_PrefabInstance: {fileID: 3608467515198330940}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &473306627002153747 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3783691952606929711, guid: 17c845a92d1948c4783ccac4b36e7c7f,
@@ -7466,6 +7460,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c47209a872c4314a8b0d6143186444b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &2036364358663740187 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3337524177640211239, guid: 17c845a92d1948c4783ccac4b36e7c7f,
+    type: 3}
+  m_PrefabInstance: {fileID: 3608467515198330940}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8176012931771732402
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7585,12 +7585,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8b84bfc4235d3d14b886dd08d4954f2d, type: 3}
---- !u!224 &1889260218415090526 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7732408266846214892, guid: 8b84bfc4235d3d14b886dd08d4954f2d,
-    type: 3}
-  m_PrefabInstance: {fileID: 8176012931771732402}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1080349384249445918 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9189916629297864620, guid: 8b84bfc4235d3d14b886dd08d4954f2d,
@@ -7603,6 +7597,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 274bf6bf95184804cb2606eda1bf2a6a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &1889260218415090526 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7732408266846214892, guid: 8b84bfc4235d3d14b886dd08d4954f2d,
+    type: 3}
+  m_PrefabInstance: {fileID: 8176012931771732402}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8581169255512481495
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7787,6 +7787,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ba8633baa70b8a74b8a1e8eb812d5527, type: 3}
+--- !u!224 &6284222883250628248 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2314960794579368015, guid: ba8633baa70b8a74b8a1e8eb812d5527,
+    type: 3}
+  m_PrefabInstance: {fileID: 8581169255512481495}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5724359877345737668 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4064337051328439571, guid: ba8633baa70b8a74b8a1e8eb812d5527,
@@ -7799,12 +7805,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 12340181b73056a4dbcb3c4fe7ded73b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &6284222883250628248 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2314960794579368015, guid: ba8633baa70b8a74b8a1e8eb812d5527,
-    type: 3}
-  m_PrefabInstance: {fileID: 8581169255512481495}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8916309094798233583
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7850,32 +7850,32 @@ PrefabInstance:
     - target: {fileID: 154563774609287026, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 154563774609287026, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 154563774609287026, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.33333
       objectReference: {fileID: 0}
     - target: {fileID: 154563774609287026, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 154563774609287026, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 66.666664
       objectReference: {fileID: 0}
     - target: {fileID: 154563774609287026, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17
       objectReference: {fileID: 0}
     - target: {fileID: 163083902401959240, guid: 01095a78852393446834e68bf8628274,
         type: 3}
@@ -8100,32 +8100,32 @@ PrefabInstance:
     - target: {fileID: 1199459342122783371, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1199459342122783371, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1199459342122783371, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.33333
       objectReference: {fileID: 0}
     - target: {fileID: 1199459342122783371, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 1199459342122783371, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 353.3333
       objectReference: {fileID: 0}
     - target: {fileID: 1199459342122783371, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17
       objectReference: {fileID: 0}
     - target: {fileID: 1232608505880105270, guid: 01095a78852393446834e68bf8628274,
         type: 3}
@@ -8161,6 +8161,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: PlacesAndEventsSection
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447187945983909996, guid: 01095a78852393446834e68bf8628274,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1483135933473731128, guid: 01095a78852393446834e68bf8628274,
         type: 3}
@@ -10310,32 +10315,32 @@ PrefabInstance:
     - target: {fileID: 8275347976327831106, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8275347976327831106, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8275347976327831106, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.33333
       objectReference: {fileID: 0}
     - target: {fileID: 8275347976327831106, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 8275347976327831106, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 210
       objectReference: {fileID: 0}
     - target: {fileID: 8275347976327831106, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -17
       objectReference: {fileID: 0}
     - target: {fileID: 8357978290671883869, guid: 01095a78852393446834e68bf8628274,
         type: 3}
@@ -10589,6 +10594,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 01095a78852393446834e68bf8628274, type: 3}
+--- !u!224 &6897819228172551501 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2595460879837104802, guid: 01095a78852393446834e68bf8628274,
+    type: 3}
+  m_PrefabInstance: {fileID: 8916309094798233583}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &9218004316370049640 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 311304691206690183, guid: 01095a78852393446834e68bf8628274,
@@ -10601,9 +10612,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 509258bf67fe12f4c90a44fb48fcc558, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &6897819228172551501 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2595460879837104802, guid: 01095a78852393446834e68bf8628274,
-    type: 3}
-  m_PrefabInstance: {fileID: 8916309094798233583}
-  m_PrefabAsset: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -159,7 +159,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
         rendererState.OnChange -= Initialize_Internal;
         DataStore.i.realm.playerRealm.OnChange -= UpdateRealmInfo;
         ownUserProfile.OnUpdate -= UpdateProfileInfo;
-        view.currentProfileCard.onClick?.RemoveAllListeners();
+        view?.currentProfileCard.onClick?.RemoveAllListeners();
         isOpen.OnChange -= IsOpenChanged;
         currentSectionIndex.OnChange -= CurrentSectionIndexChanged;
         isPlacesAndEventsSectionInitialized.OnChange -= IsPlacesAndEventsSectionInitializedChanged;
@@ -212,7 +212,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal void SetVisibility_Internal(bool visible)
     {
-        if (view == null)
+        if (view == null || DataStore.i.common.isSignUpFlow.Get())
             return;
 
         if (visible)
@@ -249,7 +249,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal void PlacesAndEventsVisibleChanged(bool current, bool previous)
     {
-        if (!isInitialized.Get())
+        if (!isInitialized.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
         if (current)
@@ -295,7 +295,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal void NavmapVisibleChanged(bool current, bool previous)
     {
-        if (!isNavmapInitialized.Get())
+        if (!isNavmapInitialized.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
         if (current)
@@ -321,7 +321,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal void BuilderVisibleChanged(bool current, bool previous)
     {
-        if (!isBuilderInitialized.Get())
+        if (!isBuilderInitialized.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
         if (current)
@@ -347,7 +347,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal void QuestVisibleChanged(bool current, bool previous)
     {
-        if (!isQuestInitialized.Get())
+        if (!isQuestInitialized.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
         if (current)
@@ -373,7 +373,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal void SettingsVisibleChanged(bool current, bool previous)
     {
-        if (!isSettingsPanelInitialized.Get())
+        if (!isSettingsPanelInitialized.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
         if (current)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -1,14 +1,11 @@
 using DCL;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public interface IExploreV2MenuComponentView : IDisposable
 {
-    /// <summary>
-    /// It will be triggered when the view is fully initialized.
-    /// </summary>
-    event Action OnInitialized;
-
     /// <summary>
     /// It will be triggered when the close button is clicked.
     /// </summary>
@@ -152,7 +149,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
     public RectTransform currentSettingsTooltipReference => sectionSelector.GetSection((int)ExploreSection.Settings).pivot;
     public RectTransform currentProfileCardTooltipReference => profileCardTooltipReference;
 
-    public event Action OnInitialized;
     public event Action<bool> OnCloseButtonPressed;
     public event Action<ExploreSection> OnSectionOpen;
     public event Action OnAfterShowAnimation;
@@ -165,10 +161,19 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
         DataStore.i.exploreV2.currentSectionIndex.Set((int)DEFAULT_SECTION, false);
 
-        CreateSectionSelectorMappings();
-        ConfigureCloseButton();
+        DataStore.i.exploreV2.isInitialized.OnChange += IsInitialized_OnChange;
+        IsInitialized_OnChange(DataStore.i.exploreV2.isInitialized.Get(), false);
 
-        OnInitialized?.Invoke();
+        ConfigureCloseButton();
+    }
+
+    private void IsInitialized_OnChange(bool current, bool previous)
+    {
+        if (!current)
+            return;
+
+        DataStore.i.exploreV2.isInitialized.OnChange -= IsInitialized_OnChange;
+        StartCoroutine(CreateSectionSelectorMappingsAfterDelay());
     }
 
     public override void Update()
@@ -193,6 +198,7 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
         RemoveSectionSelectorMappings();
         closeMenuButton.onClick.RemoveAllListeners();
         closeAction.OnTriggered -= OnCloseActionTriggered;
+        DataStore.i.exploreV2.isInitialized.OnChange -= IsInitialized_OnChange;
     }
 
     public void SetVisible(bool isActive)
@@ -201,7 +207,22 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
         {
             DataStore.i.exploreV2.isInShowAnimationTransiton.Set(true);
             Show();
-            GoToSection((ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get());
+
+            ISectionToggle sectionToGo = sectionSelector.GetSection(DataStore.i.exploreV2.currentSectionIndex.Get());
+            if (sectionToGo != null && sectionToGo.IsActive())
+                GoToSection((ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get());
+            else
+            {
+                List<ISectionToggle> allSections = sectionSelector.GetAllSections();
+                foreach (ISectionToggle section in allSections)
+                {
+                    if (section != null && section.IsActive())
+                    {
+                        section.SelectToggle(true);
+                        break;
+                    }
+                }
+            }
         }
         else
         {
@@ -254,6 +275,12 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
         }
 
         sectionView?.EncapsulateFeature(featureConfiguratorFlag);
+    }
+
+    public IEnumerator CreateSectionSelectorMappingsAfterDelay()
+    {
+        yield return null;
+        CreateSectionSelectorMappings();
     }
 
     internal void CreateSectionSelectorMappings()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsFeature.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsFeature.cs
@@ -1,0 +1,8 @@
+using DCL;
+
+public class PlacesAndEventsFeature : IPlugin
+{
+    public PlacesAndEventsFeature() { DataStore.i.exploreV2.isPlacesAndEventsSectionInitialized.Set(true); }
+
+    public void Dispose() { }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsFeature.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsFeature.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ed3fd2bd4ad008418c0c5037b9f0d7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -21,7 +21,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController = Substitute.ForPartsOf<ExploreV2MenuComponentController>();
         exploreV2MenuController.Configure().CreateView().Returns(info => exploreV2MenuView);
         exploreV2MenuController.Configure().CreateAnalyticsController().Returns(info => exploreV2Analytics);
-        exploreV2MenuController.Initialize();
+        exploreV2MenuController.Initialize_Internal(true, false);
     }
 
     [TearDown]
@@ -48,7 +48,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.placesAndEventsSectionController = null;
 
         // Act
-        exploreV2MenuController.CreateControllers();
+        exploreV2MenuController.InitializePlacesAndEventsSection();
 
         // Assert
         Assert.IsNotNull(exploreV2MenuController.placesAndEventsSectionController);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
@@ -11,9 +11,10 @@ namespace DCL
 
             pluginSystem.Register(() => new DebugPluginFeature());
             pluginSystem.Register(() => new ShortcutsFeature());
+            pluginSystem.Register(() => new ExploreV2Feature());
             pluginSystem.RegisterWithFlag(() => new BuilderInWorldPlugin(), "builder_in_world");
             pluginSystem.RegisterWithFlag(() => new TutorialController(), "tutorial");
-            pluginSystem.RegisterWithFlag(() => new ExploreV2Feature(), "explorev2");
+            pluginSystem.RegisterWithFlag(() => new PlacesAndEventsFeature(), "explorev2");
             pluginSystem.RegisterWithFlag(() => new SkyboxController(), "procedural_skybox");
 
             pluginSystem.SetFeatureFlagsData(DataStore.i.featureFlags.flags);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Shortcuts/ShortcutsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Shortcuts/ShortcutsController.cs
@@ -54,10 +54,22 @@ public class ShortcutsController : IDisposable
     }
 
     private void ToggleControlsTriggered(DCLAction_Trigger action) { DataStore.i.HUDs.controlsVisible.Set(!DataStore.i.HUDs.controlsVisible.Get()); }
-    private void ToggleAvatarEditorTriggered(DCLAction_Trigger action) { DataStore.i.HUDs.avatarEditorVisible.Set(!DataStore.i.HUDs.avatarEditorVisible.Get()); }
+    
+    private void ToggleAvatarEditorTriggered(DCLAction_Trigger action) 
+    {
+        if (!DataStore.i.HUDs.isAvatarEditorInitialized.Get())
+            return;
+
+        DataStore.i.HUDs.avatarEditorVisible.Set(!DataStore.i.HUDs.avatarEditorVisible.Get()); 
+    }
+
     private void ToggleAvatarNamesTriggered(DCLAction_Trigger action) { DataStore.i.HUDs.avatarNamesVisible.Set(!DataStore.i.HUDs.avatarNamesVisible.Get()); }
+
     private void ToggleQuestPanel(DCLAction_Trigger action)
     {
+        if (!DataStore.i.Quests.isInitialized.Get())
+            return;
+
         bool value = !DataStore.i.HUDs.questsPanelVisible.Get();
         SendQuestToggledAnalytic(value);
         DataStore.i.HUDs.questsPanelVisible.Set(value);
@@ -80,8 +92,22 @@ public class ShortcutsController : IDisposable
     }
 
     private void ToggleExpressionsTriggered(DCLAction_Trigger action) { DataStore.i.HUDs.emotesVisible.Set(!DataStore.i.HUDs.emotesVisible.Get()); }
-    private void ToggleNavMapTriggered(DCLAction_Trigger action) { DataStore.i.HUDs.navmapVisible.Set(!DataStore.i.HUDs.navmapVisible.Get()); }
-    private void TogglePlacesAndEventsTriggered(DCLAction_Trigger action) { DataStore.i.exploreV2.placesAndEventsVisible.Set(!DataStore.i.exploreV2.placesAndEventsVisible.Get()); }
+    
+    private void ToggleNavMapTriggered(DCLAction_Trigger action) 
+    {
+        if (!DataStore.i.HUDs.isNavMapInitialized.Get())
+            return;
+
+        DataStore.i.HUDs.navmapVisible.Set(!DataStore.i.HUDs.navmapVisible.Get()); 
+    }
+
+    private void TogglePlacesAndEventsTriggered(DCLAction_Trigger action)
+    {
+        if (!DataStore.i.exploreV2.isPlacesAndEventsSectionInitialized.Get())
+            return;
+
+        DataStore.i.exploreV2.placesAndEventsVisible.Set(!DataStore.i.exploreV2.placesAndEventsVisible.Get());
+    }
 
     public void Dispose() { Unsubscribe(); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_ExploreV2.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_ExploreV2.cs
@@ -5,6 +5,7 @@ namespace DCL
     public class DataStore_ExploreV2
     {
         public readonly BaseVariable<bool> isInitialized = new BaseVariable<bool>(false);
+        public readonly BaseVariable<bool> isPlacesAndEventsSectionInitialized = new BaseVariable<bool>(false);
         public readonly BaseVariable<bool> isOpen = new BaseVariable<bool>(false);
         public readonly BaseVariable<bool> isInShowAnimationTransiton = new BaseVariable<bool>(false);
         public readonly BaseVariable<int> currentSectionIndex = new BaseVariable<int>(0);

--- a/unity-renderer/Assets/Scripts/MainScripts/Debugging/Panels/UserBenchmarkToggler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/Debugging/Panels/UserBenchmarkToggler.cs
@@ -6,7 +6,7 @@ namespace DCL
 {
     public class UserBenchmarkToggler : MonoBehaviour
     {
-        const string SHORTCUT_TEXT = "[Y] Debug Panel [P] Settings [I] Backpack";
+        const string SHORTCUT_TEXT = "[Y] Debug Panel";
 
         public UserBenchmarkController userBenchmarkController;
         Text text;


### PR DESCRIPTION
## What does this PR change?
Fix #1722 
The StartMenu is now usable in PreviewMode in the same way as in the normal "world" flow. In this mode there will be some sections deactivated (for example "Explore" or "Builder"), only those that have sense to use in preview mode will be activated in the menu.

![image](https://user-images.githubusercontent.com/64659061/148279469-dfe40917-c5da-4611-836f-0a9905936169.png)

## How to test?
1. Create a new empty scene
![image](https://user-images.githubusercontent.com/64659061/148089398-82a6f326-7428-455c-8b8b-1f342e7103c5.png)

2. Play it as preview mode
![image](https://user-images.githubusercontent.com/64659061/148089478-4ea0848f-b614-4af7-83e0-f006a24e1c6a.png)

3. Add in the url the url para: `&renderer-branch=feat/Integrate-StartMenu-into-PreviewMode`
4. Notice the StartMenu is now usable in Preview Mode.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md