### PR TITLE
Fix: removed mipmaps generation on map chunks

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapChunk.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapChunk.cs
@@ -27,20 +27,14 @@ namespace DCL
 
             Texture2D result = null;
 
-            return Utils.FetchTexture(url, true, (x) =>
+            return Utils.FetchTexture(url, false, (x) =>
             {
                 result = x;
 
                 if (result == null)
                     return;
 
-                var newTexture = new Texture2D(result.width, result.height, result.format, true);
-                newTexture.SetPixels32(result.GetPixels32(0), 0);
-                newTexture.Apply(true);
-                newTexture.Compress(false);
-                Destroy(result);
-
-                targetImage.texture = newTexture;
+                targetImage.texture = result;
                 targetImage.texture.wrapMode = TextureWrapMode.Clamp;
                 targetImage.SetNativeSize();
                 targetImage.color = Color.white;


### PR DESCRIPTION
## What does this PR change?

Fetches texture as non readable for map chunks, avoids generation of mipmaps but lowers the memory impact

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/revert-map-chunk
2. Verify that the map opens and visualises correctly
3. Verify how commonly the app crashes

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
