### PR TITLE
fix: biw unpublish and physics update

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Scripts/BuilderMainPanelController.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Scripts/BuilderMainPanelController.cs
@@ -172,7 +172,7 @@ public class BuilderMainPanelController : IHUD, IBuilderMainPanelController
         this.theGraph = theGraph;
         this.catalyst = catalyst;
 
-        this.unpublishPopupController = new UnpublishPopupController(view.GetUnpublishPopup());
+        this.unpublishPopupController = new UnpublishPopupController(context,view.GetUnpublishPopup());
 
         // set listeners for sections, setup searchbar for section, handle request for opening a new section
         sectionsHandler = new SectionsHandler(sectionsController, scenesViewController, landsesController, projectsController, view.GetSearchBar());

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Scripts/Handlers/SceneContextMenuHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Scripts/Handlers/SceneContextMenuHandler.cs
@@ -11,6 +11,7 @@ internal class SceneContextMenuHandler : IDisposable
     private readonly UnpublishPopupController unpublishPopupController;
 
     private Vector2Int sceneCoords;
+    private Vector2Int sceneSize;
     private Scene.Source sceneSource;
 
     public SceneContextMenuHandler(SceneCardViewContextMenu contextMenu, ISectionsController sectionsController,
@@ -56,6 +57,7 @@ internal class SceneContextMenuHandler : IDisposable
             sceneData.isOwner || sceneData.isOperator, sceneData.isContributor);
         sceneCoords = sceneData.coords;
         sceneSource = sceneData.source;
+        sceneSize = sceneData.size;
     }
 
     public void OnContextMenuOpen(IProjectSceneCardView sceneCard)
@@ -65,6 +67,7 @@ internal class SceneContextMenuHandler : IDisposable
             sceneCard.scene.land?.role == LandRole.OWNER || sceneCard.scene.land?.role == LandRole.OPERATOR, false);
         sceneCoords = sceneCard.scene.@base;
         sceneSource = sceneCard.scene.source;
+        sceneSize =  BIWUtils.GetSceneSize(sceneCard.scene.parcels);
     }
 
     void OnRequestContextMenuHide() { contextMenu.Hide(); }
@@ -77,7 +80,7 @@ internal class SceneContextMenuHandler : IDisposable
 
     void OnContextMenuSharePressed(string id) { }
 
-    void OnContextMenuUnpublishPressed(string id) { unpublishPopupController.Show(sceneCoords, sceneSource); }
+    void OnContextMenuUnpublishPressed(string id) { unpublishPopupController.Show(sceneCoords,sceneSize, sceneSource); }
 
     void OnContextMenuDeletePressed(string id) { }
 

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Scripts/Unpublish/UnpublishPopupController.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Scripts/Unpublish/UnpublishPopupController.cs
@@ -15,11 +15,14 @@ internal class UnpublishPopupController : IDisposable
 
     private IUnpublishPopupView view;
     private Vector2Int coordinates;
+    private Vector2Int size;
     private Scene.Source source;
     private Coroutine fakeProgressRoutine = null;
+    private IContext context;
 
-    public UnpublishPopupController(IUnpublishPopupView view)
+    public UnpublishPopupController(IContext context,IUnpublishPopupView view)
     {
+        this.context = context;
         this.view = view;
         view.OnCancelPressed += OnCancel;
         view.OnConfirmPressed += OnConfirmUnpublish;
@@ -38,18 +41,19 @@ internal class UnpublishPopupController : IDisposable
         }
     }
 
-    public void Show(Vector2Int coordinates, Scene.Source source = Scene.Source.BUILDER_IN_WORLD)
+    public void Show(Vector2Int coordinates, Vector2Int sceneSize, Scene.Source source = Scene.Source.BUILDER_IN_WORLD)
     {
         this.coordinates = coordinates;
         this.source = source;
+        this.size = sceneSize;
         view.Show(TITLE, DESCRIPTION);
     }
 
     void OnConfirmUnpublish()
     {
+        context.publisher.Unpublish(coordinates,size);
         BIWAnalytics.PlayerUnpublishScene(source.ToString(), coordinates);
         DataStore.i.builderInWorld.unpublishSceneResult.OnChange += OnSceneUnpublished;
-        WebInterface.UnpublishScene(coordinates);
         fakeProgressRoutine = CoroutineStarter.Start(ProgressRoutine());
     }
 

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Tests/UnpublishPopupShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Tests/UnpublishPopupShould.cs
@@ -1,4 +1,5 @@
 using DCL;
