### PR TITLE
fix: Name input warning for special characters

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Resources/SignupHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Resources/SignupHUD.prefab
@@ -3662,7 +3662,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: non-alphanumeric characters or spaces allowed
+  m_text: No alphanumeric characters or spaces allowed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 6708c7eadd49b49f4ac3469e5104e7c9, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: dd1effe058ec94479a0dd10765262662, type: 2}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Resources/SignupHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Resources/SignupHUD.prefab
@@ -3662,7 +3662,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: No alphanumeric characters or spaces allowed
+  m_text: Letters and numbers only
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 6708c7eadd49b49f4ac3469e5104e7c9, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: dd1effe058ec94479a0dd10765262662, type: 2}


### PR DESCRIPTION
The string `non-alphanumeric characters or spaces allowed` has been replaced by `Letters and numbers only`
![2022-02-10_17h23_04](https://user-images.githubusercontent.com/51088292/153628659-6d1fbd84-1542-41e6-b8f8-8de3f519dbdc.png)

### How to test:
Enter this link and create a new account (go as Guest, is easier).
When you try to use an special character or spaces in your name this new message should appear under the text field.

