### PR TITLE
chore: avatar visibility now uses a flag based approach

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -10,6 +10,7 @@ namespace AvatarSystem
     public class Avatar : IAvatar
     {
         private const float RESCALING_BOUNDS_FACTOR = 100f;
+        internal const string LOADING_VISIBILITY_CONSTRAIN = "Loading";
         private readonly IAvatarCurator avatarCurator;
         private readonly ILoader loader;
         private readonly IAnimator animator;
@@ -51,7 +52,7 @@ namespace AvatarSystem
 
             try
             {
-                visibility.SetLoadingReady(false);
+                visibility.AddGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
                 WearableItem bodyshape = null;
                 WearableItem eyes = null;
                 WearableItem eyebrows = null;
@@ -71,7 +72,7 @@ namespace AvatarSystem
                 gpuSkinningThrottler.Bind(gpuSkinning);
 
                 visibility.Bind(gpuSkinning.renderer, loader.facialFeaturesRenderers);
-                visibility.SetLoadingReady(true);
+                visibility.RemoveGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
 
                 lod.Bind(gpuSkinning.renderer);
                 gpuSkinningThrottler.Start();
@@ -95,7 +96,9 @@ namespace AvatarSystem
             }
         }
 
-        public void SetVisibility(bool visible) { visibility.SetExplicitVisibility(visible); }
+        public void AddVisibilityConstrain(string key) { visibility.AddGlobalConstrain(key); }
+
+        public void RemoveVisibilityConstrain(string key) { visibility.RemoveGlobalConstrain(key); }
 
         public void SetExpression(string expressionId, long timestamps) { animator?.PlayExpression(expressionId, timestamps); }
 
@@ -104,7 +107,9 @@ namespace AvatarSystem
         public void SetAnimationThrottling(int framesBetweenUpdate) { gpuSkinningThrottler.SetThrottling(framesBetweenUpdate); }
 
         public void SetImpostorTexture(Texture2D impostorTexture) { lod.SetImpostorTexture(impostorTexture); }
+
         public void SetImpostorTint(Color color) { lod.SetImpostorTint(color); }
+
         public Transform[] GetBones() => loader.GetBones();
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatar.cs
@@ -19,7 +19,8 @@ namespace AvatarSystem
         int lodLevel { get; }
 
         UniTask Load(List<string> wearablesIds, AvatarSettings settings, CancellationToken ct = default);
-        void SetVisibility(bool visible);
+        void AddVisibilityConstrain(string key);
+        void RemoveVisibilityConstrain(string key);
         void SetExpression(string expressionId, long timestamps);
         void SetLODLevel(int lodIndex);
         void SetAnimationThrottling(int framesBetweenUpdate);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IVisibility.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IVisibility.cs
