### PR TITLE
fix: scenes stuck loading on GLTF promises silent forget

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/BlockedAndMasterPromisesShould.cs
@@ -70,6 +70,60 @@ namespace AssetPromiseKeeper_GLTF_Tests
             Assert.IsTrue(keeper.library.Contains(asset));
             Assert.AreEqual(1, keeper.library.masterAssets.Count);
         }
+        
+        [UnityTest]
+        public IEnumerator SucceedWhenMastersParentIsDeactivated()
+        {
+            var keeper = new AssetPromiseKeeper_GLTF();
+            keeper.throttlingCounter.enabled = false;
+
+            string url = TestAssetsUtils.GetPath() + "/GLB/Lantern/Lantern.glb";
+            GameObject parent = new GameObject("parent");
+
+            AssetPromise_GLTF prom = new AssetPromise_GLTF(scene.contentProvider, url);
+            prom.settings.parent = parent.transform;
+
+            AssetPromise_GLTF prom2 = new AssetPromise_GLTF(scene.contentProvider, url);
+            bool failEventCalled2 = false;
+            prom2.OnFailEvent += (x, error) => { failEventCalled2 = true; };
+
+            AssetPromise_GLTF prom3 = new AssetPromise_GLTF(scene.contentProvider, url);
+            bool failEventCalled3 = false;
+            prom3.OnFailEvent += (x, error) => { failEventCalled3 = true; };
+
+            keeper.Keep(prom);
+            
+            // This is what happens when a scene is unloaded while a master promise is loading from that scene
+            // (blocking other promises).
+            parent.SetActive(false);
+            
+            keeper.Keep(prom2);
+            keeper.Keep(prom3);
+
+            var asset = prom.asset;
+
+            keeper.Forget(prom);
+
+            Assert.AreEqual(3, keeper.waitingPromisesCount);
+
+            yield return prom;
+            yield return prom2;
+            yield return prom3;
+
+            Assert.AreEqual(AssetPromiseState.IDLE_AND_EMPTY, prom.state);
+            Assert.AreEqual(AssetPromiseState.FINISHED, prom2.state);
+            Assert.AreEqual(AssetPromiseState.FINISHED, prom3.state);
+
+            Assert.IsFalse(failEventCalled2);
+            Assert.IsFalse(failEventCalled3);
+
+            Assert.IsTrue(prom.asset == null);
+            Assert.IsTrue(prom2.asset != null);
+            Assert.IsTrue(prom3.asset != null);
+
+            Assert.IsTrue(keeper.library.Contains(asset));
+            Assert.AreEqual(1, keeper.library.masterAssets.Count);
+        }
 
         [UnityTest]
         public IEnumerator FailCorrectlyWhenGivenWrongURL()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/CoroutineHelpers/CoroutineUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/CoroutineHelpers/CoroutineUtils.cs
@@ -23,7 +23,7 @@ namespace DCL
             Func<double, bool> timeBudgetCounter
         )
         {
-            return monoBehaviour.StartCoroutine(DCLCoroutineRunner.Run(enumerator, onException, timeBudgetCounter));
+            return CoroutineStarter.Start(DCLCoroutineRunner.Run(enumerator, onException, timeBudgetCounter));
         }
 
 
@@ -42,7 +42,7 @@ namespace DCL
             Action<Exception> onException
         )
         {
-            return monoBehaviour.StartCoroutine(DCLCoroutineRunner.Run(enumerator, onException, null));
+            return CoroutineStarter.Start(DCLCoroutineRunner.Run(enumerator, onException, null));
         }
 
 


### PR DESCRIPTION
This PR fixes #1890 

**WHY**
* When traversing long distances without stopping, (as shown in #1890 with the railroad scene) the user can be loading and unloading a lot of scenes around him very quickly. In that scenario, many asset promises get cancelled while loading.
* When a same asset is requested from different scenes, if the first instance of the asset promise is still loading, the subsequent ones get into a WAITING blocked state that gets resolver AFTER the first one finishes downloading the asset and loading it. Those first asset promises are what we call **master promises**, and when those promises [are told to be forgotten](https://github.com/decentraland/unity-renderer/blob/ab815ad8c95bf5ddd1fb43dc80a799e28ea72af0/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs#L114) while still downloading/loading (for example when unloading the scene that requested it), if they are blocking other promises, we forget them in a special way we call ["silent forget"](https://github.com/decentraland/unity-renderer/blob/ab815ad8c95bf5ddd1fb43dc80a799e28ea72af0/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs#L135) that flags the promise as forgottten but allows it to finish downloading so that it unblocks the other promises that depend on that one
* The problem we were having is that when a far away scene gets unloaded (and its loading promises are forgotten) the scene gameobjects get deactivated, and since we were triggering the [`LoadAssetCoroutine` coroutine](https://github.com/decentraland/unity-renderer/blob/ab815ad8c95bf5ddd1fb43dc80a799e28ea72af0/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs#L222) from the [GLTFComponent monobehaviour itself](https://github.com/decentraland/unity-renderer/commit/fa747cbe5d378af438b718ca10dd5f8bf9ec4493), the running coroutine that [was waiting](https://github.com/decentraland/unity-renderer/blob/ab815ad8c95bf5ddd1fb43dc80a799e28ea72af0/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs#L296) to get a chance to download the promise asset, gets interrupted (since the GO gets deactivated by the scene unloading).
* By using the `CoroutineStarter` as we always do, the problem is solved because the coroutine that waits and ends up finishing the asset loading is never interrupted due to the scene unloading.
* The bug was more evident without using ABs, that's why it came out while developing the desktop client

**WHAT**
Fixed coroutines being started from monobehaviours (that were getting deactivated on silent forgets) instead of CoroutineStarter