### PR TITLE
fix: Explore V2 loading improvements

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Common/CloseCardModalButton.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Common/CloseCardModalButton.prefab
@@ -142,7 +142,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 3959ed98610a74ffc8cb27bda2e603e3,
+      objectReference: {fileID: 21300000, guid: e36f3569fbdef4c609c33f7a1cebace5,
         type: 3}
     - target: {fileID: 3725923502685340037, guid: fb037d81b9c10ad439a13e356a17bab6,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/EventsSubSection/EventCard.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/EventsSubSection/EventCard.prefab
@@ -2577,7 +2577,7 @@ PrefabInstance:
     - target: {fileID: 6583379474799589209, guid: b53f82112c401e94eb453570ac440340,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 63.28
       objectReference: {fileID: 0}
     - target: {fileID: 6583379474799589209, guid: b53f82112c401e94eb453570ac440340,
         type: 3}
@@ -3204,6 +3204,11 @@ PrefabInstance:
     - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
         type: 3}
       propertyPath: model.fillParent
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
+        type: 3}
+      propertyPath: model.lastUriCached
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5317768593788952491, guid: 7c46860097fdafb4abd62085d2045ad9,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/EventsSubSection/EventCard_Long.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/EventsSubSection/EventCard_Long.prefab
@@ -2584,6 +2584,11 @@ PrefabInstance:
       propertyPath: model.fillParent
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
+        type: 3}
+      propertyPath: model.lastUriCached
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5317768593788952491, guid: 7c46860097fdafb4abd62085d2045ad9,
         type: 3}
       propertyPath: m_Sprite
@@ -3590,7 +3595,7 @@ PrefabInstance:
     - target: {fileID: 6583379474799589209, guid: b53f82112c401e94eb453570ac440340,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 63.28
       objectReference: {fileID: 0}
     - target: {fileID: 6583379474799589209, guid: b53f82112c401e94eb453570ac440340,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/EventsSubSection/EventCard_Modal.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/EventsSubSection/EventCard_Modal.prefab
@@ -3367,6 +3367,11 @@ PrefabInstance:
       propertyPath: model.fillParent
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
+        type: 3}
+      propertyPath: model.lastUriCached
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5317768593788952491, guid: 7c46860097fdafb4abd62085d2045ad9,
         type: 3}
       propertyPath: m_Type

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/HighlightsSubSection/PlaceCard_Long.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/HighlightsSubSection/PlaceCard_Long.prefab
@@ -1562,7 +1562,7 @@ PrefabInstance:
     - target: {fileID: 6583379474799589209, guid: b53f82112c401e94eb453570ac440340,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 170.82
+      value: 170.87
       objectReference: {fileID: 0}
     - target: {fileID: 6583379474799589209, guid: b53f82112c401e94eb453570ac440340,
         type: 3}
@@ -1602,12 +1602,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 1323953455831319416, guid: b53f82112c401e94eb453570ac440340, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: b53f82112c401e94eb453570ac440340, type: 3}
---- !u!224 &6732545316488417311 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6583379474799589209, guid: b53f82112c401e94eb453570ac440340,
-    type: 3}
-  m_PrefabInstance: {fileID: 446439705543042886}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5307741102947407199 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5736161931655279129, guid: b53f82112c401e94eb453570ac440340,
@@ -1620,6 +1614,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 274bf6bf95184804cb2606eda1bf2a6a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &6732545316488417311 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6583379474799589209, guid: b53f82112c401e94eb453570ac440340,
+    type: 3}
+  m_PrefabInstance: {fileID: 446439705543042886}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1138945542168168517
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1670,7 +1670,7 @@ PrefabInstance:
     - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 25
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
         type: 3}
