### PR TITLE
fix: GLTF mesh creation throttling regression

### DIFF
--- a/unity-renderer/Assets/ABConverter/Core.cs
+++ b/unity-renderer/Assets/ABConverter/Core.cs
@@ -713,6 +713,7 @@ namespace DCL.ABConverter
             loader.maximumLod = 300; // todo: fix this later
             loader.forceGPUOnlyMesh = false;
             loader.forceGPUOnlyTex = false;
+            loader.forceSyncCoroutines = true;
 
             OnGLTFWillLoad?.Invoke(loader);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -80,7 +80,7 @@ namespace DCL
             {
                 gltfComponent = asset.container.AddComponent<GLTFComponent>();
 
-                gltfComponent.Initialize(webRequestController);
+                gltfComponent.Initialize(webRequestController, AssetPromiseKeeper_GLTF.i.throttlingCounter);
                 gltfComponent.RegisterCallbacks(MeshCreated, RendererCreated);
 
                 GLTFComponent.Settings tmpSettings = new GLTFComponent.Settings

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/CoroutineHelpers/CoroutineUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/CoroutineHelpers/CoroutineUtils.cs
@@ -61,5 +61,27 @@ namespace DCL
                 yield return coroutine;
             }
         }
+
+        /// <summary>
+        /// There are some cases when we need to run a coroutine syncronously for some editor scripts so we use this
+        /// </summary>
+        /// <param name="coroutine"></param>
+        public static void RunCoroutineSync(IEnumerator coroutine)
+        {
+            var stack = new Stack<IEnumerator>();
+            stack.Push(coroutine);
+            while (stack.Count > 0)
+            {
+                var enumerator = stack.Pop();
+                if (enumerator.MoveNext())
+                {
+                    stack.Push(enumerator);
+                    if (enumerator.Current is IEnumerator subEnumerator)
+                    {
+                        stack.Push(subEnumerator);
+                    }
+                }
+            }
+        }
     }
 }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -44,7 +44,7 @@ namespace UnityGLTF
         public int Timeout = 8;
         public Material LoadingTextureMaterial;
         public GLTFSceneImporter.ColliderType Collider = GLTFSceneImporter.ColliderType.None;
-        private static readonly IThrottlingCounter throttlingCounter = new GLTFThrottlingCounter();
+        private IThrottlingCounter throttlingCounter;
 
         public bool InitialVisibility
         {
@@ -105,7 +105,11 @@ namespace UnityGLTF
 
         public Action<Exception> OnFail { get { return OnFailedLoadingAsset; } set { OnFailedLoadingAsset = value; } }
 
-        public void Initialize( IWebRequestController webRequestController) { this.webRequestController = webRequestController; }
+        public void Initialize( IWebRequestController webRequestController, IThrottlingCounter throttlingCounter)
+        {
+            this.webRequestController = webRequestController;
+            this.throttlingCounter = throttlingCounter;
+        }
 
         public void LoadAsset(string baseUrl, string incomingURI = "", string idPrefix = "", bool loadEvenIfAlreadyLoaded = false, Settings settings = null, AssetIdConverter fileToHashConverter = null)
         {

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1655,31 +1655,17 @@ namespace UnityGLTF
             }
         }
 
-        // This throttle is local to this object and its not shared across all GLTF Importers
-        private async UniTask LocalThrottle(Stopwatch watch, long limit)
-        {
-            if (watch.ElapsedMilliseconds > limit)
-            {
-                watch.Restart();
-                await UniTask.Yield();
-            }
-        }
-        
         protected virtual async UniTask ConstructMesh(GLTFMesh mesh, Transform parent, int meshId, Skin skin, CancellationToken cancellationToken)
         {
             bool isColliderMesh = parent.name.Contains("_collider");
 
             _assetCache.MeshCache[meshId] ??= new MeshCacheData[mesh.Primitives.Count];
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
-
             for (int i = 0; i < mesh.Primitives.Count; ++i)
             {
                 var primitive = mesh.Primitives[i];
 
                 await ConstructMeshPrimitive(primitive, meshId, i, cancellationToken);
-                await LocalThrottle(stopwatch, 5);
 
                 cancellationToken.ThrowIfCancellationRequested();
                 var primitiveObj = new GameObject("Primitive");
@@ -1707,7 +1693,6 @@ namespace UnityGLTF
                         if (HasBones(skin))
                         {
                             await SetupBones(skin, primitive, skinnedMeshRenderer, primitiveObj, curMesh, cancellationToken);
-                            await LocalThrottle(stopwatch, 5);
                         }
 
                         OnRendererCreated?.Invoke(skinnedMeshRenderer);
@@ -1722,7 +1707,6 @@ namespace UnityGLTF
                     }
 
                     await ConstructPrimitiveMaterials(mesh, meshId, i, cancellationToken);
-                    await LocalThrottle(stopwatch, 5);
                 }
                 else
                 {
@@ -1749,8 +1733,6 @@ namespace UnityGLTF
 
                         break;
                 }
