### PR TITLE
fix: fixed prefab merging failure for backpack panel

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
@@ -1645,7 +1645,7 @@ MonoBehaviour:
   collectiblesNavigationInfo:
     toggle: {fileID: 1039268970838228618}
     canvas: {fileID: 7406321907236003421}
-    enabledByDefault: 0
+    enabledByDefault: 1
     focus: 0
   collectiblesItemSelector: {fileID: 5289564723011178695}
   skinColorSelector: {fileID: 3615833362840057512}


### PR DESCRIPTION
## What does this PR change?

Fixes an issue caused by the prefab merging from the branch fix/backpack-default-panel-for-guest  to master. In short it re enables the collectibles panel as default for regular users

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/resolve-backpack-hud-merge-failure
2. Open the backpack as regular user and verify that the first panel is the collectibles
3. Start a new session as guest and verify that the first panel is the body shape

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
