### PR TITLE
chore: improve AB GLTF editor naming

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -54,9 +54,6 @@ namespace DCL
 
         protected override void OnBeforeLoadOrReuse()
         {
-#if UNITY_EDITOR
-            asset.container.name = "AB: " + hash;
-#endif
             settings.ApplyBeforeLoad(asset.container.transform);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -56,9 +56,6 @@ namespace DCL
 
         protected override void OnBeforeLoadOrReuse()
         {
-#if UNITY_EDITOR
-            asset.container.name = "GLTF: " + this.id;
-#endif
             settings.ApplyBeforeLoad(asset.container.transform);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -128,6 +128,9 @@ namespace DCL.Components
             }
         }
 
+        private const string AB_GO_NAME_PREFIX = "AB:";
+        private const string GLTF_GO_NAME_PREFIX = "GLTF:";
+
         void LoadAssetBundle(string targetUrl, Action<Rendereable> OnSuccess, Action<Exception> OnFail)
         {
             if (abPromise != null)
@@ -156,6 +159,9 @@ namespace DCL.Components
 
             abPromise.OnSuccessEvent += (x) =>
             {
+#if UNITY_EDITOR
+                x.container.name = AB_GO_NAME_PREFIX + x.container.name; 
+#endif
                 var r = new Rendereable()
                 {
                     container = x.container,
@@ -199,6 +205,9 @@ namespace DCL.Components
 
             gltfPromise.OnSuccessEvent += (Asset_GLTF x) =>
             {
+#if UNITY_EDITOR
+                x.container.name = GLTF_GO_NAME_PREFIX + x.container.name;
+#endif
                 var r = new Rendereable
                 {
                     container = x.container,


### PR DESCRIPTION
### WHY
Currently when we override 3D assets loaded container GameObject with "AB:..." or "GLTF:..." many times the "AB:..." is not applied (but the "GLTF:..." is not applied either).

### WHAT
Moved editor naming of ABs and GLTFs to the right place