### PR TITLE
fix: missing nullref check in nftshape info success event

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTAsset/NFTInfoLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTAsset/NFTInfoLoadHelper.cs
@@ -1,20 +1,19 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using DCL;
 using DCL.Helpers.NFT;
-using Newtonsoft.Json;
-using NFTShape_Internal;
 using UnityEngine;
 
 public interface INFTInfoLoadHelper : IDisposable
 {
-    void FetchNFTInfo(string address, string id, Action<NFTInfo> OnSuccess, Action OnFail);
+    public event Action<NFTInfo> OnFetchInfoSuccess;
+    public event Action OnFetchInfoFail;
+    void FetchNFTInfo(string address, string id);
 }
 
 public class NFTInfoLoadHelper : INFTInfoLoadHelper
 {
+    public event Action<NFTInfo> OnFetchInfoSuccess;
+    public event Action OnFetchInfoFail;
     internal Coroutine fetchCoroutine;
 
     public void Dispose()
@@ -25,22 +24,22 @@ public class NFTInfoLoadHelper : INFTInfoLoadHelper
         fetchCoroutine = null;
     }
 
-    public void FetchNFTInfo(string address, string id, Action<NFTInfo> OnSuccess, Action OnFail)
+    public void FetchNFTInfo(string address, string id)
     {
         if (fetchCoroutine != null)
             CoroutineStarter.Stop(fetchCoroutine);
 
-        fetchCoroutine = CoroutineStarter.Start(FetchNFTInfoCoroutine(address, id, OnSuccess, OnFail));
+        fetchCoroutine = CoroutineStarter.Start(FetchNFTInfoCoroutine(address, id));
     }
 
-    private IEnumerator FetchNFTInfoCoroutine(string address, string id, Action<NFTInfo> OnSuccess, Action OnFail)
+    private IEnumerator FetchNFTInfoCoroutine(string address, string id)
     {
         yield return NFTUtils.FetchNFTInfo(address, id,
-            (info) => { OnSuccess?.Invoke(info); },
+            (info) => { OnFetchInfoSuccess?.Invoke(info); },
             (error) =>
             {
                 Debug.LogError($"Couldn't fetch NFT: '{address}/{id}' {error}");
-                OnFail?.Invoke();
+                OnFetchInfoFail?.Invoke();
             });
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
@@ -150,6 +150,10 @@ public class NFTShapeLoaderController : MonoBehaviour
 
     private void FetchNFTInfoSuccess(NFTInfo nftInfo)
     {
+        // the FetchNFTInfoSuccess action can get called at the NFTInfoLoadHelper after destroying this controller
+        if (this == null)
+            return;
+        
         loadNftAssetCoroutine = StartCoroutine(LoadNFTAssetCoroutine(nftInfo));
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
@@ -1,14 +1,10 @@
 using DCL.Components;
 using DCL.Helpers.NFT;
 using System.Collections;
-using System.Collections.Generic;
-using System.IO;
 using System.Text.RegularExpressions;
 using UnityEngine;
 using DCL;
-using Newtonsoft.Json;
 using NFTShape_Internal;
-using UnityGLTF.Loader;
 
 public class NFTShapeLoaderController : MonoBehaviour
 {
@@ -37,8 +33,8 @@ public class NFTShapeLoaderController : MonoBehaviour
     public GameObject errorFeedback;
 
     [HideInInspector] public bool alreadyLoadedAsset = false;
-    [HideInInspector] public INFTInfoLoadHelper nftInfoLoadHelper;
-    internal INFTAssetLoadHelper nftAssetLoadHelper;
+    private INFTInfoLoadHelper nftInfoLoadHelper;
+    private INFTAssetLoadHelper nftAssetLoadHelper;
     private NFTShapeHQImageHandler hqTextureHandler = null;
     private Coroutine loadNftAssetCoroutine;
 
@@ -67,25 +63,32 @@ public class NFTShapeLoaderController : MonoBehaviour
 
     static readonly int BASEMAP_SHADER_PROPERTY = Shader.PropertyToID("_BaseMap");
     static readonly int COLOR_SHADER_PROPERTY = Shader.PropertyToID("_BaseColor");
-
-
-    bool isDestroyed = false;
-
-
     void Awake()
     {
         // NOTE: we use half scale to keep backward compatibility cause we are using 512px to normalize the scale with a 256px value that comes from the images
         meshRenderer.transform.localScale = new Vector3(0.5f, 0.5f, 1);
 
         InitializeMaterials();
+        
         nftInfoLoadHelper = new NFTInfoLoadHelper();
         nftAssetLoadHelper = new NFTAssetLoadHelper();
+    }
+
+    private void OnEnable()
+    {
+        nftInfoLoadHelper.OnFetchInfoSuccess += FetchNFTInfoSuccess;
+        nftInfoLoadHelper.OnFetchInfoFail += FetchNFTInfoFail;
+    }
+
+    private void OnDisable()
+    {
+        nftInfoLoadHelper.OnFetchInfoSuccess -= FetchNFTInfoSuccess;
+        nftInfoLoadHelper.OnFetchInfoFail -= FetchNFTInfoFail;
     }
 
     private void Start() { spinner.layer = LayerMask.NameToLayer("ViewportCullingIgnored"); }
 
     void Update() { hqTextureHandler?.Update(); }
-
     
     public void LoadAsset(string url, bool loadEvenIfAlreadyLoaded = false)
     {
@@ -145,15 +148,11 @@ public class NFTShapeLoaderController : MonoBehaviour
     private void FetchNFTContents()
     {
         ShowLoading(true);
-        nftInfoLoadHelper.FetchNFTInfo(darURLRegistry, darURLAsset, FetchNFTInfoSuccess, FetchNFTInfoFail);
+        nftInfoLoadHelper.FetchNFTInfo(darURLRegistry, darURLAsset);
     }
 
     private void FetchNFTInfoSuccess(NFTInfo nftInfo)
-    {
-        // the FetchNFTInfoSuccess action can get called at the NFTInfoLoadHelper after destroying this controller
-        if (this == null)
-            return;
-        
+    {   
         loadNftAssetCoroutine = StartCoroutine(LoadNFTAssetCoroutine(nftInfo));
     }
 
@@ -223,7 +222,7 @@ public class NFTShapeLoaderController : MonoBehaviour
 
         UpdateTexture(texture);
 
-        if (resizeFrameMesh && !isDestroyed && meshRenderer != null)
+        if (resizeFrameMesh && meshRenderer != null)
         {
             float w, h;
             w = h = 0.5f;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/NFTInfoLoadHelperShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/NFTInfoLoadHelperShould.cs
@@ -15,14 +15,16 @@ public class NFTInfoLoadHelperShould
     public void CallFailWhenFetchFails()
     {
         //Act - Assert
-        loadHelper.FetchNFTInfo("testAddress", "testId", info => Assert.Fail(), Assert.Pass);
+        loadHelper.OnFetchInfoSuccess += info => Assert.Fail();
+        loadHelper.OnFetchInfoFail += Assert.Pass;
+        loadHelper.FetchNFTInfo("testAddress", "testId");
     }
 
     [Test]
     public void DisposeCorrectly()
     {
         //Arrange
-        loadHelper.FetchNFTInfo("testAddress", "testId", null, null);
+        loadHelper.FetchNFTInfo("testAddress", "testId");
 
         //Act
         loadHelper.Dispose();


### PR DESCRIPTION
added missing nullref check, saw this nullref appearing when moving out of the museum district scene.