### PR TITLE
fix: set collectibles as default backpack panel

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
@@ -1609,13 +1609,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3bbc2730e9cc849ef8ef058b2b5771ef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  closeAction: {fileID: 11400000, guid: 54539b42d809e284090ff4087d5c733b, type: 2}
   avatarEditorCanvas: {fileID: 3150290541654462636}
   avatarEditorCanvasGroup: {fileID: -2971377967518096820}
   navigationInfos:
   - toggle: {fileID: 3150290542716019958}
     canvas: {fileID: 3150290543018005860}
-    enabledByDefault: 1
+    enabledByDefault: 0
     focus: 0
   - toggle: {fileID: 3661532844623969922}
     canvas: {fileID: 3150290543101964660}
@@ -1685,6 +1684,11 @@ MonoBehaviour:
     canvas: {fileID: 6151202184307174224}
     enabledByDefault: 0
     focus: 1
+  defaultNavigationPanel:
+    toggle: {fileID: 0}
+    canvas: {fileID: 0}
+    enabledByDefault: 0
+    focus: 0
   wearableGridPairs:
   - categoryFilter: body_shape
     selector: {fileID: 3358252997386326019}
@@ -1721,7 +1725,7 @@ MonoBehaviour:
   collectiblesNavigationInfo:
     toggle: {fileID: 1039268970838228618}
     canvas: {fileID: 7406321907236003421}
-    enabledByDefault: 0
+    enabledByDefault: 1
     focus: 0
   collectiblesItemSelector: {fileID: 5289564723011178695}
   skinColorSelector: {fileID: 3615833362840057512}
@@ -6454,7 +6458,7 @@ PrefabInstance:
     - target: {fileID: 5176895287733378623, guid: 7d2f70c1de2924a44bbd79ddad5f3d1b,
         type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7d2f70c1de2924a44bbd79ddad5f3d1b, type: 3}


### PR DESCRIPTION
## What does this PR change?

Fix #1752

Sets Collectibles as the default panel in the backpack section

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/collectibles-as-default-section
2. Open the menu
3. Go to backpack
4. Verify that collectibles is the default selected panel
5. Change panels and verify the consistency of the selections
6. Verify selections persistency on close/open menu

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
