### PR TITLE
fix: characters disclaimer copy

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Resources/SignupHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Resources/SignupHUD.prefab
@@ -3662,7 +3662,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: non-alphanumeric characters or spaces allowed
+  m_text: No alphanumeric characters or spaces allowed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 6708c7eadd49b49f4ac3469e5104e7c9, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: dd1effe058ec94479a0dd10765262662, type: 2}


### PR DESCRIPTION
## What does this PR change?
The text indicating which characters are not allowed was override from this `non-alphanumeric characters or spaces allowed`
to this `No alphanumeric characters or spaces allowed`.

## How to test?
1- Play as Guest in the following link: https://play.decentraland.zone/?renderer-branch=fix/AlphanumericCopy
2- In the second step of creating your account, try to use space or alphanumeric characters in the Name input.

<img width="744" alt="Screen Shot 2022-02-10 at 14 33 24" src="https://user-images.githubusercontent.com/51088292/153464389-d63c20a2-890b-4e8e-a742-6073310e28d2.png">