@@ -2222,7 +2222,7 @@ PrefabInstance:
     - target: {fileID: 1193374580596543427, guid: 69bd596225e56a64ba21d5ac4b2e8351,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 53.27
+      value: 53.28
       objectReference: {fileID: 0}
     - target: {fileID: 1193374580596543427, guid: 69bd596225e56a64ba21d5ac4b2e8351,
         type: 3}
@@ -2340,6 +2340,11 @@ PrefabInstance:
     - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
         type: 3}
       propertyPath: model.fillParent
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
+        type: 3}
+      propertyPath: model.lastUriCached
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5317768593788952491, guid: 7c46860097fdafb4abd62085d2045ad9,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesSubSection/FriendHeadForPlaceCard.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesSubSection/FriendHeadForPlaceCard.prefab
@@ -677,6 +677,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 09da6730b26434c19973555545d3eb24,
         type: 3}
+    - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
+        type: 3}
+      propertyPath: model.lastUriCached
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4840955537636468590, guid: 7c46860097fdafb4abd62085d2045ad9,
         type: 3}
       propertyPath: m_SizeDelta.x
@@ -691,7 +696,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 91e559f524592ad4a94afd8829f86e75,
+      objectReference: {fileID: 21300000, guid: 09da6730b26434c19973555545d3eb24,
         type: 3}
     - target: {fileID: 6044329464138306421, guid: 7c46860097fdafb4abd62085d2045ad9,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesSubSection/PlaceCard.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesSubSection/PlaceCard.prefab
@@ -2381,6 +2381,11 @@ PrefabInstance:
       propertyPath: model.fillParent
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
+        type: 3}
+      propertyPath: model.lastUriCached
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5317768593788952491, guid: 7c46860097fdafb4abd62085d2045ad9,
         type: 3}
       propertyPath: m_Sprite
@@ -2514,12 +2519,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c46860097fdafb4abd62085d2045ad9, type: 3}
---- !u!224 &3832789837912161842 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6044329464138306421, guid: 7c46860097fdafb4abd62085d2045ad9,
-    type: 3}
-  m_PrefabInstance: {fileID: 7408715589669039431}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2794385792905576523 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
@@ -2532,3 +2531,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0aaf5a1daa0c8548ba499d4a0332eb9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &3832789837912161842 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6044329464138306421, guid: 7c46860097fdafb4abd62085d2045ad9,
+    type: 3}
+  m_PrefabInstance: {fileID: 7408715589669039431}
+  m_PrefabAsset: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesSubSection/PlaceCard_Modal.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesSubSection/PlaceCard_Modal.prefab
@@ -329,7 +329,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1071488361356379080}
   m_HandleRect: {fileID: 4120738107523320214}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -1946,6 +1946,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6356871599185150532, guid: fba0fec118dd0e346a80979a4c65028d,
         type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: e36f3569fbdef4c609c33f7a1cebace5,
+        type: 3}
+    - target: {fileID: 6356871599185150532, guid: fba0fec118dd0e346a80979a4c65028d,
+        type: 3}
       propertyPath: m_Color.a
       value: 0.8235294
       objectReference: {fileID: 0}
@@ -2108,6 +2114,12 @@ PrefabInstance:
     - {fileID: 2272975599600319705, guid: fba0fec118dd0e346a80979a4c65028d, type: 3}
     - {fileID: 8967917879034953534, guid: fba0fec118dd0e346a80979a4c65028d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: fba0fec118dd0e346a80979a4c65028d, type: 3}
+--- !u!224 &7756008126668782540 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7732408266846214892, guid: fba0fec118dd0e346a80979a4c65028d,
+    type: 3}
+  m_PrefabInstance: {fileID: 66964748830974240}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &9179686715425177228 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9189916629297864620, guid: fba0fec118dd0e346a80979a4c65028d,
@@ -2120,12 +2132,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 274bf6bf95184804cb2606eda1bf2a6a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &7756008126668782540 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7732408266846214892, guid: fba0fec118dd0e346a80979a4c65028d,
-    type: 3}
-  m_PrefabInstance: {fileID: 66964748830974240}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &647162040541456859
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2367,6 +2373,11 @@ PrefabInstance:
       propertyPath: model.fillParent
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
+        type: 3}
+      propertyPath: model.lastUriCached
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5317768593788952491, guid: 7c46860097fdafb4abd62085d2045ad9,
         type: 3}
       propertyPath: m_Type
