### PR TITLE
fix: change default panel for guest users from collectibles to body shape

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
@@ -1539,7 +1539,7 @@ MonoBehaviour:
   navigationInfos:
   - toggle: {fileID: 3150290542716019958}
     canvas: {fileID: 3150290543018005860}
-    enabledByDefault: 0
+    enabledByDefault: 1
     focus: 0
   - toggle: {fileID: 3661532844623969922}
     canvas: {fileID: 3150290543101964660}
@@ -1609,11 +1609,6 @@ MonoBehaviour:
     canvas: {fileID: 6151202184307174224}
     enabledByDefault: 0
     focus: 1
-  defaultNavigationPanel:
-    toggle: {fileID: 0}
-    canvas: {fileID: 0}
-    enabledByDefault: 0
-    focus: 0
   wearableGridPairs:
   - categoryFilter: body_shape
     selector: {fileID: 3358252997386326019}
@@ -1662,7 +1657,6 @@ MonoBehaviour:
   randomizeButton: {fileID: 1450360507441575512}
   randomizeAnimator: {fileID: 4292949885884074233}
   doneButton: {fileID: 8118935322395685570}
-  exitButton: {fileID: 0}
   loadingSpinnerGameObject: {fileID: 4028908633907793762}
   web3Container: {fileID: 233924306434789069}
   web3GoToMarketplaceButton: {fileID: 6975390227394394232}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -24,7 +24,7 @@ public class AvatarEditorHUDController : IHUD
     [NonSerialized]
     public bool bypassUpdateAvatarPreview = false;
 
-    private UserProfile userProfile;
+    internal UserProfile userProfile;
     private BaseDictionary<string, WearableItem> catalog;
     bool renderingEnabled => CommonScriptableObjects.rendererState.Get();
     bool isPlayerRendererLoaded => DataStore.i.common.isPlayerRendererLoaded.Get();
@@ -57,6 +57,9 @@ public class AvatarEditorHUDController : IHUD
         this.userProfile = userProfile;
         this.bypassUpdateAvatarPreview = bypassUpdateAvatarPreview;
 
+        LoadUserProfile(userProfile, true);
+        this.userProfile.OnUpdate += LoadUserProfile;
+
         view = AvatarEditorHUDView.Create(this);
 
         avatarEditorVisible.OnChange += OnAvatarEditorVisibleChanged;
@@ -74,8 +77,6 @@ public class AvatarEditorHUDController : IHUD
 
         SetCatalog(catalog);
 
-        LoadUserProfile(userProfile, true);
-        this.userProfile.OnUpdate += LoadUserProfile;
 
         DataStore.i.HUDs.isAvatarEditorInitialized.Set(true);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -213,10 +213,7 @@ public class AvatarEditorHUDController : IHUD
         *       due to the execution order of things. The init cannot be done below because that would mean to do it when the
         *       menu is firstly opened
         */
-        if (!view.arePanelsInitialized)
-        {
-            view.InitializeNavigationEvents(string.IsNullOrEmpty(userProfile.userName));
-        }
+        view.InitializeNavigationEvents(string.IsNullOrEmpty(userProfile.userName));
 
         CatalogController.wearableCatalog.TryGetValue(userProfile.avatar.bodyShape, out var bodyShape);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -57,9 +57,6 @@ public class AvatarEditorHUDController : IHUD
         this.userProfile = userProfile;
         this.bypassUpdateAvatarPreview = bypassUpdateAvatarPreview;
 
-        LoadUserProfile(userProfile, true);
-        this.userProfile.OnUpdate += LoadUserProfile;
-
         view = AvatarEditorHUDView.Create(this);
 
         avatarEditorVisible.OnChange += OnAvatarEditorVisibleChanged;
@@ -77,6 +74,8 @@ public class AvatarEditorHUDController : IHUD
 
         SetCatalog(catalog);
 
