### PR TITLE
fix: AB converter height 0 textures conversion

### DIFF
--- a/unity-renderer/Assets/ABConverter/Core.cs
+++ b/unity-renderer/Assets/ABConverter/Core.cs
@@ -550,7 +550,12 @@ namespace DCL.ABConverter
                 factor = (float)maxTextureSize / height;
             }
 
-            Texture2D dstTex = TextureHelpers.Resize(tmpTex, (int)(width * factor), (int)(height * factor));
+            // Minimum factor should be 1, otherwise Unity throws an exception for using tex size 0 and the whole conversion is aborted
+            factor = Mathf.Max(1, factor);
+            int newWidth = (int)(width * factor);
+            int newHeight = (int)(height * factor);
+
+            Texture2D dstTex = TextureHelpers.Resize(tmpTex, newWidth, newHeight);
             byte[] endTex = ImageConversion.EncodeToPNG(dstTex);
             UnityEngine.Object.DestroyImmediate(tmpTex);
 


### PR DESCRIPTION
## WHY
During the Metaverse Fashion Week we saw 3 main scenes whose convertion was getting aborted because a texture with height 1 was being resized by the converter and ended up using a resizing factor of 0, thus creating a RenderTexture with 0 height and making Unity throw an exception.

```
ABConverter.Core: RenderTextureDesc height must be greater than zero.
Parameter name: desc.height
  at UnityEngine.RenderTexture.ValidateRenderTextureDesc (UnityEngine.RenderTextureDescriptor desc) [0x00128] in /home/bokken/buildslave/unity/build/Runtime/Export/Graphics/Texture.cs:259 
  at UnityEngine.RenderTexture.GetTemporary (UnityEngine.RenderTextureDescriptor desc) [0x00001] in /home/bokken/buildslave/unity/build/Runtime/Export/Graphics/Texture.cs:282 
  at UnityEngine.RenderTexture.GetTemporaryImpl (System.Int32 width, System.Int32 height, System.Int32 depthBuffer, UnityEngine.Experimental.Rendering.GraphicsFormat format, System.Int32 antiAliasing, UnityEngine.RenderTextureMemoryless memorylessMode, UnityEngine.VRTextureUsage vrUsage, System.Boolean useDynamicScale) [0x00034] in /home/bokken/buildslave/unity/build/Runtime/Export/Graphics/Texture.cs:300 
  at UnityEngine.RenderTexture.GetTemporary (System.Int32 width, System.Int32 height) [0x00001] in /home/bokken/buildslave/unity/build/Runtime/Export/Graphics/Texture.cs:390 
  at TextureHelpers.Resize (UnityEngine.Texture2D source, System.Int32 newWidth, System.Int32 newHeight) [0x00007] in /opt/unity/Editor/unity-renderer/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs:38 
  at DCL.ABConverter.Core.ReduceTextureSizeIfNeeded (System.String texturePath, System.Single maxSize) [0x00066] in /opt/unity/Editor/unity-renderer/unity-renderer/Assets/ABConverter/Core.cs:553 
  at DCL.ABConverter.Core.DumpImportableAssets (System.Collections.Generic.List`1[T] assetPaths) [0x00094] in /opt/unity/Editor/unity-renderer/unity-renderer/Assets/ABConverter/Core.cs:508 
  at DCL.ABConverter.Core.DumpAssets (DCL.ContentServerUtils+MappingPair[] rawContents) [0x00048] in /opt/unity/Editor/unity-renderer/unity-renderer/Assets/ABConverter/Core.cs:325 
```

## WHAT
Added minimum factor for textures resizing in AB converter to avoid unity exception.

With this patch, we could locally convert the 3 scenes successfully
