### PR TITLE
Revert "fix: main player comms reported rotation (#1783)"

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -522,7 +522,7 @@ public class DCLCharacterController : MonoBehaviour
         float height = 0.875f;
 
         var reportPosition = characterPosition.worldPosition + (Vector3.up * height);
-        var compositeRotation = Quaternion.LookRotation(characterForward.HasValue() ? characterForward.Get().Value :cameraForward.Get());
+        var compositeRotation = Quaternion.LookRotation(cameraForward.Get());
         var playerHeight = height + (characterController.height / 2);
 
         //NOTE(Brian): We have to wait for a Teleport before sending the ReportPosition, because if not ReportPosition events will be sent


### PR DESCRIPTION
This reverts commit d269cb61efc917bc6f1a2c9c38fa99a986daba1f.

Revert https://github.com/decentraland/unity-renderer/pull/1783

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
