### PR TITLE
feat: better scene metrics (memory)

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioClip.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioClip.cs
@@ -55,8 +55,13 @@ namespace DCL.Components
         {
             if (assetAudioClip.audioClip != null)
             {
+                if (this.audioClip != null)
+                    DataStore.i.sceneWorldObjects.RemoveAudioClip(scene.sceneData.id, audioClip);
+
                 this.audioClip = assetAudioClip.audioClip;
                 loadingState = LoadState.LOADING_COMPLETED;
+
+                DataStore.i.sceneWorldObjects.AddAudioClip(scene.sceneData.id, audioClip);
             }
             else
             {
@@ -97,6 +102,9 @@ namespace DCL.Components
         {
             loadingState = LoadState.IDLE;
             AssetPromiseKeeper_AudioClip.i.Forget(audioClipPromise);
+
+            if (this.audioClip != null)
+                DataStore.i.sceneWorldObjects.RemoveAudioClip(scene.sceneData.id, audioClip);
         }
 
         public override IEnumerator ApplyChanges(BaseModel newModel)
@@ -127,6 +135,9 @@ namespace DCL.Components
 
         public override void Dispose()
         {
+            if (this.audioClip != null)
+                DataStore.i.sceneWorldObjects.RemoveAudioClip(scene.sceneData.id, audioClip);
+
             isDisposed = true;
             AssetPromiseKeeper_AudioClip.i.Forget(audioClipPromise);
             base.Dispose();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
@@ -36,7 +36,9 @@ namespace DCL.Components
             audioSource = gameObject.GetOrCreateComponent<AudioSource>();
             model = new Model();
 
-            Settings.i.audioSettings.OnChanged += OnAudioSettingsChanged;
+            if (Settings.i != null)
+                Settings.i.audioSettings.OnChanged += OnAudioSettingsChanged;
+    
             DataStore.i.virtualAudioMixer.sceneSFXVolume.OnChange += OnVirtualAudioMixerChangedValue;
         }
 
@@ -128,7 +130,7 @@ namespace DCL.Components
 
         private void UpdateAudioSourceVolume()
         {
-            AudioSettings audioSettingsData = Settings.i.audioSettings.Data;
+            AudioSettings audioSettingsData = Settings.i != null ? Settings.i.audioSettings.Data : new AudioSettings();
             float newVolume = ((Model)model).volume * Utils.ToVolumeCurve(DataStore.i.virtualAudioMixer.sceneSFXVolume.Get() * audioSettingsData.sceneSFXVolume * audioSettingsData.masterVolume);
 
             if (scene is GlobalScene globalScene && globalScene.isPortableExperience)
@@ -166,10 +168,12 @@ namespace DCL.Components
             isDestroyed = true;
             CommonScriptableObjects.sceneID.OnChange -= OnCurrentSceneChanged;
 
-            //NOTE(Brian): Unsuscribe events.
+            //NOTE(Brian): Unsubscribe events.
             InitDCLAudioClip(null);
 
-            Settings.i.audioSettings.OnChanged -= OnAudioSettingsChanged;
+            if (Settings.i != null)
+                Settings.i.audioSettings.OnChanged -= OnAudioSettingsChanged;
+            
             DataStore.i.virtualAudioMixer.sceneSFXVolume.OnChange -= OnVirtualAudioMixerChangedValue;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -151,8 +151,9 @@ namespace DCL
                 yield return MaterialCachingHelper.Process(asset.renderers.ToList(), enableRenderers: false, settings.cachingFlags);
 
                 var animators = MeshesInfoUtils.ExtractUniqueAnimations(assetBundleModelGO);
-                asset.animationClips = MeshesInfoUtils.ExtractUniqueAnimationClips(animators);
-
+                asset.animationClipSize = 0; // TODO(Brian): Extract animation clip size from metadata
+                asset.meshDataSize = 0; // TODO(Brian): Extract mesh clip size from metadata
+                
                 foreach (var animator in animators)
                 {
                     animator.cullingType = AnimationCullingType.AlwaysAnimate;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -150,11 +150,12 @@ namespace DCL
                 //NOTE(Brian): Renderers are enabled in settings.ApplyAfterLoad
                 yield return MaterialCachingHelper.Process(asset.renderers.ToList(), enableRenderers: false, settings.cachingFlags);
 
-                var animators = assetBundleModelGO.GetComponentsInChildren<Animation>(true);
+                var animators = MeshesInfoUtils.ExtractUniqueAnimations(assetBundleModelGO);
+                asset.animationClips = MeshesInfoUtils.ExtractUniqueAnimationClips(animators);
 
-                for (int animIndex = 0; animIndex < animators.Length; animIndex++)
+                foreach (var animator in animators)
                 {
-                    animators[animIndex].cullingType = AnimationCullingType.AlwaysAnimate;
+                    animator.cullingType = AnimationCullingType.AlwaysAnimate;
                 }
 
 #if UNITY_EDITOR

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
@@ -15,8 +15,8 @@ namespace DCL
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
         public int totalTriangleCount = 0;
-        public int animationClipSize = 0;
-        public int meshDataSize = 0;
+        public long animationClipSize = 0;
+        public long meshDataSize = 0;
 
         public Asset_AB_GameObject()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
@@ -14,6 +14,7 @@ namespace DCL
         public HashSet<Mesh> meshes = new HashSet<Mesh>();
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
+        public HashSet<AnimationClip> animationClips = new HashSet<AnimationClip>();
         public int totalTriangleCount = 0;
 
         public Asset_AB_GameObject()
@@ -31,6 +32,7 @@ namespace DCL
             result.renderers = new HashSet<Renderer>(renderers);
             result.materials = new HashSet<Material>(materials);
             result.textures = new HashSet<Texture>(textures);
+            result.animationClips = new HashSet<AnimationClip>(animationClips);
             return result;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
@@ -14,8 +14,9 @@ namespace DCL
         public HashSet<Mesh> meshes = new HashSet<Mesh>();
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
-        public HashSet<AnimationClip> animationClips = new HashSet<AnimationClip>();
         public int totalTriangleCount = 0;
+        public int animationClipSize = 0;
+        public int meshDataSize = 0;
 
         public Asset_AB_GameObject()
         {
@@ -32,7 +33,6 @@ namespace DCL
             result.renderers = new HashSet<Renderer>(renderers);
             result.materials = new HashSet<Material>(materials);
             result.textures = new HashSet<Texture>(textures);
-            result.animationClips = new HashSet<AnimationClip>(animationClips);
             return result;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -107,8 +107,8 @@ namespace DCL
                             MeshesInfoUtils.ComputeTotalTriangles(asset.renderers, asset.meshToTriangleCount);
                         asset.materials = MeshesInfoUtils.ExtractUniqueMaterials(asset.renderers);
                         asset.textures = MeshesInfoUtils.ExtractUniqueTextures(asset.materials);
-                        var animations = MeshesInfoUtils.ExtractUniqueAnimations(asset.container);
-                        asset.animationClips = MeshesInfoUtils.ExtractUniqueAnimationClips(animations);
+                        asset.animationClipSize = gltfComponent.GetAnimationClipMemorySize();
+                        asset.meshDataSize = gltfComponent.GetMeshesMemorySize(); 
                     }
 
                     OnSuccess.Invoke();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -107,6 +107,8 @@ namespace DCL
                             MeshesInfoUtils.ComputeTotalTriangles(asset.renderers, asset.meshToTriangleCount);
                         asset.materials = MeshesInfoUtils.ExtractUniqueMaterials(asset.renderers);
                         asset.textures = MeshesInfoUtils.ExtractUniqueTextures(asset.materials);
+                        var animations = MeshesInfoUtils.ExtractUniqueAnimations(asset.container);
+                        asset.animationClips = MeshesInfoUtils.ExtractUniqueAnimationClips(animations);
                     }
 
                     OnSuccess.Invoke();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
@@ -18,9 +18,9 @@ namespace DCL
         public HashSet<Renderer> renderers = new HashSet<Renderer>();
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
-        public int animationClipSize = 0;
         public int totalTriangleCount = 0;
-        public int meshDataSize = 0;
+        public long animationClipSize = 0;
+        public long meshDataSize = 0;
 
         Coroutine showCoroutine;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
@@ -18,6 +18,7 @@ namespace DCL
         public HashSet<Renderer> renderers = new HashSet<Renderer>();
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
+        public HashSet<AnimationClip> animationClips = new HashSet<AnimationClip>();
         public int totalTriangleCount = 0;
 
         Coroutine showCoroutine;
@@ -33,6 +34,11 @@ namespace DCL
             Asset_GLTF result = this.MemberwiseClone() as Asset_GLTF;
             result.visible = true;
             result.meshes = new HashSet<Mesh>(meshes);
+            result.renderers = new HashSet<Renderer>(renderers);
+            result.materials = new HashSet<Material>(materials);
+            result.textures = new HashSet<Texture>(textures);
+            result.animationClips = new HashSet<AnimationClip>(animationClips);
+            result.meshToTriangleCount = new Dictionary<Mesh, int>(meshToTriangleCount);
             return result;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
@@ -18,8 +18,9 @@ namespace DCL
         public HashSet<Renderer> renderers = new HashSet<Renderer>();
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
-        public HashSet<AnimationClip> animationClips = new HashSet<AnimationClip>();
+        public int animationClipSize = 0;
         public int totalTriangleCount = 0;
+        public int meshDataSize = 0;
 
         Coroutine showCoroutine;
 
@@ -37,7 +38,6 @@ namespace DCL
             result.renderers = new HashSet<Renderer>(renderers);
             result.materials = new HashSet<Material>(materials);
             result.textures = new HashSet<Texture>(textures);
-            result.animationClips = new HashSet<AnimationClip>(animationClips);
             result.meshToTriangleCount = new Dictionary<Mesh, int>(meshToTriangleCount);
             return result;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MeshesInfo/MeshesInfoUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MeshesInfo/MeshesInfoUtils.cs
@@ -84,6 +84,26 @@ namespace DCL.Models
         private static List<int> texIdsCache = new List<int>();
         private static List<string> texNameCache = new List<string>();
 
+        public static HashSet<Animation> ExtractUniqueAnimations(GameObject container)
+        {
+            return new HashSet<Animation>(container.GetComponentsInChildren<Animation>(true));
+        }
+
+        public static HashSet<AnimationClip> ExtractUniqueAnimationClips(HashSet<Animation> animations)
+        {
+            HashSet<AnimationClip> result = new HashSet<AnimationClip>();
+
+            foreach (var anim in animations)
+            {
+                foreach (AnimationState state in anim)
+                {
+                    result.Add(state.clip);
+                }
+            }
+
+            return result;
+        }
+
         public static HashSet<Renderer> ExtractUniqueRenderers(GameObject container)
         {
             return new HashSet<Renderer>(container.GetComponentsInChildren<Renderer>(true));

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MeshesInfo/Rendereable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MeshesInfo/Rendereable.cs
@@ -22,6 +22,7 @@ namespace DCL
         public HashSet<Renderer> renderers = new HashSet<Renderer>();
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
+        public HashSet<AnimationClip> animationClips = new HashSet<AnimationClip>();
         public int totalTriangleCount = 0;
 
         public bool Equals(Rendereable other)
@@ -37,6 +38,7 @@ namespace DCL
             result.materials = new HashSet<Material>(materials);
             result.textures = new HashSet<Texture>(textures);
             result.meshes = new HashSet<Mesh>(meshes);
+            result.animationClips = new HashSet<AnimationClip>(animationClips);
             return result;
         }
 
@@ -45,6 +47,8 @@ namespace DCL
             Rendereable rendereable = new Rendereable();
             rendereable.container = go;
             rendereable.renderers = MeshesInfoUtils.ExtractUniqueRenderers(go);
+            var animations = MeshesInfoUtils.ExtractUniqueAnimations(go);
+            rendereable.animationClips = MeshesInfoUtils.ExtractUniqueAnimationClips(animations);
             rendereable.materials = MeshesInfoUtils.ExtractUniqueMaterials(rendereable.renderers);
             rendereable.textures = MeshesInfoUtils.ExtractUniqueTextures(rendereable.materials);
             rendereable.meshes = MeshesInfoUtils.ExtractUniqueMeshes(rendereable.renderers);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MeshesInfo/Rendereable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MeshesInfo/Rendereable.cs
@@ -22,8 +22,9 @@ namespace DCL
         public HashSet<Renderer> renderers = new HashSet<Renderer>();
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
-        public HashSet<AnimationClip> animationClips = new HashSet<AnimationClip>();
         public int totalTriangleCount = 0;
+        public int animationClipSize = 0;
+        public int meshDataSize = 0;
 
         public bool Equals(Rendereable other)
         {
@@ -38,7 +39,6 @@ namespace DCL
             result.materials = new HashSet<Material>(materials);
             result.textures = new HashSet<Texture>(textures);
             result.meshes = new HashSet<Mesh>(meshes);
-            result.animationClips = new HashSet<AnimationClip>(animationClips);
             return result;
         }
 
@@ -47,8 +47,6 @@ namespace DCL
             Rendereable rendereable = new Rendereable();
             rendereable.container = go;
             rendereable.renderers = MeshesInfoUtils.ExtractUniqueRenderers(go);
-            var animations = MeshesInfoUtils.ExtractUniqueAnimations(go);
-            rendereable.animationClips = MeshesInfoUtils.ExtractUniqueAnimationClips(animations);
             rendereable.materials = MeshesInfoUtils.ExtractUniqueMaterials(rendereable.renderers);
             rendereable.textures = MeshesInfoUtils.ExtractUniqueTextures(rendereable.materials);
             rendereable.meshes = MeshesInfoUtils.ExtractUniqueMeshes(rendereable.renderers);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MeshesInfo/Rendereable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MeshesInfo/Rendereable.cs
@@ -23,8 +23,8 @@ namespace DCL
         public HashSet<Material> materials = new HashSet<Material>();
         public HashSet<Texture> textures = new HashSet<Texture>();
         public int totalTriangleCount = 0;
-        public int animationClipSize = 0;
-        public int meshDataSize = 0;
+        public long animationClipSize = 0;
+        public long meshDataSize = 0;
 
         public bool Equals(Rendereable other)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_WorldObjects.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_WorldObjects.cs
@@ -15,7 +15,7 @@ namespace DCL
             public readonly BaseHashSet<string> owners = new BaseHashSet<string>();
             public readonly BaseHashSet<Renderer> renderers = new BaseHashSet<Renderer>();
             public readonly BaseHashSet<AudioClip> audioClips = new BaseHashSet<AudioClip>();
-            public readonly BaseHashSet<AnimationClip> animationClips = new BaseHashSet<AnimationClip>();
+            public readonly BaseRefCounter<AnimationClip> animationClips = new BaseRefCounter<AnimationClip>();
         }
 
         public readonly BaseDictionary<string, SceneData> sceneData = new BaseDictionary<string, SceneData>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_WorldObjects.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_WorldObjects.cs
@@ -14,6 +14,8 @@ namespace DCL
             public readonly BaseVariable<int> triangles = new BaseVariable<int>();
             public readonly BaseHashSet<string> owners = new BaseHashSet<string>();
             public readonly BaseHashSet<Renderer> renderers = new BaseHashSet<Renderer>();
+            public readonly BaseHashSet<AudioClip> audioClips = new BaseHashSet<AudioClip>();
+            public readonly BaseHashSet<AnimationClip> animationClips = new BaseHashSet<AnimationClip>();
         }
 
         public readonly BaseDictionary<string, SceneData> sceneData = new BaseDictionary<string, SceneData>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_WorldObjects.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_WorldObjects.cs
@@ -11,11 +11,13 @@ namespace DCL
             public readonly BaseRefCounter<Mesh> meshes = new BaseRefCounter<Mesh>();
             public readonly BaseRefCounter<Material> materials = new BaseRefCounter<Material>();
             public readonly BaseRefCounter<Texture> textures = new BaseRefCounter<Texture>();
-            public readonly BaseVariable<int> triangles = new BaseVariable<int>();
             public readonly BaseHashSet<string> owners = new BaseHashSet<string>();
             public readonly BaseHashSet<Renderer> renderers = new BaseHashSet<Renderer>();
             public readonly BaseHashSet<AudioClip> audioClips = new BaseHashSet<AudioClip>();
-            public readonly BaseRefCounter<AnimationClip> animationClips = new BaseRefCounter<AnimationClip>();
+
+            public readonly BaseVariable<int> triangles = new BaseVariable<int>();
+            public readonly BaseVariable<int> animationClipSize = new BaseVariable<int>();
+            public readonly BaseVariable<int> meshDataSize = new BaseVariable<int>();
         }
 
         public readonly BaseDictionary<string, SceneData> sceneData = new BaseDictionary<string, SceneData>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_WorldObjects.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_WorldObjects.cs
