### PR TITLE
fix: preview menu display toast on position copied

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/DebugPlugins/PreviewMenu/DebugPlugins.PreviewMenu.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/DebugPlugins/PreviewMenu/DebugPlugins.PreviewMenu.asmdef
@@ -11,7 +11,10 @@
         "GUID:97d8897529779cb49bebd400c7f402a6",
         "GUID:e5b8a8ed154ad624f99bcb73d3284a90",
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
-        "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
+        "GUID:e6f5b34eba99b4ed9836f899578ee258",
+        "GUID:70aa308435753374584c7061e4b89ef2",
+        "GUID:029e05fd02d6c49d5ac9dd7e3725a35b"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/DebugPlugins/PreviewMenu/View/Scripts/PreviewMenuPositionView.cs
+++ b/unity-renderer/Assets/DCLPlugins/DebugPlugins/PreviewMenu/View/Scripts/PreviewMenuPositionView.cs
@@ -1,18 +1,31 @@
 using System;
 using DCL;
+using DCL.NotificationModel;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using Environment = DCL.Environment;
+using Type = DCL.NotificationModel.Type;
 
 public class PreviewMenuPositionView : MonoBehaviour, IDisposable
 {
+    private const string NOTIFICATION_GROUP = "PositionCopiedToClipboard";
+    private const string NOTIFICATION_MESSAGE = "Position copied to clipboard ({0})";
+
     [SerializeField] internal TMP_InputField xValueInputField;
     [SerializeField] internal TMP_InputField yValueInputField;
     [SerializeField] internal TMP_InputField zValueInputField;
     [SerializeField] internal Button buttonReference;
 
     private bool isDestroyed;
+
+    private static readonly Model copyPositionToast = new Model()
+    {
+        type = Type.WARNING,
+        groupID = NOTIFICATION_GROUP,
+        message = NOTIFICATION_MESSAGE,
+        timer = 1.5f
+    };
 
     public void Dispose()
     {
@@ -31,8 +44,17 @@ public class PreviewMenuPositionView : MonoBehaviour, IDisposable
     {
         buttonReference.onClick.AddListener(() =>
         {
+            var positionString = $"{xValueInputField.text},{yValueInputField.text},{zValueInputField.text}";
             Environment.i.platform.clipboard
-                       .WriteText($"{xValueInputField.text},{yValueInputField.text},{zValueInputField.text}");
+                       .WriteText(positionString);
+
+            var notificationController = NotificationsController.i;
+            if (notificationController != null)
+            {
+                copyPositionToast.message = string.Format(NOTIFICATION_MESSAGE, positionString);
+                notificationController.DismissAllNotifications(copyPositionToast.groupID);
+                notificationController.ShowNotification(copyPositionToast);
+            }
         });
     }
 


### PR DESCRIPTION
in preview mode menu user can copy the current position by clicking on the panel displaying it, but there is no visual feedback on what happen on click, so it's look more like a "hidden feature"
*added toast to notify user that the position was copied to the clipboard
fixes https://github.com/decentraland/sdk/issues/213