### PR TITLE
fix: add post process effects to avatar preview

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/CharacterPreview.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/CharacterPreview.prefab
@@ -342,8 +342,8 @@ MonoBehaviour:
   eyeMaterial: {fileID: 2100000, guid: fcfa021e0982c0840aaefe7411340f7f, type: 2}
   eyebrowMaterial: {fileID: 2100000, guid: db9e974bee285614b8ea2d8832d1a563, type: 2}
   mouthMaterial: {fileID: 2100000, guid: aa8f029bd537edb44b72b4737ca9b81d, type: 2}
-  lodRenderer: {fileID: 0}
-  lodMeshFilter: {fileID: 0}
+  impostorRenderer: {fileID: 0}
+  impostorMeshFilter: {fileID: 0}
   isLoading: 0
 --- !u!1 &8127486274469708600
 GameObject:
@@ -470,9 +470,9 @@ MonoBehaviour:
   m_RendererIndex: 0
   m_VolumeLayerMask:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 256
   m_VolumeTrigger: {fileID: 0}
-  m_RenderPostProcessing: 0
+  m_RenderPostProcessing: 1
   m_Antialiasing: 0
   m_AntialiasingQuality: 2
   m_StopNaN: 0

--- a/unity-renderer/Assets/Textures/CharacterPreviewCamera.renderTexture
+++ b/unity-renderer/Assets/Textures/CharacterPreviewCamera.renderTexture
@@ -19,7 +19,7 @@ RenderTexture:
   m_AntiAliasing: 1
   m_MipCount: -1
   m_DepthFormat: 1
-  m_ColorFormat: 8
+  m_ColorFormat: 48
   m_MipMap: 0
   m_GenerateMips: 1
   m_SRGB: 0


### PR DESCRIPTION
## What does this PR change?

Fix #1838 
Adds the postprocess effects to the camera in the backpack

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/avatar-preview-postprocessing
2. Open the backpack
3. Verify postprocessing presence in backpack panel on the avatar preview

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