@@ -2540,12 +2551,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c46860097fdafb4abd62085d2045ad9, type: 3}
---- !u!224 &8565104232734422115 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6044329464138306421, guid: 7c46860097fdafb4abd62085d2045ad9,
-    type: 3}
-  m_PrefabInstance: {fileID: 2683188205514155798}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7289698274521795098 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4618068140710309132, guid: 7c46860097fdafb4abd62085d2045ad9,
@@ -2558,6 +2563,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0aaf5a1daa0c8548ba499d4a0332eb9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &8565104232734422115 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6044329464138306421, guid: 7c46860097fdafb4abd62085d2045ad9,
+    type: 3}
+  m_PrefabInstance: {fileID: 2683188205514155798}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6893479403159938772
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentController.cs
@@ -12,6 +12,8 @@ public interface IPlacesAndEventsSectionComponentController : IDisposable
 
 public class PlacesAndEventsSectionComponentController : IPlacesAndEventsSectionComponentController
 {
+    internal const float MIN_TIME_TO_CHECK_API = 60f;
+
     public event Action<bool> OnCloseExploreV2;
 
     internal IPlacesAndEventsSectionComponentView view;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventCard/EventCardComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventCard/EventCardComponentView.cs
@@ -168,9 +168,6 @@ public class EventCardComponentView : BaseComponentView, IEventCardComponentView
 
     public override void Start()
     {
-        if (eventImage != null)
-            eventImage.OnLoaded += OnEventImageLoaded;
-
         if (closeCardButton != null)
             closeCardButton.onClick.AddListener(CloseModal);
 
@@ -251,10 +248,7 @@ public class EventCardComponentView : BaseComponentView, IEventCardComponentView
         base.Dispose();
 
         if (eventImage != null)
-        {
-            eventImage.OnLoaded -= OnEventImageLoaded;
             eventImage.Dispose();
-        }
 
         if (closeCardButton != null)
             closeCardButton.onClick.RemoveAllListeners();
@@ -468,8 +462,6 @@ public class EventCardComponentView : BaseComponentView, IEventCardComponentView
         eventInfoContainer.SetActive(!isVisible);
         loadingSpinner.SetActive(isVisible);
     }
-
-    internal void OnEventImageLoaded(Sprite sprite) { SetEventPicture(sprite); }
 
     internal void RebuildCardLayouts()
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
@@ -49,7 +49,6 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     public event Action OnCloseExploreV2;
     internal event Action OnEventsFromAPIUpdated;
 
-    internal const int MAX_NUMBER_OF_FEATURED_EVENTS = 20;
     internal const int DEFAULT_NUMBER_OF_FEATURED_EVENTS = 3;
     internal const int INITIAL_NUMBER_OF_UPCOMING_ROWS = 1;
     internal const int SHOW_MORE_UPCOMING_ROWS_INCREMENT = 2;
@@ -158,10 +157,7 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     public void LoadFeaturedEvents()
     {
         List<EventCardComponentModel> featuredEvents = new List<EventCardComponentModel>();
-        List<EventFromAPIModel> eventsFiltered = eventsFromAPI
-            .Where(e => e.highlighted)
-            .Take(MAX_NUMBER_OF_FEATURED_EVENTS)
-            .ToList();
+        List<EventFromAPIModel> eventsFiltered = eventsFromAPI.Where(e => e.highlighted).ToList();
 
         if (eventsFiltered.Count == 0)
             eventsFiltered = eventsFromAPI.Take(DEFAULT_NUMBER_OF_FEATURED_EVENTS).ToList();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
@@ -49,6 +49,7 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     public event Action OnCloseExploreV2;
     internal event Action OnEventsFromAPIUpdated;
 
+    internal const int MAX_NUMBER_OF_FEATURED_EVENTS = 20;
     internal const int DEFAULT_NUMBER_OF_FEATURED_EVENTS = 3;
     internal const int INITIAL_NUMBER_OF_UPCOMING_ROWS = 1;
     internal const int SHOW_MORE_UPCOMING_ROWS_INCREMENT = 2;
@@ -59,6 +60,7 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     internal int currentUpcomingEventsShowed = 0;
     internal bool reloadEvents = false;
     internal IExploreV2Analytics exploreV2Analytics;
+    internal float lastTimeAPIChecked = 0;
 
     public EventsSubSectionComponentController(
         IEventsSubSectionComponentView view,
@@ -84,6 +86,7 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     internal void FirstLoading()
     {
         reloadEvents = true;
+        lastTimeAPIChecked = Time.realtimeSinceStartup - PlacesAndEventsSectionComponentController.MIN_TIME_TO_CHECK_API;
         RequestAllEvents();
 
         view.OnEventsSubSectionEnable += RequestAllEvents;
@@ -103,14 +106,20 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
         if (!reloadEvents)
             return;
 
-        currentUpcomingEventsShowed = view.currentUpcomingEventsPerRow * INITIAL_NUMBER_OF_UPCOMING_ROWS;
         view.RestartScrollViewPosition();
+
+        if (Time.realtimeSinceStartup < lastTimeAPIChecked + PlacesAndEventsSectionComponentController.MIN_TIME_TO_CHECK_API)
+            return;
+
+        currentUpcomingEventsShowed = view.currentUpcomingEventsPerRow * INITIAL_NUMBER_OF_UPCOMING_ROWS;
         view.SetFeaturedEventsAsLoading(true);
         view.SetTrendingEventsAsLoading(true);
         view.SetUpcomingEventsAsLoading(true);
         view.SetShowMoreUpcomingEventsButtonActive(false);
         view.SetGoingEventsAsLoading(true);
+        
         reloadEvents = false;
+        lastTimeAPIChecked = Time.realtimeSinceStartup;
 
         if (!DataStore.i.exploreV2.isInShowAnimationTransiton.Get())
             RequestAllEventsFromAPI();
@@ -149,7 +158,10 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     public void LoadFeaturedEvents()
     {
         List<EventCardComponentModel> featuredEvents = new List<EventCardComponentModel>();
-        List<EventFromAPIModel> eventsFiltered = eventsFromAPI.Where(e => e.highlighted).ToList();
+        List<EventFromAPIModel> eventsFiltered = eventsFromAPI
+            .Where(e => e.highlighted)
+            .Take(MAX_NUMBER_OF_FEATURED_EVENTS)
+            .ToList();
 
         if (eventsFiltered.Count == 0)
             eventsFiltered = eventsFromAPI.Take(DEFAULT_NUMBER_OF_FEATURED_EVENTS).ToList();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlaceCard/PlaceCardComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlaceCard/PlaceCardComponentView.cs
@@ -367,10 +367,9 @@ public class PlaceCardComponentView : BaseComponentView, IPlaceCardComponentView
     internal void OnPlaceImageLoaded(Sprite sprite)
     {
         if (sprite != null)
-        {
-            SetPlacePicture(sprite);
-        }
-        else if (!thumbnailFromMarketPlaceRequested)
+            return;
+
+        if (!thumbnailFromMarketPlaceRequested)
         {
             thumbnailFromMarketPlaceRequested = true;
             SetPlacePicture(MapUtils.GetMarketPlaceThumbnailUrl(model.parcels, THMBL_MARKETPLACE_WIDTH, THMBL_MARKETPLACE_HEIGHT, THMBL_MARKETPLACE_SIZEFACTOR));

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentController.cs
@@ -43,6 +43,7 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
     internal int currentPlacesShowed = 0;
     internal bool reloadPlaces = false;
     internal IExploreV2Analytics exploreV2Analytics;
+    internal float lastTimeAPIChecked = 0;
 
     public PlacesSubSectionComponentController(
         IPlacesSubSectionComponentView view,
@@ -70,6 +71,7 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
     internal void FirstLoading()
     {
         reloadPlaces = true;
+        lastTimeAPIChecked = Time.realtimeSinceStartup - PlacesAndEventsSectionComponentController.MIN_TIME_TO_CHECK_API;
         RequestAllPlaces();
 
         view.OnPlacesSubSectionEnable += RequestAllPlaces;
@@ -89,11 +91,17 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
         if (!reloadPlaces)
             return;
 
-        currentPlacesShowed = view.currentPlacesPerRow * INITIAL_NUMBER_OF_ROWS;
         view.RestartScrollViewPosition();
+
+        if (Time.realtimeSinceStartup < lastTimeAPIChecked + PlacesAndEventsSectionComponentController.MIN_TIME_TO_CHECK_API)
+            return;
+
+        currentPlacesShowed = view.currentPlacesPerRow * INITIAL_NUMBER_OF_ROWS;
         view.SetPlacesAsLoading(true);
         view.SetShowMorePlacesButtonActive(false);
+        
         reloadPlaces = false;
+        lastTimeAPIChecked = Time.realtimeSinceStartup;
 
         if (!DataStore.i.exploreV2.isInShowAnimationTransiton.Get())
             RequestAllPlacesFromAPI();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventCardComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventCardComponentViewTests.cs
@@ -330,17 +330,6 @@ public class EventCardComponentViewTests
     }
 
     [Test]
-    public void CallOnPlaceImageLoadedCorrectly()
-    {
-        // Act
-        eventCardComponent.OnEventImageLoaded(testSprite);
-
-        // Assert
-        Assert.AreEqual(testSprite, eventCardComponent.model.eventPictureSprite, "The event card picture sprite does not match in the model.");
-        Assert.AreEqual(testSprite, eventCardComponent.eventImage.image.sprite, "The event card image does not match.");
-    }
-
-    [Test]
     public void CloseModalCorrectly()
     {
         // Arrange

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventsSubSectionComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventsSubSectionComponentControllerTests.cs
@@ -76,6 +76,7 @@ public class EventsSubSectionComponentControllerTests
         // Arrange
         eventsSubSectionComponentController.currentUpcomingEventsShowed = -1;
         eventsSubSectionComponentController.reloadEvents = true;
+        eventsSubSectionComponentController.lastTimeAPIChecked = Time.realtimeSinceStartup - PlacesAndEventsSectionComponentController.MIN_TIME_TO_CHECK_API;
         DataStore.i.exploreV2.isInShowAnimationTransiton.Set(false);
 
         // Act

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/HighlightsSubSectionComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/HighlightsSubSectionComponentControllerTests.cs
@@ -85,6 +85,7 @@ public class HighlightsSubSectionComponentControllerTests
     {
         // Arrange
         highlightsSubSectionComponentController.reloadHighlights = true;
+        highlightsSubSectionComponentController.lastTimeAPIChecked = Time.realtimeSinceStartup - PlacesAndEventsSectionComponentController.MIN_TIME_TO_CHECK_API;
         DataStore.i.exploreV2.isInShowAnimationTransiton.Set(false);
 
         // Act

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/PlaceCardComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/PlaceCardComponentViewTests.cs
@@ -226,17 +226,6 @@ public class PlaceCardComponentViewTests
     }
 
     [Test]
-    public void CallOnPlaceImageLoadedCorrectly()
-    {
-        // Act
-        placeCardComponent.OnPlaceImageLoaded(testSprite);
-
-        // Assert
-        Assert.AreEqual(testSprite, placeCardComponent.model.placePictureSprite, "The place card picture sprite does not match in the model.");
-        Assert.AreEqual(testSprite, placeCardComponent.placeImage.image.sprite, "The place card image does not match.");
-    }
-
-    [Test]
     public void InitializeFriendsTrackerCorrectly()
     {
         // Arrange

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/PlacesSubSectionComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/PlacesSubSectionComponentControllerTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 using static HotScenesController;
 
 public class PlacesSubSectionComponentControllerTests
@@ -76,6 +77,7 @@ public class PlacesSubSectionComponentControllerTests
         // Arrange
         placesSubSectionComponentController.currentPlacesShowed = -1;
         placesSubSectionComponentController.reloadPlaces = true;
+        placesSubSectionComponentController.lastTimeAPIChecked = Time.realtimeSinceStartup - PlacesAndEventsSectionComponentController.MIN_TIME_TO_CHECK_API;
         DataStore.i.exploreV2.isInShowAnimationTransiton.Set(false);
 
         // Act

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Image/ImageComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Image/ImageComponentView.cs
@@ -139,10 +139,7 @@ public class ImageComponentView : BaseComponentView, IImageComponentView, ICompo
     public void SetImage(string uri)
     {
         if (model.lastUriCached && uri == lastLoadedUri)
-        {
-            Debug.Log($"SANTI --> URI [{uri}] CACHED!!");
             return;
-        }
 
         model.uri = uri;
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Image/ImageComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Image/ImageComponentView.cs
@@ -1,6 +1,5 @@
 using DCL.Helpers;
 using System;
-using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -15,7 +14,7 @@ public interface IImageComponentView
     /// Set an image directly from a sprite.
     /// </summary>
     /// <param name="sprite">A sprite.</param>
-    void SetImage(Sprite sprite);
+    void SetImage(Sprite sprite, bool cleanLastLoadedUri = true);
 
     /// <summary>
     /// Set an image from a 2D texture,
@@ -105,7 +104,7 @@ public class ImageComponentView : BaseComponentView, IImageComponentView, ICompo
         Destroy(currentSprite);
     }
 
-    public void SetImage(Sprite sprite)
+    public void SetImage(Sprite sprite, bool cleanLastLoadedUri = true)
     {
         model.sprite = sprite;
 
@@ -113,33 +112,37 @@ public class ImageComponentView : BaseComponentView, IImageComponentView, ICompo
             return;
 
         image.sprite = sprite;
-        lastLoadedUri = null;
+        
+        if (cleanLastLoadedUri)
+            lastLoadedUri = null;
+        
         SetFitParent(model.fitParent);
     }
 
     public void SetImage(Texture2D texture)
     {
-        if (model.texture != texture)
+        model.texture = texture;
+
+        if (!Application.isPlaying)
         {
-            model.texture = texture;
-
-            if (!Application.isPlaying)
-            {
-                OnImageObserverUpdated(texture);
-                return;
-            }
-
-            SetLoadingIndicatorVisible(true);
-            imageObserver.RefreshWithTexture(texture);
+            OnImageObserverUpdated(texture);
+            return;
         }
 
+        SetLoadingIndicatorVisible(true);
+        imageObserver.RefreshWithTexture(texture);
+
+        lastLoadedUri = null;
         SetFitParent(model.fitParent);
     }
 
     public void SetImage(string uri)
     {
         if (model.lastUriCached && uri == lastLoadedUri)
+        {
+            Debug.Log($"SANTI --> URI [{uri}] CACHED!!");
             return;
+        }
 
         model.uri = uri;
 
@@ -183,7 +186,7 @@ public class ImageComponentView : BaseComponentView, IImageComponentView, ICompo
             DestroyImmediate(currentSprite);
 
         currentSprite = texture != null ? Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0.5f, 0.5f)) : null;
-        SetImage(currentSprite);
+        SetImage(currentSprite, false);
         SetLoadingIndicatorVisible(false);
         lastLoadedUri = currentUriLoading;
         currentUriLoading = null;


### PR DESCRIPTION
## What does this PR change?
- Use the **caching option provided by the `Image` UI Component** for the event and place cards (before this improvement the images were being requested each time the card was instantiated and it took a lot of time).
- Set a **min time of 1 minute to request the data to the API** (before this improvement were always requesting data to the API each time the start menu was open).
- **Remove some unneeded calls** in the code.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/explore-v2-loading-improvements
2. Test the "Explore" section of the Start Menu.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
