### PR TITLE
fix: main player comms reported rotation

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -524,6 +524,7 @@ public class DCLCharacterController : MonoBehaviour
         var reportPosition = characterPosition.worldPosition + (Vector3.up * height);
         var compositeRotation = Quaternion.LookRotation(characterForward.HasValue() ? characterForward.Get().Value :cameraForward.Get());
         var playerHeight = height + (characterController.height / 2);
+        var cameraRotation = Quaternion.LookRotation(cameraForward.Get());
 
         //NOTE(Brian): We have to wait for a Teleport before sending the ReportPosition, because if not ReportPosition events will be sent
         //             When the spawn point is being selected / scenes being prepared to be sent and the Kernel gets crazy.
@@ -532,7 +533,7 @@ public class DCLCharacterController : MonoBehaviour
         //                  - Scenes not being sent for loading, making ActivateRenderer never being sent, only in WSS mode.
         //                  - Random teleports to 0,0 or other positions that shouldn't happen.
         if (initialPositionAlreadySet)
-            DCL.Interface.WebInterface.ReportPosition(reportPosition, compositeRotation, playerHeight);
+            DCL.Interface.WebInterface.ReportPosition(reportPosition, compositeRotation, playerHeight, cameraRotation);
 
         lastMovementReportTime = DCLTime.realtimeSinceStartup;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.asmdef