@@ -6,9 +6,13 @@ namespace AvatarSystem
     public interface IVisibility : IDisposable
     {
         void Bind(Renderer combinedRenderer, Renderer[] facialFeatures);
-        void SetExplicitVisibility(bool explicitVisibility);
-        void SetLoadingReady(bool loadingReady);
-        void SetCombinedRendererVisibility(bool combinedRendererVisibility);
-        void SetFacialFeaturesVisibility(bool facialFeaturesVisibility);
+        public void AddGlobalConstrain(string key);
+        public void RemoveGlobalConstrain(string key);
+
+        public void AddCombinedRendererConstrain(string key);
+        public void RemoveCombinedRendererConstrain(string key);
+
+        public void AddFacialFeaturesConstrain(string key);
+        public void RemoveFacialFeaturesConstrain(string key);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/LOD.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/LOD.cs
@@ -31,6 +31,8 @@ namespace AvatarSystem
 
         private CancellationTokenSource transitionCTS;
         private CancellationTokenSource billboardLookAtCameraCTS;
+        private string VISIBILITY_CONSTRAIN_IN_IMPOSTOR = "in_impostor";
+        private string VISIBILITY_CONSTRAIN_IN_LOD1 = "in_LOD1";
 
         public LOD(GameObject impostorContainer, IVisibility visibility, IAvatarMovementController avatarMovementController)
         {
@@ -84,8 +86,17 @@ namespace AvatarSystem
                 UpdateSSAO(combinedAvatar, lodIndex);
                 UpdateAlpha(avatarAlpha);
                 UpdateMovementLerping(lodIndex);
-                visibility.SetCombinedRendererVisibility(lodIndex <= 1);
-                visibility.SetFacialFeaturesVisibility(lodIndex <= 0);
+
+                if (avatarAlpha > 0)
+                    visibility.RemoveCombinedRendererConstrain(VISIBILITY_CONSTRAIN_IN_IMPOSTOR);
+                else
+                    visibility.AddCombinedRendererConstrain(VISIBILITY_CONSTRAIN_IN_IMPOSTOR);
+
+                if (lodIndex == 0)
+                    visibility.RemoveFacialFeaturesConstrain(VISIBILITY_CONSTRAIN_IN_LOD1);
+                else
+                    visibility.AddFacialFeaturesConstrain(VISIBILITY_CONSTRAIN_IN_LOD1);
+
                 SetImpostorEnabled(avatarAlpha == 0);
                 return;
             }
@@ -114,7 +125,7 @@ namespace AvatarSystem
 
             try
             {
-                visibility.SetCombinedRendererVisibility(true);
+                visibility.RemoveCombinedRendererConstrain(VISIBILITY_CONSTRAIN_IN_IMPOSTOR);
                 impostorRenderer.enabled = true;
                 float targetAvatarAlpha = lodIndex <= 1 ? 1f : 0f;
                 while (!Mathf.Approximately(targetAvatarAlpha, avatarAlpha))
@@ -127,8 +138,15 @@ namespace AvatarSystem
                 UpdateSSAO(combinedAvatar, lodIndex);
                 UpdateMovementLerping(lodIndex);
 
-                visibility.SetCombinedRendererVisibility(avatarAlpha > 0);
-                visibility.SetFacialFeaturesVisibility(lodIndex == 0);
+                if (avatarAlpha > 0)
+                    visibility.RemoveCombinedRendererConstrain(VISIBILITY_CONSTRAIN_IN_IMPOSTOR);
+                else
+                    visibility.AddCombinedRendererConstrain(VISIBILITY_CONSTRAIN_IN_IMPOSTOR);
+
+                if (lodIndex == 0)
+                    visibility.RemoveFacialFeaturesConstrain(VISIBILITY_CONSTRAIN_IN_LOD1);
+                else
+                    visibility.AddFacialFeaturesConstrain(VISIBILITY_CONSTRAIN_IN_LOD1);
 
                 SetImpostorEnabled(avatarAlpha == 0);
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Tests/AvatarShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Tests/AvatarShould.cs
@@ -73,7 +73,8 @@ namespace Test.AvatarSystem
             var wearableIds = new List<string>();
 
             await TestUtils.ThrowsAsync<Exception>(avatar.Load(wearableIds, settings));
-            visibility.Received().SetLoadingReady(false);
+            visibility.Received().AddGlobalConstrain(Avatar.LOADING_VISIBILITY_CONSTRAIN);
+            visibility.DidNotReceive().RemoveGlobalConstrain(Avatar.LOADING_VISIBILITY_CONSTRAIN);
             curator.Received().Curate(settings, wearableIds, Arg.Any<CancellationToken>());
             loader.DidNotReceiveWithAnyArgs()
                   .Load(default, default, default, default, default, default);
@@ -128,7 +129,8 @@ namespace Test.AvatarSystem
             gpuSkinning.Received().Prepare(combinedRenderer);
             gpuSkinningThrottler.Received().Bind(gpuSkinning);
             visibility.Received().Bind(gpuSkinnedRenderer, facialFeatures);
-            visibility.Received().SetLoadingReady(true);
+            visibility.Received().AddGlobalConstrain(Avatar.LOADING_VISIBILITY_CONSTRAIN);
+            visibility.Received().RemoveGlobalConstrain(Avatar.LOADING_VISIBILITY_CONSTRAIN);
             lod.Received().Bind(gpuSkinnedRenderer);
             gpuSkinningThrottler.Received().Start();
             Assert.AreEqual(IAvatar.Status.Loaded, avatar.status);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Tests/VisibilityShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Tests/VisibilityShould.cs
@@ -27,33 +27,143 @@ namespace Test.AvatarSystem
         }
 
         [Test]
-        [TestCase(false, false, false, false)]
-        [TestCase(true, false, false, false)]
-        [TestCase(false, true, false, false)]
-        [TestCase(false, false, true, false)]
-        [TestCase(true, true, true, true)]
-        public void SetVisibilityForCombinedRenderer(bool loadingReady, bool explicitVisibility, bool combinedRendererVisibility, bool expected)
+        [TestCase("constrain1")]
+        [TestCase("constrain1", "constrain2")]
+        [TestCase("constrain1", "constrain2", "constrain3")]
+        [TestCase("constrain1", "constrain2", "constrain3", "constrain4")]
+        public void HideCombinedRendererIfAnyGlobalConstrain(params string[] constrains)
         {
-            visibility.SetLoadingReady(loadingReady);
-            visibility.SetExplicitVisibility(explicitVisibility);
-            visibility.SetCombinedRendererVisibility(combinedRendererVisibility);
+            combined.enabled = true;
 
-            Assert.AreEqual(expected, combined.enabled);
+            visibility.globalConstrains.UnionWith(constrains);
+            visibility.UpdateCombinedRendererVisibility();
+
+            Assert.AreEqual(false, combined.enabled);
         }
 
         [Test]
-        [TestCase(false, false, false, false)]
-        [TestCase(true, false, false, false)]
-        [TestCase(false, true, false, false)]
-        [TestCase(false, false, true, false)]
-        [TestCase(true, true, true, true)]
-        public void SetVisibilityForFacialFeatures(bool loadingReady, bool explicitVisibility, bool facialFeaturesVisibility, bool expected)
+        [TestCase("constrain1")]
+        [TestCase("constrain1", "constrain2")]
+        [TestCase("constrain1", "constrain2", "constrain3")]
+        [TestCase("constrain1", "constrain2", "constrain3", "constrain4")]
+        public void HideCombinedRendererIfAnySpecificConstrain(params string[] constrains)
         {
-            visibility.SetLoadingReady(loadingReady);
-            visibility.SetExplicitVisibility(explicitVisibility);
-            visibility.SetFacialFeaturesVisibility(facialFeaturesVisibility);
+            combined.enabled = true;
 
-            Assert.AreEqual(expected, combined.enabled);
+            visibility.combinedRendererConstrains.UnionWith(constrains);
+            visibility.UpdateCombinedRendererVisibility();
+
+            Assert.AreEqual(false, combined.enabled);
+        }
+
+        [Test]
+        [TestCase("constrain1")]
+        [TestCase("constrain1", "constrain2")]
+        [TestCase("constrain1", "constrain2", "constrain3")]
+        [TestCase("constrain1", "constrain2", "constrain3", "constrain4")]
+        public void HideCombinedRendererIfAnyCombinedConstrain(params string[] constrains)
+        {
+            combined.enabled = true;
+
+            visibility.globalConstrains.UnionWith(constrains);
+            visibility.combinedRendererConstrains.UnionWith(constrains);
+            visibility.UpdateCombinedRendererVisibility();
+
+            Assert.AreEqual(false, combined.enabled);
+        }
+
+        [Test]
+        public void ShowCombinedRendererIfNoConstrains()
+        {
+            combined.enabled = false;
+
+            visibility.globalConstrains.Clear();
+            visibility.combinedRendererConstrains.Clear();
+            visibility.UpdateCombinedRendererVisibility();
+
+            Assert.AreEqual(true, combined.enabled);
+        }
+
+        [Test]
+        [TestCase("constrain1")]
+        [TestCase("constrain1", "constrain2")]
+        [TestCase("constrain1", "constrain2", "constrain3")]
+        [TestCase("constrain1", "constrain2", "constrain3", "constrain4")]
+        public void HideFacialFeaturesIfAnyGlobalConstrain(params string[] constrains)
+        {
+            foreach (Renderer facialFeature in facialFeatures)
+            {
+                facialFeature.enabled = true;
+            }
+
+            visibility.globalConstrains.UnionWith(constrains);
+            visibility.UpdateFacialFeatureVisibility();
+
+            foreach (Renderer facialFeature in facialFeatures)
+            {
+                Assert.AreEqual(false, facialFeature.enabled);
+            }
+        }
+
+        [Test]
+        [TestCase("constrain1")]
+        [TestCase("constrain1", "constrain2")]
+        [TestCase("constrain1", "constrain2", "constrain3")]
+        [TestCase("constrain1", "constrain2", "constrain3", "constrain4")]
+        public void HideFacialFeaturesIfAnySpecificConstrain(params string[] constrains)
+        {
+            foreach (Renderer facialFeature in facialFeatures)
+            {
+                facialFeature.enabled = true;
+            }
+
+            visibility.facialFeaturesConstrains.UnionWith(constrains);
+            visibility.UpdateFacialFeatureVisibility();
+
+            foreach (Renderer facialFeature in facialFeatures)
+            {
+                Assert.AreEqual(false, facialFeature.enabled);
+            }
+        }
+
+        [Test]
+        [TestCase("constrain1")]
+        [TestCase("constrain1", "constrain2")]
+        [TestCase("constrain1", "constrain2", "constrain3")]
+        [TestCase("constrain1", "constrain2", "constrain3", "constrain4")]
+        public void HideFacialFeaturesIfAnyCombinedConstrain(params string[] constrains)
+        {
+            foreach (Renderer facialFeature in facialFeatures)
+            {
+                facialFeature.enabled = true;
+            }
+
+            visibility.globalConstrains.UnionWith(constrains);
+            visibility.facialFeaturesConstrains.UnionWith(constrains);
+            visibility.UpdateFacialFeatureVisibility();
+
+            foreach (Renderer facialFeature in facialFeatures)
+            {
+                Assert.AreEqual(false, facialFeature.enabled);
+            }
+        }
+
+        [Test]
+        public void ShowFacialFeaturesIfNoConstrains()
+        {
+            foreach (Renderer facialFeature in facialFeatures)
+            {
+                facialFeature.enabled = true;
+            }
+
+            visibility.globalConstrains.Clear();
+            visibility.facialFeaturesConstrains.Clear();
+            visibility.UpdateFacialFeatureVisibility();
+
+            foreach (Renderer facialFeature in facialFeatures)
+            {
+                Assert.AreEqual(true, facialFeature.enabled);
+            }
         }
 
         [TearDown]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Visibility.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Visibility.cs
@@ -1,16 +1,16 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace AvatarSystem
 {
     public class Visibility : IVisibility
     {
+        internal readonly HashSet<string> globalConstrains = new HashSet<string>();
+        internal readonly HashSet<string> combinedRendererConstrains = new HashSet<string>();
+        internal readonly HashSet<string> facialFeaturesConstrains = new HashSet<string>();
+
         private Renderer combinedRenderer = null;
         private Renderer[] facialFeatures = null;
-
-        private bool explicitVisibility = true;
-        private bool loadingReady = true;
-        private bool combinedRendererVisibility = true;
-        private bool facialFeaturesVisibility = true;
 
         /// <summary>
         /// Bind a set of renderers, previous renderers enabled wont be modified
@@ -21,51 +21,74 @@ namespace AvatarSystem
         {
             this.combinedRenderer = combinedRenderer;
             this.facialFeatures = facialFeatures;
-            UpdateVisibility();
+            UpdateCombinedRendererVisibility();
+            UpdateFacialFeatureVisibility();
         }
 
-        public void SetExplicitVisibility(bool explicitVisibility)
+        public void AddGlobalConstrain(string key)
         {
-            this.explicitVisibility = explicitVisibility;
-            UpdateVisibility();
+            globalConstrains.Add(key);
+            UpdateCombinedRendererVisibility();
+            UpdateFacialFeatureVisibility();
         }
 
-        public void SetLoadingReady(bool loadingReady)
+        public void RemoveGlobalConstrain(string key)
         {
-            this.loadingReady = loadingReady;
-            UpdateVisibility();
-        }
-        public void SetCombinedRendererVisibility(bool combinedRendererVisibility)
-        {
-            this.combinedRendererVisibility = combinedRendererVisibility;
-            UpdateVisibility();
-        }
-        public void SetFacialFeaturesVisibility(bool facialFeaturesVisibility)
-        {
-            this.facialFeaturesVisibility = facialFeaturesVisibility;
-            UpdateVisibility();
+            globalConstrains.Remove(key);
+            UpdateCombinedRendererVisibility();
+            UpdateFacialFeatureVisibility();
         }
 
-        private void UpdateVisibility()
+        public void AddCombinedRendererConstrain(string key)
         {
-            if (combinedRenderer != null)
+            combinedRendererConstrains.Add(key);
+            UpdateCombinedRendererVisibility();
+        }
+
+        public void RemoveCombinedRendererConstrain(string key)
+        {
+            combinedRendererConstrains.Remove(key);
+            UpdateCombinedRendererVisibility();
+        }
+
+        public void AddFacialFeaturesConstrain(string key)
+        {
+            facialFeaturesConstrains.Add(key);
+            UpdateFacialFeatureVisibility();
+        }
+
+        public void RemoveFacialFeaturesConstrain(string key)
+        {
+            facialFeaturesConstrains.Remove(key);
+            UpdateFacialFeatureVisibility();
+        }
+
+        internal void UpdateCombinedRendererVisibility()
+        {
+            if (combinedRenderer == null)
+                return;
+
+            combinedRenderer.enabled = globalConstrains.Count == 0 && combinedRendererConstrains.Count == 0;
+        }
+
+        internal void UpdateFacialFeatureVisibility()
+        {
+            if (facialFeatures == null)
+                return;
+
+            bool facialFeaturesVisibility = globalConstrains.Count == 0 && facialFeaturesConstrains.Count == 0;
+            for (int i = 0; i < facialFeatures.Length; i++)
             {
-                bool combinedRendererComposedVisibility = explicitVisibility && loadingReady && combinedRendererVisibility;
-                combinedRenderer.enabled = combinedRendererComposedVisibility;
-            }
-
-            if (facialFeatures != null)
-            {
-                bool facialFeaturesComposedVisibility = explicitVisibility && loadingReady && facialFeaturesVisibility;
-                for (int i = 0; i < facialFeatures.Length; i++)
-                {
-                    facialFeatures[i].enabled = facialFeaturesComposedVisibility;
-                }
+                facialFeatures[i].enabled = facialFeaturesVisibility;
             }
         }
 
         public void Dispose()
         {
+            globalConstrains.Clear();
+            combinedRendererConstrains.Clear();
+            facialFeaturesConstrains.Clear();
+
             combinedRenderer = null;
             facialFeatures = null;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -19,6 +19,7 @@ namespace DCL
 
     public class AvatarLODController : IAvatarLODController
     {
+        private string VISIBILITY_CONSTRAIN = "behind_camera_or_out_of_limits";
         public Player player { get; }
 
         public AvatarLODController(Player player)
@@ -36,7 +37,7 @@ namespace DCL
 
             player.onPointerDownCollider.SetColliderEnabled(true);
             player.avatar.SetLODLevel(0);
-            player.avatar.SetVisibility(true);
+            player.avatar.RemoveVisibilityConstrain(VISIBILITY_CONSTRAIN);
         }
 
         public void SetLOD1()
@@ -46,7 +47,7 @@ namespace DCL
 
             player.onPointerDownCollider.SetColliderEnabled(true);
             player.avatar.SetLODLevel(1);
-            player.avatar.SetVisibility(true);
+            player.avatar.RemoveVisibilityConstrain(VISIBILITY_CONSTRAIN);
         }
 
         public void SetLOD2()
@@ -56,7 +57,7 @@ namespace DCL
 
             player.onPointerDownCollider.SetColliderEnabled(false);
             player.avatar.SetLODLevel(2);
-            player.avatar.SetVisibility(true);
+            player.avatar.RemoveVisibilityConstrain(VISIBILITY_CONSTRAIN);
         }
 
         public void SetInvisible()
@@ -64,7 +65,7 @@ namespace DCL
             if (player?.avatar == null)
                 return;
 
-            player.avatar.SetVisibility(false);
+            player.avatar.AddVisibilityConstrain(VISIBILITY_CONSTRAIN);
             player.onPointerDownCollider.SetColliderEnabled(false);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
@@ -33,6 +33,7 @@ public class PlayerAvatarController : MonoBehaviour
     private Camera mainCamera;
     private PlayerAvatarAnalytics playerAvatarAnalytics;
     private IFatalErrorReporter fatalErrorReporter; // TODO?
+    private string VISIBILITY_CONSTRAIN;
 
     private void Start()
     {
@@ -103,7 +104,14 @@ public class PlayerAvatarController : MonoBehaviour
         avatarVisibility.SetVisibility("PLAYER_AVATAR_CONTROLLER", shouldBeVisible);
     }
 
-    public void SetAvatarVisibility(bool isVisible) { avatar.SetVisibility(isVisible); }
+    public void SetAvatarVisibility(bool isVisible)
+    {
+        VISIBILITY_CONSTRAIN = "own_player_invisible";
+        if (isVisible)
+            avatar.RemoveVisibilityConstrain(VISIBILITY_CONSTRAIN);
+        else
+            avatar.AddVisibilityConstrain(VISIBILITY_CONSTRAIN);
+    }
 
     private void OnEnable()
     {


### PR DESCRIPTION
## What does this PR change?
Avatar visibility was not really scalable. Adding layers meant adding a new method to both `IVisibility` and `Visibility`. The raising need of different systems to switch an avatar visibility were causing collisions on the visibility state.

Now Visibility just handle constrains that can be added or removed by other systems so an avatar is only visible when all its constrains are cleared.

## How to test the changes?
Avatars should behave as usual

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
