### PR TITLE
fix: click on PEX icon while loading

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/PortableExperienceTaskbarItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/PortableExperienceTaskbarItem.cs
@@ -38,9 +38,10 @@ public class PortableExperienceTaskbarItem : MonoBehaviour
         button.Initialize();
         contextMenu.ConfigureMenu(portableExperienceId, portableExperienceName, taskbarController);
 
+        icon.color = Color.clear;
+
         if (!string.IsNullOrEmpty(portableExperienceIconUrl))
         {
-            icon.enabled = false;
             loading.SetActive(true);
             ThumbnailsManager.GetThumbnail(portableExperienceIconUrl, OnIconReady);
         }
@@ -51,7 +52,7 @@ public class PortableExperienceTaskbarItem : MonoBehaviour
         if (iconAsset != null)
         {
             icon.sprite = ThumbnailsManager.CreateSpriteFromTexture(iconAsset.texture);
-            icon.enabled = true;
+            icon.color = Color.white;
             loading.SetActive(false);
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Resources/PortableExperienceItem.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Resources/PortableExperienceItem.prefab
@@ -594,20 +594,20 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4507158153228174598}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 647c19a2d48324d368a4da9362adedad, type: 3}
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -1336,6 +1336,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4256949815693989084, guid: d565b61885fb1ef41b1582a285e748e9,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6176207359657508845, guid: d565b61885fb1ef41b1582a285e748e9,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}


### PR DESCRIPTION
context menu, for portable experiences, won't open on clicked while icon is still loading