### PR TITLE
fix: duplicated keys in content mappings

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using DCL.Helpers;
 using System.Collections.Generic;
 using UnityEngine;
@@ -65,7 +66,13 @@ namespace DCL
             for (int i = 0; i < contents.Count; i++)
             {
                 MappingPair m = contents[i];
-                fileToHash.Add(m.file, m.hash);
+                var key = m.file.ToLower();
+                if (fileToHash.ContainsKey(key))
+                {
+                    Debug.Log($"Hash key: {key} already exists in the map");
+                    continue;
+                }
+                fileToHash.Add(key, m.hash);
 
                 if (VERBOSE)
                 {
@@ -92,7 +99,7 @@ namespace DCL
                 return false;
             }
 
-            return fileToHash.ContainsKey(url);
+            return fileToHash.ContainsKey(url.ToLower());
         }
 
         public virtual string GetContentsUrl(string url)
@@ -109,6 +116,7 @@ namespace DCL
 
         public virtual bool TryGetContentsUrl_Raw(string url, out string result)
         {
+            url = url.ToLower();
             result = url;
 
 #if UNITY_EDITOR
@@ -137,6 +145,7 @@ namespace DCL
 
         public virtual bool TryGetContentsUrl(string url, out string result)
         {
+            url = url.ToLower();
             result = url;
 
             if (HasTestSchema(url))
@@ -193,7 +202,7 @@ namespace DCL
                 return true;
             }
 
-            if (fileToHash.TryGetValue(file, out result))
+            if (fileToHash.TryGetValue(file.ToLower(), out result))
             {
                 return true;
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
@@ -65,7 +65,7 @@ namespace DCL
             for (int i = 0; i < contents.Count; i++)
             {
                 MappingPair m = contents[i];
-                fileToHash.Add(m.file.ToLower(), m.hash);
+                fileToHash.Add(m.file, m.hash);
 
                 if (VERBOSE)
                 {
@@ -92,7 +92,7 @@ namespace DCL
                 return false;
             }
 
-            return fileToHash.ContainsKey(url.ToLower());
+            return fileToHash.ContainsKey(url);
         }
 
         public virtual string GetContentsUrl(string url)
@@ -109,7 +109,6 @@ namespace DCL
 
         public virtual bool TryGetContentsUrl_Raw(string url, out string result)
         {
-            url = url.ToLower();
             result = url;
 
 #if UNITY_EDITOR
@@ -138,7 +137,6 @@ namespace DCL
 
         public virtual bool TryGetContentsUrl(string url, out string result)
         {
-            url = url.ToLower();
             result = url;
 
             if (HasTestSchema(url))
@@ -195,7 +193,7 @@ namespace DCL
                 return true;
             }
 
-            if (fileToHash.TryGetValue(file.ToLower(), out result))
+            if (fileToHash.TryGetValue(file, out result))
             {
                 return true;
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 963564a6af9c8704ea8f31c47752ea38
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderShould.cs
@@ -10,7 +10,7 @@ public class ContentProviderShould
     public void SetUp() { contentProvider = new ContentProvider(); }
 
     [Test]
-    public void BakeFilesWithTheSameToLowerName()
+    public void NotAddFilesWithTheSameCaseInsensitiveName()
     {
         contentProvider.contents = new List<ContentServerUtils.MappingPair>()
         {
@@ -24,11 +24,10 @@ public class ContentProviderShould
 
         Assert.IsTrue(contentProvider.fileToHash.ContainsKey("file1"));
         Assert.AreEqual(contentProvider.fileToHash["file1"], "file1Hash");
-        Assert.IsTrue(contentProvider.fileToHash.ContainsKey("File1"));
-        Assert.AreEqual(contentProvider.fileToHash["File1"], "File1Hash");
+        Assert.IsFalse(contentProvider.fileToHash.ContainsKey("File1"));
+
         Assert.IsTrue(contentProvider.fileToHash.ContainsKey("file2"));
         Assert.AreEqual(contentProvider.fileToHash["file2"], "file2Hash");
-        Assert.IsTrue(contentProvider.fileToHash.ContainsKey("File2"));
-        Assert.AreEqual(contentProvider.fileToHash["File2"], "File2Hash");
+        Assert.IsFalse(contentProvider.fileToHash.ContainsKey("File2"));
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderShould.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using DCL;
+using NUnit.Framework;
+
+public class ContentProviderShould
+{
+    private ContentProvider contentProvider;
+
+    [SetUp]
+    public void SetUp() { contentProvider = new ContentProvider(); }
+
+    [Test]
+    public void BakeFilesWithTheSameToLowerName()
+    {
+        contentProvider.contents = new List<ContentServerUtils.MappingPair>()
+        {
+            new ContentServerUtils.MappingPair { file = "file1", hash = "file1Hash" },
+            new ContentServerUtils.MappingPair { file = "File1", hash = "File1Hash" },
+            new ContentServerUtils.MappingPair { file = "file2", hash = "file2Hash" },
+            new ContentServerUtils.MappingPair { file = "File2", hash = "File2Hash" },
+        };
+
+        contentProvider.BakeHashes();
+
+        Assert.IsTrue(contentProvider.fileToHash.ContainsKey("file1"));
+        Assert.AreEqual(contentProvider.fileToHash["file1"], "file1Hash");
+        Assert.IsTrue(contentProvider.fileToHash.ContainsKey("File1"));
+        Assert.AreEqual(contentProvider.fileToHash["File1"], "File1Hash");
+        Assert.IsTrue(contentProvider.fileToHash.ContainsKey("file2"));
+        Assert.AreEqual(contentProvider.fileToHash["file2"], "file2Hash");
+        Assert.IsTrue(contentProvider.fileToHash.ContainsKey("File2"));
+        Assert.AreEqual(contentProvider.fileToHash["File2"], "File2Hash");
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1e3cc2a37f703e4a812af5e7f0b03b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderTests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "ContentProviderTests",
+    "rootNamespace": "",
+    "references": [
+        "GUID:b24824f3bc2a60641a01e2083614f802",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:6e6a87f97192ec947993f360104e75b7"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderTests.asmdef.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/Tests/ContentProviderTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 986603e51b617b24ca050498969b6913
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #1823 

## What does this PR change?

Handle duplications  exceptions in the content map hashing (because of the use `ToLower()` to the name) to prevent scenes from crashing the explorer.

## How to test the changes?
`-16,-126` surroundings are affected by this bug, test there but also extensively in other parts of the world, since this changes a core aspect of the project.