### PR TITLE
fix: opensea 403 workaround

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/RequestController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/RequestController.cs
@@ -9,6 +9,11 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
     {
         private const bool VERBOSE = false;
 
+        private const string EDITOR_USER_AGENT =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36";
+
+        private const string EDITOR_REFERRER = "https://play.decentraland.org"; 
+
         internal readonly RequestScheduler requestScheduler = new RequestScheduler();
         private readonly Dictionary<string, RequestBase<AssetResponse>> cacheAssetResponses = new Dictionary<string, RequestBase<AssetResponse>>();
         private readonly Dictionary<string, RequestBase<AssetsResponse>> cacheSeveralAssetsResponse = new Dictionary<string, RequestBase<AssetsResponse>>();
@@ -89,9 +94,20 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             if (VERBOSE)
                 Debug.Log($"RequestController: Send Request: {url}");
 
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+
+#if (UNITY_EDITOR) || (UNITY_STANDALONE)
+            headers.Add("User-Agent", EDITOR_USER_AGENT);
+            headers.Add("referrer", EDITOR_REFERRER);
+#endif
+            
             // NOTE: In this case, as this code is implementing a very specific retries system (including delays), we use our
             //              custom WebRequest system without retries (requestAttemps = 1) and let the current code to apply the retries.
-            WebRequestAsyncOperation asyncOp = (WebRequestAsyncOperation) Environment.i.platform.webRequest.Get(url, requestAttemps: 1, disposeOnCompleted: true);
+            WebRequestAsyncOperation asyncOp = (WebRequestAsyncOperation) Environment.i.platform.webRequest.Get(
+                url,
+                requestAttemps: 1,
+                disposeOnCompleted: true,
+                headers: headers);
 
             asyncOp.completed += operation =>
             {


### PR DESCRIPTION
## What does this PR change?

In editor and desktop, opensea was giving 403 for all our requests.
This should fix the issue temporarily without having to use an api key.

## How to test the changes?

An easy way to test this is running from desktop or editor and go to 45,93. Or any scene that makes heavy use of NFTShapes.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
