### PR TITLE
chore: set max texture size to 512

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -128,7 +128,7 @@ namespace UnityGLTF
 
         public bool useMaterialTransition { get => useMaterialTransitionValue && !renderingIsDisabled; set => useMaterialTransitionValue = value; }
 
-        public int maxTextureSize = 1024;
+        public int maxTextureSize = 512;
         private const float SAME_KEYFRAME_TIME_DELTA = 0.0001f;
 
         protected struct GLBStream


### PR DESCRIPTION
Reduce max texture size to 512