### PR TITLE
fix: workaround for backpack avatar preview loading failure

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
@@ -221,7 +221,14 @@ public class BodyShapeController : WearableController, IBodyShapeController
     {
         //NOTE(Mordi): Adds handler for animation events, and passes in the audioContainer for the avatar
         AvatarAnimationEventHandler animationEventHandler = createdAnimation.gameObject.AddComponent<AvatarAnimationEventHandler>();
-        AudioContainer audioContainer = container.transform.parent.parent.parent.GetComponentInChildren<AudioContainer>();
+
+        //Temporary ugly fix to avoid backpack avatar preview loading failure, this part will vanish with the avatar refactor merge
+        AudioContainer audioContainer = null;
+        if (container.transform.parent.parent.parent != null)
+        {
+            audioContainer = container.transform.parent.parent.parent.GetComponentInChildren<AudioContainer>();
+        }
+         
         if (audioContainer != null)
         {
             animationEventHandler.Init(audioContainer);


### PR DESCRIPTION
## What does this PR change?

Fix #1829

With this PR the avatar preview doesn't fail loading anymore in the backpack

...

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/backpack-loading-failure
2. Open the backpack
3. Verify that everything loads properly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
