### PR TITLE
fix: enable mipmap streaming

### DIFF
--- a/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
+++ b/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
@@ -8,7 +8,6 @@ using DCL.Helpers;
 using UnityEngine.Rendering.Universal;
 using Object = UnityEngine.Object;
 
-// test
 public class VisualTestsBase : IntegrationTestSuite_Legacy
 {
     protected ParcelScene scene;

--- a/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
+++ b/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
@@ -8,6 +8,7 @@ using DCL.Helpers;
 using UnityEngine.Rendering.Universal;
 using Object = UnityEngine.Object;
 
+// test
 public class VisualTestsBase : IntegrationTestSuite_Legacy
 {
     protected ParcelScene scene;

--- a/unity-renderer/ProjectSettings/QualitySettings.asset
+++ b/unity-renderer/ProjectSettings/QualitySettings.asset
@@ -17,7 +17,7 @@ QualitySettings:
     shadowNearPlaneOffset: 3
     shadowCascade2Split: 0.33333334
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
-    shadowmaskMode: 0
+    shadowmaskMode: 1
     skinWeights: 4
     textureQuality: 0
     anisotropicTextures: 2
@@ -29,7 +29,7 @@ QualitySettings:
     vSyncCount: 0
     lodBias: 0.3
     maximumLODLevel: 0
-    streamingMipmapsActive: 0
+    streamingMipmapsActive: 1
     streamingMipmapsAddAllCameras: 1
     streamingMipmapsMemoryBudget: 512
     streamingMipmapsRenderersPerFrame: 512


### PR DESCRIPTION
## What does this PR change?

This PR enables mipmap streaming, so all the loaded mipmaps have a max budget of 512 MB and are loaded/unloaded by a process.

https://docs.unity3d.com/Manual/TextureStreaming.html

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
