### PR TITLE
fix: memory leak caused by cancellations

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/TestScene/APK_GLTF_InteractiveTest.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/TestScene/APK_GLTF_InteractiveTest.cs
@@ -11,6 +11,10 @@ public class APK_GLTF_InteractiveTest : MonoBehaviour
     List<AssetPromise_GLTF> promiseList = new List<AssetPromise_GLTF>();
 
     private int counter = 0;
+    private bool automatedMode = false;
+    private bool create = true;
+    private float lastTime = 0;
+    private float timeToAct = 0;
 
     private string[] urls = new string[]
     {
@@ -45,20 +49,48 @@ public class APK_GLTF_InteractiveTest : MonoBehaviour
     {
         if (Input.GetKeyUp(KeyCode.Z))
         {
-            counter++;
-            counter %= urls.Length;
-            string finalUrl = TestAssetsUtils.GetPath() + urls[counter];
-            Generate(finalUrl);
+            Create();
         }
         else if (Input.GetKeyUp(KeyCode.X))
         {
-            if (promiseList.Count > 0)
-            {
-                var promiseToRemove = promiseList[Random.Range(0, promiseList.Count)];
-                keeper.Forget(promiseToRemove);
-                promiseList.Remove(promiseToRemove);
-                PoolManager.i.Cleanup(true);
-            }
+            Destroy();
         }
+        else if (Input.GetKeyUp(KeyCode.C))
+        {
+            automatedMode = !automatedMode;
+        }
+
+        if (automatedMode && (Time.time - lastTime) > timeToAct)
+        {
+            if (create)
+            {
+                Create();
+            }
+            else
+            {
+                Destroy();
+            }
+
+            create = !create;
+            lastTime = Time.time;
+            timeToAct = Random.Range(0.05f, 0.15f);
+        }
+    }
+    private void Destroy()
+    {
+        if (promiseList.Count > 0)
+        {
+            var promiseToRemove = promiseList[Random.Range(0, promiseList.Count)];
+            keeper.Forget(promiseToRemove);
+            promiseList.Remove(promiseToRemove);
+            PoolManager.i.Cleanup(true);
+        }
+    }
+    private void Create()
+    {
+        counter++;
+        counter %= urls.Length;
+        string finalUrl = TestAssetsUtils.GetPath() + urls[counter];
+        Generate(finalUrl);
     }
 }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -100,16 +100,12 @@ namespace UnityGLTF
         private Settings settings;
 
         private  CancellationTokenSource ctokenSource;
-        private bool isDestroyed;
 
         public Action OnSuccess { get { return OnFinishedLoadingAsset; } set { OnFinishedLoadingAsset = value; } }
 
         public Action<Exception> OnFail { get { return OnFailedLoadingAsset; } set { OnFailedLoadingAsset = value; } }
 
-        public void Initialize( IWebRequestController webRequestController)
-        {
-            this.webRequestController = webRequestController;
-        }
+        public void Initialize( IWebRequestController webRequestController) { this.webRequestController = webRequestController; }
 
         public void LoadAsset(string baseUrl, string incomingURI = "", string idPrefix = "", bool loadEvenIfAlreadyLoaded = false, Settings settings = null, AssetIdConverter fileToHashConverter = null)
         {
@@ -222,7 +218,7 @@ namespace UnityGLTF
             if (DataStore.i.common.isApplicationQuitting.Get())
                 return;
 #endif
-            
+
             if (!string.IsNullOrEmpty(GLTFUri))
             {
                 if (VERBOSE)
@@ -274,7 +270,7 @@ namespace UnityGLTF
                     if (DataStore.i.common.isApplicationQuitting.Get())
                         return;
 #endif
-                    
+
                     Debug.LogException(e);
                 }
                 finally
@@ -295,22 +291,18 @@ namespace UnityGLTF
                             sceneImporter = null;
                         }
                     }
