### PR TITLE
fix: removed mouse event over in map parcels

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -82,7 +82,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameObjectsToToggle:
-  - {fileID: 0}
+  - {fileID: 7509157592280631724}
   - {fileID: 5854254909640412467}
   - {fileID: 5582000225371496597}
 --- !u!1 &5582000225371496597
@@ -533,6 +533,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c53ec74589327644bba45b4054fb78dc, type: 3}
+--- !u!1 &7509157592280631724 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3778843143832927354, guid: c53ec74589327644bba45b4054fb78dc,
+    type: 3}
+  m_PrefabInstance: {fileID: 6648657593541883350}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4161845772322530390 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -82,7 +82,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameObjectsToToggle:
-  - {fileID: 7509157592280631724}
+  - {fileID: 0}
   - {fileID: 5854254909640412467}
   - {fileID: 5582000225371496597}
 --- !u!1 &5582000225371496597
@@ -533,12 +533,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c53ec74589327644bba45b4054fb78dc, type: 3}
---- !u!1 &7509157592280631724 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3778843143832927354, guid: c53ec74589327644bba45b4054fb78dc,
-    type: 3}
-  m_PrefabInstance: {fileID: 6648657593541883350}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4161845772322530390 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -43,7 +43,7 @@ namespace DCL
                     return;
 
                 MapRenderer.i.atlas.UpdateCulling();
-                toastView.OnCloseClick();
+                CloseToast();
             });
 
             toastView.OnGotoClicked += () => navmapVisible.Set(false);