-
-                stopwatch.Restart();
             }
         }
 

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1946,6 +1946,8 @@ namespace UnityGLTF
             };
 
             _assetCache.MeshCache[meshId][primitiveIndex].LoadedMesh = mesh;
+            
+            meshesEstimatedSize += GLTFSceneImporterUtils.ComputeEstimatedMeshSize(unityMeshData);
 
             mesh.vertices = unityMeshData.Vertices;
 

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -215,7 +215,7 @@ namespace UnityGLTF
             if (DataStore.i.common.isApplicationQuitting.Get())
                 return;
 #endif
-            
+
             //NOTE(Brian): If the coroutine is interrupted and the local streaming list contains something,
             //             we must clean the static list or other GLTFSceneImporter instances might get stuck.
             int streamingImagesLocalListCount = streamingImagesLocalList.Count;
@@ -513,7 +513,7 @@ namespace UnityGLTF
         {
 
             await _loader.LoadStream(_gltfFileName, token);
-            
+
             token.ThrowIfCancellationRequested();
 
             if (_loader.LoadedStream == null)
@@ -572,7 +572,7 @@ namespace UnityGLTF
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             CreatedObject = new GameObject(string.IsNullOrEmpty(scene.Name) ? ("GLTFScene") : scene.Name);
             _lastLoadedScene = CreatedObject;
 
@@ -690,7 +690,7 @@ namespace UnityGLTF
             texture.wrapMode = settings.wrapMode;
             texture.filterMode = settings.filterMode;
             texture.Apply(settings.generateMipmaps, settings.uploadToGpu);
-            
+
             // Resizing must be the last step to avoid breaking the texture when copying with Graphics.CopyTexture()
             _assetCache.ImageCache[imageCacheIndex] = CheckAndReduceTextureSize(texture, settings.linear);
         }
@@ -930,7 +930,7 @@ namespace UnityGLTF
         }
 
         async UniTask ProcessCurves(Transform root, GameObject[] nodes, AnimationClip clip, GLTFAnimation animation, AnimationCacheData animationCache, CancellationToken cancellationToken)
