### PR TITLE
chore: disable prefabs merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #
@@ -10,6 +11,7 @@
 # Note: This is only used by command line
 ###############################################################################
 *.cs     diff=csharp
+
 ###############################################################################
 # Set the merge driver for project and solution files
 #
@@ -32,6 +34,7 @@
 #*.modelproj merge=binary
 #*.sqlproj   merge=binary
 #*.wwaproj   merge=binary
+
 ###############################################################################
 # behavior for image files
 #
@@ -50,25 +53,21 @@
 *.unityweb filter=lfs diff=lfs merge=lfs -text
 *.vox filter=lfs diff=lfs merge=lfs -text
 *.wav filter=lfs diff=lfs merge=lfs -text
-#*.gif   binary
-###############################################################################
-# diff behavior for common document formats
-#
-# Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the
-# entries below.
-###############################################################################
-#*.doc   diff=astextplain
-#*.DOC   diff=astextplain
-#*.docx  diff=astextplain
-#*.DOCX  diff=astextplain
-#*.dot   diff=astextplain
-#*.DOT   diff=astextplain
-#*.pdf   diff=astextplain
-#*.PDF   diff=astextplain
-#*.rtf   diff=astextplain
-#*.RTF   diff=astextplain
-TestResources/Audio/Train.wav filter=lfs diff=lfs merge=lfs -text
+
 *.jspre linguist-language=JavaScript
+
 # Shell scripts require LF
-*.sh text eol=lf 
+*.sh text eol=lf
+
+##############################################################################
+# unity specifics
+#
+##############################################################################
+*.mat binary
+*.anim binary
+*.unity binary
+*.prefab binary
+*.physicsMaterial2D binary
+*.physicMaterial binary
+*.asset binary
+*.controller binary


### PR DESCRIPTION
Updated `gitattributes` to force conflicts in unity files.

## Test
A simple test is to create two branches from this one, modify the same prefab changing values (both values should be far away in the file, to ensure no text conflicts) and merge one into another. With the `gitattributes` change a conflict should arise, and without it the file should auto-merge.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
