### PR TITLE
chore: removed unused face/face128 definitions

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Textures/DCLAvatarTexture.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Textures/DCLAvatarTexture.cs
@@ -32,8 +32,6 @@ namespace DCL.Components
             [System.Serializable]
             public class Snapshots
             {
-                public string face;
-                public string face128;
                 public string face256;
                 public string body;
             }


### PR DESCRIPTION
## What does this PR change?

Fix #2088
Removed unused face and face128 variables in Snapshots class
...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/remove-face
2. Change wearables
3. Save
4. Close and reopen
5. Verify the correctness of the profile pic

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