@@ -148,7 +148,7 @@ namespace DCL
             }
             else
             {
-                toastView.OnCloseClick();
+                CloseToast();
 
                 MapRenderer.i.atlas.viewport = minimapViewport;
                 MapRenderer.i.transform.SetParent(mapRendererMinimapParent);
@@ -178,6 +178,8 @@ namespace DCL
 
         void TriggerToast(int cursorTileX, int cursorTileY)
         {
+            if(toastView.isOpen)
+                CloseToast();
             var sceneInfo = mapMetadata.GetSceneInfo(cursorTileX, cursorTileY);
             if (sceneInfo == null)
                 WebInterface.RequestScenesInfoAroundParcel(new Vector2(cursorTileX, cursorTileY), 15);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -49,8 +49,7 @@ namespace DCL
             toastView.OnGotoClicked += () => navmapVisible.Set(false);
 
             MapRenderer.OnParcelClicked += TriggerToast;
-            MapRenderer.OnParcelHold += TriggerToast;
-            MapRenderer.OnParcelHoldCancel += () => { toastView.OnCloseClick(); };
+            MapRenderer.OnCursorFarFromParcel += () => { toastView.OnCloseClick(); };
             CommonScriptableObjects.playerCoords.OnChange += UpdateCurrentSceneData;
             closeAction.OnTriggered += OnCloseAction;
             navmapVisible.OnChange += OnNavmapVisibleChanged;
@@ -73,7 +72,6 @@ namespace DCL
         private void OnDestroy()
         {
             MapRenderer.OnParcelClicked -= TriggerToast;
-            MapRenderer.OnParcelHold -= TriggerToast;
             CommonScriptableObjects.playerCoords.OnChange -= UpdateCurrentSceneData;
             navmapVisible.OnChange -= OnNavmapVisibleChanged;
             closeAction.OnTriggered += OnCloseAction;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -49,7 +49,7 @@ namespace DCL
             toastView.OnGotoClicked += () => navmapVisible.Set(false);
 
             MapRenderer.OnParcelClicked += TriggerToast;
-            MapRenderer.OnCursorFarFromParcel += () => { toastView.OnCloseClick(); };
+            MapRenderer.OnCursorFarFromParcel += CloseToast;
             CommonScriptableObjects.playerCoords.OnChange += UpdateCurrentSceneData;
             closeAction.OnTriggered += OnCloseAction;
             navmapVisible.OnChange += OnNavmapVisibleChanged;
@@ -72,6 +72,7 @@ namespace DCL
         private void OnDestroy()
         {
             MapRenderer.OnParcelClicked -= TriggerToast;
+            MapRenderer.OnCursorFarFromParcel -= CloseToast;
             CommonScriptableObjects.playerCoords.OnChange -= UpdateCurrentSceneData;
             navmapVisible.OnChange -= OnNavmapVisibleChanged;
             closeAction.OnTriggered += OnCloseAction;
@@ -183,6 +184,8 @@ namespace DCL
 
             toastView.Populate(new Vector2Int(cursorTileX, cursorTileY), sceneInfo);
         }
+
+        private void CloseToast() { toastView.OnCloseClick(); }
 
         public void SetExitButtonActive(bool isActive) { closeButton.gameObject.SetActive(isActive); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Tests/NavmapToastViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Tests/NavmapToastViewShould.cs
@@ -28,7 +28,6 @@ namespace Tests
 
             controller = new MinimapHUDController();
             navmapView = Object.FindObjectOfType<NavmapView>();
-            Debug.Log("Navmapview is null? " + navmapView);
             navmapToastView = navmapView.toastView;
 
             if (!DataStore.i.HUDs.navmapVisible.Get())

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Tests/NavmapToastViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Tests/NavmapToastViewShould.cs
@@ -11,14 +11,24 @@ namespace Tests
     {
         NavmapToastView navmapToastView;
         private NavmapView navmapView;
+        private MinimapHUDController controller;
 
+        protected override List<GameObject> SetUp_LegacySystems()
+        {
+            List<GameObject> result = new List<GameObject>();
+            result.Add(MainSceneFactory.CreateNavMap());
+            return result;
+        }
+        
         [UnitySetUp]
         protected override IEnumerator SetUp()
         {
             yield return base.SetUp();
             yield return null;
 
+            controller = new MinimapHUDController();
             navmapView = Object.FindObjectOfType<NavmapView>();
+            Debug.Log("Navmapview is null? " + navmapView);
             navmapToastView = navmapView.toastView;
 
             if (!DataStore.i.HUDs.navmapVisible.Get())
@@ -27,12 +37,11 @@ namespace Tests
 
         protected override IEnumerator TearDown()
         {
+            controller.Dispose();
             yield return base.TearDown();
         }
 
         [Test]
-        [Explicit("Broke with Legacy suite refactor, fix later")]
-        [Category("Explicit")]
         public void CloseWhenCloseButtonIsClicked()
         {
             var sceneInfo = new MinimapMetadata.MinimapSceneInfo()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -17,20 +17,18 @@ namespace DCL
         const int WORLDMAP_WIDTH_IN_PARCELS = 300;
         const string MINIMAP_USER_ICONS_POOL_NAME = "MinimapUserIconsPool";
         const int MINIMAP_USER_ICONS_MAX_PREWARM = 30;
+        private const int MAX_CURSOR_PARCEL_DISTANCE = 40;
         private int NAVMAP_CHUNK_LAYER;
 
         public static MapRenderer i { get; private set; }
 
         [SerializeField] private float parcelHightlightScale = 1.25f;
-        [SerializeField] private float parcelHoldTimeInSeconds = 1f;
         [SerializeField] private Button ParcelHighlightButton;
         private float parcelSizeInMap;
         private Vector3Variable playerWorldPosition => CommonScriptableObjects.playerWorldPosition;
         private Vector3Variable playerRotation => CommonScriptableObjects.cameraForward;
         private Vector3[] mapWorldspaceCorners = new Vector3[4];
         private Vector3 worldCoordsOriginInMap;
-        private Vector3 lastCursorMapCoords;
-        private float parcelHoldCountdown;
         private List<RaycastResult> uiRaycastResults = new List<RaycastResult>();
         private PointerEventData uiRaycastPointerEventData = new PointerEventData(EventSystem.current);
 
@@ -58,6 +56,7 @@ namespace DCL
         private Dictionary<MinimapMetadata.MinimapSceneInfo, GameObject> scenesOfInterestMarkers = new Dictionary<MinimapMetadata.MinimapSceneInfo, GameObject>();
         private Dictionary<string, PoolableObject> usersInfoMarkers = new Dictionary<string, PoolableObject>();
 
+        private Vector3 lastClickedCursorMapCoords;
         private Pool usersInfoPool;
 
         private bool parcelHighlightEnabledValue = false;
@@ -78,8 +77,7 @@ namespace DCL
         }
 
         public static System.Action<int, int> OnParcelClicked;
-        public static System.Action<int, int> OnParcelHold;
-        public static System.Action OnParcelHoldCancel;
+        public static System.Action OnCursorFarFromParcel;
 
         private BaseDictionary<string, Player> otherPlayers => DataStore.i.player.otherPlayers;
 
@@ -115,8 +113,6 @@ namespace DCL
             playerRotation.OnChange += OnCharacterRotate;
 
             parcelHighlightImage.rectTransform.localScale = new Vector3(parcelHightlightScale, parcelHightlightScale, 1f);
-
-            parcelHoldCountdown = parcelHoldTimeInSeconds;
 
             usersPositionMarkerController = new MapGlobalUsersPositionMarkerController(globalUserMarkerPrefab,
                 globalUserMarkerContainer,
@@ -190,8 +186,6 @@ namespace DCL
             UpdateParcelHighlight();
 
             UpdateParcelHold();
-
-            lastCursorMapCoords = cursorMapCoords;
         }
 
         void UpdateCursorMapCoords()
@@ -244,24 +238,9 @@ namespace DCL
 
         void UpdateParcelHold()
         {
-            if (cursorMapCoords == lastCursorMapCoords)
+            if(Vector3.Distance(lastClickedCursorMapCoords, cursorMapCoords) > MAX_CURSOR_PARCEL_DISTANCE)
             {
-                if (parcelHoldCountdown <= 0f)
-                    return;
-
-                parcelHoldCountdown -= Time.deltaTime;
-
-                if (parcelHoldCountdown <= 0)
-                {
-                    parcelHoldCountdown = 0f;
-                    highlightedParcelText.text = string.Empty;
-                    OnParcelHold?.Invoke((int)cursorMapCoords.x, (int)cursorMapCoords.y);
-                }
-            }
-            else
-            {
-                parcelHoldCountdown = parcelHoldTimeInSeconds;
-                OnParcelHoldCancel?.Invoke();
+                OnCursorFarFromParcel?.Invoke();
             }
         }
 
@@ -389,6 +368,7 @@ namespace DCL
         public void ClickMousePositionParcel()
         {
             highlightedParcelText.text = string.Empty;
+            lastClickedCursorMapCoords = new Vector3((int)cursorMapCoords.x, (int)cursorMapCoords.y, 0);
             OnParcelClicked?.Invoke((int)cursorMapCoords.x, (int)cursorMapCoords.y);
         }
     }


### PR DESCRIPTION
## What does this PR change?

Closes #1750

removes the mouse hold on parcels event in the map
Forces the parcel toast to appear only on the parcel click
Adds the auto closure of the toast when the cursor is at least 40 parcels away
Restores an old explicit test


## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/remove-mouse-over-on-map
2. Open the map
3. Test the toast opening and closing with the new behavior

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
