### PR TITLE
fix: Prevent the experiences title from being cut off

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Resources/Taskbar.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Resources/Taskbar.prefab
@@ -94,7 +94,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: 12.7}
-  m_SizeDelta: {x: 100, y: 20}
+  m_SizeDelta: {x: 120, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5343217344267773924
 CanvasRenderer:
@@ -4345,7 +4345,7 @@ PrefabInstance:
     - target: {fileID: 5156119195053263761, guid: ffadaebc1af107142a4c7fd23524095c,
         type: 3}
       propertyPath: m_fontSize
-      value: 10.4
+      value: 10.5
       objectReference: {fileID: 0}
     - target: {fileID: 5156119195053263761, guid: ffadaebc1af107142a4c7fd23524095c,
         type: 3}


### PR DESCRIPTION
## What does this PR change?
Prevent the experiences title from being cut off in the taskbar.

**BEFORE:**
![image](https://user-images.githubusercontent.com/64659061/159942019-e587d3ae-9b74-489f-b894-5f75d5660fcc.png)

**NOW:**
![image](https://user-images.githubusercontent.com/64659061/159942981-25a569f4-ea67-49cf-9ab0-bb992cc1c5d0.png)


## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
