### PR TITLE
chore: removed plugin system dispose from Main

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -123,11 +123,9 @@ namespace DCL
 
             DataStore.i.common.isApplicationQuitting.Set(true);
 
-            pluginSystem?.Dispose();
-
             if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
                 Environment.Dispose();
-            pluginSystem?.Dispose();
+            
             kernelCommunication?.Dispose();
         }
 


### PR DESCRIPTION
## What does this PR change?

Removed the disposal of PluginSystem from `Main.OnDestroy` because we have no use case for this and its always the source of crashes on the Desktop client when exiting the Application

## How to test the changes?

Try this PR on Desktop and exit the application via the menu or ALT+F4

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
