### PR TITLE
fix: Fix pools prewarming + Explore section loading improvement

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Common/ExploreEventsHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Common/ExploreEventsHelpers.cs
@@ -54,6 +54,8 @@ public static class ExploreEventsHelpers
                 GameObject.Instantiate(eventCardPrefab).gameObject,
                 maxPrewarmCount: maxPrewarmCount,
                 isPersistent: true);
+
+            pool.ForcePrewarm();
         }
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Common/ExplorePlacesHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Common/ExplorePlacesHelpers.cs
@@ -54,6 +54,8 @@ public static class ExplorePlacesHelpers
                 GameObject.Instantiate(placeCardPrefab).gameObject,
                 maxPrewarmCount: maxPrewarmCount,
                 isPersistent: true);
+
+            pool.ForcePrewarm();
         }
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
@@ -77,6 +77,8 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
         OnEventsFromAPIUpdated += OnRequestedEventsUpdated;
 
         this.exploreV2Analytics = exploreV2Analytics;
+
+        view.ConfigurePools();
     }
 
     internal void FirstLoading()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentView.cs
@@ -128,14 +128,23 @@ public interface IEventsSubSectionComponentView
     /// Set the current scroll view position to 1.
     /// </summary>
     void RestartScrollViewPosition();
+
+    /// <summary>
+    /// Configure the needed pools for the events instantiation.
+    /// </summary>
+    void ConfigurePools();
 }
 
 public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectionComponentView
 {
     internal const string FEATURED_EVENT_CARDS_POOL_NAME = "Events_FeaturedEventCardsPool";
+    internal const int FEATURED_EVENT_CARDS_POOL_PREWARM = 10;
     internal const string TRENDING_EVENT_CARDS_POOL_NAME = "Events_TrendingEventCardsPool";
+    internal const int TRENDING_EVENT_CARDS_POOL_PREWARM = 12;
     internal const string UPCOMING_EVENT_CARDS_POOL_NAME = "Events_UpcomingEventCardsPool";
+    internal const int UPCOMING_EVENT_CARDS_POOL_PREWARM = 9;
     internal const string GOING_EVENT_CARDS_POOL_NAME = "Events_FeatureGoingEventCardsPool";
+    internal const int GOING_EVENT_CARDS_POOL_PREWARM = 9;
 
     [Header("Assets References")]
     [SerializeField] internal EventCardComponentView eventCardPrefab;
@@ -176,13 +185,17 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
 
     public override void OnEnable() { OnEventsSubSectionEnable?.Invoke(); }
 
+    public void ConfigurePools()
+    {
+        ExploreEventsHelpers.ConfigureEventCardsPool(out featuredEventCardsPool, FEATURED_EVENT_CARDS_POOL_NAME, eventCardLongPrefab, FEATURED_EVENT_CARDS_POOL_PREWARM);
+        ExploreEventsHelpers.ConfigureEventCardsPool(out trendingEventCardsPool, TRENDING_EVENT_CARDS_POOL_NAME, eventCardPrefab, TRENDING_EVENT_CARDS_POOL_PREWARM);
+        ExploreEventsHelpers.ConfigureEventCardsPool(out upcomingEventCardsPool, UPCOMING_EVENT_CARDS_POOL_NAME, eventCardPrefab, UPCOMING_EVENT_CARDS_POOL_PREWARM);
+        ExploreEventsHelpers.ConfigureEventCardsPool(out goingEventCardsPool, GOING_EVENT_CARDS_POOL_NAME, eventCardPrefab, GOING_EVENT_CARDS_POOL_PREWARM);
+    }
+
     public override void Start()
     {
         eventModal = ExploreEventsHelpers.ConfigureEventCardModal(eventCardModalPrefab);
-        ExploreEventsHelpers.ConfigureEventCardsPool(out featuredEventCardsPool, FEATURED_EVENT_CARDS_POOL_NAME, eventCardLongPrefab, 10);
-        ExploreEventsHelpers.ConfigureEventCardsPool(out trendingEventCardsPool, TRENDING_EVENT_CARDS_POOL_NAME, eventCardPrefab, 100);
-        ExploreEventsHelpers.ConfigureEventCardsPool(out upcomingEventCardsPool, UPCOMING_EVENT_CARDS_POOL_NAME, eventCardPrefab, 100);
-        ExploreEventsHelpers.ConfigureEventCardsPool(out goingEventCardsPool, GOING_EVENT_CARDS_POOL_NAME, eventCardPrefab, 100);
 
         featuredEvents.RemoveItems();
         trendingEvents.RemoveItems();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/HighlightsSubSection/HighlightsSubSectionMenu/HighlightsSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/HighlightsSubSection/HighlightsSubSectionMenu/HighlightsSubSectionComponentController.cs
@@ -85,6 +85,8 @@ public class HighlightsSubSectionComponentController : IHighlightsSubSectionComp
         friendsTrackerController = new FriendTrackerController(friendsController, view.currentFriendColors);
 
         this.exploreV2Analytics = exploreV2Analytics;
+
+        view.ConfigurePools();
     }
 
     internal void FirstLoading()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/HighlightsSubSection/HighlightsSubSectionMenu/HighlightsSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/HighlightsSubSection/HighlightsSubSectionMenu/HighlightsSubSectionComponentView.cs
@@ -131,14 +131,23 @@ public interface IHighlightsSubSectionComponentView
     /// Set the current scroll view position to 1.
     /// </summary>
     void RestartScrollViewPosition();
+
+    /// <summary>
+    /// Configure the needed pools for the places and events instantiation.
+    /// </summary>
+    void ConfigurePools();
 }
 
 public class HighlightsSubSectionComponentView : BaseComponentView, IHighlightsSubSectionComponentView
 {
     internal const string TRENDING_PLACE_CARDS_POOL_NAME = "Highlights_TrendingPlaceCardsPool";
+    internal const int TRENDING_PLACE_CARDS_POOL_PREWARM = 10;
     internal const string TRENDING_EVENT_CARDS_POOL_NAME = "Highlights_TrendingEventCardsPool";
+    internal const int TRENDING_EVENT_CARDS_POOL_PREWARM = 10;
     internal const string FEATURED_PLACE_CARDS_POOL_NAME = "Highlights_FeaturedPlaceCardsPool";
+    internal const int FEATURED_PLACE_CARDS_POOL_PREWARM = 9;
     internal const string LIVE_EVENT_CARDS_POOL_NAME = "Highlights_LiveEventCardsPool";
+    internal const int LIVE_EVENT_CARDS_POOL_PREWARM = 3;
 
     [Header("Assets References")]
     [SerializeField] internal PlaceCardComponentView placeCardLongPrefab;
@@ -183,14 +192,18 @@ public class HighlightsSubSectionComponentView : BaseComponentView, IHighlightsS
 
     public override void OnEnable() { OnHighlightsSubSectionEnable?.Invoke(); }
 
+    public void ConfigurePools()
+    {
+        ExplorePlacesHelpers.ConfigurePlaceCardsPool(out trendingPlaceCardsPool, TRENDING_PLACE_CARDS_POOL_NAME, placeCardLongPrefab, TRENDING_PLACE_CARDS_POOL_PREWARM);
+        ExploreEventsHelpers.ConfigureEventCardsPool(out trendingEventCardsPool, TRENDING_EVENT_CARDS_POOL_NAME, eventCardLongPrefab, TRENDING_EVENT_CARDS_POOL_PREWARM);
+        ExplorePlacesHelpers.ConfigurePlaceCardsPool(out featuredPlaceCardsPool, FEATURED_PLACE_CARDS_POOL_NAME, placeCardPrefab, FEATURED_PLACE_CARDS_POOL_PREWARM);
+        ExploreEventsHelpers.ConfigureEventCardsPool(out liveEventCardsPool, LIVE_EVENT_CARDS_POOL_NAME, eventCardPrefab, LIVE_EVENT_CARDS_POOL_PREWARM);
+    }
+
     public override void Start()
     {
         placeModal = ExplorePlacesHelpers.ConfigurePlaceCardModal(placeCardModalPrefab);
         eventModal = ExploreEventsHelpers.ConfigureEventCardModal(eventCardModalPrefab);
-        ExplorePlacesHelpers.ConfigurePlaceCardsPool(out trendingPlaceCardsPool, TRENDING_PLACE_CARDS_POOL_NAME, placeCardLongPrefab, 10);
-        ExploreEventsHelpers.ConfigureEventCardsPool(out trendingEventCardsPool, TRENDING_EVENT_CARDS_POOL_NAME, eventCardLongPrefab, 10);
-        ExplorePlacesHelpers.ConfigurePlaceCardsPool(out featuredPlaceCardsPool, FEATURED_PLACE_CARDS_POOL_NAME, placeCardPrefab, 6);
-        ExploreEventsHelpers.ConfigureEventCardsPool(out liveEventCardsPool, LIVE_EVENT_CARDS_POOL_NAME, eventCardPrefab, 3);
 
         trendingPlacesAndEvents.RemoveItems();
         featuredPlaces.RemoveItems();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentController.cs
@@ -63,6 +63,8 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
         friendsTrackerController = new FriendTrackerController(friendsController, view.currentFriendColors);
 
         this.exploreV2Analytics = exploreV2Analytics;
+
+        view.ConfigurePools();
     }
 
     internal void FirstLoading()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentView.cs
@@ -86,11 +86,17 @@ public interface IPlacesSubSectionComponentView
     /// Set the current scroll view position to 1.
     /// </summary>
     void RestartScrollViewPosition();
+
+    /// <summary>
+    /// Configure the needed pools for the places instantiation.
+    /// </summary>
+    void ConfigurePools();
 }
 
 public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectionComponentView
 {
     internal const string PLACE_CARDS_POOL_NAME = "Places_PlaceCardsPool";
+    internal const int PLACE_CARDS_POOL_PREWARM = 20;
 
     [Header("Assets References")]
     [SerializeField] internal PlaceCardComponentView placeCardPrefab;
@@ -121,10 +127,14 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
 
     public override void OnEnable() { OnPlacesSubSectionEnable?.Invoke(); }
 
+    public void ConfigurePools()
+    {
+        ExplorePlacesHelpers.ConfigurePlaceCardsPool(out placeCardsPool, PLACE_CARDS_POOL_NAME, placeCardPrefab, PLACE_CARDS_POOL_PREWARM);
+    }
+
     public override void Start()
     {
         placeModal = ExplorePlacesHelpers.ConfigurePlaceCardModal(placeCardModalPrefab);
-        ExplorePlacesHelpers.ConfigurePlaceCardsPool(out placeCardsPool, PLACE_CARDS_POOL_NAME, placeCardPrefab, 200);
 
         places.RemoveItems();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventsSubSectionComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventsSubSectionComponentViewTests.cs
@@ -13,6 +13,7 @@ public class EventsSubSectionComponentViewTests
     public void SetUp()
     {
         eventsSubSectionComponent = Object.Instantiate(Resources.Load<GameObject>("Sections/PlacesAndEventsSection/EventsSubSection/EventsSubSection")).GetComponent<EventsSubSectionComponentView>();
+        eventsSubSectionComponent.ConfigurePools();
         eventsSubSectionComponent.Start();
         testTexture = new Texture2D(20, 20);
         testSprite = Sprite.Create(testTexture, new Rect(), Vector2.zero);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreEventsCommonTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreEventsCommonTests.cs
@@ -12,6 +12,7 @@ public class ExploreEventsCommonTests
     public void SetUp()
     {
         eventsSubSectionComponent = Object.Instantiate(Resources.Load<GameObject>("Sections/PlacesAndEventsSection/EventsSubSection/EventsSubSection")).GetComponent<EventsSubSectionComponentView>();
+        eventsSubSectionComponent.ConfigurePools();
         eventsSubSectionComponent.Start();
 
         testEventCard = Object.Instantiate(Resources.Load<GameObject>("Sections/PlacesAndEventsSection/EventsSubSection/EventCard_Modal")).GetComponent<EventCardComponentView>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExplorePlacesCommonTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExplorePlacesCommonTests.cs
@@ -13,6 +13,7 @@ public class ExplorePlacesCommonTests
     public void SetUp()
     {
         placesSubSectionComponent = Object.Instantiate(Resources.Load<GameObject>("Sections/PlacesAndEventsSection/PlacesSubSection/PlacesSubSection")).GetComponent<PlacesSubSectionComponentView>();
+        placesSubSectionComponent.ConfigurePools();
         placesSubSectionComponent.Start();
 
         testPlaceCard = Object.Instantiate(Resources.Load<GameObject>("Sections/PlacesAndEventsSection/PlacesSubSection/PlaceCard_Modal")).GetComponent<PlaceCardComponentView>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/HighlightsSubSectionComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/HighlightsSubSectionComponentViewTests.cs
@@ -13,6 +13,7 @@ public class HighlightsSubSectionComponentViewTests
     public void SetUp()
     {
         highlightsSubSectionComponent = Object.Instantiate(Resources.Load<GameObject>("Sections/PlacesAndEventsSection/HighlightsSubSection/HighlightsSubSection")).GetComponent<HighlightsSubSectionComponentView>();
+        highlightsSubSectionComponent.ConfigurePools();
         highlightsSubSectionComponent.Start();
         testTexture = new Texture2D(20, 20);
         testSprite = Sprite.Create(testTexture, new Rect(), Vector2.zero);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/PlacesSubSectionComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/PlacesSubSectionComponentViewTests.cs
@@ -13,6 +13,7 @@ public class PlacesSubSectionComponentViewTests
     public void SetUp()
     {
         placesSubSectionComponent = Object.Instantiate(Resources.Load<GameObject>("Sections/PlacesAndEventsSection/PlacesSubSection/PlacesSubSection")).GetComponent<PlacesSubSectionComponentView>();
+        placesSubSectionComponent.ConfigurePools();
         placesSubSectionComponent.Start();
         testTexture = new Texture2D(20, 20);
         testSprite = Sprite.Create(testTexture, new Rect(), Vector2.zero);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDView.cs
@@ -8,8 +8,8 @@ public class FriendsHUDView : MonoBehaviour
     public const string NOTIFICATIONS_ID = "Friends";
     static readonly int ANIM_PROPERTY_SELECTED = Animator.StringToHash("Selected");
     const string VIEW_PATH = "FriendsHUD";
-    const int PREINSTANTIATED_FRIENDS_ENTRIES = 50;
-    const int PREINSTANTIATED_FRIENDS_REQUEST_ENTRIES = 10;
+    const int PREINSTANTIATED_FRIENDS_ENTRIES = 25;
+    const int PREINSTANTIATED_FRIENDS_REQUEST_ENTRIES = 5;
 
     public Button closeButton;
     public Button friendsButton;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
@@ -65,7 +65,8 @@ namespace DCL
             if (maxPrewarmCount <= objectsCount)
                 return;
 
-            for (int i = 0; i < Mathf.Max(0, maxPrewarmCount - objectsCount); i++)
+            int objectsToInstantiate = Mathf.Max(0, maxPrewarmCount - objectsCount);
+            for (int i = 0; i < objectsToInstantiate; i++)
             {
                 Instantiate();
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/PoolManagerFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/PoolManagerFactory.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace DCL
 {
@@ -12,7 +12,7 @@ namespace DCL
                 return;
 
             GameObject go = new GameObject();
-            Pool pool = PoolManager.i.AddPool(EMPTY_GO_POOL_NAME, go, maxPrewarmCount: 2000, isPersistent: true);
+            Pool pool = PoolManager.i.AddPool(EMPTY_GO_POOL_NAME, go, maxPrewarmCount: 1000, isPersistent: true);
 
             if (prewarm)
                 pool.ForcePrewarm();


### PR DESCRIPTION
## What does this PR change?
Fix #1728 
### Fix pools prewarming
We realized something that was wrongly implemented related to the Pool creation: When we used the `ForcePrewarm()` function (from our `Pool` class) after creating a pool, the number of instantiated objects was half of what was indicated in the `maxPrewarmCount` param.

So our Pools system was not working correctly, in fact in all places where we were using a prewarming, it was always creating the half of objects.

#### The wrong code
```
public void ForcePrewarm()
{
   if (maxPrewarmCount <= objectsCount)
      return;

   for (int i = 0; i < Mathf.Max(0, maxPrewarmCount - objectsCount); i++)
   {
      Instantiate();
   }
}
```

#### The fixed code
```
public void ForcePrewarm()
{
   if (maxPrewarmCount <= objectsCount)
      return;

   int objectsToInstantiate = Mathf.Max(0, maxPrewarmCount - objectsCount);
   for (int i = 0; i < objectsToInstantiate); i++)
   {
      Instantiate();
   }
}
```

### Explore section loading improvement
Also, making use of the Pools system, we have improved the loading of the Explore section in our **Start Menu**. For this purpose we have used the `ForcePrewarm()` function to pre-instantiate some game objects (mostly related to places and events cards) and gain performance on the first opening of the Start Menu.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/Fix-pools-pre-warming
2. Test the application and confirm everything is working fine.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
