### PR TITLE
fix: Revert "Move the StartMenu initialization before the world is up"

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -35,6 +35,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
     internal float chatInputHUDCloseTime = 0f;
     internal List<RealmRowComponentModel> currentAvailableRealms = new List<RealmRowComponentModel>();
 
+    internal RendererState rendererState => CommonScriptableObjects.rendererState;
     internal BaseVariable<bool> isOpen => DataStore.i.exploreV2.isOpen;
     internal BaseVariable<int> currentSectionIndex => DataStore.i.exploreV2.currentSectionIndex;
     internal BaseVariable<bool> profileCardIsOpen => DataStore.i.exploreV2.profileCardIsOpen;
@@ -59,6 +60,18 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     public void Initialize()
     {
+        // It waits for the world is up before starting to initialize the Start Menu
+        rendererState.OnChange += Initialize_Internal;
+        Initialize_Internal(rendererState.Get(), false);
+    }
+
+    internal void Initialize_Internal(bool currentRendererState, bool previousRendererState)
+    {
+        if (!currentRendererState)
+            return;
+
+        rendererState.OnChange -= Initialize_Internal;
+
         exploreV2Analytics = CreateAnalyticsController();
         view = CreateView();
         SetVisibility(false);
@@ -122,7 +135,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
         IsSettingsPanelInitializedChanged(isSettingsPanelInitialized.Get(), false);
         settingsVisible.OnChange += SettingsVisibleChanged;
         SettingsVisibleChanged(settingsVisible.Get(), false);
-
+        
         ConfigureOhterUIDependencies();
 
         isInitialized.Set(true);
@@ -162,6 +175,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     public void Dispose()
     {
+        rendererState.OnChange -= Initialize_Internal;
         DataStore.i.realm.playerRealm.OnChange -= UpdateRealmInfo;
         DataStore.i.realm.realmsInfo.OnSet -= UpdateAvailableRealmsInfo;
         ownUserProfile.OnUpdate -= UpdateProfileInfo;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -21,7 +21,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController = Substitute.ForPartsOf<ExploreV2MenuComponentController>();
         exploreV2MenuController.Configure().CreateView().Returns(info => exploreV2MenuView);
         exploreV2MenuController.Configure().CreateAnalyticsController().Returns(info => exploreV2Analytics);
-        exploreV2MenuController.Initialize();
+        exploreV2MenuController.Initialize_Internal(true, false);
     }
 
     [TearDown]


### PR DESCRIPTION
## What does this PR change?
Reverts https://github.com/decentraland/unity-renderer/pull/1852 because it seems this change affected to the Map behaviour and broke it.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/revert-start-menu-initialization-improvement
2. Open the Map.
3. Notice it is working correctly.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
