### PR TITLE
fix: you dont own any skin yet phrase

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/AvatarEditorHUD.prefab
@@ -5094,7 +5094,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: You don't own any category name yet.
+  m_text: You don't own any skin yet.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 1196159134475820439, guid: a02669827dd9144f39b4b164e753a21a,


### PR DESCRIPTION
## What does this PR change?

Fixes the phrase shown when you dont have any skin to select at avatar editor.

![Screenshot 2022-02-04 144118](https://user-images.githubusercontent.com/98896458/152576806-21a787b2-7597-44f1-acc9-514e1aeef65c.jpg)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