@@ -1,33 +1,34 @@
 {
-  "name": "CharacterControllerTests",
-  "rootNamespace": "",
-  "references": [
-    "GUID:e555144732b726c4cba5b0f6337fea75",
-    "GUID:54b09a4a10c111e46a817873fcea53fe",
-    "GUID:cc6bfabbfe87b7949aa248893f89ce37",
-    "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-    "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
-    "GUID:ef84d7ce90ba34f07be26ace428e9bc8",
-    "GUID:27619889b8ba8c24980f49ee34dbb44a",
-    "GUID:0acc523941302664db1f4e527237feb3",
-    "GUID:a881b57670b1d2747a6d7f9e32b63230",
-    "GUID:a78c5d8dad39efe45ab1b21901f8db0f",
-    "GUID:1dd0780aa6be12b428c8005d0bee46b8",
-    "GUID:97d8897529779cb49bebd400c7f402a6",
-    "GUID:bd51ff2b035ce4ab4be7c38c43c88889"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": true,
-  "precompiledReferences": [
-    "nunit.framework.dll",
-    "Newtonsoft.Json.dll"
-  ],
-  "autoReferenced": false,
-  "defineConstraints": [
-    "UNITY_INCLUDE_TESTS"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "CharacterControllerTests",
+    "rootNamespace": "",
+    "references": [
+        "GUID:e555144732b726c4cba5b0f6337fea75",
+        "GUID:54b09a4a10c111e46a817873fcea53fe",
+        "GUID:cc6bfabbfe87b7949aa248893f89ce37",
+        "GUID:b1087c5731ff68448a0a9c625bb7e52d",
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
+        "GUID:ef84d7ce90ba34f07be26ace428e9bc8",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:a881b57670b1d2747a6d7f9e32b63230",
+        "GUID:a78c5d8dad39efe45ab1b21901f8db0f",
+        "GUID:1dd0780aa6be12b428c8005d0bee46b8",
+        "GUID:97d8897529779cb49bebd400c7f402a6",
+        "GUID:bd51ff2b035ce4ab4be7c38c43c88889",
+        "GUID:4973650d2444c4561a15d50f24d91cd9"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "Newtonsoft.Json.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.cs
@@ -1,14 +1,17 @@
-using DCL.Components;
-using DCL.Configuration;
-using DCL.Helpers;
-using Newtonsoft.Json;
-using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
 using DCL;
+using DCL.Components;
+using DCL.Configuration;
 using DCL.Controllers;
+using DCL.Helpers;
+using DCL.Interface;
+using DCL.Models;
+using Newtonsoft.Json;
+using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using Assert = UnityEngine.Assertions.Assert;
 
 namespace Tests
 {
@@ -44,7 +47,7 @@ namespace Tests
 
             DCLCharacterController.i.Teleport(JsonUtility.ToJson(position));
 
-            UnityEngine.Assertions.Assert.AreApproximatelyEqual(0, Vector3.Distance(DCLCharacterController.i.characterPosition.worldPosition, position), 2.0f);
+            Assert.AreApproximatelyEqual(0, Vector3.Distance(DCLCharacterController.i.characterPosition.worldPosition, position), 2.0f);
 
             yield return null;
         }
@@ -59,7 +62,7 @@ namespace Tests
         [UnityTest]
         public IEnumerator CharacterAdjustPosition()
         {
-            UnityEngine.Assertions.Assert.AreApproximatelyEqual(0,
+            Assert.AreApproximatelyEqual(0,
                 Vector3.Distance(Vector3.zero,
                     CommonScriptableObjects.worldOffset), 0.05f);
 
@@ -80,7 +83,7 @@ namespace Tests
             };
 
             yield return InitCharacterPosition(pos2, true);
-            UnityEngine.Assertions.Assert.AreApproximatelyEqual(0, Vector3.Distance(new Vector3(50f, 2f, 50f), DCLCharacterController.i.transform.position), 0.5f);
+            Assert.AreApproximatelyEqual(0, Vector3.Distance(new Vector3(50f, 2f, 50f), DCLCharacterController.i.transform.position), 0.5f);
 
             var pos3 = new Vector3
             {
@@ -90,7 +93,7 @@ namespace Tests
             };
 
             yield return InitCharacterPosition(pos3, true);
-            Assert.AreEqual(new Vector3(-50f, 2f, -50f), DCLCharacterController.i.transform.position);
+            NUnit.Framework.Assert.AreEqual(new Vector3(-50f, 2f, -50f), DCLCharacterController.i.transform.position);
         }
 
         [UnityTest]
@@ -99,7 +102,7 @@ namespace Tests
         public IEnumerator CharacterIsNotParentedOnWorldReposition()
         {
             // We use a shape that represents a static ground and has collisions
-            TestUtils.InstantiateEntityWithShape(scene, "groundShape", DCL.Models.CLASS_ID.PLANE_SHAPE, Vector3.zero);
+            TestUtils.InstantiateEntityWithShape(scene, "groundShape", CLASS_ID.PLANE_SHAPE, Vector3.zero);
             var shapeEntity = scene.entities["groundShape"];
 
             // Reposition ground shape to be on the world-reposition-limit
@@ -121,7 +124,7 @@ namespace Tests
 
             yield return WaitUntilGrounded();
 
-            Assert.IsTrue(DCLCharacterController.i.groundTransform == shapeEntity.meshRootGameObject.transform);
+            NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.groundTransform == shapeEntity.meshRootGameObject.transform);
 
             // Place the character barely passing the limits to trigger the world repositioning
             DCLCharacterController.i.Teleport(JsonConvert.SerializeObject(new
@@ -134,18 +137,18 @@ namespace Tests
             yield return null;
 
             // check if the character got repositioned correctly
-            Assert.AreEqual(new Vector3(1f, DCLCharacterController.i.transform.position.y, 1f), DCLCharacterController.i.transform.position);
+            NUnit.Framework.Assert.AreEqual(new Vector3(1f, DCLCharacterController.i.transform.position.y, 1f), DCLCharacterController.i.transform.position);
 
             // check it's not parented but still has the same ground
-            Assert.IsTrue(DCLCharacterController.i.groundTransform == shapeEntity.meshRootGameObject.transform);
-            Assert.IsTrue(DCLCharacterController.i.transform.parent == null);
+            NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.groundTransform == shapeEntity.meshRootGameObject.transform);
+            NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.transform.parent == null);
         }
 
         [UnityTest]
         public IEnumerator Character_UpdateSOPosition()
         {
             yield return InitCharacterPosition(50, 2, 0);
-            Assert.AreEqual(new Vector3(50f, 2f, 0f), CommonScriptableObjects.playerUnityPosition.Get());
+            NUnit.Framework.Assert.AreEqual(new Vector3(50f, 2f, 0f), CommonScriptableObjects.playerUnityPosition.Get());
         }
 
         [UnityTest]
@@ -160,12 +163,12 @@ namespace Tests
             Cursor.lockState = CursorLockMode.Locked;
             yield return new WaitForSeconds(0.1f);
 
-            Assert.AreEqual(DCLCharacterController.i.transform.eulerAngles, CommonScriptableObjects.playerUnityEulerAngles);
+            NUnit.Framework.Assert.AreEqual(DCLCharacterController.i.transform.eulerAngles, CommonScriptableObjects.playerUnityEulerAngles);
             DCLCharacterController.i.ResumeGravity();
         }
 
         [UnityTest]
-        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterSupportsMovingPlatforms()
         {
@@ -179,20 +182,20 @@ namespace Tests
             yield return InitCharacterPosition(originalCharacterPosition);
 
             string platformEntityId = "movingPlatform";
-            TestUtils.InstantiateEntityWithShape(scene, platformEntityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(2f, 1f, 8f));
+            TestUtils.InstantiateEntityWithShape(scene, platformEntityId, CLASS_ID.BOX_SHAPE, new Vector3(2f, 1f, 8f));
 
             Transform platformTransform = scene.entities[platformEntityId].gameObject.transform;
             platformTransform.localScale = new Vector3(2f, 0.5f, 2f);
 
             yield return null;
-            Assert.IsTrue(Vector3.Distance(platformTransform.position, new Vector3(2f, 1f, 8f)) < 0.1f);
+            NUnit.Framework.Assert.IsTrue(Vector3.Distance(platformTransform.position, new Vector3(2f, 1f, 8f)) < 0.1f);
 
             // enable character gravity
             DCLCharacterController.i.ResumeGravity();
 
             yield return WaitUntilGrounded();
 
-            Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
+            NUnit.Framework.Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
 
             // Lerp the platform's position
             float lerpTime = 0f;
@@ -216,22 +219,22 @@ namespace Tests
 
                 if (!checkedParent && lerpTime >= 0.25f)
                 {
-                    Assert.IsTrue(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true when the platform moves/rotates");
+                    NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true when the platform moves/rotates");
                     checkedParent = true;
                 }
             }
 
             // check positions
-            Assert.IsTrue(Vector3.Distance(platformTransform.position, targetPosition) < 0.1f);
+            NUnit.Framework.Assert.IsTrue(Vector3.Distance(platformTransform.position, targetPosition) < 0.1f);
 
             float dist1 = Vector3.Distance(originalCharacterPosition, DCLCharacterController.i.transform.position);
             float dist2 = Vector3.Distance(originalPosition, targetPosition);
 
-            UnityEngine.Assertions.Assert.AreApproximatelyEqual(dist1, dist2, 1f);
+            Assert.AreApproximatelyEqual(dist1, dist2, 1f);
         }
 
         [UnityTest]
-        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterSupportsRotatingPlatforms()
         {
@@ -245,20 +248,20 @@ namespace Tests
             yield return InitCharacterPosition(originalCharacterPosition);
 
             string platformEntityId = "rotatingPlatform";
-            TestUtils.InstantiateEntityWithShape(scene, platformEntityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(8f, 1f, 8f));
+            TestUtils.InstantiateEntityWithShape(scene, platformEntityId, CLASS_ID.BOX_SHAPE, new Vector3(8f, 1f, 8f));
 
             Transform platformTransform = scene.entities[platformEntityId].gameObject.transform;
             platformTransform.localScale = new Vector3(8f, 0.5f, 8f);
 
             yield return null;
-            Assert.IsTrue(Vector3.Distance(platformTransform.position, new Vector3(8f, 1f, 8f)) < 0.1f);
+            NUnit.Framework.Assert.IsTrue(Vector3.Distance(platformTransform.position, new Vector3(8f, 1f, 8f)) < 0.1f);
 
             // enable character gravity
             DCLCharacterController.i.ResumeGravity();
 
             yield return WaitUntilGrounded();
 
-            Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
+            NUnit.Framework.Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
 
             var initialDirection = CommonScriptableObjects.characterForward.Get().Value;
             // Lerp the platform's rotation
@@ -280,33 +283,33 @@ namespace Tests
 
                 if (!checkedParent && lerpTime >= 0.5f)
                 {
-                    Assert.IsTrue(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true when the platform moves/rotates");
+                    NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true when the platform moves/rotates");
 
                     checkedParent = true;
                 }
             }
 
             // check positions
-            Assert.IsTrue(Vector3.Distance(platformTransform.rotation.eulerAngles, targetRotation.eulerAngles) < 0.1f);
+            NUnit.Framework.Assert.IsTrue(Vector3.Distance(platformTransform.rotation.eulerAngles, targetRotation.eulerAngles) < 0.1f);
 
-            UnityEngine.Assertions.Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.x, 11f, 1f);
-            UnityEngine.Assertions.Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.z, 11f, 1f);
+            Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.x, 11f, 1f);
+            Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.z, 11f, 1f);
 
             //test for rotation
             var currentDirection = CommonScriptableObjects.characterForward.Get().Value;
             var expectedDirection = Quaternion.AngleAxis(180, Vector3.up) * initialDirection;
             var rotationIsExpected = Vector3.Distance(currentDirection, expectedDirection) <= 0.05f;