@@ -16,8 +16,8 @@ namespace DCL
             public readonly BaseHashSet<AudioClip> audioClips = new BaseHashSet<AudioClip>();
 
             public readonly BaseVariable<int> triangles = new BaseVariable<int>();
-            public readonly BaseVariable<int> animationClipSize = new BaseVariable<int>();
-            public readonly BaseVariable<int> meshDataSize = new BaseVariable<int>();
+            public readonly BaseVariable<long> animationClipSize = new BaseVariable<long>();
+            public readonly BaseVariable<long> meshDataSize = new BaseVariable<long>();
         }
 
         public readonly BaseDictionary<string, SceneData> sceneData = new BaseDictionary<string, SceneData>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataStore_Rendering_Extensions/DataStore_WorldObjects_Extensions.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataStore_Rendering_Extensions/DataStore_WorldObjects_Extensions.cs
@@ -65,7 +65,8 @@ namespace DCL
             RemoveRendereable(self, sceneId, r);
         }
 
-        public static void AddMaterial(this DataStore_WorldObjects self, string sceneId, string ownerId, Material material )
+        public static void AddMaterial(this DataStore_WorldObjects self, string sceneId, string ownerId,
+            Material material)
         {
             var r = new Rendereable();
             r.materials.Add(material);
@@ -73,12 +74,23 @@ namespace DCL
             AddRendereable(self, sceneId, r);
         }
 
