### PR TITLE
fix: AttachToAvatar 'choppy' position

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/AvatarAttach.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/AvatarAttach.asmdef
@@ -17,7 +17,8 @@
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
         "GUID:5289a39f46259954ca74010d7c9ded16",
         "GUID:1de3566cccb280f4a982c59ad0d08c96",
-        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8"
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
+        "GUID:9857fe4bae4e30441bc3a577c5de790a"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/AvatarAttachComponent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/AvatarAttachComponent.cs
@@ -30,7 +30,7 @@ namespace DCL.Components
 
         void IEntityComponent.Initialize(IParcelScene scene, IDCLEntity entity)
         {
-            handler.Initialize(scene, entity);
+            handler.Initialize(scene, entity, Environment.i.platform.updateEventHandler);
         }
 
         bool IComponent.IsValid() => true;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/AvatarAttachHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/AvatarAttachHandler.cs
@@ -107,8 +107,6 @@ namespace DCL.Components
                 return;
             }
 
-            Physics.SyncTransforms();
-
             var anchorPoint = anchorPoints.GetTransform(anchorPointId);
 
             if (IsInsideScene(CommonScriptableObjects.worldOffset + anchorPoint.position))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/AvatarAttachHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/AvatarAttachHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using DCL.Configuration;
 using DCL.Controllers;
 using DCL.Helpers;
@@ -21,19 +20,21 @@ namespace DCL.Components
         private IAvatarAnchorPoints anchorPoints;
         private AvatarAnchorPointIds anchorPointId;
 
-        private Coroutine componentUpdate = null;
+        private Action componentUpdate = null;
 
         private readonly GetAnchorPointsHandler getAnchorPointsHandler = new GetAnchorPointsHandler();
         private ISceneBoundsChecker sceneBoundsChecker => Environment.i?.world?.sceneBoundsChecker;
+        private IUpdateEventHandler updateEventHandler;
 
         private Vector2Int? currentCoords = null;
         private bool isInsideScene = true;
         private float lastBoundariesCheckTime = 0;
 
-        public void Initialize(IParcelScene scene, IDCLEntity entity)
+        public void Initialize(IParcelScene scene, IDCLEntity entity, IUpdateEventHandler updateEventHandler)
         {
             this.scene = scene;
             this.entity = entity;
+            this.updateEventHandler = updateEventHandler;
             getAnchorPointsHandler.OnAvatarRemoved += Detach;
         }
 
