### PR TITLE
fix: Move the StartMenu initialization before the world is up (II)

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -35,7 +35,6 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
     internal float chatInputHUDCloseTime = 0f;
     internal List<RealmRowComponentModel> currentAvailableRealms = new List<RealmRowComponentModel>();
 
-    internal RendererState rendererState => CommonScriptableObjects.rendererState;
     internal BaseVariable<bool> isOpen => DataStore.i.exploreV2.isOpen;
     internal BaseVariable<int> currentSectionIndex => DataStore.i.exploreV2.currentSectionIndex;
     internal BaseVariable<bool> profileCardIsOpen => DataStore.i.exploreV2.profileCardIsOpen;
@@ -60,18 +59,6 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     public void Initialize()
     {
-        // It waits for the world is up before starting to initialize the Start Menu
-        rendererState.OnChange += Initialize_Internal;
-        Initialize_Internal(rendererState.Get(), false);
-    }
-
-    internal void Initialize_Internal(bool currentRendererState, bool previousRendererState)
-    {
-        if (!currentRendererState)
-            return;
-
-        rendererState.OnChange -= Initialize_Internal;
-
         exploreV2Analytics = CreateAnalyticsController();
         view = CreateView();
         SetVisibility(false);
@@ -175,7 +162,6 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     public void Dispose()
     {
-        rendererState.OnChange -= Initialize_Internal;
         DataStore.i.realm.playerRealm.OnChange -= UpdateRealmInfo;
         DataStore.i.realm.realmsInfo.OnSet -= UpdateAvailableRealmsInfo;
         ownUserProfile.OnUpdate -= UpdateProfileInfo;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -21,7 +21,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController = Substitute.ForPartsOf<ExploreV2MenuComponentController>();
         exploreV2MenuController.Configure().CreateView().Returns(info => exploreV2MenuView);
         exploreV2MenuController.Configure().CreateAnalyticsController().Returns(info => exploreV2Analytics);
-        exploreV2MenuController.Initialize_Internal(true, false);
+        exploreV2MenuController.Initialize();
     }
 
     [TearDown]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -145,6 +145,9 @@ namespace DCL
             }
             else
             {
+                if (minimapViewport == null)
+                    return;
+
                 CloseToast();
 
                 MapRenderer.i.atlas.viewport = minimapViewport;


### PR DESCRIPTION
## What does this PR change?
Moves the StartMenu initialization before the `RendererState` is activated in order to avoid unnecessary hiccups when the world is up.

**NOTE**: It is the second part of https://github.com/decentraland/unity-renderer/pull/1852

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/move-start-menu-initialization-before-the-world-is-up-II
2. Wait for the world is up.
3. Open the StartMenu and check that everything is working fine.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