-        public static void RemoveMaterial(this DataStore_WorldObjects self, string sceneId, string ownerId, Material material )
+        public static void RemoveMaterial(this DataStore_WorldObjects self, string sceneId, string ownerId,
+            Material material)
         {
             var r = new Rendereable();
             r.materials.Add(material);
             r.ownerId = ownerId;
             RemoveRendereable(self, sceneId, r);
+        }
+
+        public static void AddAudioClip(this DataStore_WorldObjects self, string sceneId, string ownerId,
+            AudioClip clip)
+        {
+        }
+
+        public static void RemoveAudioClip(this DataStore_WorldObjects self, string sceneId, string ownerId,
+            AudioClip clip)
+        {
         }
 
 
@@ -110,6 +122,7 @@ namespace DCL
             sceneData.materials.AddRefCount(rendereable.materials);
             sceneData.meshes.AddRefCount(rendereable.meshes);
             sceneData.textures.AddRefCount(rendereable.textures);
+            sceneData.animationClips.AddRefCount(rendereable.animationClips);
             sceneData.renderers.Add(rendereable.renderers);
             sceneData.owners.Add(rendereable.ownerId);
             sceneData.triangles.Set( sceneData.triangles.Get() + rendereable.totalTriangleCount);
@@ -143,6 +156,7 @@ namespace DCL
             sceneData.materials.RemoveRefCount(rendereable.materials);
             sceneData.meshes.RemoveRefCount(rendereable.meshes);
             sceneData.textures.RemoveRefCount(rendereable.textures);
+            sceneData.animationClips.RemoveRefCount(rendereable.animationClips);
             sceneData.renderers.Remove(rendereable.renderers);
             sceneData.owners.Remove(rendereable.ownerId);
             sceneData.triangles.Set( sceneData.triangles.Get() - rendereable.totalTriangleCount);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataStore_Rendering_Extensions/DataStore_WorldObjects_Extensions.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataStore_Rendering_Extensions/DataStore_WorldObjects_Extensions.cs
@@ -122,10 +122,11 @@ namespace DCL
             sceneData.materials.AddRefCount(rendereable.materials);
             sceneData.meshes.AddRefCount(rendereable.meshes);
             sceneData.textures.AddRefCount(rendereable.textures);
-            sceneData.animationClips.AddRefCount(rendereable.animationClips);
             sceneData.renderers.Add(rendereable.renderers);
             sceneData.owners.Add(rendereable.ownerId);
             sceneData.triangles.Set( sceneData.triangles.Get() + rendereable.totalTriangleCount);
+            sceneData.animationClipSize.Set(sceneData.animationClipSize.Get() + rendereable.animationClipSize);
+            sceneData.meshDataSize.Set(sceneData.meshDataSize.Get() + rendereable.meshDataSize);
         }
 
         public static void RemoveRendereable( this DataStore_WorldObjects self, string sceneId, Rendereable rendereable )
@@ -156,10 +157,11 @@ namespace DCL
             sceneData.materials.RemoveRefCount(rendereable.materials);
             sceneData.meshes.RemoveRefCount(rendereable.meshes);
             sceneData.textures.RemoveRefCount(rendereable.textures);
-            sceneData.animationClips.RemoveRefCount(rendereable.animationClips);
             sceneData.renderers.Remove(rendereable.renderers);
             sceneData.owners.Remove(rendereable.ownerId);
             sceneData.triangles.Set( sceneData.triangles.Get() - rendereable.totalTriangleCount);
+            sceneData.animationClipSize.Set(sceneData.animationClipSize.Get() - rendereable.animationClipSize);
+            sceneData.meshDataSize.Set(sceneData.meshDataSize.Get() - rendereable.meshDataSize);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataStore_Rendering_Extensions/DataStore_WorldObjects_Extensions.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/DataStore_Rendering_Extensions/DataStore_WorldObjects_Extensions.cs
@@ -83,14 +83,21 @@ namespace DCL
             RemoveRendereable(self, sceneId, r);
         }
 
-        public static void AddAudioClip(this DataStore_WorldObjects self, string sceneId, string ownerId,
-            AudioClip clip)
+        public static void AddAudioClip(this DataStore_WorldObjects self, string sceneId, AudioClip clip)
         {
+            // NOTE(Brian): entityId is not used here, so audio clips do not work with the ignoreOwners
+            //              feature. This is done on purpose as ignoreOwners is only used by the smart item component
+            //              and should be deprecated. Also, supporting this would complicate the tracking logic and
+            //              has a high maintenance cost.
+
+            var sceneData = self.sceneData[sceneId];
+            sceneData.audioClips.Add(clip);
         }
 
-        public static void RemoveAudioClip(this DataStore_WorldObjects self, string sceneId, string ownerId,
-            AudioClip clip)
+        public static void RemoveAudioClip(this DataStore_WorldObjects self, string sceneId, AudioClip clip)
         {
+            var sceneData = self.sceneData[sceneId];
+            sceneData.audioClips.Remove(clip);
         }
 
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -164,7 +164,8 @@ namespace DCL.Components
                     renderers = x.renderers,
                     materials = x.materials,
                     textures = x.textures,
-                    meshToTriangleCount = x.meshToTriangleCount
+                    meshToTriangleCount = x.meshToTriangleCount,
+                    animationClips = x.animationClips
                 };
 
                 OnSuccessWrapper(r, OnSuccess);
@@ -204,7 +205,8 @@ namespace DCL.Components
                     renderers = x.renderers,
                     materials = x.materials,
                     textures = x.textures,
-                    meshToTriangleCount = x.meshToTriangleCount
+                    meshToTriangleCount = x.meshToTriangleCount,
+                    animationClips = x.animationClips
                 };
 
                 OnSuccessWrapper(r, OnSuccess);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -165,7 +165,8 @@ namespace DCL.Components
                     materials = x.materials,
                     textures = x.textures,
                     meshToTriangleCount = x.meshToTriangleCount,
-                    animationClips = x.animationClips
+                    animationClipSize = x.animationClipSize,
+                    meshDataSize = x.meshDataSize
                 };
 
                 OnSuccessWrapper(r, OnSuccess);
@@ -206,7 +207,8 @@ namespace DCL.Components
                     materials = x.materials,
                     textures = x.textures,
                     meshToTriangleCount = x.meshToTriangleCount,
-                    animationClips = x.animationClips
+                    animationClipSize = x.animationClipSize,
+                    meshDataSize = x.meshDataSize
                 };
 
                 OnSuccessWrapper(r, OnSuccess);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/BaseComponent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/BaseComponent.cs
