### PR TITLE
Fix: fixed general settings order

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Widgets/GeneralWidget.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Widgets/GeneralWidget.asset
@@ -23,9 +23,9 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 83813f0a3b25180468ace5f2297b7a3e, type: 2}
         - {fileID: 11400000, guid: ab5eaa6801a87654a87e47948716e153, type: 2}
         - {fileID: 11400000, guid: bb6c50358f2355f4f8245f3974b6db3f, type: 2}
+        - {fileID: 11400000, guid: 891daf979e603094b867bd233e346d3c, type: 2}
     - controls:
         array:
         - {fileID: 11400000, guid: 3c45a30e818384851ab2b246f44e90ad, type: 2}
         - {fileID: 11400000, guid: 1ec31801283824f4bb71f46f2af1a7b0, type: 2}
-        - {fileID: 11400000, guid: 891daf979e603094b867bd233e346d3c, type: 2}
         - {fileID: 11400000, guid: 0430a240bc6f82c4bbe87804db432668, type: 2}


### PR DESCRIPTION
## What does this PR change?

Moves the general settings in a new order, from this:

<img width="992" alt="Screenshot 2022-03-01 at 16 19 20" src="https://user-images.githubusercontent.com/4254522/156196098-23072bab-83f3-452a-ba84-ed7d639a63bf.png">

to this:

<img width="535" alt="Screenshot 2022-03-01 at 16 20 13" src="https://user-images.githubusercontent.com/4254522/156196261-b4af16bf-3ac8-48ec-b031-2a1e0af9e506.png">

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/settings-order
2. Go into general settings
3. Verify that the order is as in the screenshot

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
