### PR TITLE
fix: changed how the application quit is handled

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -141,12 +141,7 @@ namespace DCL
             
             kernelCommunication?.Dispose();
         }
-
-        private void OnDestroy()
-        {
-            Debug.Log("DESTROYING!");
-        }
-
+        
         protected virtual void InitializeSceneDependencies()
         {
             gameObject.AddComponent<UserProfileController>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -116,8 +116,19 @@ namespace DCL
         {
             performanceMetricsController?.Update();
         }
+        
+        [RuntimeInitializeOnLoadMethod]
+        static void RunOnStart()
+        {
+            Application.wantsToQuit += ApplicationWantsToQuit;
+        }
+        private static bool ApplicationWantsToQuit()
+        {
+            i.Dispose();
+            return true;
+        }
 
-        protected virtual void OnDestroy()
+        protected virtual void Dispose()
         {
             DataStore.i.HUDs.loadingHUD.visible.OnChange -= OnLoadingScreenVisibleStateChange;
 
@@ -127,8 +138,13 @@ namespace DCL
 
             if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
                 Environment.Dispose();
-            pluginSystem?.Dispose();
+            
             kernelCommunication?.Dispose();
+        }
+
+        private void OnDestroy()
+        {
+            Debug.Log("DESTROYING!");
         }
 
         protected virtual void InitializeSceneDependencies()


### PR DESCRIPTION
## What does this PR change?

Changes the behavior on exiting the application, this might fix some errors when exiting the application from Desktop (https://github.com/decentraland/explorer-desktop/issues/116).

## How to test the changes?

Enter play mode, wait until genesis plaza is loaded and exit play mode, no error should show up after exiting.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
