### PR TITLE
fix: gif nftshapes preview modal breaks subsequent preview modals

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
@@ -7,6 +7,7 @@ using DCL.Helpers;
 using DCL.Helpers.NFT;
 using DCL.Interface;
 using System.Collections;
+using NFTShape_Internal;
 
 internal interface INFTPromptHUDView : IDisposable
 {
@@ -87,6 +88,7 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
 
     private bool isDestroyed = false;
     internal INFTAssetLoadHelper nftAssetLoadHelper;
+    private INFTAsset nftAsset;
 
     private void Awake()
     {
@@ -275,17 +277,19 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
         ShowImageErrorFeedback(false);
         ShowImageLoading(true);
 
-        if (nftAssetLoadHelper != null)
-            nftAssetLoadHelper.Dispose();
-
+        nftAssetLoadHelper?.Dispose();
+        nftAsset?.Dispose();
+        
         nftAssetLoadHelper = new NFTAssetLoadHelper();
         yield return nftAssetLoadHelper.LoadNFTAsset(
             nftInfo.previewImageUrl,
             OnSuccess: nftAsset =>
             {
-                nftAsset.OnTextureUpdate += UpdateTexture;
+                this.nftAsset = nftAsset;
+                this.nftAsset.Dispose();
+                this.nftAsset.OnTextureUpdate += UpdateTexture;
 
-                if (!(nftAsset is Asset_Gif))
+                if (!(this.nftAsset is Asset_Gif))
                 {
                     if (!backgroundColorSet)
                     {
@@ -293,8 +297,8 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
                     }
                 }
 
-                UpdateTexture(nftAsset.previewAsset.texture);
-                SetNFTImageSize(nftAsset.previewAsset.texture);
+                UpdateTexture(this.nftAsset.previewAsset.texture);
+                SetNFTImageSize(this.nftAsset.previewAsset.texture);
                 imageNft.gameObject.SetActive(true);
                 ShowImageLoading(false);
             },
@@ -398,6 +402,7 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
         ownersPopup.OnClosePopup -= OnOwnersPopupClose;
 
         nftAssetLoadHelper?.Dispose();
+        nftAsset?.Dispose();
     }
 
     private void OnViewAllOwnersPressed() { OnViewAllPressed?.Invoke(); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
@@ -288,7 +288,6 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
             OnSuccess: nftAsset =>
             {
                 this.nftAsset = nftAsset;
-                nftAsset.Dispose();
                 nftAsset.OnTextureUpdate += UpdateTexture;
 
                 if (!(nftAsset is Asset_Gif))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
@@ -114,6 +114,7 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
         }
 
         nftAssetLoadHelper?.Dispose();
+        nftAsset?.Dispose();
     }
 
     internal void Hide()
@@ -121,6 +122,7 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
         content.SetActive(false);
 
         nftAssetLoadHelper?.Dispose();
+        nftAsset?.Dispose();
 
         if (fetchNFTImageRoutine != null)
             StopCoroutine(fetchNFTImageRoutine);
@@ -286,10 +288,10 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
             OnSuccess: nftAsset =>
             {
                 this.nftAsset = nftAsset;
-                this.nftAsset.Dispose();
-                this.nftAsset.OnTextureUpdate += UpdateTexture;
+                nftAsset.Dispose();
+                nftAsset.OnTextureUpdate += UpdateTexture;
 
-                if (!(this.nftAsset is Asset_Gif))
+                if (!(nftAsset is Asset_Gif))
                 {
                     if (!backgroundColorSet)
                     {
@@ -297,8 +299,8 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
                     }
                 }
 
-                UpdateTexture(this.nftAsset.previewAsset.texture);
-                SetNFTImageSize(this.nftAsset.previewAsset.texture);
+                UpdateTexture(nftAsset.previewAsset.texture);
+                SetNFTImageSize(nftAsset.previewAsset.texture);
                 imageNft.gameObject.SetActive(true);
                 ShowImageLoading(false);
             },


### PR DESCRIPTION
## What does this PR change?

`fixes decentraland/explorer-desktop/#118`

## How to test the changes?

1. Go to desktop launcher (--developer-mode) and set `fix/overlapping-gif` over explorer-desktop branch
2. Go to soho plaza (-88,8) and enter into the gallery
3. Open the nft preview on all the gifs you see
4. The gifs should be previewed correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
