### PR TITLE
fix: flickering pointerevent hover feedback

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs
@@ -29,7 +29,7 @@ namespace DCL.Components
         {
             bool isHoveringDirty = state != isHovering;
             isHovering = state;
-            eventHandler.SetFeedbackState(model.showFeedback, state && passportEnabled, model.button, model.hoverText);
+            eventHandler?.SetFeedbackState(model.showFeedback, state && passportEnabled, model.button, model.hoverText);
             if (!isHoveringDirty)
                 return;
             if (isHovering)
@@ -119,7 +119,6 @@ namespace DCL.Components
         public void SetPassportEnabled(bool newEnabledState)
         {
             passportEnabled = newEnabledState;
-            eventHandler?.SetFeedbackState(model.showFeedback, false, model.button, model.hoverText);
             isHovering = false;
         }
 


### PR DESCRIPTION
WHY
OnPointerEvent hover feedback is flickering on every avatar ApplyChanges() call (avatars loading, avatars changing wearables, emotes, etc.). It affects any onpointer event feedback, not only avatar on pointer down feedback
A video with the issue can be seen: https://github.com/decentraland/unity-renderer/issues/1745

WHAT
Removed unneeded interaction hover feedback update in `AvatarOnPointerDown.SetPassportEnabled()`, since that update is already done in its `SetHoverFeedback()`.