### PR TITLE
Fix: avoid plus/minus key focus removal from chat input text

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -107,7 +107,9 @@ namespace DCL
             {
                 CalculateZoomLevelAndDirection(-1);
             }
-            EventSystem.current.SetSelectedGameObject(null);
+            
+            if (navmapVisible.Get())
+                EventSystem.current.SetSelectedGameObject(null);
         }
 
         private void OnMouseWheelChangeValue(DCLAction_Measurable action, float value)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -99,6 +99,8 @@ namespace DCL
 
         private void OnZoomPlusMinus(DCLAction_Hold action)
         {
+            if (!navmapVisible.Get()) return;
+
             if (action.Equals(DCLAction_Hold.ZoomIn))
             {
                 CalculateZoomLevelAndDirection(1);
@@ -107,9 +109,7 @@ namespace DCL
             {
                 CalculateZoomLevelAndDirection(-1);
             }
-            
-            if (navmapVisible.Get())
-                EventSystem.current.SetSelectedGameObject(null);
+            EventSystem.current.SetSelectedGameObject(null);
         }
 
         private void OnMouseWheelChangeValue(DCLAction_Measurable action, float value)


### PR DESCRIPTION
## What does this PR change?

Fix #1954 
avoids the chat focus to be lost when pressing + or - keys when typing
...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/minus-key-removes-chat-focus
2. Open the chat
3. Start typing
4. Type the "+" or "-" character
5. Verify that the focus is still on the chat input

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
