### PR TITLE
fix: set camera rotation from kernel message

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateFPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateFPS.cs
@@ -38,10 +38,13 @@ namespace DCL.Camera
 
             if (payload.cameraTarget.HasValue)
             {
-                var newPos = new Vector3(payload.x, payload.y, payload.z);
                 var cameraTarget = payload.cameraTarget.GetValueOrDefault();
-                var dirToLook = (cameraTarget - newPos);
-                eulerDir = Quaternion.LookRotation(dirToLook).eulerAngles;
+
+                var horizontalAxisLookAt = payload.y - cameraTarget.y;
+                var verticalAxisLookAt = new Vector3(cameraTarget.x - payload.x, 0, cameraTarget.z - payload.z);
+
+                eulerDir.y = Vector3.SignedAngle(Vector3.forward, verticalAxisLookAt, Vector3.up);
+                eulerDir.x = Mathf.Atan2(horizontalAxisLookAt, verticalAxisLookAt.magnitude) * Mathf.Rad2Deg;
             }
 
             if (pov != null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
@@ -1,4 +1,3 @@
-using System;
 using Cinemachine;
 using UnityEngine;
 
@@ -177,10 +176,13 @@ namespace DCL.Camera
 
             if (payload.cameraTarget.HasValue)
             {
-                var newPos = new Vector3(payload.x, payload.y, payload.z);
                 var cameraTarget = payload.cameraTarget.GetValueOrDefault();
-                var dirToLook = (cameraTarget - newPos);
-                eulerDir = Quaternion.LookRotation(dirToLook).eulerAngles;
+
+                var horizontalAxisLookAt = payload.y - cameraTarget.y;
+                var verticalAxisLookAt = new Vector3(cameraTarget.x - payload.x, 0, cameraTarget.z - payload.z);
+
+                eulerDir.y = Vector3.SignedAngle(Vector3.forward, verticalAxisLookAt, Vector3.up);
+                eulerDir.x = Mathf.Atan2(horizontalAxisLookAt, verticalAxisLookAt.magnitude) * Mathf.Rad2Deg;
             }
 
             defaultVirtualCameraAsFreeLook.m_XAxis.Value = eulerDir.y;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/CameraTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/CameraTests.cs
@@ -32,14 +32,15 @@ namespace CameraController_Test
         }
 
         [Test]
-        [TestCase(1, 0, 0)]
-        [TestCase(0, 0, 1)]
-        [TestCase(1, 0, 1)]
-        [TestCase(-1, 0, 0)]
-        [TestCase(0, 0, -1)]
-        [TestCase(-1, 0, -1)]
-        public void ReactToSetRotation(float lookAtX, float lookAtY, float lookAtZ)
+        [TestCase(1, -1, 0, ExpectedResult = new float[] { 45, 90 })]
+        [TestCase(0, 1, 1, ExpectedResult = new float[] { -45, 0 })]
+        [TestCase(1, 0, 1, ExpectedResult = new float[] { 0, 45 })]
+        [TestCase(-1, 0, 0, ExpectedResult = new float[] { 0, -90 })]
+        [TestCase(0, 0, -1, ExpectedResult = new float[] { 0, 180 })]
+        [TestCase(-1, 0, -1, ExpectedResult = new float[] { 0, -135 })]
+        public float[] ReactToSetRotation(float lookAtX, float lookAtY, float lookAtZ)
         {
+            CommonScriptableObjects.cameraMode.Set(CameraMode.ModeId.FirstPerson);
             var payload = new DCL.Camera.CameraController.SetRotationPayload()
             {
                 x = 0,
@@ -48,15 +49,12 @@ namespace CameraController_Test
                 cameraTarget = new Vector3(lookAtX, lookAtY, lookAtZ)
             };
 
-            var rotationEuler = Quaternion.LookRotation(payload.cameraTarget.Value).eulerAngles;
-
             cameraController.SetRotation(JsonConvert.SerializeObject(payload, Formatting.None, new JsonSerializerSettings()
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore
             }));
 
-            Assert.AreEqual(cameraController.GetRotation().y, rotationEuler.y);
-            Assert.AreEqual(cameraController.GetRotation().x, rotationEuler.x);
+            return new[] { cameraController.GetRotation().x, cameraController.GetRotation().y };
         }
 
         [UnityTest]


### PR DESCRIPTION
fixes https://github.com/decentraland/sdk/issues/121
camera was not rotating correctly when receiving rotation message from kernel
*modified `OnSetRotation` math from first and third camera state controller