### PR TITLE
fix: scene ui not refreshing correctly when screen size changes

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/Tests/UIContainerStackTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/Tests/UIContainerStackTests.cs
@@ -153,6 +153,8 @@ namespace Tests
 
             //Screen resize event
             DataStore.i.screen.size.Set(desiredScreenSize);
+            // Size changes occurs on the next late update
+            yield return null;
 
             var currentSize = uiContainerStack.childHookRectTransform.rect.size;
             Assert.AreEqual(desiredScreenSize.x * widthPercent / 100f, currentSize.x, 0.01f, "UIContainer width after screen resize");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
@@ -169,7 +169,10 @@ namespace DCL.Components
                 layoutRefreshWatcher = CoroutineStarter.Start(LayoutRefreshWatcher());
         }
 
-        private void OnScreenResize(Vector2Int current, Vector2Int previous) => RefreshAll();
+        private void OnScreenResize(Vector2Int current, Vector2Int previous)
+        {
+            isLayoutDirty = GetRootParent() == this;
+        }
 
         public override int GetClassId() { return (int) CLASS_ID.UI_IMAGE_SHAPE; }
 


### PR DESCRIPTION
## What does this PR change?

`Fixes #1714 `
Looked like all the shapes were refreshing after another when screen size changed messing up the size. Now `UIShape` refreshes when its the root shape only.

## How to test the changes?

1. Go to wondermine (-29,55), resize the browser tab, the UI (bottom right) should stay where it was
2. Go to casinos and repeat
3. Another list of scenes: Wilderness : (-45, 107), Salmonomicon:  (-52, 1), Museum District: (15,80), Golfcraft: (47, -45)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
