### PR TITLE
fix: non global-scene avatars

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
@@ -74,7 +74,7 @@ namespace DCL
         {
             var offsetPosition = new Vector3(0, DCLCharacterController.i.characterController.height * 0.5f, 0);
             MoveTo(
-                position - offsetPosition, // To fix the "always flying" avatars bug, We report the chara's centered position but the body hast its pivot at its feet
+                position - offsetPosition, // To fix the "always flying" avatars issue, We report the chara's centered position but the body hast its pivot at its feet
                 rotation,
                 inmediate);
         } 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
@@ -67,11 +67,17 @@ namespace DCL
         public void OnTransformChanged(object model)
         {
             DCLTransform.Model transformModel = (DCLTransform.Model)model;
-
-            MoveTo(
-                transformModel.position - Vector3.up * DCLCharacterController.i.characterController.height / 2, // To fix the "always flying" avatars bug, We report the chara's centered position but the body hast its pivot at its feet
-                transformModel.rotation);
+            OnTransformChanged(transformModel.position, transformModel.rotation, false);
         }
+        
+        public void OnTransformChanged(in Vector3 position, in Quaternion rotation, bool inmediate)
+        {
+            var offsetPosition = new Vector3(0, DCLCharacterController.i.characterController.height * 0.5f, 0);
+            MoveTo(
+                position - offsetPosition, // To fix the "always flying" avatars bug, We report the chara's centered position but the body hast its pivot at its feet
+                rotation,
+                inmediate);
+        } 
 
         public void MoveTo(Vector3 position, Quaternion rotation, bool immediate = false)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -169,7 +169,9 @@ namespace DCL
             onPointerDown.OnPointerExitReport -= PlayerPointerExit;
             onPointerDown.OnPointerExitReport += PlayerPointerExit;
 
-            UpdatePlayerStatus(model);
+            bool isAvatarGlobalScene = IsGlobalSceneAvatar();
+
+            UpdatePlayerStatus(model, isAvatarGlobalScene);
             
             onPointerDown.Initialize(
                 new OnPointerDown.Model()
@@ -188,7 +190,6 @@ namespace DCL
 
             EnablePassport();
 
-            bool isAvatarGlobalScene = scene.sceneData.id == EnvironmentSettings.AVATAR_GLOBAL_SCENE_ID;
             onPointerDown.SetColliderEnabled(isAvatarGlobalScene);
             onPointerDown.SetOnClickReportEnabled(isAvatarGlobalScene);
         }
@@ -210,20 +211,19 @@ namespace DCL
         private void PlayerPointerExit() { playerName?.SetForceShow(false); }
         private void PlayerPointerEnter() { playerName?.SetForceShow(true); }
 
-        private void UpdatePlayerStatus(AvatarModel model)
+        private void UpdatePlayerStatus(AvatarModel model, bool isGlobalSceneAvatar)
         {
             // Remove the player status if the userId changes
             if (player != null && (player.id != model.id || player.name != model.name))
                 otherPlayers.Remove(player.id);
 
-            if (string.IsNullOrEmpty(model?.id))
+            if (isGlobalSceneAvatar && string.IsNullOrEmpty(model?.id))
                 return;
 
-            bool isNew = false;
-            if (player == null)
+            bool isNew = player == null;
+            if (isNew)
             {
                 player = new Player();
-                isNew = true;
             }
 
             player.id = model.id;
@@ -240,7 +240,10 @@ namespace DCL
                 player.playerName.SetName(player.name);
                 player.playerName.Show();
                 player.anchorPoints = anchorPoints;
-                otherPlayers.Add(player.id, player);
+                if (isGlobalSceneAvatar)
+                {
+                    otherPlayers.Add(player.id, player);
+                }
                 avatarReporterController.ReportAvatarRemoved();
             }
 
@@ -336,5 +339,7 @@ namespace DCL
 
         [ContextMenu("Print current profile")]
         private void PrintCurrentProfile() { Debug.Log(JsonUtility.ToJson(model)); }
+        
+        private bool IsGlobalSceneAvatar ()=> scene.sceneData.id == EnvironmentSettings.AVATAR_GLOBAL_SCENE_ID;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -166,7 +166,7 @@ namespace DCL
             onPointerDown.OnPointerExitReport -= PlayerPointerExit;
             onPointerDown.OnPointerExitReport += PlayerPointerExit;
 
-            UpdatePlayerStatus(model, isGlobalSceneAvatar);
+            UpdatePlayerStatus(model);
             
             onPointerDown.Initialize(
                 new OnPointerDown.Model()
@@ -206,7 +206,7 @@ namespace DCL
         private void PlayerPointerExit() { playerName?.SetForceShow(false); }
         private void PlayerPointerEnter() { playerName?.SetForceShow(true); }
 
-        private void UpdatePlayerStatus(AvatarModel model, bool isGlobalSceneAvatar)
+        private void UpdatePlayerStatus(AvatarModel model)
         {
             // Remove the player status if the userId changes
             if (player != null && (player.id != model.id || player.name != model.name))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -116,11 +116,7 @@ namespace DCL
             if (!initializedPosition && entity.components.ContainsKey(DCL.Models.CLASS_ID_COMPONENT.TRANSFORM))
             {
                 initializedPosition = true;
-
-                float characterHeight = DCLCharacterController.i != null ? DCLCharacterController.i.characterController.height : 0.8f;
-
-                avatarMovementController.MoveTo(
-                    entity.gameObject.transform.localPosition - Vector3.up * characterHeight / 2,
+                avatarMovementController.OnTransformChanged(entity.gameObject.transform.localPosition, 
                     entity.gameObject.transform.localRotation, true);
             }
 


### PR DESCRIPTION
for the moment we do not officially support using `AvatarShape` through the sdk, but devs can still use it.
so here are some fixes to mitigate the possibility of the explorer malfunctioning when an `AvatarShape` is created by a scene.
changes:
*avoid adding scene avatars to `DataStore` variable `otherPlayers`
*fix issues generated by avatar model's field `id` not being set
*use local scene position instead of world position to translate avatars created by a scene (we might want, in the near future, to start supporting devs using `AvatarShape` in their scenes)
*removed some duplicated code regarding avatar movement (the calculation was already done by `AvatarMovementController`)
*relocated subscription to entity's transform changes, since the subscription was done after the avatar is loaded, we were sometimes "losing" that event
*deleted `lastAvatarPosition` field since it was not being used
fixes https://github.com/decentraland/sdk/issues/145