### PR TITLE
Revert "set collectibles as default backpack panel"

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
@@ -1539,7 +1539,7 @@ MonoBehaviour:
   navigationInfos:
   - toggle: {fileID: 3150290542716019958}
     canvas: {fileID: 3150290543018005860}
-    enabledByDefault: 0
+    enabledByDefault: 1
     focus: 0
   - toggle: {fileID: 3661532844623969922}
     canvas: {fileID: 3150290543101964660}
@@ -1609,11 +1609,6 @@ MonoBehaviour:
     canvas: {fileID: 6151202184307174224}
     enabledByDefault: 0
     focus: 1
-  defaultNavigationPanel:
-    toggle: {fileID: 0}
-    canvas: {fileID: 0}
-    enabledByDefault: 0
-    focus: 0
   wearableGridPairs:
   - categoryFilter: body_shape
     selector: {fileID: 3358252997386326019}
@@ -1650,7 +1645,7 @@ MonoBehaviour:
   collectiblesNavigationInfo:
     toggle: {fileID: 1039268970838228618}
     canvas: {fileID: 7406321907236003421}
-    enabledByDefault: 1
+    enabledByDefault: 0
     focus: 0
   collectiblesItemSelector: {fileID: 5289564723011178695}
   skinColorSelector: {fileID: 3615833362840057512}


### PR DESCRIPTION
## What does this PR change?
Revert the PR #1828: "set collectibles as default backpack panel"

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/revert-set-collectibles-as-default-backpack-panel
2. Open the Backpack.
3. Notice the default open section is BODY.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
