### PR TITLE
fix: disable scrollwheel camera change when mouse on UI element

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
@@ -134,6 +134,7 @@ namespace DCL.Camera
         private void OnMouseWheelChangeValue(DCLAction_Measurable action, float value)
         {
             if (value > -mouseWheelThreshold && value < mouseWheelThreshold) return;
+            if (Utils.IsPointerOverUIElement()) return;
 
             if (CommonScriptableObjects.cameraMode == CameraMode.ModeId.FirstPerson && value < -mouseWheelThreshold)
                 SetCameraMode(CameraMode.ModeId.ThirdPerson);   

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -551,5 +551,16 @@ namespace DCL.Helpers
             }
             return false;
         }
+
+        public static bool IsPointerOverUIElement(Vector3 mousePosition)
+        {
+            var eventData = new PointerEventData(EventSystem.current);
+            eventData.position = mousePosition;
+            var results = new List<RaycastResult>();
+            EventSystem.current.RaycastAll(eventData, results);
+            return results.Count > 1;
+        }
+
+        public static bool IsPointerOverUIElement() { return IsPointerOverUIElement(Input.mousePosition); }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fix #1888
Avoid camera change when using mouse scrollwheel and cursor over an UI element

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/disable-scrollwheel-when-ui-mouseover
2. Scroll in and out to change from first to third person camera
3. Place the cursor above an UI element
4. Scroll in and out and verify that the camera mode doesn't change

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