+        LoadUserProfile(userProfile, true);
+        this.userProfile.OnUpdate += LoadUserProfile;
 
         DataStore.i.HUDs.isAvatarEditorInitialized.Set(true);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -210,6 +210,15 @@ public class AvatarEditorHUDController : IHUD
         if (userProfile.avatar == null || string.IsNullOrEmpty(userProfile.avatar.bodyShape))
             return;
 
+        /*TODO: this has to be refactored, currently there is no other way of understanding if the user is a regular or a guest
+        *       due to the execution order of things. The init cannot be done below because that would mean to do it when the
+        *       menu is firstly opened
+        */
+        if (!view.arePanelsInitialized)
+        {
+            view.InitializeNavigationEvents(string.IsNullOrEmpty(userProfile.userName));
+        }
+
         CatalogController.wearableCatalog.TryGetValue(userProfile.avatar.bodyShape, out var bodyShape);
 
         if (bodyShape == null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -144,6 +144,7 @@ public class AvatarEditorHUDView : MonoBehaviour
     {
         if (arePanelsInitialized)
             return;
+
         for (int i = 0; i < navigationInfos.Length; i++)
         {
             InitializeNavigationInfo(navigationInfos[i]);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -15,7 +15,7 @@ public class AvatarEditorHUDView : MonoBehaviour
 
     public bool isOpen { get; private set; }
 
-    internal bool arePanelsInitialized { get; private set; }
+    internal bool arePanelsInitialized = false;
 
     [System.Serializable]
     public class AvatarEditorNavigationInfo

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -142,6 +142,8 @@ public class AvatarEditorHUDView : MonoBehaviour
 
     internal void InitializeNavigationEvents(bool isGuest)
     {
+        if (arePanelsInitialized)
+            return;
         for (int i = 0; i < navigationInfos.Length; i++)
         {
             InitializeNavigationInfo(navigationInfos[i]);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using UnityEngine;
@@ -98,6 +99,8 @@ public class AvatarEditorHUDView : MonoBehaviour
     public event System.Action<bool> OnSetVisibility;
     public event System.Action OnRandomize;
 
+    private UserProfile userProfile;
+
     private void Awake()
     {
         loadingSpinnerGameObject.SetActive(false);
@@ -116,6 +119,8 @@ public class AvatarEditorHUDView : MonoBehaviour
         ItemToggle.getEquippedWearablesReplacedByFunc = controller.GetWearablesReplacedBy;
         this.controller = controller;
         gameObject.name = VIEW_OBJECT_NAME;
+        userProfile = controller.userProfile;
+        userProfile.OnUpdate += InizializeWithUserInfo;
 
         randomizeButton.onClick.AddListener(OnRandomizeButton);
         doneButton.onClick.AddListener(OnDoneButton);
@@ -130,6 +135,12 @@ public class AvatarEditorHUDView : MonoBehaviour
         characterPreviewController.camera.enabled = false;
     }
 
+    private void InizializeWithUserInfo(UserProfile profile)
+    {
+        InitializeNavigationEvents();
+        userProfile.OnUpdate -= InizializeWithUserInfo;
+    }
+
     public void SetIsWeb3(bool isWeb3User)
     {
         web3Container.SetActive(isWeb3User);
@@ -142,24 +153,29 @@ public class AvatarEditorHUDView : MonoBehaviour
         {
             InitializeNavigationInfo(navigationInfos[i]);
         }
-
-        InitializeNavigationInfo(collectiblesNavigationInfo);
-
+        
+        InitializeNavigationInfo(collectiblesNavigationInfo, !string.IsNullOrEmpty(userProfile.userName));
+        
         characterPreviewRotation.OnHorizontalRotation += characterPreviewController.Rotate;
     }
 
-    private void InitializeNavigationInfo(AvatarEditorNavigationInfo current)
+    private void InitializeNavigationInfo(AvatarEditorNavigationInfo current, bool isActive) 
     {
         current.Initialize();
 
-        current.toggle.isOn = current.enabledByDefault;
+        current.toggle.isOn = isActive ? current.enabledByDefault : false;
+        current.canvas.gameObject.SetActive(isActive ? current.enabledByDefault : false);
 
-        current.canvas.gameObject.SetActive(current.enabledByDefault);
         current.toggle.onValueChanged.AddListener((on) =>
         {
             current.canvas.gameObject.SetActive(@on);
             characterPreviewController.SetFocus(current.focus);
         });
+    }
+
+    private void InitializeNavigationInfo(AvatarEditorNavigationInfo current)
+    {
+        InitializeNavigationInfo(current, true);
     }
 
     private void InitializeWearableChangeEvents()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.UI;
+using DCL;
 
 [assembly: InternalsVisibleTo("AvatarEditorHUDTests")]
 
@@ -13,6 +14,8 @@ public class AvatarEditorHUDView : MonoBehaviour
     private const string VIEW_OBJECT_NAME = "_AvatarEditorHUD";
 
     public bool isOpen { get; private set; }
+
+    internal bool arePanelsInitialized { get; private set; }
 
     [System.Serializable]
     public class AvatarEditorNavigationInfo
@@ -99,8 +102,6 @@ public class AvatarEditorHUDView : MonoBehaviour
     public event System.Action<bool> OnSetVisibility;
     public event System.Action OnRandomize;
 
-    private UserProfile userProfile;
-
     private void Awake()
     {
         loadingSpinnerGameObject.SetActive(false);
@@ -112,6 +113,7 @@ public class AvatarEditorHUDView : MonoBehaviour
         }
 
         isOpen = false;
+        arePanelsInitialized = false;
     }
 
     private void Initialize(AvatarEditorHUDController controller)
@@ -119,12 +121,9 @@ public class AvatarEditorHUDView : MonoBehaviour
         ItemToggle.getEquippedWearablesReplacedByFunc = controller.GetWearablesReplacedBy;
         this.controller = controller;
         gameObject.name = VIEW_OBJECT_NAME;
-        userProfile = controller.userProfile;
-        userProfile.OnUpdate += InizializeWithUserInfo;
 
         randomizeButton.onClick.AddListener(OnRandomizeButton);
         doneButton.onClick.AddListener(OnDoneButton);
-        InitializeNavigationEvents();
         InitializeWearableChangeEvents();
 
         web3GoToMarketplaceButton.onClick.RemoveAllListeners();
@@ -135,28 +134,22 @@ public class AvatarEditorHUDView : MonoBehaviour
         characterPreviewController.camera.enabled = false;
     }
 
-    private void InizializeWithUserInfo(UserProfile profile)
-    {
-        InitializeNavigationEvents();
-        userProfile.OnUpdate -= InizializeWithUserInfo;
-    }
-
     public void SetIsWeb3(bool isWeb3User)
     {
         web3Container.SetActive(isWeb3User);
         noWeb3Container.SetActive(!isWeb3User);
     }
 
-    private void InitializeNavigationEvents()
+    internal void InitializeNavigationEvents(bool isGuest)
     {
         for (int i = 0; i < navigationInfos.Length; i++)
         {
             InitializeNavigationInfo(navigationInfos[i]);
         }
-        
-        InitializeNavigationInfo(collectiblesNavigationInfo, !string.IsNullOrEmpty(userProfile.userName));
+        InitializeNavigationInfo(collectiblesNavigationInfo, !isGuest);
         
         characterPreviewRotation.OnHorizontalRotation += characterPreviewController.Rotate;
+        arePanelsInitialized = true;
     }
 
     private void InitializeNavigationInfo(AvatarEditorNavigationInfo current, bool isActive) 


### PR DESCRIPTION
## What does this PR change?

Fix #1856 
The default panel of the guest onboarding is no longer collectibles but body shape

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/backpack-default-panel-for-guest
2. Connect with a guest session
3. Verify that the first panel is the first one and not collectibles
4. Disconnect
5. Connect with a valid user
6. Verify that opening the backpack loads the collectibles panel first

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