-            UnityEngine.Assertions.Assert.IsTrue(rotationIsExpected, "character is rotated");
+            Assert.IsTrue(rotationIsExpected, "character is rotated");
 
             // remove platform and check character parent
             TestUtils.RemoveSceneEntity(scene, platformEntityId);
             yield return null;
 
-            Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be false as there's no platform anymore");
+            NUnit.Framework.Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be false as there's no platform anymore");
         }
 
         [UnityTest]
-        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnEntityRemoval()
         {
@@ -319,11 +322,11 @@ namespace Tests
             yield return null;
             yield return null;
 
-            Assert.IsNull(DCLCharacterController.i.transform.parent, "The character shouldn't be parented as there's no platform anymore");
+            NUnit.Framework.Assert.IsNull(DCLCharacterController.i.transform.parent, "The character shouldn't be parented as there's no platform anymore");
         }
 
         [UnityTest]
-        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnPlatformCollisionToggle()
         {
@@ -340,11 +343,11 @@ namespace Tests
             yield return null;
             yield return null;
 
-            Assert.IsNull(DCLCharacterController.i.transform.parent, "The character shouldn't be parented as the shape colliders were disabled");
+            NUnit.Framework.Assert.IsNull(DCLCharacterController.i.transform.parent, "The character shouldn't be parented as the shape colliders were disabled");
         }
 
         [UnityTest]
