### PR TITLE
fix: Several fixes in the Emotes UI (II)

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesHUD/EmotesHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesHUD/EmotesHUDController.cs
@@ -48,8 +48,25 @@ namespace EmotesCustomization
         private bool ownedWearablesAlreadyRequested = false;
         private BaseDictionary<string, EmoteWheelSlot> slotsInLoadingState = new BaseDictionary<string, EmoteWheelSlot>();
 
+        // TODO (Santi): Remove it when we don't longer need keep the retrocompatibility.
+        private List<string> oldEmotes;
+
         public EmotesHUDController(UserProfile userProfile, BaseDictionary<string, WearableItem> catalog)
         {
+            oldEmotes = new List<string>
+            {
+                "handsair",
+                "wave",
+                "fistpump",
+                "dance",
+                "raiseHand",
+                "clap",
+                "money",
+                "kiss",
+                "headexplode",
+                "shrug"
+            };
+
             closeWindow = Resources.Load<InputAction_Trigger>("CloseWindow");
             closeWindow.OnTriggered += OnCloseWindowPressed;
 
@@ -78,22 +95,8 @@ namespace EmotesCustomization
         {
             if (!isEmotesCustomizationFFEnabled)
             {
-                List<string> storedEquippedEmotes = new List<string>
-                {
-                    "handsair",
-                    "wave",
-                    "fistpump",
-                    "dance",
-                    "raiseHand",
-                    "clap",
-                    "money",
-                    "kiss",
-                    "headexplode",
-                    "shrug"
-                };
-
                 List<EquippedEmoteData> storedEquippedEmotesData = new List<EquippedEmoteData>();
-                foreach (string emoteId in storedEquippedEmotes)
+                foreach (string emoteId in oldEmotes)
                 {
                     storedEquippedEmotesData.Add(new EquippedEmoteData { id = emoteId, cachedThumbnail = null });
                 }
@@ -388,43 +391,43 @@ namespace EmotesCustomization
                     break;
                 case DCLAction_Trigger.ToggleShortcut0:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[0]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[0]?.id : oldEmotes[0]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut1:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[1]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[1]?.id : oldEmotes[1]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut2:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[2]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[2]?.id : oldEmotes[2]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut3:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[3]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[3]?.id : oldEmotes[3]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut4:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[4]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[4]?.id : oldEmotes[4]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut5:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[5]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[5]?.id : oldEmotes[5]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut6:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[6]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[6]?.id : oldEmotes[6]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut7:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[7]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[7]?.id : oldEmotes[7]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut8:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[8]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[8]?.id : oldEmotes[8]);
                     break;
                 case DCLAction_Trigger.ToggleShortcut9:
                     if (emotesVisible.Get() || !isEmotesCustomizationFFEnabled)
-                        PlayEmote(emotesCustomizationDataStore.equippedEmotes[9]?.id);
+                        PlayEmote(isEmotesCustomizationFFEnabled ? emotesCustomizationDataStore.equippedEmotes[9]?.id : oldEmotes[9]);
                     break;
             }
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExternalUrlPromptHUD/Resources/ExternalUrlPromptHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExternalUrlPromptHUD/Resources/ExternalUrlPromptHUD.prefab
@@ -1811,7 +1811,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 851b72df6e5bd4b91a42eb20ae6323f0, type: 3}
+  m_Sprite: {fileID: 21300000, guid: d6993c6f413d843cd86f9221b1f98736, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/GotoPanelHUD/Resources/GotoPanelHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/GotoPanelHUD/Resources/GotoPanelHUD.prefab
@@ -1627,7 +1627,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 851b72df6e5bd4b91a42eb20ae6323f0, type: 3}
+  m_Sprite: {fileID: 21300000, guid: d6993c6f413d843cd86f9221b1f98736, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -2929,15 +2929,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4cdf4cefa747946779aabe419a904eab, type: 3}
---- !u!224 &2871505075204391640 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1212382325503483037, guid: 4cdf4cefa747946779aabe419a904eab,
-    type: 3}
-  m_PrefabInstance: {fileID: 3966156058150493765}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &6649734309962038473 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7728748656648610444, guid: 4cdf4cefa747946779aabe419a904eab,
+    type: 3}
+  m_PrefabInstance: {fileID: 3966156058150493765}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2871505075204391640 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1212382325503483037, guid: 4cdf4cefa747946779aabe419a904eab,
     type: 3}
   m_PrefabInstance: {fileID: 3966156058150493765}
   m_PrefabAsset: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HelpAndSupportHUD/Resources/HelpAndSupportHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HelpAndSupportHUD/Resources/HelpAndSupportHUD.prefab