-                    
-                    if (!isDestroyed)
-                    {
-                        if (!token.IsCancellationRequested)
-                        {
-                            if ( state == State.COMPLETED)
-                                OnFinishedLoadingAsset?.Invoke();
-                            else
-                                OnFailedLoadingAsset?.Invoke(new Exception($"GLTF state finished as: {state}"));
-                        }
 
-                        CleanUp();
-                        Destroy(loadingPlaceholder);
-                        Destroy(this);
-                        isDestroyed = true;
+                    if (!token.IsCancellationRequested)
+                    {
+                        if ( state == State.COMPLETED)
+                            OnFinishedLoadingAsset?.Invoke();
+                        else
+                            OnFailedLoadingAsset?.Invoke(new Exception($"GLTF state finished as: {state}"));
                     }
+
+                    CleanUp();
+                    Destroy(loadingPlaceholder);
+                    Destroy(this);
                 }
             }
             else
@@ -375,15 +367,9 @@ namespace UnityGLTF
 
         private long animationsEstimatedSize;
         private long meshesEstimatedSize;
-        public long GetAnimationClipMemorySize()
-        {
-            return animationsEstimatedSize;
-        }
+        public long GetAnimationClipMemorySize() { return animationsEstimatedSize; }
 
-        public long GetMeshesMemorySize()
-        {
-            return meshesEstimatedSize;
-        }
+        public long GetMeshesMemorySize() { return meshesEstimatedSize; }
 
         private void OnDestroy()
         {

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -299,7 +299,7 @@ namespace UnityGLTF
                         else
                             OnFailedLoadingAsset?.Invoke(new Exception($"GLTF state finished as: {state}"));
                     }
-
+                    
                     CleanUp();
                     Destroy(loadingPlaceholder);
                     Destroy(this);
@@ -377,6 +377,8 @@ namespace UnityGLTF
             if (DataStore.i.common.isApplicationQuitting.Get())
                 return;
 #endif
+            CleanUp();
+            
             if (state != State.COMPLETED)
             {
                 ctokenSource.Cancel();
@@ -385,8 +387,6 @@ namespace UnityGLTF
         }
         private void CleanUp()
         {
-            sceneImporter?.Dispose();
-
             if (state == State.QUEUED)
             {
                 DequeueDownload();
@@ -401,6 +401,8 @@ namespace UnityGLTF
             {
                 OnFail_Internal(null);
             }
+
+            state = State.NONE;
         }
 
         bool IDownloadQueueElement.ShouldPrioritizeDownload() { return prioritizeDownload; }
@@ -415,8 +417,8 @@ namespace UnityGLTF
 
         float IDownloadQueueElement.GetSqrDistance()
         {
-            if (mainCamera == null)
-                return 0;
+            if (mainCamera == null || transform == null)
+                return float.MaxValue;
 
             Vector3 cameraPosition = mainCamera.transform.position;
             Vector3 gltfPosition = transform.position;

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -391,9 +391,6 @@ namespace UnityGLTF
             if (DataStore.i.common.isApplicationQuitting.Get())
                 return;
 #endif
-            isDestroyed = true;
-            CleanUp();
-            
             if (state != State.COMPLETED)
             {
                 ctokenSource.Cancel();

--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.7",
     "com.unity.ide.vscode": "1.2.3",
-    "com.unity.memoryprofiler": "0.2.4-preview.1",
+    "com.unity.memoryprofiler": "0.6.0-preview.1",
     "com.unity.performance.profile-analyzer": "1.0.3",
     "com.unity.postprocessing": "3.1.0",
     "com.unity.render-pipelines.universal": "10.4.0",

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -87,7 +87,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.memoryprofiler": {
-      "version": "0.2.4-preview.1",
+      "version": "0.6.0-preview.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## What does this PR change?

Fixes a Memory Leak caused by textures being created asynchronously and the process being canceled before those textures were handled correctly for their deletion.
This was introduced with #1761 

## How to test the changes?

Unity Only:
- Open up APK_GLTF_InteractiveTest scene and run it
- Open up the Profiler and check out current Texture and Mesh memory and **save those numbers**.
- Press Z to spawn GLTFs and X to delete the last one loaded, you can press C for an automated and randomized Loading and Deletion and press again to toggle it Off.
- Press X until no GLTFs are loaded
- Check the Texture and Memory usage and compare it with the initial values, they must be equal or somewhat close (< 1 MB of tolerance )

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