-        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnShapeRemoval()
         {
@@ -358,7 +361,33 @@ namespace Tests
             yield return null;
             yield return null;
 
-            Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be false when the shape colliders are disabled");
+            NUnit.Framework.Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be false when the shape colliders are disabled");
         }
+        
+        [UnityTest]
+        public IEnumerator ReportCameraRotationCorrectly()
+        {
+            yield return InitCharacterPosition(50, 2, 0);
+            CommonScriptableObjects.characterForward.Set(Vector3.back);
+            CommonScriptableObjects.cameraForward.Set(Vector3.right);
+            Quaternion cameraRotation = Quaternion.LookRotation(CommonScriptableObjects.cameraForward.Get());
+            DCLCharacterController.i.SetPosition(new Vector3(51, 2, 0));
+
+            bool rotationMatch = false;
+            void OnMessageFromEngine(string type, string payload)
+            {
+                if (type == "ReportPosition")
+                {
+                    var reportPayload = JsonUtility.FromJson<WebInterface.ReportPositionPayload>(payload);
+                    rotationMatch = cameraRotation.eulerAngles == reportPayload.cameraRotation.eulerAngles;
+                }
+            }
+
+            WebInterface.OnMessageFromEngine += OnMessageFromEngine;
+            yield return null;
+            WebInterface.OnMessageFromEngine -= OnMessageFromEngine;
+            
+            Assert.IsTrue(rotationMatch);
+        }        
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.cs
@@ -1,17 +1,15 @@
+using DCL.Components;
+using DCL.Configuration;
+using DCL.Helpers;
+using Newtonsoft.Json;
+using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
 using DCL;
-using DCL.Components;
-using DCL.Configuration;
 using DCL.Controllers;
-using DCL.Helpers;
 using DCL.Interface;
-using DCL.Models;
-using Newtonsoft.Json;
-using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Assert = UnityEngine.Assertions.Assert;
 
 namespace Tests
 {
@@ -47,7 +45,7 @@ namespace Tests
 
             DCLCharacterController.i.Teleport(JsonUtility.ToJson(position));
 
-            Assert.AreApproximatelyEqual(0, Vector3.Distance(DCLCharacterController.i.characterPosition.worldPosition, position), 2.0f);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(0, Vector3.Distance(DCLCharacterController.i.characterPosition.worldPosition, position), 2.0f);
 
             yield return null;
         }