@@ -55,7 +55,10 @@ namespace DCL.Components
 
         public bool IsValid() { return this != null; }
 
-        public virtual void Cleanup() { updateHandler.Cleanup(); }
+        public virtual void Cleanup()
+        {
+            updateHandler?.Cleanup();
+        }
 
         public virtual void OnPoolRelease() { Cleanup(); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/SceneMetricsModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/SceneMetricsModel.cs
@@ -11,10 +11,10 @@
         public int entities;
         public float sceneHeight;
 
-        public float textureMemory;
-        public float meshMemory;
-        public float audioClipMemory;
-        public float animationClipMemory;
+        public long textureMemory;
+        public long meshMemory;
+        public long audioClipMemory;
+        public long animationClipMemory;
 
         public SceneMetricsModel Clone() { return (SceneMetricsModel) MemberwiseClone(); }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/SceneMetricsModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/SceneMetricsModel.cs
@@ -11,6 +11,11 @@
         public int entities;
         public float sceneHeight;
 
+        public float textureMemory;
+        public float meshMemory;
+        public float audioClipMemory;
+        public float animationClipMemory;
+
         public SceneMetricsModel Clone() { return (SceneMetricsModel) MemberwiseClone(); }
 
         public static bool operator >(SceneMetricsModel lhs, SceneMetricsModel rhs)
@@ -55,7 +60,21 @@
 
         public override string ToString()
         {
-            return $"Textures: {textures} - Triangles: {triangles} - Materials: {materials} - Meshes: {meshes} - Bodies: {bodies} - Entities: {entities} - Scene Height: {sceneHeight}";
+            string result = "";
+
+            result += $"Textures: {textures}";
+            result += $"- Texture Memory: {textureMemory}";
+            result += $"- Triangles: {triangles}";
+            result += $"- Mesh Memory: {meshMemory}";
+            result += $"- Materials: {materials}";
+            result += $"- Meshes: {meshes}";
+            result += $"- Bodies: {bodies}";
+            result += $"- Entities: {entities}";
+            result += $"- Scene Height: {sceneHeight}";
+            result += $"- Audio Memory: {audioClipMemory}";
+            result += $"- Animation Memory: {animationClipMemory}";
+
+            return result;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs
@@ -4,17 +4,17 @@ namespace DCL
 {
     public static class MetricsScoreUtils
     {
-        public static float ComputeAudioClipScore(AudioClip audioClip)
+        public static long ComputeAudioClipScore(AudioClip audioClip)
         {
-            const float BYTES_PER_SAMPLE = 2; // We assume sample resolution of 65535
-            return audioClip.samples * audioClip.channels * BYTES_PER_SAMPLE;
+            const double BYTES_PER_SAMPLE = 2; // We assume sample resolution of 65535
+            return (long) (audioClip.samples * audioClip.channels * BYTES_PER_SAMPLE);
         }
 
-        public static float ComputeTextureScore(Texture2D texture)
+        public static long ComputeTextureScore(Texture2D texture)
         {
-            const float MIPMAP_FACTOR = 1.3f;
-            const float BYTES_PER_PIXEL = 4;
-            return texture.width * texture.height * BYTES_PER_PIXEL * MIPMAP_FACTOR;
+            const double MIPMAP_FACTOR = 2.4f;
+            const double BYTES_PER_PIXEL = 4;
+            return (long) (texture.width * texture.height * BYTES_PER_PIXEL * MIPMAP_FACTOR);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs
@@ -17,11 +17,14 @@ namespace DCL
 
         public static long ComputeTextureScore(Texture2D texture)
         {
+            // https://forum.unity.com/threads/does-unity-always-use-double-memory-for-texture-in-runtime.198270/
+            const double ARBITRARY_UNITY_MEMORY_MULTIPLIER = 2;
+
             // The mipmap memory increase should be actually 1.33 according to many sources
-            // But for Unity it seems to be up to 2.33. This was tested even with GPU only textures.
-            const double MIPMAP_FACTOR = 2.4f; 
+            const double MIPMAP_FACTOR = 1.4f; 
             const double BYTES_PER_PIXEL = 4;
-            return (long) (texture.width * texture.height * BYTES_PER_PIXEL * MIPMAP_FACTOR);
+            return (long) (texture.width * texture.height * BYTES_PER_PIXEL * MIPMAP_FACTOR *
+                           ARBITRARY_UNITY_MEMORY_MULTIPLIER);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+
+namespace DCL
+{
+    public static class MetricsScoreUtils
+    {
+        public static float ComputeAudioClipScore(AudioClip audioClip)
+        {
+            const float BYTES_PER_SAMPLE = 2; // We assume sample resolution of 65535
+            return audioClip.samples * audioClip.channels * BYTES_PER_SAMPLE;
+        }
+
+        public static float ComputeTextureScore(Texture2D texture)
+        {
+            const float MIPMAP_FACTOR = 1.3f;
+            const float BYTES_PER_PIXEL = 4;
+            return texture.width * texture.height * BYTES_PER_PIXEL * MIPMAP_FACTOR;
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs
@@ -6,13 +6,20 @@ namespace DCL
     {
         public static long ComputeAudioClipScore(AudioClip audioClip)
         {
-            const double BYTES_PER_SAMPLE = 2; // We assume sample resolution of 65535
-            return (long) (audioClip.samples * audioClip.channels * BYTES_PER_SAMPLE);
+            long baseOverhead = 3000; // Measured 2708 profiling AudioClip with 1 sample and 2 channels.
+            // Rounding up just in case.
+
+            // For most cases the sample resolution should be of 65535 (PCM)
+            // But the size seems to be rounded up to 4 bytes. (Maybe due to Mono aligning the bytes?)
+            const double BYTES_PER_SAMPLE = 4;
+            return (long) (audioClip.samples * audioClip.channels * BYTES_PER_SAMPLE) + baseOverhead;
         }
 
         public static long ComputeTextureScore(Texture2D texture)
         {
-            const double MIPMAP_FACTOR = 2.4f;
+            // The mipmap memory increase should be actually 1.33 according to many sources
+            // But for Unity it seems to be up to 2.33. This was tested even with GPU only textures.
+            const double MIPMAP_FACTOR = 2.4f; 
             const double BYTES_PER_PIXEL = 4;
             return (long) (texture.width * texture.height * BYTES_PER_PIXEL * MIPMAP_FACTOR);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/MetricsScoreUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 65131ef0e7f0484b9d27faad63048c78
+timeCreated: 1646775844

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
@@ -224,13 +224,13 @@ namespace DCL
         }
 
 
-        private void OnMeshDataSizeChange(int current, int previous)
+        private void OnMeshDataSizeChange(long current, long previous)
         {
             MarkDirty();
             currentCountValue.meshMemory = current;
         }
 
-        void OnAnimationClipSizeChange(int animationClipSize, int previous)
+        void OnAnimationClipSizeChange(long animationClipSize, long previous)
         {
             MarkDirty();
             currentCountValue.animationClipMemory = animationClipSize;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
@@ -271,17 +271,20 @@ namespace DCL
         {
             if (string.IsNullOrEmpty(sceneId))
                 return;
-            
-            var sceneData = data?.sceneData[sceneId];
 
-            if ( sceneData != null )
+            if (data != null && data.sceneData.ContainsKey(sceneId))
             {
-                currentCountValue.materials = sceneData.materials.Count();
-                currentCountValue.textures = sceneData.textures.Count();
-                currentCountValue.meshes = sceneData.meshes.Count();
-                currentCountValue.entities = sceneData.owners.Count();
-                currentCountValue.bodies = sceneData.renderers.Count();
-                currentCountValue.triangles = sceneData.triangles.Get() / 3;
+                var sceneData = data.sceneData[sceneId];
+
+                if (sceneData != null)
+                {
+                    currentCountValue.materials = sceneData.materials.Count();
+                    currentCountValue.textures = sceneData.textures.Count();
+                    currentCountValue.meshes = sceneData.meshes.Count();
+                    currentCountValue.entities = sceneData.owners.Count();
+                    currentCountValue.bodies = sceneData.renderers.Count();
+                    currentCountValue.triangles = sceneData.triangles.Get() / 3;
+                }
             }
 
             logger.Verbose($"Current metrics: {currentCountValue}");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
@@ -292,7 +292,7 @@ namespace DCL
         {
             float size = Profiler.GetRuntimeMemorySizeLong(mesh);
             Debug.unityLogger.logEnabled = true;
-            Debug.Log("Mesh Size: " + size);
+            Debug.Log($"Mesh Size: {size} ... is readable: {mesh.isReadable} ... vert count: {mesh.vertexCount}");
             Debug.unityLogger.logEnabled = false;
             return size;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
@@ -99,8 +99,8 @@ namespace DCL
             sceneData.meshes.OnAdded += OnMeshAdded;
             sceneData.meshes.OnRemoved += OnMeshRemoved;
 
-            sceneData.animationClips.OnAdded += OnAnimationClipAdded;
-            sceneData.animationClips.OnRemoved += OnAnimationClipRemoved;
+            sceneData.animationClipSize.OnChange += OnAnimationClipSizeChange;
+            sceneData.meshDataSize.OnChange += OnMeshDataSizeChange;
 
             sceneData.audioClips.OnAdded += OnAudioClipAdded;
             sceneData.audioClips.OnRemoved += OnAudioClipRemoved;
@@ -218,16 +218,16 @@ namespace DCL
         }
 
 
-        void OnAnimationClipAdded(AnimationClip animationClip)
+        private void OnMeshDataSizeChange(int current, int previous)
         {
             MarkDirty();
-            currentCountValue.animationClipMemory += ComputeAnimationClipScore(animationClip);
+            currentCountValue.meshMemory = current;
         }
 
-        void OnAnimationClipRemoved(AnimationClip animationClip)
+        void OnAnimationClipSizeChange(int animationClipSize, int previous)
         {
             MarkDirty();
-            currentCountValue.animationClipMemory -= ComputeAnimationClipScore(animationClip);
+            currentCountValue.animationClipMemory = animationClipSize;
         }
 
         void OnMaterialAdded(Material material)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneMetricsCounter/SceneMetricsCounter.cs
@@ -89,14 +89,20 @@ namespace DCL
 
             var sceneData = data.sceneData[sceneId];
 
-            sceneData.materials.OnAdded += OnDataChanged;
-            sceneData.materials.OnRemoved += OnDataChanged;
+            sceneData.materials.OnAdded += OnMaterialAdded;
+            sceneData.materials.OnRemoved += OnMaterialRemoved;
 
-            sceneData.textures.OnAdded += OnDataChanged;
-            sceneData.textures.OnRemoved += OnDataChanged;
+            sceneData.textures.OnAdded += OnTextureAdded;
+            sceneData.textures.OnRemoved += OnTextureRemoved;
 
-            sceneData.meshes.OnAdded += OnDataChanged;
-            sceneData.meshes.OnRemoved += OnDataChanged;
+            sceneData.meshes.OnAdded += OnMeshAdded;
+            sceneData.meshes.OnRemoved += OnMeshRemoved;
+
+            sceneData.animationClips.OnAdded += OnAnimationClipAdded;
+            sceneData.animationClips.OnRemoved += OnAnimationClipRemoved;
+
+            sceneData.audioClips.OnAdded += OnAudioClipAdded;
+            sceneData.audioClips.OnRemoved += OnAudioClipRemoved;
 
             sceneData.renderers.OnAdded += OnDataChanged;
             sceneData.renderers.OnRemoved += OnDataChanged;
@@ -119,11 +125,11 @@ namespace DCL
             sceneData.materials.OnAdded -= OnDataChanged;
             sceneData.materials.OnRemoved -= OnDataChanged;
 
-            sceneData.textures.OnAdded -= OnDataChanged;
-            sceneData.textures.OnRemoved -= OnDataChanged;
+            sceneData.textures.OnAdded -= OnTextureAdded;
+            sceneData.textures.OnRemoved -= OnTextureRemoved;
 
-            sceneData.meshes.OnAdded -= OnDataChanged;
-            sceneData.meshes.OnRemoved -= OnDataChanged;
+            sceneData.meshes.OnAdded -= OnMeshAdded;
+            sceneData.meshes.OnRemoved -= OnMeshRemoved;
 
             sceneData.renderers.OnAdded -= OnDataChanged;
             sceneData.renderers.OnRemoved -= OnDataChanged;
@@ -196,6 +202,72 @@ namespace DCL
             UpdateMetrics();
 
             Interface.WebInterface.ReportOnMetricsUpdate(sceneId, currentCountValue.ToMetricsModel(), maxCount.ToMetricsModel());
+        }
+
+        void OnAudioClipAdded(AnimationClip animationClip)
+        {
+            MarkDirty();
+        }
+
+        void OnAudioClipRemoved(AnimationClip animationClip)
+        {
+            MarkDirty();
+        }
+
+        void OnAnimationClipAdded(AnimationClip animationClip)
+        {
+            MarkDirty();
+        }
+
+        void OnAnimationClipRemoved(AnimationClip animationClip)
+        {
+            MarkDirty();
+        }
+
+        void OnMaterialAdded(Material material)
+        {
+            MarkDirty();
+        }
+
+        void OnMaterialRemoved(Material material)
+        {
+            MarkDirty();
+        }
+
+        void OnMeshAdded(Mesh mesh)
+        {
+            MarkDirty();
+        }
+
+        void OnMeshRemoved(Mesh mesh)
+        {
+            MarkDirty();
+        }
+
+        void OnTextureAdded(Texture texture)
+        {
+            MarkDirty();
+
+            if (texture is Texture2D tex2D)
+            {
+                const float MIPMAP_FACTOR = 1.3f;
+                const float BYTES_PER_PIXEL = 4;
+
+                currentCountValue.textureMemory += tex2D.width * tex2D.height * BYTES_PER_PIXEL * MIPMAP_FACTOR;
+            }
+        }
+
+        void OnTextureRemoved(Texture texture)
+        {
+            MarkDirty();
+
+            if (texture is Texture2D tex2D)
+            {
+                const float MIPMAP_FACTOR = 1.3f;
+                const float BYTES_PER_PIXEL = 4;
+
+                currentCountValue.textureMemory -= tex2D.width * tex2D.height * BYTES_PER_PIXEL * MIPMAP_FACTOR;
+            }
         }
 
         void OnDataChanged<T>(T obj)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/MemoryScoreFormulasShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/MemoryScoreFormulasShould.cs
@@ -13,6 +13,7 @@ public class MemoryScoreFormulasShould
     public void OvershootTextureMemoryWhenScoreIsComputed()
     {
         var texture = new Texture2D(100, 100);
+        texture.Apply(false, true);
         long score = MetricsScoreUtils.ComputeTextureScore(texture);
         Assert.That(score, Is.GreaterThan(Profiler.GetRuntimeMemorySizeLong(texture)));
         Object.Destroy(texture);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/MemoryScoreFormulasShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/MemoryScoreFormulasShould.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections;
+using DCL;
+using DCL.Helpers;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Profiling;
+using UnityEngine.TestTools;
+using UnityGLTF;
+
+public class MemoryScoreFormulasShould
+{
+    [Test]
+    public void OvershootTextureMemoryWhenScoreIsComputed()
+    {
+        var texture = new Texture2D(100, 100);
+        long score = MetricsScoreUtils.ComputeTextureScore(texture);
+        Assert.That(score, Is.GreaterThan(Profiler.GetRuntimeMemorySizeLong(texture)));
+        Object.Destroy(texture);
+    }
+
+    [Test]
+    public void OvershootAudioClipMemoryWhenScoreIsComputed()
+    {
+        var audioClip = AudioClip.Create("test", 10000, 2, 11000, false);
+        long score = MetricsScoreUtils.ComputeAudioClipScore(audioClip);
+        Assert.That(score, Is.GreaterThan(Profiler.GetRuntimeMemorySizeLong(audioClip)));
+        Object.Destroy(audioClip);
+    }
+
+    [UnityTest]
+    public IEnumerator OvershootAnimationClipMemoryWhenScoreIsComputed()
+    {
+        AssetPromiseKeeper_GLTF keeper = new AssetPromiseKeeper_GLTF();
+        keeper.throttlingCounter.enabled = false;
+        IWebRequestController webRequestController = WebRequestController.Create();
+        ContentProvider_Dummy provider = new ContentProvider_Dummy();
+
+        string url = TestAssetsUtils.GetPath() + "/GLB/Trevor/Trevor.glb";
+
+        AssetPromise_GLTF promise = new AssetPromise_GLTF(provider, url, webRequestController);
+        promise.settings.visibleFlags = AssetPromiseSettings_Rendering.VisibleFlags.VISIBLE_WITHOUT_TRANSITION;
+
+        GameObject holder1 = new GameObject("Test1");
+        promise.settings.parent = holder1.transform;
+        keeper.Keep(promise);
+
+        yield return promise;
+
+        Debug.Log("Container: " + promise.asset.container.name);
+
+        Animation animation = promise.asset.container.GetComponentInChildren<Animation>();
+        AnimationClip clip = animation.clip;
+
+        long animationClipEstimatedSize = promise.asset.animationClipSize;
+        long animationClipRealSize = Profiler.GetRuntimeMemorySizeLong(clip);
+
+        Debug.Log($"Animation clip real size: {animationClipRealSize} - Estimated: {animationClipEstimatedSize}");
+        Assert.That(animationClipEstimatedSize, Is.GreaterThan(animationClipRealSize));
+
+        keeper.Cleanup();
+    }
+
+    [UnityTest]
+    public IEnumerator OvershootMeshMemoryWhenScoreIsComputed()
+    {
+        AssetPromiseKeeper_GLTF keeper = new AssetPromiseKeeper_GLTF();
+        keeper.throttlingCounter.enabled = false;
+        IWebRequestController webRequestController = WebRequestController.Create();
+        ContentProvider_Dummy provider = new ContentProvider_Dummy();
+
+        string url = TestAssetsUtils.GetPath() + "/GLB/Trunk/Trunk.glb";
+        AssetPromise_GLTF promise = new AssetPromise_GLTF(provider, url, webRequestController);
+        promise.settings.visibleFlags = AssetPromiseSettings_Rendering.VisibleFlags.VISIBLE_WITHOUT_TRANSITION;
+
+        GameObject holder1 = new GameObject("Test1");
+        promise.settings.parent = holder1.transform;
+        keeper.Keep(promise);
+
+        yield return promise;
+
+        long meshesEstimatedSize = promise.asset.meshDataSize;
+        long meshesRealSize = 0;
+
+        foreach (MeshFilter mf in holder1.GetComponentsInChildren<MeshFilter>())
+        {
+            meshesRealSize += Profiler.GetRuntimeMemorySizeLong(mf.sharedMesh);
+        }
+
+        Debug.Log($"Mesh real size: {meshesRealSize} - Estimated: {meshesEstimatedSize}");
+        Assert.That(meshesEstimatedSize, Is.GreaterThan(meshesRealSize));
+
+        keeper.Cleanup();
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/MemoryScoreFormulasShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/MemoryScoreFormulasShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7a0af9176ffa44adafd88b71e4e0fe26
+timeCreated: 1646924924

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneMetricsCounterShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneMetricsCounterShould.cs
@@ -149,11 +149,11 @@ public class SceneMetricsCounterShould
         dataStore.AddRendereable("1", rendereable2);
         dataStore.AddRendereable("2", rendereable3);
 
-        Assert.That(sceneMetricsCounter.currentCount.textureMemory, Is.EqualTo(206437));
+        Assert.That(sceneMetricsCounter.currentCount.textureMemory, Is.EqualTo(240843));
 
         dataStore.RemoveRendereable("1", rendereable2);
 
-        Assert.That(sceneMetricsCounter.currentCount.textureMemory, Is.EqualTo(196607));
+        Assert.That(sceneMetricsCounter.currentCount.textureMemory, Is.EqualTo(229375));
 
         dataStore.RemoveRendereable("1", rendereable1);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneMetricsCounterShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneMetricsCounterShould.cs
@@ -5,6 +5,169 @@ using UnityEngine;
 public class SceneMetricsCounterShould
 {
     [Test]
+    public void CountAnimationClipMemoryWhenAddedAndRemoved()
+    {
+        DataStore_WorldObjects dataStore = new DataStore_WorldObjects();
+        var sceneMetricsCounter = new SceneMetricsCounter(dataStore, "1", Vector2Int.zero, 10);
+
+        dataStore.sceneData.Add("1", new DataStore_WorldObjects.SceneData());
+        dataStore.sceneData.Add("2", new DataStore_WorldObjects.SceneData());
+        sceneMetricsCounter.Enable();
+
+        Rendereable rendereable1 = new Rendereable();
+        rendereable1.ownerId = "A";
+        rendereable1.animationClipSize = 256;
+
+        Rendereable rendereable2 = new Rendereable();
+        rendereable2.ownerId = "B";
+        rendereable2.animationClipSize = 512;
+
+        Rendereable rendereable3 = new Rendereable();
+        rendereable3.ownerId = "C";
+        rendereable3.animationClipSize = 1024;
+
+        dataStore.AddRendereable("1", rendereable1);
+        dataStore.AddRendereable("1", rendereable2);
+        dataStore.AddRendereable("2", rendereable3);
+
+        Assert.That(sceneMetricsCounter.currentCount.animationClipMemory, Is.EqualTo(768));
+
+        dataStore.RemoveRendereable("1", rendereable2);
+
+        Assert.That(sceneMetricsCounter.currentCount.animationClipMemory, Is.EqualTo(256));
+
+        dataStore.RemoveRendereable("1", rendereable1);
+
+        Assert.That(sceneMetricsCounter.currentCount.animationClipMemory, Is.EqualTo(0));
+
+        sceneMetricsCounter.Dispose();
+    }
+
+    [Test]
+    public void CountAudioClipMemoryWhenAddedAndRemoved()
+    {
+        DataStore_WorldObjects dataStore = new DataStore_WorldObjects();
+        var sceneMetricsCounter = new SceneMetricsCounter(dataStore, "1", Vector2Int.zero, 10);
+
+        dataStore.sceneData.Add("1", new DataStore_WorldObjects.SceneData());
+        dataStore.sceneData.Add("2", new DataStore_WorldObjects.SceneData());
+        sceneMetricsCounter.Enable();
+
+        var audioClip1 = AudioClip.Create("Test1", 10000, 2, 44250, false, null, null);
+        var audioClip2 = AudioClip.Create("Test2", 10000, 2, 44250, false, null, null);
+        var audioClip3 = AudioClip.Create("Test3", 10000, 2, 44250, false, null, null);
+
+        dataStore.AddAudioClip("1", audioClip1);
+        dataStore.AddAudioClip("1", audioClip2);
+        dataStore.AddAudioClip("2", audioClip3);
+
+        Assert.That(sceneMetricsCounter.currentCount.audioClipMemory, Is.EqualTo(166000));
+
+        dataStore.RemoveAudioClip("1", audioClip1);
+
+        Assert.That(sceneMetricsCounter.currentCount.audioClipMemory, Is.EqualTo(83000));
+
+        dataStore.RemoveAudioClip("1", audioClip2);
+
+        Assert.That(sceneMetricsCounter.currentCount.audioClipMemory, Is.EqualTo(0));
+
+        sceneMetricsCounter.Dispose();
+
+        Object.Destroy(audioClip1);
+        Object.Destroy(audioClip2);
+        Object.Destroy(audioClip3);
+    }
+
+    [Test]
+    public void CountMeshesMemoryWhenAddedAndRemoved()
+    {
+        DataStore_WorldObjects dataStore = new DataStore_WorldObjects();
+        var sceneMetricsCounter = new SceneMetricsCounter(dataStore, "1", Vector2Int.zero, 10);
+
+        dataStore.sceneData.Add("1", new DataStore_WorldObjects.SceneData());
+        dataStore.sceneData.Add("2", new DataStore_WorldObjects.SceneData());
+        sceneMetricsCounter.Enable();
+
+        Rendereable rendereable1 = new Rendereable();
+        rendereable1.ownerId = "A";
+        rendereable1.meshDataSize = 1024;
+
+        Rendereable rendereable2 = new Rendereable();
+        rendereable2.ownerId = "B";
+        rendereable2.meshDataSize = 1024;
+
+        Rendereable rendereable3 = new Rendereable();
+        rendereable3.ownerId = "C";
+        rendereable3.meshDataSize = 1024;
+
+        dataStore.AddRendereable("1", rendereable1);
+        dataStore.AddRendereable("1", rendereable2);
+        dataStore.AddRendereable("2", rendereable3);
+
+        Assert.That(sceneMetricsCounter.currentCount.meshMemory, Is.EqualTo(2048));
+
+        dataStore.RemoveRendereable("1", rendereable2);
+
+        Assert.That(sceneMetricsCounter.currentCount.meshMemory, Is.EqualTo(1024));
+
+        dataStore.RemoveRendereable("1", rendereable1);
+
+        Assert.That(sceneMetricsCounter.currentCount.meshMemory, Is.EqualTo(0));
+
+        sceneMetricsCounter.Dispose();
+    }
+
+    [Test]
+    public void CountTexturesMemoryWhenAddedAndRemoved()
+    {
+        DataStore_WorldObjects dataStore = new DataStore_WorldObjects();
+        var sceneMetricsCounter = new SceneMetricsCounter(dataStore, "1", Vector2Int.zero, 10);
+
+        dataStore.sceneData.Add("1", new DataStore_WorldObjects.SceneData());
+        dataStore.sceneData.Add("2", new DataStore_WorldObjects.SceneData());
+        sceneMetricsCounter.Enable();
+
+        Texture2D tex1 = new Texture2D(128, 128);
+        Texture2D tex2 = new Texture2D(64, 64);
+        Texture2D tex3 = new Texture2D(32, 32);
+        Texture2D tex4 = new Texture2D(16, 16);
+
+        Rendereable rendereable1 = new Rendereable();
+        rendereable1.ownerId = "A";
+        rendereable1.textures.Add(tex1);
+        rendereable1.textures.Add(tex2);
+
+        Rendereable rendereable2 = new Rendereable();
+        rendereable2.ownerId = "B";
+        rendereable2.textures.Add(tex3);
+
+        Rendereable rendereable3 = new Rendereable();
+        rendereable3.ownerId = "C";
+        rendereable3.textures.Add(tex4);
+
+        dataStore.AddRendereable("1", rendereable1);
+        dataStore.AddRendereable("1", rendereable2);
+        dataStore.AddRendereable("2", rendereable3);
+
+        Assert.That(sceneMetricsCounter.currentCount.textureMemory, Is.EqualTo(206437));
+
+        dataStore.RemoveRendereable("1", rendereable2);
+
+        Assert.That(sceneMetricsCounter.currentCount.textureMemory, Is.EqualTo(196607));
+
+        dataStore.RemoveRendereable("1", rendereable1);
+
+        Assert.That(sceneMetricsCounter.currentCount.textureMemory, Is.EqualTo(0));
+
+        sceneMetricsCounter.Dispose();
+
+        UnityEngine.Object.Destroy(tex1);
+        UnityEngine.Object.Destroy(tex2);
+        UnityEngine.Object.Destroy(tex3);
+        UnityEngine.Object.Destroy(tex4);
+    }
+
+    [Test]
     public void CountEntitiesWhenAddedAndRemoved()
     {
         var dataStore = new DataStore_WorldObjects();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.asmdef
@@ -38,7 +38,9 @@
     "GUID:0b3e983b6c2fed54ebecf9d146c251ba",
     "GUID:a78c5d8dad39efe45ab1b21901f8db0f",
     "GUID:f51a759358124dc4180700f1f4f717d8",
-    "GUID:0e39b687cf35c7e40a87f984cdaed9f5"
+    "GUID:0e39b687cf35c7e40a87f984cdaed9f5",
+    "GUID:a3ceb534947fac14da25035bc5c24788",
+    "GUID:54b09a4a10c111e46a817873fcea53fe"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/WithAudioClip_SceneMetricsCounterShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/WithAudioClip_SceneMetricsCounterShould.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using DCL.Helpers;
+using DCL.Models;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+public class WithAudioClip_SceneMetricsCounterShould : IntegrationTestSuite_SceneMetricsCounter
+{
+    [UnityTest]
+    public IEnumerator CountAudioClipMemorySize()
+    {
+        var entity = CreateEntityWithTransform();
+        yield return TestUtils.CreateAudioSourceWithClipForEntity(entity);
+
+        Assert.That(scene.metricsCounter.currentCount.audioClipMemory, Is.EqualTo(5117752));
+
+        var audioClip = scene.GetSharedComponent("audioClipTest");
+        audioClip.Dispose();
+
+        Assert.That(scene.metricsCounter.currentCount.audioClipMemory, Is.EqualTo(0));
+
+        yield return null;
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/WithAudioClip_SceneMetricsCounterShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/WithAudioClip_SceneMetricsCounterShould.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c721749771cd45f880079cf0774102b7
+timeCreated: 1646934953

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -371,6 +371,17 @@ namespace UnityGLTF
         public void Load(string url) { throw new NotImplementedException(); }
 
         public void SetPrioritized() { prioritizeDownload = true; }
+
+        public int GetAnimationClipMemorySize()
+        {
+            return sceneImporter.animationsEstimatedSize;
+        }
+
+        public int GetMeshesMemorySize()
+        {
+            return sceneImporter.meshesEstimatedSize;
+        }
+
         private void OnDestroy()
         {
 #if UNITY_STANDALONE || UNITY_EDITOR

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -289,6 +289,8 @@ namespace UnityGLTF
                         else
                         {
                             loadedAssetRootGameObject = sceneImporter.CreatedObject;
+                            animationsEstimatedSize = sceneImporter.animationsEstimatedSize;
+                            meshesEstimatedSize = sceneImporter.meshesEstimatedSize;
 
                             sceneImporter?.Dispose();
                             sceneImporter = null;
@@ -372,14 +374,16 @@ namespace UnityGLTF
 
         public void SetPrioritized() { prioritizeDownload = true; }
 
-        public int GetAnimationClipMemorySize()
+        private long animationsEstimatedSize;
+        private long meshesEstimatedSize;
+        public long GetAnimationClipMemorySize()
         {
-            return sceneImporter.animationsEstimatedSize;
+            return animationsEstimatedSize;
         }
 
-        public int GetMeshesMemorySize()
+        public long GetMeshesMemorySize()
         {
-            return sceneImporter.meshesEstimatedSize;
+            return meshesEstimatedSize;
         }
 
         private void OnDestroy()

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -171,6 +171,10 @@ namespace UnityGLTF
         //             This is because the GLTF cache cleanup setup expects ref owners to be the entire GLTF object.
         HashSet<Material> usedMaterials = new HashSet<Material>();
 
+        const int KEYFRAME_SIZE = 32;
+        public int meshesEstimatedSize { get; private set; }
+        public int animationsEstimatedSize { get; private set; }
+
         /// <summary>
         /// Creates a GLTFSceneBuilder object which will be able to construct a scene based off a url
         /// </summary>
@@ -1124,6 +1128,7 @@ namespace UnityGLTF
                     // copy all key frames data to animation curve and add it to the clip
                     AnimationCurve curve = new AnimationCurve(keyframeCollection);
                     clip.SetCurve(relativePath, curveType, propertyNames[index], curve);
+                    animationsEstimatedSize += KEYFRAME_SIZE * keyframeCollection.Length;
                 }
             }
             else
@@ -1133,6 +1138,7 @@ namespace UnityGLTF
                     // copy all key frames data to animation curve and add it to the clip
                     AnimationCurve curve = new AnimationCurve(keyframes[ci]);
                     clip.SetCurve(relativePath, curveType, propertyNames[ci], curve);
+                    animationsEstimatedSize += KEYFRAME_SIZE * keyframes[ci].Length;
                 }
             }
         }
@@ -2018,6 +2024,7 @@ namespace UnityGLTF
                 await  UniTask.Yield();
             }
         }
+
         private async UniTask AsyncConstructUnityMesh(MeshConstructionData meshConstructionData, int meshId, int primitiveIndex, UnityMeshData unityMeshData)
         {
             var stopwatch = new Stopwatch();
@@ -2034,6 +2041,8 @@ namespace UnityGLTF
 
             _assetCache.MeshCache[meshId][primitiveIndex].LoadedMesh = mesh;
 
+            meshesEstimatedSize += GLTFSceneImporterUtils.ComputeEstimatedMeshSize(unityMeshData);
+            
             mesh.vertices = unityMeshData.Vertices;
             await ThrottleWatch(stopwatch, 1);
             mesh.normals = unityMeshData.Normals;

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -172,8 +172,8 @@ namespace UnityGLTF
         HashSet<Material> usedMaterials = new HashSet<Material>();
 
         const int KEYFRAME_SIZE = 32;
-        public int meshesEstimatedSize { get; private set; }
-        public int animationsEstimatedSize { get; private set; }
+        public long meshesEstimatedSize { get; private set; }
+        public long animationsEstimatedSize { get; private set; }
 
         /// <summary>
         /// Creates a GLTFSceneBuilder object which will be able to construct a scene based off a url
@@ -1129,6 +1129,8 @@ namespace UnityGLTF
                     AnimationCurve curve = new AnimationCurve(keyframeCollection);
                     clip.SetCurve(relativePath, curveType, propertyNames[index], curve);
                     animationsEstimatedSize += KEYFRAME_SIZE * keyframeCollection.Length;
+                    animationsEstimatedSize += relativePath.Length;
+                    animationsEstimatedSize += propertyNames[index].Length;
                 }
             }
             else
@@ -1139,6 +1141,8 @@ namespace UnityGLTF
                     AnimationCurve curve = new AnimationCurve(keyframes[ci]);
                     clip.SetCurve(relativePath, curveType, propertyNames[ci], curve);
                     animationsEstimatedSize += KEYFRAME_SIZE * keyframes[ci].Length;
+                    animationsEstimatedSize += relativePath.Length;
+                    animationsEstimatedSize += propertyNames[ci].Length;
                 }
             }
         }
@@ -1262,6 +1266,9 @@ namespace UnityGLTF
             };
 
             _assetCache.AnimationCache[animationId].LoadedAnimationClip = clip;
+
+            // Animation instance memory overhead
+            animationsEstimatedSize += 20;
 
             // needed because Animator component is unavailable at runtime
             clip.legacy = true;

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporterUtils.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporterUtils.cs
@@ -1,0 +1,41 @@
+﻿namespace UnityGLTF
+{
+    public static class GLTFSceneImporterUtils
+    {
+        public static int ComputeEstimatedMeshSize(UnityMeshData unityMeshData)
+        {
+            int result = 0;
+            if (unityMeshData.Vertices != null)
+                result += unityMeshData.Vertices.Length * 4 * 3;
+
+            if (unityMeshData.Normals != null)
+                result += unityMeshData.Normals.Length * 4 * 3;
+
+            if (unityMeshData.Uv1 != null)
+                result += unityMeshData.Uv1.Length * 4 * 2;
+
+            if (unityMeshData.Uv2 != null)
+                result += unityMeshData.Uv2.Length * 4 * 3;
+
+            if (unityMeshData.Uv3 != null)
+                result += unityMeshData.Uv3.Length * 4 * 3;
+
+            if (unityMeshData.Uv4 != null)
+                result += unityMeshData.Uv4.Length * 4 * 3;
+
+            if (unityMeshData.Colors != null)
+                result += unityMeshData.Colors.Length * 4 * 4;
+
+            if (unityMeshData.Tangents != null)
+                result += unityMeshData.Tangents.Length * 4 * 4;
+
+            if (unityMeshData.BoneWeights != null)
+                result += unityMeshData.BoneWeights.Length * 4 * 8;
+
+            if (unityMeshData.Triangles != null)
+                result += unityMeshData.Triangles.Length * 4;
+
+            return result;
+        }
+    }
+}

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporterUtils.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporterUtils.cs
@@ -2,40 +2,50 @@
 {
     public static class GLTFSceneImporterUtils
     {
-        public static int ComputeEstimatedMeshSize(UnityMeshData unityMeshData)
+        /// <summary>
+        /// This method returns the approximate mesh size that result from the given UnityMeshData object.
+        /// The calculation is not exact and is set to overshoot the true size by a small margin.
+        /// </summary>
+        /// <param name="unityMeshData">A UnityMeshData object to compute the memory size.</param>
+        /// <returns>The estimated memory size in bytes.</returns>
+        public static long ComputeEstimatedMeshSize(UnityMeshData unityMeshData)
         {
-            int result = 0;
+            long result = 4080; // NOTE(Brian): I found an overhead of 4080 bytes in isolated tests.
+            const long WORD_SIZE = 4; // word size = 4 bytes 
+
             if (unityMeshData.Vertices != null)
-                result += unityMeshData.Vertices.Length * 4 * 3;
+                result += unityMeshData.Vertices.Length * WORD_SIZE * 3;
 
             if (unityMeshData.Normals != null)
-                result += unityMeshData.Normals.Length * 4 * 3;
+                result += unityMeshData.Normals.Length * WORD_SIZE * 3;
 
             if (unityMeshData.Uv1 != null)
-                result += unityMeshData.Uv1.Length * 4 * 2;
+                result += unityMeshData.Uv1.Length * WORD_SIZE * 2;
 
             if (unityMeshData.Uv2 != null)
-                result += unityMeshData.Uv2.Length * 4 * 3;
+                result += unityMeshData.Uv2.Length * WORD_SIZE * 2;
 
             if (unityMeshData.Uv3 != null)
-                result += unityMeshData.Uv3.Length * 4 * 3;
+                result += unityMeshData.Uv3.Length * WORD_SIZE * 2;
 
             if (unityMeshData.Uv4 != null)
-                result += unityMeshData.Uv4.Length * 4 * 3;
+                result += unityMeshData.Uv4.Length * WORD_SIZE * 2;
 
             if (unityMeshData.Colors != null)
-                result += unityMeshData.Colors.Length * 4 * 4;
+                result += unityMeshData.Colors.Length * WORD_SIZE * 4;
 
             if (unityMeshData.Tangents != null)
-                result += unityMeshData.Tangents.Length * 4 * 4;
+                result += unityMeshData.Tangents.Length * WORD_SIZE * 4;
 
             if (unityMeshData.BoneWeights != null)
-                result += unityMeshData.BoneWeights.Length * 4 * 8;
+                result += unityMeshData.BoneWeights.Length * WORD_SIZE * 8;
 
             if (unityMeshData.Triangles != null)
-                result += unityMeshData.Triangles.Length * 4;
+                result += unityMeshData.Triangles.Length * WORD_SIZE;
 
-            return result;
+            // For some reason we have to duplicate the result.
+            // Maybe is because the actual word size is long?
+            return result * 2; 
         }
     }
 }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporterUtils.cs.meta
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporterUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f801b7d1b63646718c5c8ca2483313c7
+timeCreated: 1646340550

--- a/unity-renderer/Assets/UnityGLTF/Scripts/IGLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/IGLTFComponent.cs
@@ -11,7 +11,7 @@ namespace UnityGLTF.Scripts
         void LoadAsset(string assetDirectoryPath, string fileName, string id, bool loadEvenIfAlreadyLoaded, GLTFComponent.Settings settings, AssetIdConverter fileToHash);
         void RegisterCallbacks(Action<Mesh> meshCreated, Action<Renderer> rendererCreated);
         void SetPrioritized();
-        int GetAnimationClipMemorySize();
-        int GetMeshesMemorySize();
+        long GetAnimationClipMemorySize();
+        long GetMeshesMemorySize();
     }
 }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/IGLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/IGLTFComponent.cs
@@ -11,5 +11,7 @@ namespace UnityGLTF.Scripts
         void LoadAsset(string assetDirectoryPath, string fileName, string id, bool loadEvenIfAlreadyLoaded, GLTFComponent.Settings settings, AssetIdConverter fileToHash);
         void RegisterCallbacks(Action<Mesh> meshCreated, Action<Renderer> rendererCreated);
         void SetPrioritized();
+        int GetAnimationClipMemorySize();
+        int GetMeshesMemorySize();
     }
 }


### PR DESCRIPTION
## What does this PR change?

This PR implements limits score counting for memory. The memory we are counting per scene covers:

- Textures
- Meshes
- AnimationClips
- AudioClips

For now, the counting is enabled for GLTF loading only. Convering asset bundle loading requires to bundle meta-data to each AB package and will be covered in other PR.

The memory metrics are counted only, not limited or enforced in any way (yet).

The scoring formulas aren't exact. To deal with the lack of accuracy in a safe way, they are designed to overshoot the actual memory footprint. This is covered by tests.

## How to test the changes?

https://play.decentraland.zone/?renderer-branch=feat/better-scene-metrics

As this PR doesn't add visible functionality, you should at least see that the existing limit counting mechanics keep working.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
