### PR TITLE
Fix: avoid voice chat to get stuck

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDBridge.cs
@@ -47,7 +47,7 @@ public class HUDBridge : MonoBehaviour
 
     public void SetVoiceChatEnabledByScene(int enabledPayload)
     {
-        Debug.Log($"VOICECHATDEBUG: Set voice chat enabled by scene {talking}");
+        Debug.Log($"VOICECHATDEBUG: Set voice chat enabled by scene {enabledPayload}");
         bool isEnabled = enabledPayload != 0;
         HUDController.i.taskbarHud?.SetVoiceChatEnabledByScene(isEnabled);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDBridge.cs
@@ -40,16 +40,21 @@ public class HUDBridge : MonoBehaviour
         HUDController.i.termsOfServiceHud?.ShowTermsOfService(model);
     }
 
-    public void SetPlayerTalking(string talking) { HUDController.i.taskbarHud?.SetVoiceChatRecording("true".Equals(talking)); }
+    public void SetPlayerTalking(string talking) {
+        Debug.Log($"VOICECHATDEBUG: Set player talking {talking}");
+        HUDController.i.taskbarHud?.SetVoiceChatRecording("true".Equals(talking)); 
+    }
 
     public void SetVoiceChatEnabledByScene(int enabledPayload)
     {
+        Debug.Log($"VOICECHATDEBUG: Set voice chat enabled by scene {talking}");
         bool isEnabled = enabledPayload != 0;
         HUDController.i.taskbarHud?.SetVoiceChatEnabledByScene(isEnabled);
     }
 
     public void SetUserTalking(string payload)
     {
+        Debug.Log($"VOICECHATDEBUG: Set user talking {payload}");
         var model = JsonUtility.FromJson<UserTalkingModel>(payload);
         HUDController.i.usersAroundListHud?.SetUserRecording(model.userId, model.talking);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/VoiceChatButton/VoiceChatButton.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/VoiceChatButton/VoiceChatButton.cs
@@ -16,9 +16,16 @@ public class VoiceChatButton : MonoBehaviour, IPointerDownHandler, IPointerUpHan
     private bool isRecording = false;
     private bool isEnabledByScene = true;
 
-    public void OnPointerDown(PointerEventData eventData) { voiceChatAction.RaiseOnStarted(); }
+    public void OnPointerDown(PointerEventData eventData) {
+        Debug.Log("Pointer down");
+        voiceChatAction.RaiseOnStarted(); 
+    }
 
-    public void OnPointerUp(PointerEventData eventData) { voiceChatAction.RaiseOnFinished(); }
+    public void OnPointerUp(PointerEventData eventData)
+    {
+        Debug.Log("Pointer up");
+        voiceChatAction.RaiseOnFinished(); 
+    }
 
     public void SetOnRecording(bool recording)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/VoiceChatButton/VoiceChatButton.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/VoiceChatButton/VoiceChatButton.cs
@@ -17,13 +17,13 @@ public class VoiceChatButton : MonoBehaviour, IPointerDownHandler, IPointerUpHan
     private bool isEnabledByScene = true;
 
     public void OnPointerDown(PointerEventData eventData) {
-        Debug.Log("Pointer down");
+        Debug.Log("VOICECHATDEBUG: Pointer down");
         voiceChatAction.RaiseOnStarted(); 
     }
 
     public void OnPointerUp(PointerEventData eventData)
     {
-        Debug.Log("Pointer up");
+        Debug.Log("VOICECHATDEBUG: Pointer up");
         voiceChatAction.RaiseOnFinished(); 
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -67,7 +67,7 @@ namespace DCL
 
 #if UNITY_WEBGL && !UNITY_EDITOR
             Debug.Log("DCL Unity Build Version: " + DCL.Configuration.ApplicationSettings.version);
-            Debug.unityLogger.logEnabled = false;
+            Debug.unityLogger.logEnabled = true;
 
             kernelCommunication = new NativeBridgeCommunication(Environment.i.world.sceneController);
 #else

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -1348,12 +1348,14 @@ namespace DCL.Interface
 
         public static void SendSetVoiceChatRecording(bool recording)
         {
+            Debug.Log($"VOICECHATDEBUG: Send voice chat recording {recording}");
             setVoiceChatRecordingPayload.recording = recording;
             SendMessage("SetVoiceChatRecording", setVoiceChatRecordingPayload);
         }
 
         public static void ToggleVoiceChatRecording()
         {
+            Debug.Log("VOICECHATDEBUG: Toggle voice chat recording");
             SendMessage("ToggleVoiceChatRecording");
         }
 


### PR DESCRIPTION
## What does this PR change?

Fix decentraland/sdk#232 
Avoids voice chat button to be stuck on enabled
...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/voice-stuck
2. Press the voice chat icon
3. Verify it stops on mouse release
4. Verify the behaviour with the "T" key

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