@@ -62,7 +60,7 @@ namespace Tests
         [UnityTest]
         public IEnumerator CharacterAdjustPosition()
         {
-            Assert.AreApproximatelyEqual(0,
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(0,
                 Vector3.Distance(Vector3.zero,
                     CommonScriptableObjects.worldOffset), 0.05f);
 
@@ -83,7 +81,7 @@ namespace Tests
             };
 
             yield return InitCharacterPosition(pos2, true);
-            Assert.AreApproximatelyEqual(0, Vector3.Distance(new Vector3(50f, 2f, 50f), DCLCharacterController.i.transform.position), 0.5f);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(0, Vector3.Distance(new Vector3(50f, 2f, 50f), DCLCharacterController.i.transform.position), 0.5f);
 
             var pos3 = new Vector3
             {
@@ -93,7 +91,7 @@ namespace Tests
             };
 
             yield return InitCharacterPosition(pos3, true);
-            NUnit.Framework.Assert.AreEqual(new Vector3(-50f, 2f, -50f), DCLCharacterController.i.transform.position);
+            Assert.AreEqual(new Vector3(-50f, 2f, -50f), DCLCharacterController.i.transform.position);
         }
 
         [UnityTest]
@@ -102,7 +100,7 @@ namespace Tests
         public IEnumerator CharacterIsNotParentedOnWorldReposition()
         {
             // We use a shape that represents a static ground and has collisions
-            TestUtils.InstantiateEntityWithShape(scene, "groundShape", CLASS_ID.PLANE_SHAPE, Vector3.zero);
+            TestUtils.InstantiateEntityWithShape(scene, "groundShape", DCL.Models.CLASS_ID.PLANE_SHAPE, Vector3.zero);
             var shapeEntity = scene.entities["groundShape"];
 
             // Reposition ground shape to be on the world-reposition-limit
@@ -124,7 +122,7 @@ namespace Tests
 
             yield return WaitUntilGrounded();
 
-            NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.groundTransform == shapeEntity.meshRootGameObject.transform);
+            Assert.IsTrue(DCLCharacterController.i.groundTransform == shapeEntity.meshRootGameObject.transform);
 
             // Place the character barely passing the limits to trigger the world repositioning
             DCLCharacterController.i.Teleport(JsonConvert.SerializeObject(new
@@ -137,18 +135,18 @@ namespace Tests
             yield return null;
 
             // check if the character got repositioned correctly
-            NUnit.Framework.Assert.AreEqual(new Vector3(1f, DCLCharacterController.i.transform.position.y, 1f), DCLCharacterController.i.transform.position);
+            Assert.AreEqual(new Vector3(1f, DCLCharacterController.i.transform.position.y, 1f), DCLCharacterController.i.transform.position);
 
             // check it's not parented but still has the same ground
-            NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.groundTransform == shapeEntity.meshRootGameObject.transform);
-            NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.transform.parent == null);
+            Assert.IsTrue(DCLCharacterController.i.groundTransform == shapeEntity.meshRootGameObject.transform);
+            Assert.IsTrue(DCLCharacterController.i.transform.parent == null);
         }
 
         [UnityTest]
         public IEnumerator Character_UpdateSOPosition()
         {
             yield return InitCharacterPosition(50, 2, 0);
-            NUnit.Framework.Assert.AreEqual(new Vector3(50f, 2f, 0f), CommonScriptableObjects.playerUnityPosition.Get());
+            Assert.AreEqual(new Vector3(50f, 2f, 0f), CommonScriptableObjects.playerUnityPosition.Get());
         }
 
         [UnityTest]
@@ -163,12 +161,12 @@ namespace Tests
             Cursor.lockState = CursorLockMode.Locked;
             yield return new WaitForSeconds(0.1f);
 
-            NUnit.Framework.Assert.AreEqual(DCLCharacterController.i.transform.eulerAngles, CommonScriptableObjects.playerUnityEulerAngles);
+            Assert.AreEqual(DCLCharacterController.i.transform.eulerAngles, CommonScriptableObjects.playerUnityEulerAngles);
             DCLCharacterController.i.ResumeGravity();
         }
 
         [UnityTest]