-        {            
+        {
             foreach (AnimationChannel channel in animation.Channels)
             {
                 AnimationSamplerCacheData samplerCache = animationCache.Samplers[channel.Sampler.Id];
@@ -943,7 +943,7 @@ namespace UnityGLTF
                     // Model 08
                     continue;
                 }
-                
+
                 var node = nodes[channel.Target.Node.Id];
                 string relativePath = RelativePathFrom(node.transform, root);
 
@@ -1307,7 +1307,7 @@ namespace UnityGLTF
 
                 NodeId_Like nodeId = nodesWithMeshes[i];
                 Node node = nodeId.Value;
-                
+
                 await ConstructMesh(mesh: node.Mesh.Value,
                     parent: _assetCache.NodeCache[nodeId.Id].transform,
                     meshId: node.Mesh.Id,
@@ -1345,7 +1345,7 @@ namespace UnityGLTF
                     AnimationClip clip = ConstructClip(i, out gltfAnimation, out animationCache);
 
                     await ProcessCurves(CreatedObject.transform, _assetCache.NodeCache, clip, gltfAnimation, animationCache, token);
-                    
+
                     clip.wrapMode = WrapMode.Loop;
 
                     animation.AddClip(clip, clip.name);
@@ -1655,6 +1655,16 @@ namespace UnityGLTF
             }
         }
 
+        // This throttle is local to this object and its not shared across all GLTF Importers
+        private async UniTask LocalThrottle(Stopwatch watch, long limit)
+        {
+            if (watch.ElapsedMilliseconds > limit)
+            {
+                watch.Restart();
+                await UniTask.Yield();
+            }
+        }
+        
         protected virtual async UniTask ConstructMesh(GLTFMesh mesh, Transform parent, int meshId, Skin skin, CancellationToken cancellationToken)
         {
             bool isColliderMesh = parent.name.Contains("_collider");
@@ -1669,7 +1679,7 @@ namespace UnityGLTF
                 var primitive = mesh.Primitives[i];
 
                 await ConstructMeshPrimitive(primitive, meshId, i, cancellationToken);
-                await ThrottleWatch(stopwatch, 5);
+                await LocalThrottle(stopwatch, 5);
 
                 cancellationToken.ThrowIfCancellationRequested();
                 var primitiveObj = new GameObject("Primitive");
@@ -1697,7 +1707,7 @@ namespace UnityGLTF
                         if (HasBones(skin))
                         {
                             await SetupBones(skin, primitive, skinnedMeshRenderer, primitiveObj, curMesh, cancellationToken);
-                            await ThrottleWatch(stopwatch, 5);
+                            await LocalThrottle(stopwatch, 5);
                         }
 
                         OnRendererCreated?.Invoke(skinnedMeshRenderer);
@@ -1712,7 +1722,7 @@ namespace UnityGLTF
                     }
 
                     await ConstructPrimitiveMaterials(mesh, meshId, i, cancellationToken);
-                    await ThrottleWatch(stopwatch, 5);
+                    await LocalThrottle(stopwatch, 5);
                 }
                 else
                 {
@@ -1800,13 +1810,11 @@ namespace UnityGLTF
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                /*await TaskUtils.RunThrottledCoroutine(
+                await TaskUtils.RunThrottledCoroutine(
                                    ConstructUnityMesh(meshConstructionData, meshID, primitiveIndex, unityMeshData),
                                    exception => throw exception,
                                    throttlingCounter.EvaluateTimeBudget)
-                               .AttachExternalCancellation(cancellationToken);*/
-
-                await AsyncConstructUnityMesh(meshConstructionData, meshID, primitiveIndex, unityMeshData);
+                               .AttachExternalCancellation(cancellationToken);
             }
         }
 
@@ -2024,80 +2032,7 @@ namespace UnityGLTF
             }
         }
 
-        private async UniTask ThrottleWatch(Stopwatch watch, long limit)
-        {
-            if (watch.ElapsedMilliseconds > limit)
-            {
-                watch.Restart();
-                await  UniTask.Yield();
-            }
-        }
 
