### PR TITLE
fix: avoid the websocket server to close inactive connections

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/SettingsPanelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/SettingsPanelHUDController.cs
@@ -202,7 +202,11 @@ namespace DCL.SettingsPanelHUD
 
         public void ResetAllSettings() { Settings.i.ResetAllSettings(); }
 
-        public void SetTutorialButtonEnabled(bool isEnabled) { view.SetTutorialButtonEnabled(isEnabled); }
+        public void SetTutorialButtonEnabled(bool isEnabled)
+        {
+            if (view != null)
+                view.SetTutorialButtonEnabled(isEnabled);
+        }
 
         public void AddHelpAndSupportWindow(HelpAndSupportHUDController controller)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs
@@ -45,8 +45,9 @@ public class WebSocketCommunication : IKernelCommunication
                         ClientCertificateRequired = false,
                         CheckCertificateRevocation = false,
                         ClientCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true
-                    }
-                };                
+                    },
+                    KeepClean = false
+                };
             }
             else
             {


### PR DESCRIPTION
fix: SetTutorialButtonEnabled is used after the view is disposed of, add check to avoid null reference

Fix partially: https://github.com/decentraland/unity-renderer/issues/1759

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