-        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterSupportsMovingPlatforms()
         {
@@ -182,20 +180,20 @@ namespace Tests
             yield return InitCharacterPosition(originalCharacterPosition);
 
             string platformEntityId = "movingPlatform";
-            TestUtils.InstantiateEntityWithShape(scene, platformEntityId, CLASS_ID.BOX_SHAPE, new Vector3(2f, 1f, 8f));
+            TestUtils.InstantiateEntityWithShape(scene, platformEntityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(2f, 1f, 8f));
 
             Transform platformTransform = scene.entities[platformEntityId].gameObject.transform;
             platformTransform.localScale = new Vector3(2f, 0.5f, 2f);
 
             yield return null;
-            NUnit.Framework.Assert.IsTrue(Vector3.Distance(platformTransform.position, new Vector3(2f, 1f, 8f)) < 0.1f);
+            Assert.IsTrue(Vector3.Distance(platformTransform.position, new Vector3(2f, 1f, 8f)) < 0.1f);
 
             // enable character gravity
             DCLCharacterController.i.ResumeGravity();
 
             yield return WaitUntilGrounded();
 
-            NUnit.Framework.Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
+            Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
 
             // Lerp the platform's position
             float lerpTime = 0f;
@@ -219,22 +217,22 @@ namespace Tests
 
                 if (!checkedParent && lerpTime >= 0.25f)
                 {
-                    NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true when the platform moves/rotates");
+                    Assert.IsTrue(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true when the platform moves/rotates");
                     checkedParent = true;
                 }
             }
 
             // check positions
-            NUnit.Framework.Assert.IsTrue(Vector3.Distance(platformTransform.position, targetPosition) < 0.1f);
+            Assert.IsTrue(Vector3.Distance(platformTransform.position, targetPosition) < 0.1f);
 
             float dist1 = Vector3.Distance(originalCharacterPosition, DCLCharacterController.i.transform.position);
             float dist2 = Vector3.Distance(originalPosition, targetPosition);
 
-            Assert.AreApproximatelyEqual(dist1, dist2, 1f);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(dist1, dist2, 1f);
         }
 
         [UnityTest]
-        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterSupportsRotatingPlatforms()
         {
@@ -248,20 +246,20 @@ namespace Tests
             yield return InitCharacterPosition(originalCharacterPosition);
 
             string platformEntityId = "rotatingPlatform";
-            TestUtils.InstantiateEntityWithShape(scene, platformEntityId, CLASS_ID.BOX_SHAPE, new Vector3(8f, 1f, 8f));
+            TestUtils.InstantiateEntityWithShape(scene, platformEntityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(8f, 1f, 8f));
 
             Transform platformTransform = scene.entities[platformEntityId].gameObject.transform;
             platformTransform.localScale = new Vector3(8f, 0.5f, 8f);
 
             yield return null;
-            NUnit.Framework.Assert.IsTrue(Vector3.Distance(platformTransform.position, new Vector3(8f, 1f, 8f)) < 0.1f);
+            Assert.IsTrue(Vector3.Distance(platformTransform.position, new Vector3(8f, 1f, 8f)) < 0.1f);
 
             // enable character gravity
             DCLCharacterController.i.ResumeGravity();
 
             yield return WaitUntilGrounded();
 
-            NUnit.Framework.Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
+            Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true only if the platform moves/rotates");
 
             var initialDirection = CommonScriptableObjects.characterForward.Get().Value;
             // Lerp the platform's rotation
@@ -283,33 +281,33 @@ namespace Tests
 
                 if (!checkedParent && lerpTime >= 0.5f)
                 {
-                    NUnit.Framework.Assert.IsTrue(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true when the platform moves/rotates");
+                    Assert.IsTrue(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be true when the platform moves/rotates");
 
                     checkedParent = true;
                 }
             }
 
             // check positions
-            NUnit.Framework.Assert.IsTrue(Vector3.Distance(platformTransform.rotation.eulerAngles, targetRotation.eulerAngles) < 0.1f);
+            Assert.IsTrue(Vector3.Distance(platformTransform.rotation.eulerAngles, targetRotation.eulerAngles) < 0.1f);
 
-            Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.x, 11f, 1f);
-            Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.z, 11f, 1f);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.x, 11f, 1f);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(DCLCharacterController.i.transform.position.z, 11f, 1f);
 
             //test for rotation
             var currentDirection = CommonScriptableObjects.characterForward.Get().Value;
             var expectedDirection = Quaternion.AngleAxis(180, Vector3.up) * initialDirection;
             var rotationIsExpected = Vector3.Distance(currentDirection, expectedDirection) <= 0.05f;
