### PR TITLE
fix: AvatarModifierArea losing modifiers after model update

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/AvatarModifierArea.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/AvatarModifierArea.cs
@@ -138,6 +138,7 @@ public class AvatarModifierArea : BaseComponent
     private void RemoveAllModifiers()
     {
         RemoveAllModifiers(DetectAllAvatarsInArea());
+        avatarsInArea = null;
     }
 
     private void RemoveAllModifiers(HashSet<GameObject> avatars)
@@ -182,6 +183,10 @@ public class AvatarModifierArea : BaseComponent
                 DataStore.i.player.ownPlayer.OnChange += OwnPlayerOnOnChange;
                 DataStore.i.player.otherPlayers.OnAdded += OtherPlayersOnOnAdded;
             }
+            
+            // Force update due to after model update modifiers are removed and re-added
+            // leaving a frame with the avatar without the proper modifications
+            Update();
         }
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifierAreaShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifierAreaShould.cs
@@ -2,10 +2,12 @@
 using DCL.Helpers;
 using DCL.Models;
 using System.Collections;
+using System.Collections.Generic;
 using DCL;
 using DCL.Controllers;
 using UnityEngine;
 using NSubstitute;
+using NUnit.Framework;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
@@ -142,6 +144,25 @@ public class AvatarModifierAreaShould : IntegrationTestSuite_Legacy
         Object.Destroy(player4.gameObject);
         Object.Destroy(avatarModifierArea.gameObject);
     }
+    
+    [UnityTest]
+    public IEnumerator NotRemoveModifierOnWhenModelChange()
+    {
+        var model = (AvatarModifierArea.Model)avatarModifierArea.GetModel();
+
+        var fakeObject = PrepareGameObjectForModifierArea();
+        yield return null;
+        
+        mockAvatarModifier.Received().ApplyModifier(fakeObject);
+        mockAvatarModifier.ClearReceivedCalls();
+
+        model.area = new BoxTriggerArea { box = new Vector3(11, 11, 11) };
+        yield return TestUtils.EntityComponentUpdate(avatarModifierArea, model);
+        yield return null;
+        
+        mockAvatarModifier.Received(1).RemoveModifier(fakeObject);
+        mockAvatarModifier.Received().ApplyModifier(fakeObject);
+    }    
 
     private GameObject PrepareGameObjectForModifierArea()
     {


### PR DESCRIPTION
Avatar inside `AvatarModifierArea` were losing it modifiers every time the component was updated.
For example, in the following code, the avatar inside the area becomes visible every time the area size changes and the avatar must move out and in the area to become invisible again.
```

let active = true
const e1 = new Entity();
const m = e1.addComponent(new AvatarModifierArea({ area: { box: new Vector3(16, 1, 14) }, modifiers: [AvatarModifiers.HIDE_AVATARS] }))
e1.addComponent(new Transform({ position: new Vector3(16 * 0.5, 1, 9), scale: new Vector3(16, 1, 14) }))
e1.addComponent(new BoxShape()).withCollisions = false

Input.instance.subscribe("BUTTON_DOWN", ActionButton.PRIMARY, false, ev => {
    if (active) {
        m.area = { ...m.area, box: new Vector3(16, 2, 14) }
        log(`change avatar area`)
    }
    else {
        m.area = { ...m.area, box: new Vector3(16, 1, 14) }
        log(`change avatar area again`)
    }
    active = !active
})

engine.addEntity(e1)
```

root cause of the issue was that, even though `RemoveAllModifiers()` was called on every component update, the list containing the avatars inside the area was not being cleaned. so when the code checks again to add the modifiers it would skip applying the modifiers because it assumes that the avatar has the modifier already applied