### PR TITLE
fix: CopyTexture

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
@@ -67,28 +67,8 @@ public static class TextureHelpers
     {
         Texture2D texture = new Texture2D(sourceTexture.width, sourceTexture.height, sourceTexture.format, false);
         
-        bool supportsGPUTextureCopy = SystemInfo.copyTextureSupport != CopyTextureSupport.None;
-        if (supportsGPUTextureCopy)
-        {
-            Graphics.CopyTexture(sourceTexture, texture);
-        }
-        else
-        {
-            RenderTexture rt = RenderTexture.GetTemporary(sourceTexture.width, sourceTexture.height);
-            rt.filterMode = FilterMode.Point;
-            FilterMode sourceFilterMode = sourceTexture.filterMode; 
-            sourceTexture.filterMode = FilterMode.Point;
-
-            RenderTexture.active = rt;
-            Graphics.Blit(sourceTexture, rt);
-            
-            texture.ReadPixels(new Rect(0, 0, sourceTexture.width, sourceTexture.height), 0, 0);
-            texture.Apply();
-            
-            RenderTexture.ReleaseTemporary(rt);
-            RenderTexture.active = null;
-            sourceTexture.filterMode = sourceFilterMode;
-        }
+        // Note: Surprisingly this works in WebGL here but it doesn't work in Resize()
+        Graphics.CopyTexture(sourceTexture, texture);
         
         return texture;
     }


### PR DESCRIPTION
left only the `Graphics.CopyTexture()` approach in `TextureHelpers.CopyTexture()` as it works in WebGL.

I ran countless test scenarios with local builds and for some reason `Graphics.CopyTexture()` works fine in WebGL in our `TextureHelpers.CopyTexture()` (even though `SystemInfo.copyTextureSupport == CopyTextureSupport.None` in WebGL) but it doesn't in `TextureHelpers.Resize()`.

## Testing
bugged in master: https://play.decentraland.zone/?position=-20,1&DISABLE_ASSET_BUNDLES
![Screen Shot 2022-03-17 at 16 55 48](https://user-images.githubusercontent.com/1031741/158888657-c7996342-5e4b-48aa-92f1-e0103f09c153.png)

fixed in this PR: https://play.decentraland.org/?position=-20,1&renderer-branch=fix/CopyTexture&DISABLE_ASSET_BUNDLES
![Screen Shot 2022-03-17 at 17 47 03](https://user-images.githubusercontent.com/1031741/158892488-cc1ee972-d946-4ec8-9b3e-30e809b088bb.png)