-            Assert.IsTrue(rotationIsExpected, "character is rotated");
+            UnityEngine.Assertions.Assert.IsTrue(rotationIsExpected, "character is rotated");
 
             // remove platform and check character parent
             TestUtils.RemoveSceneEntity(scene, platformEntityId);
             yield return null;
 
-            NUnit.Framework.Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be false as there's no platform anymore");
+            Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be false as there's no platform anymore");
         }
 
         [UnityTest]
-        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnEntityRemoval()
         {
@@ -322,11 +320,11 @@ namespace Tests
             yield return null;
             yield return null;
 
-            NUnit.Framework.Assert.IsNull(DCLCharacterController.i.transform.parent, "The character shouldn't be parented as there's no platform anymore");
+            Assert.IsNull(DCLCharacterController.i.transform.parent, "The character shouldn't be parented as there's no platform anymore");
         }
 
         [UnityTest]
-        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnPlatformCollisionToggle()
         {
@@ -343,11 +341,11 @@ namespace Tests
             yield return null;
             yield return null;
 
-            NUnit.Framework.Assert.IsNull(DCLCharacterController.i.transform.parent, "The character shouldn't be parented as the shape colliders were disabled");
+            Assert.IsNull(DCLCharacterController.i.transform.parent, "The character shouldn't be parented as the shape colliders were disabled");
         }
 
         [UnityTest]
-        [Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
         [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnShapeRemoval()
         {
@@ -361,9 +359,9 @@ namespace Tests
             yield return null;
             yield return null;
 
-            NUnit.Framework.Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be false when the shape colliders are disabled");
+            Assert.IsFalse(DCLCharacterController.i.isOnMovingPlatform, "isOnMovingPlatform should be false when the shape colliders are disabled");
         }
-        
+
         [UnityTest]
         public IEnumerator ReportCameraRotationCorrectly()
         {
@@ -388,6 +386,6 @@ namespace Tests
             WebInterface.OnMessageFromEngine -= OnMessageFromEngine;
             
             Assert.IsTrue(rotationMatch);
-        }        
+        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -28,8 +28,11 @@ namespace DCL.Interface
             /** Camera position, world space */
             public Vector3 position;
 
-            /** Camera rotation */
+            /** Character rotation */
             public Quaternion rotation;
+            
+            /** Camera rotation */
+            public Quaternion cameraRotation;
 
             /** Camera height, relative to the feet of the avatar or ground */
             public float playerHeight;
@@ -822,11 +825,12 @@ namespace DCL.Interface
             SendMessage("AllScenesEvent", allScenesEvent);
         }
 
-        public static void ReportPosition(Vector3 position, Quaternion rotation, float playerHeight)
+        public static void ReportPosition(Vector3 position, Quaternion rotation, float playerHeight, Quaternion cameraRotation)
         {
             positionPayload.position = position;
             positionPayload.rotation = rotation;
             positionPayload.playerHeight = playerHeight;
+            positionPayload.cameraRotation = cameraRotation;
 
             SendMessage("ReportPosition", positionPayload);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -23,7 +23,7 @@ namespace DCL.Interface
         public static bool VERBOSE = false;
 
         [System.Serializable]
-        private class ReportPositionPayload
+        public class ReportPositionPayload
         {
             /** Camera position, world space */
             public Vector3 position;


### PR DESCRIPTION
Fixes #476

WHY
Through comms we always report the CAMERA rotation but we should be reporting the CHARACTER rotation, otherwise when players are using the third person camera, they think the rest of the users see them in the direction they point their avatar but they actually see the rotation of the camera...

<s>kernel PR need to be merged first: https://github.com/decentraland/kernel/pull/181</s>