### PR TITLE
chore: move GLTFs texture resize to the GPU for desktop client

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
@@ -34,42 +34,29 @@ public static class TextureHelpers
 
     public static Texture2D Resize(Texture2D source, int newWidth, int newHeight, bool linear = false)
     {
-        source.filterMode = FilterMode.Point;
+        // RenderTexture default format is ARGB32
+        Texture2D nTex = new Texture2D(newWidth, newHeight, TextureFormat.ARGB32, 1, false);
+        nTex.filterMode = source.filterMode;
+        nTex.wrapMode = source.wrapMode;
 
         RenderTexture rt = RenderTexture.GetTemporary(newWidth, newHeight);
         rt.filterMode = FilterMode.Point;
+        source.filterMode = FilterMode.Point;
 
         RenderTexture.active = rt;
         Graphics.Blit(source, rt);
         
-        // Texture2D nTex = new Texture2D(newWidth, newHeight, source.format, source.mipmapCount, linear);
-        // Texture2D nTex = new Texture2D(newWidth, newHeight, TextureFormat.RGBA32, rt.mipmapCount, linear);
-        // Texture2D nTex = new Texture2D(newWidth, newHeight);
-        // Texture2D nTex = new Texture2D(newWidth, newHeight, TextureFormat.ARGB32, -1, linear);
-        // Texture2D nTex = new Texture2D(rt.width, rt.height, TextureFormat.RGBA32, -1, linear);
-        Texture2D nTex = new Texture2D(rt.width, rt.height, TextureFormat.ARGB32, -1, false);
-        
-        // nTex.filterMode = FilterMode.Point;
-        
-        // This works for Graphics.CopyTexture() copying from the source (not RT) without resizing...
-        // Texture2D nTex = new Texture2D(source.width, source.height, source.format, -1, linear);
-        
-        Debug.Log($"TextureHelpers - Resize - copyTeSupport: {SystemInfo.copyTextureSupport.ToString()}");
         bool supportsGPUTextureCopy = SystemInfo.copyTextureSupport != CopyTextureSupport.None;
+        
+        Debug.unityLogger.logEnabled = true;
+        Debug.Log("SUPPORTS GPU TEXTURE COPY? " + supportsGPUTextureCopy);
+        
         if (supportsGPUTextureCopy)
         {
-            Debug.Log($"TextureHelpers - Resize - Uses COPYTEXTURE. RT format: {rt.format.ToString()}, rt mipCount: {rt.mipmapCount}");
-            // Graphics.CopyTexture(rt, nTex);
-            // Graphics.CopyTexture(rt, 0, nTex, 0);
-            // Graphics.CopyTexture(rt, 0, 0, nTex, 0, 0);
-            Graphics.CopyTexture(rt, 0, 0, nTex, 0, 0);
-            // Graphics.CopyTexture(rt, 0, 0, 0, 0, newWidth, newHeight, nTex, 0, 0, 0, 0);
-
-            nTex.alphaIsTransparency = true;
+            Graphics.CopyTexture(rt, nTex);
         }
         else
         {
-            Debug.Log("TextureHelpers - Resize - Uses READPIXELS");
             nTex.ReadPixels(new Rect(0, 0, newWidth, newHeight), 0, 0);
             nTex.Apply();
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
@@ -35,7 +35,7 @@ public static class TextureHelpers
     public static Texture2D Resize(Texture2D source, int newWidth, int newHeight, bool linear = false)
     {
         // RenderTexture default format is ARGB32
-        Texture2D nTex = new Texture2D(newWidth, newHeight, TextureFormat.ARGB32, 1, false);
+        Texture2D nTex = new Texture2D(newWidth, newHeight, TextureFormat.ARGB32, 1, linear);
         nTex.filterMode = source.filterMode;
         nTex.wrapMode = source.wrapMode;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
@@ -47,10 +47,6 @@ public static class TextureHelpers
         Graphics.Blit(source, rt);
         
         bool supportsGPUTextureCopy = SystemInfo.copyTextureSupport != CopyTextureSupport.None;
-        
-        Debug.unityLogger.logEnabled = true;
-        Debug.Log("SUPPORTS GPU TEXTURE COPY? " + supportsGPUTextureCopy);
-        
         if (supportsGPUTextureCopy)
         {
             Graphics.CopyTexture(rt, nTex);
@@ -70,7 +66,10 @@ public static class TextureHelpers
     public static Texture2D CopyTexture(Texture2D sourceTexture)
     {
         Texture2D texture = new Texture2D(sourceTexture.width, sourceTexture.height, sourceTexture.format, false);
-        Graphics.CopyTexture(sourceTexture, texture); // TODO: does this work in WebGL?
+        
+        // TODO: WebGL doesn't support this, should we add the ReadPixels/GetPixels approach as in Resize() ?
+        Graphics.CopyTexture(sourceTexture, texture);
+        
         return texture;
     }
 }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -675,8 +675,6 @@ namespace UnityGLTF
 
             //  NOTE: the second parameter of LoadImage() marks non-readable, but we can't mark it until after we call Apply()
             texture.LoadImage(buffer, false);
-            texture = CheckAndReduceTextureSize(texture, settings.linear);
-            _assetCache.ImageCache[imageCacheIndex] = texture;
 
             // We need to keep compressing in UNITY_EDITOR for the Asset Bundles Converter
 #if !UNITY_STANDALONE || UNITY_EDITOR
@@ -690,6 +688,9 @@ namespace UnityGLTF
             texture.wrapMode = settings.wrapMode;
             texture.filterMode = settings.filterMode;
             texture.Apply(settings.generateMipmaps, settings.uploadToGpu);
+            
+            // Resizing must be the last step to avoid breaking the texture when copying with Graphics.CopyTexture()
+            _assetCache.ImageCache[imageCacheIndex] = CheckAndReduceTextureSize(texture, settings.linear);
 
             await UniTask.Yield();
         }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -675,7 +675,7 @@ namespace UnityGLTF
 
             //  NOTE: the second parameter of LoadImage() marks non-readable, but we can't mark it until after we call Apply()
             texture.LoadImage(buffer, false);
-            texture = CheckAndReduceTextureSize(texture);
+            texture = CheckAndReduceTextureSize(texture, settings.linear);
             _assetCache.ImageCache[imageCacheIndex] = texture;
 
             if ( Application.isPlaying )
@@ -721,7 +721,7 @@ namespace UnityGLTF
         }
 
         // Note that if the texture is reduced in size, the source one is destroyed
-        protected Texture2D CheckAndReduceTextureSize(Texture2D source)
+        protected Texture2D CheckAndReduceTextureSize(Texture2D source, bool linear = false)
         {
             if (source.width <= maxTextureSize && source.height <= maxTextureSize)
                 return source;
@@ -739,7 +739,7 @@ namespace UnityGLTF
                 factor = (float)maxTextureSize / height;
             }
 
-            Texture2D dstTex = TextureHelpers.Resize(source, (int) (width * factor), (int) (height * factor));
+            Texture2D dstTex = TextureHelpers.Resize(source, (int) (width * factor), (int) (height * factor), linear);
 
             if (Application.isPlaying)
                 Object.Destroy(source);


### PR DESCRIPTION
* In many parts of the world we are resizing every texture loaded that is bigger than 1024x1024. We even have lots of textures in the first base wearables that get resized every time we enter the world if any avatar is using them. (With Asset Bundles this resizing is avoided as those textures were already resized when converting the asset to AB).

* If we can move to the GPU the textures resize we do in runtime for the Desktop Client, it will run smoother now that we have removed the runtime compressions for the Desktop Client as well.

* This optimization of using `Graphics.CopyTexture()` (copying everything directly in the GPU without passing through the CPU) instead of reading from the `RenderTexture` with `Texture2d.ReadPixels()` + `Texture2d.Apply()` that's quite expensive, can only be done for the Desktop client as it supports using the CopyTexture() method and the Web client doesn't.

A place where textures resizing can be seen is at:
https://play.decentraland.zone/?renderer-branch=chore/MoveGLTFsTextureResizeToGPUForDesktop&DISABLE_ASSET_BUNDLES&DISABLE_WEARABLE_ASSET_BUNDLES&position=-32,68&LOS=2

If these images can be seen, the resizing worked fine:
![chrome_zBmTglA1LL](https://user-images.githubusercontent.com/1031741/157163095-35497995-7f80-48c2-b032-0754cfcce44d.png)