@@ -72,11 +73,7 @@ namespace DCL.Components
 
         internal virtual void Detach()
         {
-            if (componentUpdate != null)
-            {
-                CoroutineStarter.Stop(componentUpdate);
-                componentUpdate = null;
-            }
+            StopComponentUpdate();
 
             if (entity != null)
             {
@@ -99,42 +96,34 @@ namespace DCL.Components
             this.anchorPoints = anchorPoints;
             this.anchorPointId = anchorPointId;
 
-            if (componentUpdate == null)
-            {
-                componentUpdate = CoroutineStarter.Start(ComponentUpdate());
-            }
+            StartComponentUpdate();
         }
 
-        IEnumerator ComponentUpdate()
+        internal void LateUpdate()
         {
-            currentCoords = null;
-
-            while (true)
+            if (entity == null || scene == null)
             {
-                if (entity == null || scene == null)
+                StopComponentUpdate();
+                return;
+            }
+
+            Physics.SyncTransforms();
+
+            var anchorPoint = anchorPoints.GetTransform(anchorPointId);
+
+            if (IsInsideScene(CommonScriptableObjects.worldOffset + anchorPoint.position))
+            {
+                entity.gameObject.transform.position = anchorPoint.position;
+                entity.gameObject.transform.rotation = anchorPoint.rotation;
+
+                if (Time.unscaledTime - lastBoundariesCheckTime > BOUNDARIES_CHECK_INTERVAL)
                 {
-                    componentUpdate = null;
-                    yield break;
+                    CheckSceneBoundaries(entity);
                 }
-
-                var anchorPoint = anchorPoints.GetTransform(anchorPointId);
-
-                if (IsInsideScene(CommonScriptableObjects.worldOffset + anchorPoint.position))
-                {
-                    entity.gameObject.transform.position = anchorPoint.position;
-                    entity.gameObject.transform.rotation = anchorPoint.rotation;
-
-                    if (Time.unscaledTime - lastBoundariesCheckTime > BOUNDARIES_CHECK_INTERVAL)
-                    {
-                        CheckSceneBoundaries(entity);
-                    }
-                }
-                else
-                {
-                    entity.gameObject.transform.localPosition = EnvironmentSettings.MORDOR;
-                }
-
-                yield return null;
+            }
+            else
+            {
+                entity.gameObject.transform.localPosition = EnvironmentSettings.MORDOR;
             }
         }
 
@@ -155,6 +144,25 @@ namespace DCL.Components
         {
             sceneBoundsChecker?.AddEntityToBeChecked(entity);
             lastBoundariesCheckTime = Time.unscaledTime;
+        }
+
+        private void StartComponentUpdate()
+        {
+            if (componentUpdate != null)
+                return;
+
+            currentCoords = null;
+            componentUpdate = LateUpdate;
+            updateEventHandler?.AddListener(IUpdateEventHandler.EventType.LateUpdate, componentUpdate);
+        }
+
+        private void StopComponentUpdate()
+        {
+            if (componentUpdate == null)
+                return;
+
+            updateEventHandler?.RemoveListener(IUpdateEventHandler.EventType.LateUpdate, componentUpdate);
+            componentUpdate = null;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/Tests/AvatarAttachHandlerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/Tests/AvatarAttachHandlerShould.cs
@@ -22,6 +22,7 @@ namespace AvatarAttach_Tests
         {
             AvatarAttachHandler handler = Substitute.ForPartsOf<AvatarAttachHandler>();
             handler.model = new AvatarAttachComponent.Model() { avatarId = "Temptation" };
+
             handler.OnModelUpdated(new AvatarAttachComponent.Model() { avatarId = "Temptation" });
             handler.DidNotReceive().Detach();
             handler.DidNotReceive().Attach(Arg.Any<string>(), Arg.Any<AvatarAnchorPointIds>());
@@ -102,8 +103,9 @@ namespace AvatarAttach_Tests
             AvatarAttachHandler handler = Substitute.ForPartsOf<AvatarAttachHandler>();
             handler.IsInsideScene(Arg.Any<Vector3>()).Returns(true);
 
-            handler.Initialize(Substitute.For<IParcelScene>(), entity);
+            handler.Initialize(Substitute.For<IParcelScene>(), entity, Substitute.For<IUpdateEventHandler>());
             handler.OnModelUpdated(new AvatarAttachComponent.Model() { avatarId = userId, anchorPointId = 0 });
+            handler.LateUpdate();
 
             Assert.AreEqual(targetPosition, entityGo.transform.position);
             Assert.AreEqual(targetRotation.eulerAngles, entityGo.transform.rotation.eulerAngles);
@@ -134,8 +136,9 @@ namespace AvatarAttach_Tests
             AvatarAttachHandler handler = Substitute.ForPartsOf<AvatarAttachHandler>();
             handler.IsInsideScene(Arg.Any<Vector3>()).Returns(false);
 
-            handler.Initialize(Substitute.For<IParcelScene>(), entity);
+            handler.Initialize(Substitute.For<IParcelScene>(), entity, Substitute.For<IUpdateEventHandler>());
             handler.OnModelUpdated(new AvatarAttachComponent.Model() { avatarId = userId, anchorPointId = 0 });
+            handler.LateUpdate();
 
             Assert.AreEqual(EnvironmentSettings.MORDOR, entityGo.transform.position);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/Tests/AvatarAttachTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/Tests/AvatarAttachTests.asmdef
@@ -12,7 +12,8 @@
         "GUID:97d8897529779cb49bebd400c7f402a6",
         "GUID:1dd0780aa6be12b428c8005d0bee46b8",
         "GUID:1de3566cccb280f4a982c59ad0d08c96",
-        "GUID:cc6bfabbfe87b7949aa248893f89ce37"
+        "GUID:cc6bfabbfe87b7949aa248893f89ce37",
+        "GUID:9857fe4bae4e30441bc3a577c5de790a"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -20
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
Attached objects to player's avatar looks "choppy", kind of "shaky", with some erratic positioning.
*changed to use `IUpdateEventHandler` for component update instead of a `Coroutine`.
*modified tests accordingly.
*modified execution order for `DCLCharacterController` script to make sure it's `LateUpdate` is executed before `IUpdateEventHandler` `LateUpdate` event.
