### PR TITLE
fix: added avatar name in hide gameobject list

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -82,7 +82,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameObjectsToToggle:
-  - {fileID: 7509157592280631724}
+  - {fileID: 5916271607637106390}
   - {fileID: 5854254909640412467}
   - {fileID: 5582000225371496597}
 --- !u!1 &5582000225371496597
@@ -533,15 +533,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c53ec74589327644bba45b4054fb78dc, type: 3}
---- !u!1 &7509157592280631724 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3778843143832927354, guid: c53ec74589327644bba45b4054fb78dc,
-    type: 3}
-  m_PrefabInstance: {fileID: 6648657593541883350}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4161845772322530390 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
+    type: 3}
+  m_PrefabInstance: {fileID: 6648657593541883350}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5916271607637106390 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1035290754004822784, guid: c53ec74589327644bba45b4054fb78dc,
     type: 3}
   m_PrefabInstance: {fileID: 6648657593541883350}
   m_PrefabAsset: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -82,7 +82,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameObjectsToToggle:
-  - {fileID: 0}
+  - {fileID: 7509157592280631724}
   - {fileID: 5854254909640412467}
   - {fileID: 5582000225371496597}
 --- !u!1 &5582000225371496597
@@ -533,6 +533,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c53ec74589327644bba45b4054fb78dc, type: 3}
+--- !u!1 &7509157592280631724 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3778843143832927354, guid: c53ec74589327644bba45b4054fb78dc,
+    type: 3}
+  m_PrefabInstance: {fileID: 6648657593541883350}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4161845772322530390 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -1,5 +1,38 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1776317465262857995
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8731731711895383798}
+  m_Layer: 23
+  m_Name: AvatarHideableObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8731731711895383798
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1776317465262857995}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4161845772322530390}
+  - {fileID: 4675848658069725358}
+  - {fileID: 4331657482804467835}
+  m_Father: {fileID: 2842120016485600253}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3389185268529299172
 GameObject:
   m_ObjectHideFlags: 0
@@ -30,12 +63,10 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 4331657482804467835}
   - {fileID: 6301578636949877838}
-  - {fileID: 4675848658069725358}
   - {fileID: 80406326182283783}
   - {fileID: 3553539495342899975}
-  - {fileID: 4161845772322530390}
+  - {fileID: 8731731711895383798}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -82,9 +113,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameObjectsToToggle:
-  - {fileID: 5916271607637106390}
-  - {fileID: 5854254909640412467}
-  - {fileID: 5582000225371496597}
+  - {fileID: 1776317465262857995}
 --- !u!1 &5582000225371496597
 GameObject:
   m_ObjectHideFlags: 0
@@ -112,13 +141,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5582000225371496597}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1553297373313799886}
-  m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 2
+  m_Father: {fileID: 8731731711895383798}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7373291436495039860
 MonoBehaviour:
@@ -229,7 +258,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 4
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5854254909640412467
 GameObject:
@@ -256,12 +285,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5854254909640412467}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
   m_Children: []
-  m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 0
+  m_Father: {fileID: 8731731711895383798}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3865137627712764486
 MonoBehaviour:
@@ -399,7 +428,7 @@ Transform:
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
   m_Children: []
   m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &7755590202629118220
 BoxCollider:
@@ -439,7 +468,7 @@ PrefabInstance:
     - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
         type: 3}
@@ -504,7 +533,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2842120016485600253}
+    m_TransformParent: {fileID: 8731731711895383798}
     m_Modifications:
     - target: {fileID: 3778843143832927354, guid: c53ec74589327644bba45b4054fb78dc,
         type: 3}
@@ -514,7 +543,22 @@ PrefabInstance:
     - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
         type: 3}
@@ -531,17 +575,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8559866741916390979, guid: c53ec74589327644bba45b4054fb78dc,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c53ec74589327644bba45b4054fb78dc, type: 3}
 --- !u!4 &4161845772322530390 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
