### PR TITLE
feat: compress map texture chunks to reduce memory usage

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapChunk.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapChunk.cs
@@ -36,6 +36,7 @@ namespace DCL
 
                 var newTexture = new Texture2D(result.width, result.height, result.format, true);
                 newTexture.SetPixels32(result.GetPixels32(0), 0);
+                newTexture.Compress(false);
                 newTexture.Apply(true);
                 Destroy(result);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapChunk.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapChunk.cs
@@ -36,8 +36,8 @@ namespace DCL
 
                 var newTexture = new Texture2D(result.width, result.height, result.format, true);
                 newTexture.SetPixels32(result.GetPixels32(0), 0);
-                newTexture.Compress(false);
                 newTexture.Apply(true);
+                newTexture.Compress(false);
                 Destroy(result);
 
                 targetImage.texture = newTexture;


### PR DESCRIPTION
## What does this PR change?

Reduces the memory usage of the Map Textures by ~75%

Before ( 7x7x10.6 = 519.4 MB ) 
![image](https://user-images.githubusercontent.com/7646450/159598877-3203c26a-4860-45ec-8d31-91a66092a270.png)

After: (7x7x2.7 = 132.3 MB )
![image](https://user-images.githubusercontent.com/7646450/159598892-4118b0d8-28ee-49a9-bb69-faf01cb69c4b.png)

**IMPORTANT NOTE:**  The side effect of doing this is that there's a new hiccup when opening the map. 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
