### PR TITLE
chore: toggle world blocker colliders on renderer state change

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/BlockerHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/BlockerHandler.cs
@@ -40,7 +40,7 @@ namespace DCL.Controllers
             // similar to how we set toon shader material in the Editor to disable the skybox
         }
 
-        public void ShowBlocker(Vector2Int pos, bool instant = false)
+        public void ShowBlocker(Vector2Int pos, bool instant = false, bool colliderEnabled = true)
         {            
             float centerOffset = ParcelSettings.PARCEL_SIZE / 2;
             PoolableObject blockerPoolable = PoolManager.i.Get(PARCEL_BLOCKER_POOL_NAME);
@@ -60,6 +60,7 @@ namespace DCL.Controllers
 
             blockerCollider.size = Vector3.one + (Vector3.up * auxScaleVec.y);
             blockerCollider.center = Vector3.up * ((auxScaleVec.y / 2) - 0.5f);
+            blockerCollider.enabled = colliderEnabled;
 
 #if UNITY_EDITOR
             blockerGo.name = "BLOCKER " + pos;
@@ -114,6 +115,14 @@ namespace DCL.Controllers
 
         public Dictionary<Vector2Int, IPoolableObject> GetBlockers() { return new Dictionary<Vector2Int, IPoolableObject>(blockers); }
 
+        public void ToggleBlockersCollision(bool newState)
+        {
+            foreach (var keyValuePair in blockers)
+            {
+                keyValuePair.Value.gameObject.GetComponent<Collider>().enabled = newState;
+            }
+        }
+        
         public void DestroyAllBlockers()
         {
             var keys = blockers.Keys.ToArray();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/BlockerHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/BlockerHandler.cs
@@ -115,7 +115,7 @@ namespace DCL.Controllers
 
         public Dictionary<Vector2Int, IPoolableObject> GetBlockers() { return new Dictionary<Vector2Int, IPoolableObject>(blockers); }
 
-        public void ToggleBlockersCollision(bool newState)
+        public void SetCollision(bool newState)
         {
             foreach (var keyValuePair in blockers)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/Interfaces/IBlockerInstanceHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/Interfaces/IBlockerInstanceHandler.cs
@@ -8,7 +8,8 @@ namespace DCL.Controllers
         void DestroyAllBlockers();
         Dictionary<Vector2Int, IPoolableObject> GetBlockers();
         void HideBlocker(Vector2Int coords, bool instant = false);
-        void ShowBlocker(Vector2Int pos, bool instant = false);
+        void ShowBlocker(Vector2Int pos, bool instant = false, bool colliderEnabled = true);
+        void ToggleBlockersCollision(bool newState);
         void SetParent(Transform parent);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/Interfaces/IBlockerInstanceHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/Interfaces/IBlockerInstanceHandler.cs
@@ -9,7 +9,7 @@ namespace DCL.Controllers
         Dictionary<Vector2Int, IPoolableObject> GetBlockers();
         void HideBlocker(Vector2Int coords, bool instant = false);
         void ShowBlocker(Vector2Int pos, bool instant = false, bool colliderEnabled = true);
-        void ToggleBlockersCollision(bool newState);
+        void SetCollision(bool newState);
         void SetParent(Transform parent);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/WorldBlockersController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/WorldBlockersController.cs
@@ -41,7 +41,7 @@ namespace DCL.Controllers
 
         void OnRendererStateChange(bool newValue, bool oldValue)
         {
-            blockerInstanceHandler.ToggleBlockersCollision(newValue);
+            blockerInstanceHandler.SetCollision(newValue);
             
             if (newValue && DataStore.i.debugConfig.isDebugMode.Get())
                 SetEnabled(false);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/WorldBlockersController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/WorldBlockersController.cs
@@ -41,6 +41,8 @@ namespace DCL.Controllers
 
         void OnRendererStateChange(bool newValue, bool oldValue)
         {
+            blockerInstanceHandler.ToggleBlockersCollision(newValue);
+            
             if (newValue && DataStore.i.debugConfig.isDebugMode.Get())
                 SetEnabled(false);
         }
@@ -189,7 +191,7 @@ namespace DCL.Controllers
             // Add missing blockers
             foreach (var coords in blockersToAdd)
             {
-                blockerInstanceHandler.ShowBlocker(coords);
+                blockerInstanceHandler.ShowBlocker(coords, false, CommonScriptableObjects.rendererState.Get());
             }
         }
     }


### PR DESCRIPTION
**WHY**
When we are initializing the world, sometimes it happens that we end up loading (and prioritizing) the parcel next to the one we specified in the URL instead of the desired one because the character collides with the world blockers when the rendering is OFF. The problem is specially annoying for debugging entering to a specific scene with LOS=0 for example.

**WHAT**
Added world blocker colliders enabled state initialization and toggling based on renderer state