### PR TITLE
fix: loading stuck on unity editor (macos)

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -411,10 +411,19 @@ namespace UnityGLTF
 
         bool IDownloadQueueElement.ShouldPrioritizeDownload() { return prioritizeDownload; }
 
-        bool IDownloadQueueElement.ShouldForceDownload() { return mainCamera == null; }
+        bool IDownloadQueueElement.ShouldForceDownload()
+        {
+#if UNITY_EDITOR_OSX
+            return false;
+#endif
+            return mainCamera == null;
+        }
 
         float IDownloadQueueElement.GetSqrDistance()
         {
+            if (mainCamera == null)
+                return 0;
+            
             Vector3 cameraPosition = mainCamera.transform.position;
             Vector3 gltfPosition = transform.position;
             gltfPosition.y = cameraPosition.y;


### PR DESCRIPTION
## What does this PR change?

Fixes #1800

Disabled unlimited concurrent GLTF downloads.

## How to test the changes?

Uncheck `Msg Step by Step` this forced message queue to work 1 by 1.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