+using DCL.Helpers;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
@@ -15,7 +16,7 @@ namespace Tests
         {
             var prefab = Resources.Load<UnpublishPopupView>("UnpublishPopup/UnpublishPopupView");
             view = UnityEngine.Object.Instantiate(prefab);
-            controller = new UnpublishPopupController(view);
+            controller = new UnpublishPopupController(BIWTestUtils.CreateMockedContext(), view);
 
             // This is needed because BuilderMainPanelController uses the Analytics utils, which in turn use
             // Environment.i.serviceProviders.analytics
@@ -33,7 +34,7 @@ namespace Tests
         [Test]
         public void ShowConfirmationPopupCorrectly()
         {
-            controller.Show(Vector2Int.zero);
+            controller.Show(Vector2Int.zero,Vector2Int.zero);
             Assert.IsTrue(view.gameObject.activeSelf);
 
             Assert.IsTrue(view.cancelButton.gameObject.activeSelf);
@@ -102,7 +103,7 @@ namespace Tests
         [Test]
         public void ControllerSuccessFlowCorrectly()
         {
-            controller.Show(Vector2Int.zero);
+            controller.Show(Vector2Int.zero,Vector2Int.zero);
             Assert.AreEqual(UnpublishPopupView.State.CONFIRM_UNPUBLISH, view.state);
 
             view.unpublishButton.onClick.Invoke();
@@ -115,7 +116,7 @@ namespace Tests
         [Test]
         public void ControllerErrorFlowCorrectly()
         {
-            controller.Show(Vector2Int.zero);
+            controller.Show(Vector2Int.zero, Vector2Int.zero);
             Assert.AreEqual(UnpublishPopupView.State.CONFIRM_UNPUBLISH, view.state);
 
             view.unpublishButton.onClick.Invoke();

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Publisher/ProjectPublishHUD/Scripts/Projects/PublishMapView.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Publisher/ProjectPublishHUD/Scripts/Projects/PublishMapView.cs
@@ -99,6 +99,9 @@ namespace DCL.Builder
                     bool found = false;
                     foreach (Scene scene in land.scenes)
                     {
+                        if(scene.isEmpty)
+                            continue;
+                        
                         foreach (Vector2Int sceneParcel in scene.parcels)
                         {
                             if (sceneParcel == landParcel)

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Publisher/Scripts/Publisher.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Publisher/Scripts/Publisher.cs
@@ -14,7 +14,8 @@ namespace DCL.Builder
     {
         private const string BIGGER_LAND_TO_PUBLISH_TEXT = "Your scene is bigger than any Land you own.\nBrowse the Marketplace and buy some new Land where you can deploy.";
         private const string NO_LAND_TO_PUBLISH_TEXT = "To publish a scene first you need a Land where you can deploy it. Browse the marketplace to get some and show the world what you have created.";
-
+        public const string UNPUBLISH_EMPTY_SCENE_NAME = "Empty";
+        
         public enum TYPE
         {
             PUBLISH = 0,
@@ -145,7 +146,7 @@ namespace DCL.Builder
 
             //Display info
             sceneJson.display = new CatalystSceneEntityMetadata.Display();
-            sceneJson.display.title = "Empty";
+            sceneJson.display.title = UNPUBLISH_EMPTY_SCENE_NAME;
 
             //Scenes
             sceneJson.scene = new CatalystSceneEntityMetadata.Scene();
@@ -156,14 +157,14 @@ namespace DCL.Builder
 
             //  All parcels 
             string[] parcels = new string[size.x*size.y];
-            int cont = 0;
+            int count = 0;
 
             for (int x = 0; x < size.x; x++)
             {
                 for (int y = 0; y < size.y; y++)
                 {
-                    parcels[cont] = (coords.x + x) + "," + (coords.y + y);
-                    cont++;
+                    parcels[count] = (coords.x + x) + "," + (coords.y + y);
+                    count++;
                 }
             }
 

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Publisher/Scripts/Publisher.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Publisher/Scripts/Publisher.cs
@@ -15,6 +15,11 @@ namespace DCL.Builder
         private const string BIGGER_LAND_TO_PUBLISH_TEXT = "Your scene is bigger than any Land you own.\nBrowse the Marketplace and buy some new Land where you can deploy.";
         private const string NO_LAND_TO_PUBLISH_TEXT = "To publish a scene first you need a Land where you can deploy it. Browse the marketplace to get some and show the world what you have created.";
 
+        public enum TYPE
+        {
+            PUBLISH = 0,
+            UNPUBLISH = 1
+        }
         public event Action<bool> OnPublishFinish;
         
         private IPublishProjectController projectPublisher;
@@ -29,6 +34,7 @@ namespace DCL.Builder
         private IBuilderScene builderSceneToDeploy;
         private PublishInfo publishInfo;
         private IBuilderScene.SceneType lastTypeWhoStartedPublish;
+        private TYPE type = TYPE.PUBLISH;
         
         public void Initialize(IContext context)
         {
@@ -112,6 +118,7 @@ namespace DCL.Builder
             }
             
             DataStore.i.builderInWorld.areShortcutsBlocked.Set(true);
+            type = TYPE.PUBLISH;
             
             switch (scene.sceneType)
             {
@@ -124,6 +131,74 @@ namespace DCL.Builder
             }
 
             lastTypeWhoStartedPublish = scene.sceneType;
+        }
+
+        public async void Unpublish(Vector2Int coords, Vector2Int size)
+        {
+            type = TYPE.UNPUBLISH;
+            
+            var manifest = BIWUtils.CreateEmptyDefaultBuilderManifest(size, BIWUtils.Vector2INTToString(coords));
+            
+            CatalystSceneEntityMetadata sceneJson = new CatalystSceneEntityMetadata();
+
+            //Display info
+            sceneJson.display = new CatalystSceneEntityMetadata.Display();
+            sceneJson.display.title = "Empty";
+
+            //Scenes
+            sceneJson.scene = new CatalystSceneEntityMetadata.Scene();
+
+            //  Base Parcels 
+            string baseParcels = BIWUtils.Vector2INTToString(coords);
+            sceneJson.scene.@base = baseParcels;
+
+            //  All parcels 
+            string[] parcels = new string[size.x*size.y];
+            int cont = 0;
+
+            for (int x = 0; x < size.x; x++)
+            {
+                for (int y = 0; y < size.y; y++)
+                {
+                    parcels[cont] = (coords.x + x) + "," + (coords.y + y);
+                    cont++;
+                }
+            }
+
+            sceneJson.scene.parcels = parcels;
+
+            //Main
+            sceneJson.main = BIWSettings.DEPLOYMENT_BUNDLED_GAME_FILE;
+
+            //Source
+            sceneJson.source = new CatalystSceneEntityMetadata.Source();
+            sceneJson.source.origin = BIWSettings.DEPLOYMENT_SOURCE_TYPE;
+            sceneJson.source.version = 1;
+            sceneJson.source.layout = new CatalystSceneEntityMetadata.Source.Layout();
+            sceneJson.source.layout.rows = size.x.ToString();
+            sceneJson.source.layout.cols = size.y.ToString();
+            sceneJson.source.point = coords;
+            sceneJson.source.isEmpty = true;
+            
+
+            // Prepare the assets
+            List<SceneObject> assets = manifest.scene.assets.Values.ToList();
+
+            // Download the assets files
+            Dictionary<string, object> downloadedFiles = await DownloadAssetFiles(assets);
+            
+            // This files are not encoded
+            Dictionary<string, object> entityFiles = new Dictionary<string, object>
+            {
+                { BIWSettings.DEPLOYMENT_SCENE_FILE, sceneJson },
+                { BIWSettings.DEPLOYMENT_ASSETS, assets },
+            };
+            
+            // Prepare the stateless manifest
+            StatelessManifest statelessManifest = ManifestTranslator.WebBuilderSceneToStatelessManifest(manifest.scene);
+            
+            // Sent scene to kernel
+            StartUnpublishScene(downloadedFiles,entityFiles,statelessManifest, sceneJson);
         }
 
         internal void Canceled()
@@ -223,6 +298,11 @@ namespace DCL.Builder
             }
         }
 
+        private void StartUnpublishScene(Dictionary<string, object > filesToDecode, Dictionary<string, object > files,StatelessManifest statelessManifest, CatalystSceneEntityMetadata metadata)
+        {
+            builderInWorldBridge.PublishScene(filesToDecode, files, metadata, statelessManifest, true);
+        }
+        
         private void StartPublishScene(IBuilderScene scene, Dictionary<string, object > filesToDecode, Dictionary<string, object > files, CatalystSceneEntityMetadata metadata, StatelessManifest statelessManifest )
         {
             startPublishingTimestamp = Time.realtimeSinceStartup;
@@ -237,30 +317,40 @@ namespace DCL.Builder
 
         private void PublishEnd(bool isOk, string message)
         {
-            if (isOk)
+            if (type == TYPE.UNPUBLISH)
             {
-                // We notify the success of the deployment
-                progressController.DeploySuccess();
-
-                // Remove link to a land if exists
-                builderSceneToDeploy.manifest.project.creation_coords = null;
-
-                // Update project on the builder server
-                context.builderAPIController.SetManifest(builderSceneToDeploy.manifest);
+                PublishSceneResultPayload payload = new PublishSceneResultPayload();
+                payload.ok = isOk;
+                payload.error = message;
+                DataStore.i.builderInWorld.unpublishSceneResult.Set(payload);
             }
             else
             {
-                progressController.DeployError(message);
-            }
-            string successString = isOk ? "Success" : message;
-            BIWAnalytics.EndScenePublish(builderSceneToDeploy.scene.metricsCounter.currentCount, successString, Time.realtimeSinceStartup - startPublishingTimestamp);
+                if (isOk)
+                {
+                    // We notify the success of the deployment
+                    progressController.DeploySuccess();
 
-            if (isOk)
-                builderSceneToDeploy = null;
-            
-            DataStore.i.builderInWorld.areShortcutsBlocked.Set(false);
-            
-            OnPublishFinish?.Invoke(isOk);
+                    // Remove link to a land if exists
+                    builderSceneToDeploy.manifest.project.creation_coords = null;
+
+                    // Update project on the builder server
+                    context.builderAPIController.SetManifest(builderSceneToDeploy.manifest);
+                }
+                else
+                {
+                    progressController.DeployError(message);
+                }
+                string successString = isOk ? "Success" : message;
+                BIWAnalytics.EndScenePublish(builderSceneToDeploy.scene.metricsCounter.currentCount, successString, Time.realtimeSinceStartup - startPublishingTimestamp);
+
+                if (isOk)
+                    builderSceneToDeploy = null;
+
+                DataStore.i.builderInWorld.areShortcutsBlocked.Set(false);
+
+                OnPublishFinish?.Invoke(isOk);
+            }
         }
 
         internal CatalystSceneEntityMetadata CreateSceneJson(IBuilderScene builderScene, PublishInfo info)

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/BuilderEntity/BIWEntity.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/BuilderEntity/BIWEntity.cs
@@ -220,16 +220,6 @@ public class BIWEntity
         lastPositionReported = rootEntity.gameObject.transform.position;
         lastScaleReported = rootEntity.gameObject.transform.lossyScale;
         lastRotationReported = rootEntity.gameObject.transform.rotation;
-        
-        // Note: This is a unity bug where colliders are not updated when we move/scale/rotate the item
-        // We workaround it by disabling and reenabling the physics after selection / deselection
-        foreach (List<GameObject> gameObjects in collidersGameObjectDictionary.Values)
-        {
-            foreach (GameObject colliderGameObject in gameObjects)
-            {
-                colliderGameObject.SetActive(false);
-            }
-        }
     }
 
     public void Deselect()
@@ -243,16 +233,6 @@ public class BIWEntity
             rootEntity.gameObject.transform.SetParent(originalParent);
 
         SetOriginalMaterials();
-        
-        // Note: This is a unity bug where colliders are not updated when we move/scale/rotate the item
-        // We workaround it by disabling and reenabling the physics
-        foreach (List<GameObject> gameObjects in collidersGameObjectDictionary.Values)
-        {
-            foreach (GameObject colliderGameObject in gameObjects)
-            {
-                colliderGameObject.SetActive(true);
-            }
-        }
     }
 
     public void ToggleShowStatus()

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/BuildingTool.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/BuildingTool.asmdef
@@ -92,7 +92,8 @@
         "GUID:c34e38f41494f834abff029ddf82af43",
         "GUID:49176a91bbf7f8a4aaf35f6df0643d1a",
         "GUID:896ac1ef7dceedf49b9a9b0f3c8e798d",
-        "GUID:301149363e31a4bdaa1943465a825c8e"
+        "GUID:301149363e31a4bdaa1943465a825c8e",
+        "GUID:f7e9188a17be15d47a0263f53dc7142c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/Gizmos/BIWGizmos.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/Gizmos/BIWGizmos.cs
@@ -1,3 +1,4 @@
+using DCL;
 using DCL.Builder;
 using DCL.Configuration;
 using UnityEngine;
@@ -99,11 +100,8 @@ public abstract class BIWGizmos : MonoBehaviour, IBIWGizmos
 
     public void OnEndDrag()
     {
+        Environment.i.platform.physicsSyncController.MarkDirty();
         activeAxis?.SetColorDefault();
-        // Note: This is a unity bug where colliders are not updated when we move/scale/rotate the item
-        // We workaround it by disabling and reenabling the physics after selection / deselection
-        gameObject.SetActive(false);
-        gameObject.SetActive(true);
     }
 
     public virtual bool RaycastHit(Ray ray, out Vector3 hitPoint)

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/Interfaces/IPublisher.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/Interfaces/IPublisher.cs
@@ -29,5 +29,11 @@ namespace DCL.Builder
         /// </summary>
         /// <param name="scene"></param>
         void StartPublish(IBuilderScene scene);
+
+        /// <summary>
+        /// This will publish an empty scene in 
+        /// </summary>
+        /// <param name="scene"></param>
+        void Unpublish(Vector2Int coords, Vector2Int size);
     }
 }


### PR DESCRIPTION
## What does this PR change?

This PR fixes #1712. It enables the unpublish from the builder in world again
This PR fixes #1945. The physics are now sync correctly when we end transforming items

## How to test the changes?


1. Go to: https://play.decentraland.zone/?renderer-branch=fix/biw-unpublish&kernel-branch=feat/biw-invalidate-scene-info)
2. Test that you can unpublish an scene

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
