### PR TITLE
Fix: Remove esc to open explore

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -547,17 +547,6 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
                 SetVisibility(false);
                 exploreV2Analytics.SendStartMenuVisibility(false, fromShortcut ? ExploreUIVisibilityMethod.FromShortcut : ExploreUIVisibilityMethod.FromClick);
             }
-            else
-            {
-                if (Time.realtimeSinceStartup - controlsHUDCloseTime >= MIN_TIME_AFTER_CLOSE_OTHER_UI_TO_OPEN_START_MENU &&
-                    Time.realtimeSinceStartup - emotesHUDCloseTime >= MIN_TIME_AFTER_CLOSE_OTHER_UI_TO_OPEN_START_MENU &&
-                    Time.realtimeSinceStartup - playerInfoCardHUDCloseTime >= MIN_TIME_AFTER_CLOSE_OTHER_UI_TO_OPEN_START_MENU &&
-                    Time.realtimeSinceStartup - chatInputHUDCloseTime >= MIN_TIME_AFTER_CLOSE_OTHER_UI_TO_OPEN_START_MENU)
-                {
-                    SetVisibility(true);
-                    exploreV2Analytics.SendStartMenuVisibility(true, fromShortcut ? ExploreUIVisibilityMethod.FromShortcut : ExploreUIVisibilityMethod.FromClick);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## What does this PR change?

Fix #2017
Removes the usage of ESC to open the explore

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/escape-explore
2. Press esc and verify it unlocks the cursor
3. Open the map and press escape to close it
4. Start chatting and press esc to close the chat

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
