### PR TITLE
fix: avoid fps affecting movement speed

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -252,7 +252,7 @@ public class DCLCharacterController : MonoBehaviour
 
     internal void LateUpdate()
     {
-        deltaTime = Mathf.Min(deltaTimeCap, Time.deltaTime);
+        deltaTime = Time.deltaTime;//Mathf.Min(deltaTimeCap, Time.deltaTime);
 
         if (transform.position.y < minimumYPosition)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -35,8 +35,6 @@ public class DCLCharacterController : MonoBehaviour
 
     new Collider collider;
 
-    float deltaTime = 0.032f;
-    float deltaTimeCap = 0.032f; // 32 milliseconds = 30FPS, 16 millisecodns = 60FPS
     float lastUngroundedTime = 0f;
     float lastJumpButtonPressedTime = 0f;
     float lastMovementReportTime;
@@ -252,8 +250,6 @@ public class DCLCharacterController : MonoBehaviour
 
     internal void LateUpdate()
     {
-        deltaTime = Time.deltaTime;//Mathf.Min(deltaTimeCap, Time.deltaTime);
-
         if (transform.position.y < minimumYPosition)
         {
             SetPosition(characterPosition.worldPosition);
@@ -268,7 +264,7 @@ public class DCLCharacterController : MonoBehaviour
         {
             velocity.x = 0f;
             velocity.z = 0f;
-            velocity.y += gravity * deltaTime;
+            velocity.y += gravity * Time.deltaTime;
 
             bool previouslyGrounded = isGrounded;
 
@@ -278,7 +274,7 @@ public class DCLCharacterController : MonoBehaviour
             if (isGrounded)
             {
                 isJumping = false;
-                velocity.y = gravity * deltaTime; // to avoid accumulating gravity in velocity.y while grounded
+                velocity.y = gravity * Time.deltaTime; // to avoid accumulating gravity in velocity.y while grounded
             }
             else if (previouslyGrounded && !isJumping)
             {
@@ -337,7 +333,7 @@ public class DCLCharacterController : MonoBehaviour
             //NOTE(Brian): Transform has to be in sync before the Move call, otherwise this call
             //             will reset the character controller to its previous position.
             Environment.i.platform.physicsSyncController?.Sync();
-            characterController.Move(velocity * deltaTime);
+            characterController.Move(velocity * Time.deltaTime);
         }
 
         SetPosition(PositionUtils.UnityToWorldPosition(transform.position));
@@ -352,7 +348,7 @@ public class DCLCharacterController : MonoBehaviour
             SaveLateUpdateGroundTransforms();
         }
 
-        OnUpdateFinish?.Invoke(deltaTime);
+        OnUpdateFinish?.Invoke(Time.deltaTime);
     }
 
     private void SaveLateUpdateGroundTransforms()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -347,7 +347,6 @@ public class DCLCharacterController : MonoBehaviour
         {
             SaveLateUpdateGroundTransforms();
         }
-
         OnUpdateFinish?.Invoke(Time.deltaTime);
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/FreeMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/FreeMovementController.cs
@@ -19,8 +19,6 @@ public class FreeMovementController : MonoBehaviour
     bool isSprinting = false;
     bool isActive;
 
-    float deltaTime = 0.032f;
-
     Vector3 velocity = Vector3.zero;
 
     private Vector3NullableVariable characterForward => CommonScriptableObjects.characterForward;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/FreeMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/FreeMovementController.cs
@@ -78,7 +78,7 @@ public class FreeMovementController : MonoBehaviour
             velocity += forwardTarget * speed;
             CommonScriptableObjects.playerUnityEulerAngles.Set(transform.eulerAngles);
 
-            characterController.Move(velocity * deltaTime);
+            characterController.Move(velocity * Time.deltaTime);
         }
 
         return velocity;


### PR DESCRIPTION
## What does this PR change?

Fix #1753
With this PR the avatar movement speed should not be influenced by FPS anymore

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/fps-affecting-avatar-movement
2. Go to a crowded area and maximize the settings
3. Walk around
4. Lower the settings to minimum
5. Walk around
6. Verify the consistency between speeds

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
