### PR TITLE
fix: main player comms reported rotation

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -522,7 +522,7 @@ public class DCLCharacterController : MonoBehaviour
         float height = 0.875f;
 
         var reportPosition = characterPosition.worldPosition + (Vector3.up * height);
-        var compositeRotation = Quaternion.LookRotation(cameraForward.Get());
+        var compositeRotation = Quaternion.LookRotation(characterForward.HasValue() ? characterForward.Get().Value :cameraForward.Get());
         var playerHeight = height + (characterController.height / 2);
 
         //NOTE(Brian): We have to wait for a Teleport before sending the ReportPosition, because if not ReportPosition events will be sent


### PR DESCRIPTION
Fixes #476

**WHY**
Through comms we always report the CAMERA rotation but we should be reporting the CHARACTER rotation, otherwise when players are using the third person camera, they think the rest of the users see them in the direction they point their avatar but they actually see the rotation of the camera...

**WHAT**
Re-implemented mini fix originally implemented by Santi at https://github.com/decentraland/unity-renderer/pull/864