### PR TITLE
fix: remove AttachToAvatar when Transform is added

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -463,6 +463,14 @@ namespace DCL.Controllers
                 OnPointerEvent.Model model = JsonUtility.FromJson<OnPointerEvent.Model>(data as string);
                 classId = model.GetClassIdFromType();
             }
+            // NOTE: TRANSFORM and AVATAR_ATTACH can't be used in the same Entity at the same time.
+            // so we remove AVATAR_ATTACH (if exists) when a TRANSFORM is created.
+            else if (classId == CLASS_ID_COMPONENT.TRANSFORM
+                     && entity.TryGetBaseComponent(CLASS_ID_COMPONENT.AVATAR_ATTACH, out IEntityComponent component))
+            {
+                component.Cleanup();
+                entity.components.Remove( CLASS_ID_COMPONENT.AVATAR_ATTACH );
+            }
 
             if (!entity.components.ContainsKey(classId))
             {


### PR DESCRIPTION
`AttachToAvatar` and `Transform` components can't coexist in the same Entity.
We must make sure that `AttachToAvatar` is removed from the Entity when a `Transform` is added to it.

closes https://github.com/decentraland/sdk/issues/159