-        private async UniTask AsyncConstructUnityMesh(MeshConstructionData meshConstructionData, int meshId, int primitiveIndex, UnityMeshData unityMeshData)
-        {
-            var stopwatch = new Stopwatch();
-            MeshPrimitive primitive = meshConstructionData.Primitive;
-            int vertexCount = (int) primitive.Attributes[SemanticProperties.POSITION].Value.Count;
-            bool hasNormals = unityMeshData.Normals != null;
-
-            Mesh mesh = new Mesh
-            {
-#if UNITY_2017_3_OR_NEWER
-                indexFormat = vertexCount > 65535 ? IndexFormat.UInt32 : IndexFormat.UInt16,
-#endif
-            };
-
-            _assetCache.MeshCache[meshId][primitiveIndex].LoadedMesh = mesh;
-
-            meshesEstimatedSize += GLTFSceneImporterUtils.ComputeEstimatedMeshSize(unityMeshData);
-            
-            mesh.vertices = unityMeshData.Vertices;
-            await ThrottleWatch(stopwatch, 1);
-            mesh.normals = unityMeshData.Normals;
-            await ThrottleWatch(stopwatch, 1);
-            mesh.uv = unityMeshData.Uv1;
-            await ThrottleWatch(stopwatch, 1);
-            mesh.uv2 = unityMeshData.Uv2;
-            await ThrottleWatch(stopwatch, 1);
-            mesh.uv3 = unityMeshData.Uv3;
-            await ThrottleWatch(stopwatch, 1);
-            mesh.uv4 = unityMeshData.Uv4;
-            await ThrottleWatch(stopwatch, 1);
-            mesh.colors = unityMeshData.Colors;
-
-            if ( !Application.isPlaying )
-            {
-                if (AreMeshTrianglesValid(unityMeshData.Triangles, vertexCount)) // Some scenes contain broken meshes that can trigger a fatal error
-                {
-                    mesh.triangles = unityMeshData.Triangles;
-                }
-                else
-                {
-                    Debug.Log("GLTFSceneImporter - ERROR - ConstructUnityMesh - Couldn't assign triangles to mesh as there are indices pointing to vertices out of bounds");
-                }
-            }
-            else
-            {
-                mesh.triangles = unityMeshData.Triangles;
-            }
-
-            mesh.tangents = unityMeshData.Tangents;
-            mesh.boneWeights = unityMeshData.BoneWeights;
-
-            if (!hasNormals)
-                mesh.RecalculateNormals();
-
-            if ( !Application.isPlaying )
-                mesh.Optimize();
-
-            OnMeshCreated?.Invoke(mesh);
-
-            if (forceGPUOnlyMesh)
-            {
-                Physics.BakeMesh(mesh.GetInstanceID(), false);
-                mesh.UploadMeshData(true);
-            }
-        }
 
         // This check is to avoid broken meshes fatal error "Failed setting triangles. Some indices are referencing out of bounds vertices."
         private bool AreMeshTrianglesValid(int[] triangles, int vertexCount)
@@ -2381,7 +2316,7 @@ namespace UnityGLTF
             else
             {
                 await ConstructImage(settings, image, sourceId, cancellationToken);
-                
+
                 if (_assetCache.ImageCache[sourceId] == null)
                 {
                     Debug.Log($"GLTFSceneImporter - ConstructTexture - null tex detected for {image.Uri} / {id}, applying invalid-tex texture...");

--- a/unity-renderer/Assets/UnityGLTF/Scripts/IGLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/IGLTFComponent.cs
@@ -7,7 +7,7 @@ namespace UnityGLTF.Scripts
 {
     public interface IGLTFComponent : ILoadable, IDownloadQueueElement
     {
-        void Initialize(IWebRequestController webRequestController);
+        void Initialize(IWebRequestController webRequestController, IThrottlingCounter throttlingCounter);
         void LoadAsset(string assetDirectoryPath, string fileName, string id, bool loadEvenIfAlreadyLoaded, GLTFComponent.Settings settings, AssetIdConverter fileToHash);
         void RegisterCallbacks(Action<Mesh> meshCreated, Action<Renderer> rendererCreated);
         void SetPrioritized();

--- a/unity-renderer/Assets/UnityGLTF/Tests/GLTFBenchmark.cs
+++ b/unity-renderer/Assets/UnityGLTF/Tests/GLTFBenchmark.cs
@@ -46,7 +46,7 @@ public class GLTFBenchmark : MonoBehaviour
         GameObject gameObject = new GameObject("Test");
         lastGameObjectCreated = gameObject;
         GLTFComponent gltfComponent = gameObject.AddComponent<GLTFComponent>();
-        gltfComponent.Initialize(DCL.Environment.i.platform.webRequest);
+        gltfComponent.Initialize(DCL.Environment.i.platform.webRequest, gltfThrottlingCounter);
         GLTFComponent.Settings tmpSettings = new GLTFComponent.Settings()
         {
             useVisualFeedback = false,


### PR DESCRIPTION
## What does this PR change?

Fixes #1980 throttling regression.

Bonus:
Removed all local throttles as they do little to no difference on performance rather than fix very specific use cases. 
Also added an option to force the coroutines to be run synchronously to fix the Asset Bundle converter. 

## How to test the changes?

Run through the world with Asset Bundles disabled, meshes should be correctly throttled on their creation and should be fewer hiccups.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
