### PR TITLE
moved player icon render above other player icons

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -35,6 +35,7 @@ namespace DCL
         public RawImage parcelHighlightImage;
         public TextMeshProUGUI highlightedParcelText;
         public Transform overlayContainer;
+        public Transform overlayContainerPlayers;
         public Transform globalUserMarkerContainer;
         public RectTransform playerPositionIcon;
 
@@ -131,7 +132,7 @@ namespace DCL
             {
                 usersInfoPool = PoolManager.i.AddPool(
                     MINIMAP_USER_ICONS_POOL_NAME,
-                    Instantiate(userIconPrefab.gameObject, overlayContainer.transform),
+                    Instantiate(userIconPrefab.gameObject, overlayContainerPlayers.transform),
                     maxPrewarmCount: MINIMAP_USER_ICONS_MAX_PREWARM,
                     isPersistent: true);
 
@@ -313,7 +314,7 @@ namespace DCL
             var poolable = usersInfoPool.Get();
             var marker = poolable.gameObject.GetComponent<MapUserIcon>();
             marker.gameObject.name = $"UserIcon-{player.name}";
-            marker.gameObject.transform.SetParent(overlayContainer.transform, true);
+            marker.gameObject.transform.SetParent(overlayContainerPlayers.transform, true);
             marker.Populate(player);
             usersInfoMarkers.Add(userId, poolable);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Resources/Map Renderer.prefab
@@ -227,16 +227,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parcelHightlightScale: 1.25
   ParcelHighlightButton: {fileID: 3511145948971381255}
-  containerRectTransform: {fileID: 2249193035634569280}
-  mouseWheelAction: {fileID: 11400000, guid: 321d843783c1847a2a90e7e46f44e476, type: 2}
   cursorMapCoords: {x: 0, y: 0, z: 0}
   showCursorCoords: 1
   atlas: {fileID: 8867674412829076673}
   parcelHighlightImage: {fileID: 5226131346438990493}
   highlightedParcelText: {fileID: 7940259258301411768}
   overlayContainer: {fileID: 90597117798403300}
+  overlayContainerPlayers: {fileID: 6100807533600505858}
   globalUserMarkerContainer: {fileID: 3332934504654532118}
   playerPositionIcon: {fileID: 1340394175305253205}
+  scaleFactor: 1
   centeredReferenceParcel: {fileID: 1025416073224921776}
   scenesOfInterestIconPrefab: {fileID: 4461918297282884638, guid: f7b91bf31609c8a43b5dbc0ae70e47ab,
     type: 3}
@@ -271,6 +271,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 6100807533600505858}
   - {fileID: 3332934504654532118}
   - {fileID: 1340394175305253205}
   - {fileID: 6083578241133350518}
@@ -311,7 +312,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 90597117798403300}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -411,6 +412,41 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
+--- !u!1 &6100793881404188159
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6100807533600505858}
+  m_Layer: 0
+  m_Name: OverlayContainerPlayers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6100807533600505858
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6100793881404188159}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 90597117798403300}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &6407972158151617183
 GameObject:
   m_ObjectHideFlags: 0
@@ -444,7 +480,7 @@ RectTransform:
   m_Children:
   - {fileID: 2624566956026777839}
   m_Father: {fileID: 90597117798403300}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -609,7 +645,7 @@ RectTransform:
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children: []
   m_Father: {fileID: 90597117798403300}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -101.61}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}


### PR DESCRIPTION
## What does this PR change?

Fix #2064 
Renders player icon above other player icons

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/player-icon
2. Verify that in a crowded area your player icon in the map is above others

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