-    type: 3}
-  m_PrefabInstance: {fileID: 6648657593541883350}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &5916271607637106390 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1035290754004822784, guid: c53ec74589327644bba45b4054fb78dc,
     type: 3}
   m_PrefabInstance: {fileID: 6648657593541883350}
   m_PrefabAsset: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
@@ -221,7 +221,7 @@ public class BodyShapeController : WearableController, IBodyShapeController
     {
         //NOTE(Mordi): Adds handler for animation events, and passes in the audioContainer for the avatar
         AvatarAnimationEventHandler animationEventHandler = createdAnimation.gameObject.AddComponent<AvatarAnimationEventHandler>();
-        AudioContainer audioContainer = container.transform.parent.parent.GetComponentInChildren<AudioContainer>();
+        AudioContainer audioContainer = container.transform.parent.parent.parent.GetComponentInChildren<AudioContainer>();
         if (audioContainer != null)
         {
             animationEventHandler.Init(audioContainer);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
@@ -82,6 +82,37 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &2859035944831098904
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2293322081122938220}
+  m_Layer: 16
+  m_Name: AvatarHideableObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2293322081122938220
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2859035944831098904}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6758273427026275198}
+  m_Father: {fileID: 6922703132412175459}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3711435650905816617
 GameObject:
   m_ObjectHideFlags: 0
@@ -113,8 +144,8 @@ Transform:
   m_LocalPosition: {x: 0, y: -1.6, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 6922703132412175459}
-  m_RootOrder: 1
+  m_Father: {fileID: 2293322081122938220}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4484426042789304097
 MonoBehaviour:
@@ -165,8 +196,8 @@ MonoBehaviour:
   eyeMaterial: {fileID: 2100000, guid: fcfa021e0982c0840aaefe7411340f7f, type: 2}
   eyebrowMaterial: {fileID: 2100000, guid: db9e974bee285614b8ea2d8832d1a563, type: 2}
   mouthMaterial: {fileID: 2100000, guid: aa8f029bd537edb44b72b4737ca9b81d, type: 2}
-  lodRenderer: {fileID: 0}
-  lodMeshFilter: {fileID: 0}
+  impostorRenderer: {fileID: 0}
+  impostorMeshFilter: {fileID: 0}
   isLoading: 0
 --- !u!114 &2374946182991755626
 MonoBehaviour:
@@ -196,6 +227,7 @@ MonoBehaviour:
   particlePrefab: {fileID: 6770550120539757041, guid: 672039325d1b74c9aab6155bf97154bd,
     type: 3}
   followAvatar: 0
+  ignoreIfFaraway: 1
 --- !u!1 &4323503760844960451
 GameObject:
   m_ObjectHideFlags: 0
@@ -224,7 +256,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6922703132412175459}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5357437800171952595
 GameObject:
@@ -255,7 +287,7 @@ Transform:
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
   m_Children: []
   m_Father: {fileID: 6922703132412175459}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &7115442889188564318
 BoxCollider:
@@ -299,7 +331,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6922703132412175459}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8788203599366875970
 MonoBehaviour:
@@ -348,11 +380,11 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1248863400464373723}
-  - {fileID: 6758273427026275198}
   - {fileID: 7578571033673015707}
   - {fileID: 2958890434058661020}
   - {fileID: 4710899382381041556}
   - {fileID: 8397923773477180334}
+  - {fileID: 2293322081122938220}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -431,7 +463,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameObjectsToToggle:
-  - {fileID: 3711435650905816617}
+  - {fileID: 2859035944831098904}
 --- !u!114 &8266689621276731347
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -560,7 +592,7 @@ PrefabInstance:
     - target: {fileID: 6559289174053957746, guid: d3178cc2fd4e9c84d8c74c3984a0b853,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6559289174053957746, guid: d3178cc2fd4e9c84d8c74c3984a0b853,
         type: 3}


### PR DESCRIPTION
## What does this PR change?

Fix #1782
Hides avatar names in HIDE_AVATARS modified areas

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/hide-nametags-in-modifier&position=-134%2C74
2. Go to the tennis court inside
3. Verify that other players are entirely hidden and even their name disappears

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
