### PR TITLE
chore: update apt-get before installing a package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ jobs:
           working_directory: *node_workspace
           name: npm run test
           command: npm run test
-      - run: sudo apt-get -y -qq install awscli
+      - run: sudo apt-get update && sudo apt-get -y -qq install awscli
       - run:
           working_directory: *node_workspace
           name: Deploy artifacts


### PR DESCRIPTION
Pipeline error because of missing apt-get update

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
