### PR TITLE
chore: set SetOSXUniversal Architecture to Intel x64

### DIFF
--- a/unity-renderer/Assets/Scripts/Editor/BuildCommand.cs
+++ b/unity-renderer/Assets/Scripts/Editor/BuildCommand.cs
@@ -150,6 +150,11 @@ static class BuildCommand
         {
             PlayerSettings.WebGL.emscriptenArgs = " --profiling-funcs ";
         }
+        else if (buildTarget == BuildTarget.StandaloneOSX)
+        {
+            Console.WriteLine(":: Set OSXUniversal Architecture to x64");
+            EditorUserBuildSettings.SetPlatformSettings("OSXUniversal", "Architecture", "x64");
+        }
 
         var buildSummary = BuildPipeline.BuildPlayer(GetEnabledScenes(), fixedBuildPath, buildTarget, GetBuildOptions());
         Console.WriteLine(":: Done with build process");


### PR DESCRIPTION
Needed by https://github.com/decentraland/explorer-desktop/pull/193
to fix: https://github.com/decentraland/explorer-desktop/issues/192

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