@@ -869,7 +869,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 851b72df6e5bd4b91a42eb20ae6323f0, type: 3}
+  m_Sprite: {fileID: 21300000, guid: d6993c6f413d843cd86f9221b1f98736, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/Prefabs/OwnersPopup.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/Prefabs/OwnersPopup.prefab
@@ -1122,7 +1122,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 851b72df6e5bd4b91a42eb20ae6323f0, type: 3}
+  m_Sprite: {fileID: 21300000, guid: d6993c6f413d843cd86f9221b1f98736, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/Resources/NFTPromptHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/Resources/NFTPromptHUD.prefab
@@ -4209,7 +4209,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 851b72df6e5bd4b91a42eb20ae6323f0, type: 3}
+  m_Sprite: {fileID: 21300000, guid: d6993c6f413d843cd86f9221b1f98736, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -4659,15 +4659,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e798386ae9422d2428a43e293bb4add7, type: 3}
---- !u!224 &1460111516450856479 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2113852084972505189, guid: e798386ae9422d2428a43e293bb4add7,
-    type: 3}
-  m_PrefabInstance: {fileID: 654907563950986874}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &4660436856838827317 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5312981286632553295, guid: e798386ae9422d2428a43e293bb4add7,
+    type: 3}
+  m_PrefabInstance: {fileID: 654907563950986874}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1460111516450856479 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2113852084972505189, guid: e798386ae9422d2428a43e293bb4add7,
     type: 3}
   m_PrefabInstance: {fileID: 654907563950986874}
   m_PrefabAsset: {fileID: 0}
@@ -4832,7 +4832,7 @@ PrefabInstance:
     - target: {fileID: 1893788018749953862, guid: 19d77508a9e1e44029db75cc00b71c03,
         type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2020970618945887429, guid: 19d77508a9e1e44029db75cc00b71c03,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/QuestsPanelHUD/Resources/QuestsPanelHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/QuestsPanelHUD/Resources/QuestsPanelHUD.prefab
@@ -2863,6 +2863,17 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7707238299008712195, guid: 49eaaf30e8891e64492f14c5d00dd127,
+        type: 3}
+      propertyPath: m_Type
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7707238299008712195, guid: 49eaaf30e8891e64492f14c5d00dd127,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: e36f3569fbdef4c609c33f7a1cebace5,
+        type: 3}
     - target: {fileID: 7890178782521346346, guid: 49eaaf30e8891e64492f14c5d00dd127,
         type: 3}
       propertyPath: m_IsActive
@@ -2977,7 +2988,7 @@ PrefabInstance:
     - target: {fileID: 8308202765081094454, guid: 49eaaf30e8891e64492f14c5d00dd127,
         type: 3}
       propertyPath: m_Value
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8536448808959233715, guid: 49eaaf30e8891e64492f14c5d00dd127,
         type: 3}
@@ -3028,6 +3039,17 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8951575091893288073, guid: 49eaaf30e8891e64492f14c5d00dd127,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d6993c6f413d843cd86f9221b1f98736,
+        type: 3}
+    - target: {fileID: 8951575091893288073, guid: 49eaaf30e8891e64492f14c5d00dd127,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9007719506322232360, guid: 49eaaf30e8891e64492f14c5d00dd127,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TeleportPromptHUD/Resources/TeleportPromptHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TeleportPromptHUD/Resources/TeleportPromptHUD.prefab
@@ -2511,7 +2511,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 851b72df6e5bd4b91a42eb20ae6323f0, type: 3}
+  m_Sprite: {fileID: 21300000, guid: d6993c6f413d843cd86f9221b1f98736, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -3865,15 +3865,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4cdf4cefa747946779aabe419a904eab, type: 3}
---- !u!1 &1071493178686972256 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7728748656648610444, guid: 4cdf4cefa747946779aabe419a904eab,
-    type: 3}
-  m_PrefabInstance: {fileID: 7321923538136679404}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &8453131049288703857 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1212382325503483037, guid: 4cdf4cefa747946779aabe419a904eab,
+    type: 3}
+  m_PrefabInstance: {fileID: 7321923538136679404}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1071493178686972256 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7728748656648610444, guid: 4cdf4cefa747946779aabe419a904eab,
     type: 3}
   m_PrefabInstance: {fileID: 7321923538136679404}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
## What does this PR change?
- Recover the close button in the some HUDs that were missed it.
- Fix the issue of the unavailable base emotes when the feature flag was disabled and the user didn't open the wheel.

## How to test the changes?
- **TEST WITH FEATURE FLAG ENABLED**: https://play.decentraland.zone/?renderer-branch=fix/Several-fixes-in-the-emotes-ui-2&ENABLE_EMOTES_CUSTOMIZATION
- **TEST WITH FEATURE FLAG DISABLED**: https://play.decentraland.zone/?renderer-branch=fix/Several-fixes-in-the-emotes-ui-2&DISABLE_EMOTES_CUSTOMIZATION

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
