### PR TITLE
chore: replace profile image and image128 with image256

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -528,7 +528,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
         view.currentProfileCard.SetIsClaimedName(profile.hasClaimedName);
         view.currentProfileCard.SetProfileName(profile.userName);
         view.currentProfileCard.SetProfileAddress(profile.ethAddress);
-        view.currentProfileCard.SetProfilePicture(profile.face128SnapshotURL);
+        view.currentProfileCard.SetProfilePicture(profile.face256SnapshotURL);
     }
 
     internal void OnCloseButtonPressed(bool fromShortcut)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -396,7 +396,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuView.currentProfileCard.Received().SetIsClaimedName(testUserProfile.hasClaimedName);
         exploreV2MenuView.currentProfileCard.Received().SetProfileName(testUserProfile.userName);
         exploreV2MenuView.currentProfileCard.Received().SetProfileAddress(testUserProfile.ethAddress);
-        exploreV2MenuView.currentProfileCard.Received().SetProfilePicture(testUserProfile.face128SnapshotURL);
+        exploreV2MenuView.currentProfileCard.Received().SetProfilePicture(testUserProfile.face256SnapshotURL);
     }
 
     [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -654,11 +654,11 @@ public class AvatarEditorHUDController : IHUD
 
     public void SetConfiguration(HUDConfiguration configuration) { SetVisibility(configuration.active); }
 
-    public void SaveAvatar(Texture2D faceSnapshot, Texture2D face128Snapshot, Texture2D face256Snapshot, Texture2D bodySnapshot)
+    public void SaveAvatar(Texture2D face256Snapshot, Texture2D bodySnapshot)
     {
         var avatarModel = model.ToAvatarModel();
 
-        WebInterface.SendSaveAvatar(avatarModel, faceSnapshot, face128Snapshot, face256Snapshot, bodySnapshot, DataStore.i.common.isSignUpFlow.Get());
+        WebInterface.SendSaveAvatar(avatarModel, face256Snapshot, bodySnapshot, DataStore.i.common.isSignUpFlow.Get());
         userProfile.OverrideAvatar(avatarModel, face256Snapshot);
         if (DataStore.i.common.isSignUpFlow.Get())
             DataStore.i.HUDs.signupVisible.Set(true);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -372,10 +372,10 @@ public class AvatarEditorHUDView : MonoBehaviour
         characterPreviewController.TakeSnapshots(OnSnapshotsReady, OnSnapshotsFailed);
     }
 
-    private void OnSnapshotsReady(Texture2D face, Texture2D face128, Texture2D face256, Texture2D body)
+    private void OnSnapshotsReady(Texture2D face256, Texture2D body)
     {
         doneButton.interactable = true;
-        controller.SaveAvatar(face, face128, face256, body);
+        controller.SaveAvatar(face256, body);
     }
 
     private void OnSnapshotsFailed() { doneButton.interactable = true; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
@@ -14,19 +14,13 @@ public class CharacterPreviewController : MonoBehaviour
     private const int SNAPSHOT_BODY_WIDTH_RES = 256;
     private const int SNAPSHOT_BODY_HEIGHT_RES = 512;
 
-    private const int SNAPSHOT_FACE_WIDTH_RES = 512;
-    private const int SNAPSHOT_FACE_HEIGHT_RES = 512;
-
     private const int SNAPSHOT_FACE_256_WIDTH_RES = 256;
     private const int SNAPSHOT_FACE_256_HEIGHT_RES = 256;
-
-    private const int SNAPSHOT_FACE_128_WIDTH_RES = 128;
-    private const int SNAPSHOT_FACE_128_HEIGHT_RES = 128;
 
     private const int SUPERSAMPLING = 1;
     private const float CAMERA_TRANSITION_TIME = 0.5f;
 
-    public delegate void OnSnapshotsReady(Texture2D face, Texture2D face128, Texture2D face256, Texture2D body);
+    public delegate void OnSnapshotsReady(Texture2D face256, Texture2D body);
 
     public enum CameraFocus
     {
@@ -132,8 +126,6 @@ public class CharacterPreviewController : MonoBehaviour
         SetFocus(CameraFocus.FaceSnapshot, false);
         avatarAnimator.Reset();
         yield return null;
-        Texture2D face = Snapshot(SNAPSHOT_FACE_WIDTH_RES, SNAPSHOT_FACE_HEIGHT_RES);
-        Texture2D face128 = Snapshot(SNAPSHOT_FACE_128_WIDTH_RES, SNAPSHOT_FACE_128_HEIGHT_RES);
         Texture2D face256 = Snapshot(SNAPSHOT_FACE_256_WIDTH_RES, SNAPSHOT_FACE_256_HEIGHT_RES);
 
         SetFocus(CameraFocus.BodySnapshot, false);
@@ -146,7 +138,7 @@ public class CharacterPreviewController : MonoBehaviour
         camera.targetTexture = current;
 
         DCL.Environment.i.platform.cullingController.Start();
-        callback?.Invoke(face, face128, face256, body);
+        callback?.Invoke(face256, body);
     }
 
     private Texture2D Snapshot(int width, int height)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/AvatarEditorHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/AvatarEditorHUDControllerShould.cs
@@ -283,7 +283,7 @@ namespace AvatarEditorHUD_Tests
             controller.WearableClicked("urn:decentraland:off-chain:base-avatars:blue_bandana");
             controller.WearableClicked("urn:decentraland:off-chain:base-avatars:black_jacket");
 
-            controller.SaveAvatar(Texture2D.whiteTexture, Texture2D.whiteTexture, Texture2D.whiteTexture, Texture2D.whiteTexture);
+            controller.SaveAvatar(Texture2D.whiteTexture, Texture2D.whiteTexture);
 
             AssertAvatarModelAgainstAvatarEditorHUDModel(userProfile.avatar, controller.myModel);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/Tests/UserProfileTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/Tests/UserProfileTests.cs
@@ -46,8 +46,6 @@ namespace Tests
         {
             return new UserProfileModel.Snapshots()
             {
-                face = faceUrl,
-                face128 = faceUrl,
                 face256 = faceUrl
             };
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -19,7 +19,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     public string description => model.description;
     public string email => model.email;
     public string bodySnapshotURL => model.snapshots.body;
-    public string face128SnapshotURL => model.snapshots.face128;
+    public string face256SnapshotURL => model.snapshots.face256;
     public UserProfileModel.ParcelsWithAccess[] parcelsWithAccess => model.parcelsWithAccess;
     public List<string> blocked => model.blocked != null ? model.blocked : new List<string>();
     public List<string> muted => model.muted ?? new List<string>();
@@ -45,7 +45,6 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
             model = null;
             return;
         }
-
         bool faceSnapshotDirty = model.snapshots.face256 != newModel.snapshots.face256;
         bool bodySnapshotDirty = model.snapshots.body != newModel.snapshots.body;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileModel.cs
@@ -6,8 +6,6 @@ public class UserProfileModel
     [System.Serializable]
     public class Snapshots
     {
-        public string face;
-        public string face128;
         public string face256;
         public string body;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -1135,8 +1135,8 @@ namespace DCL.Interface
         [System.Serializable]
         public class SaveAvatarPayload
         {
+            [Obsolete("This will be removed in kernel in the future")]
             public string face;
-            public string face128;
             public string face256;
             public string body;
             public bool isSignUpFlow;
@@ -1195,13 +1195,12 @@ namespace DCL.Interface
             SendMessage("RequestOwnProfileUpdate");
         }
 
-        public static void SendSaveAvatar(AvatarModel avatar, Texture2D faceSnapshot, Texture2D face128Snapshot, Texture2D face256Snapshot, Texture2D bodySnapshot, bool isSignUpFlow = false)
+        public static void SendSaveAvatar(AvatarModel avatar, Texture2D face256Snapshot, Texture2D bodySnapshot, bool isSignUpFlow = false)
         {
             var payload = new SaveAvatarPayload()
             {
                 avatar = avatar,
-                face = System.Convert.ToBase64String(faceSnapshot.EncodeToPNG()),
-                face128 = System.Convert.ToBase64String(face128Snapshot.EncodeToPNG()),
+                face = System.Convert.ToBase64String(face256Snapshot.EncodeToPNG()),
                 face256 = System.Convert.ToBase64String(face256Snapshot.EncodeToPNG()),
                 body = System.Convert.ToBase64String(bodySnapshot.EncodeToPNG()),
                 isSignUpFlow = isSignUpFlow


### PR DESCRIPTION
## What does this PR change?

Fix #1886
Removes reading and sending image and image128, uses instead only image 256 for profile pictures.

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=improv/remove-face-assets-from-explore
2. Change your profile
3. Verify that the images of your profile in top right and in the menu are correctly updated
4. Close the session and reopen
5. Verify that the images are still correct

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
