### PR TITLE
chore: disable texture compression for desktop client

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/Asset_Texture.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/Asset_Texture.cs
@@ -20,7 +20,11 @@ namespace DCL
 
             texture.wrapMode = textureWrapMode;
             texture.filterMode = textureFilterMode;
+            
+#if !UNITY_STANDALONE
             texture.Compress(false);
+#endif
+            
             texture.Apply(textureFilterMode != FilterMode.Point, makeNoLongerReadable);
         }
 

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -678,11 +678,14 @@ namespace UnityGLTF
             texture = CheckAndReduceTextureSize(texture);
             _assetCache.ImageCache[imageCacheIndex] = texture;
 
+            // We need to keep compressing in UNITY_EDITOR for the Asset Bundles Converter
+#if !UNITY_STANDALONE || UNITY_EDITOR
             if ( Application.isPlaying )
             {
                 //NOTE(Brian): This breaks importing in editor mode
                 texture.Compress(false);
             }
+#endif
 
             texture.wrapMode = settings.wrapMode;
             texture.filterMode = settings.filterMode;


### PR DESCRIPTION
**WHY**
Avoiding runtime textures compression using the Deskttop client shows better results than spreadin compression accross frames, and memory doesn't seem to be affected that much:
```
* WITH compression:
    - Standalone process:
        - Testing N-W from WonderMine at -32,66
            - several micro-hiccups, 2 or 3 heavy hiccups taking tops 6 sec
            - Task Manager stats: 2~GB memory usage (top 3.5GB)
            - Unity Editor profiler memory stats: top memory used... 9GB (System Used Memory 10GB~); textures 3.3GB
        - Testing in WonderMine -29, 58
            - Task Manager stats: 3.4~GB memory usage

* WITHOUT compression:
    - Standalone process:
        - Testing N-W from WonderMine at -32,66
            - less hiccups, taking tops 2.5 sec
            - Task Manager stats: 2.3~GB memory usage (top 3.5GB)
            - Unity Editor profiler memory stats: top memory used... 10GB (System Used Memory 14GB~); textures 5GB
```

**WHAT**
Added compiler conditionals to avoid runtime tex compression in desktop client