### PR TITLE
Fix: show minimap on explore closure

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -202,7 +202,7 @@ namespace DCL
             zoomIn.OnStarted -= OnZoomPlusMinus;
             zoomOut.OnStarted -= OnZoomPlusMinus;
             CommonScriptableObjects.isFullscreenHUDOpen.OnChange -= IsFullscreenHUDOpen_OnChange;
-            navmapVisible.OnChange -= OnNavmapVisibleChanged;
+            DataStore.i.exploreV2.isOpen.OnChange -= OnExploreChange;
         }
 
         private void OnExploreChange(bool current, bool previous)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -72,6 +72,7 @@ namespace DCL
             MapRenderer.OnParcelClicked += TriggerToast;
             MapRenderer.OnCursorFarFromParcel += CloseToast;
             CommonScriptableObjects.playerCoords.OnChange += UpdateCurrentSceneData;
+            DataStore.i.exploreV2.isOpen.OnChange += OnExploreChange;
             navmapVisible.OnChange += OnNavmapVisibleChanged;
 
             configureMapInFullscreenMenu.OnChange += ConfigureMapInFullscreenMenuChanged;
@@ -201,6 +202,15 @@ namespace DCL
             zoomIn.OnStarted -= OnZoomPlusMinus;
             zoomOut.OnStarted -= OnZoomPlusMinus;
             CommonScriptableObjects.isFullscreenHUDOpen.OnChange -= IsFullscreenHUDOpen_OnChange;
+            navmapVisible.OnChange -= OnNavmapVisibleChanged;
+        }
+
+        private void OnExploreChange(bool current, bool previous)
+        {
+            if (current)
+                return;
+
+            SetVisible(false);
         }
 
         internal void SetVisible(bool visible)
@@ -229,7 +239,6 @@ namespace DCL
 
         private void IsFullscreenHUDOpen_OnChange(bool current, bool previous)
         {
-
             if (!current)
                 return;
 


### PR DESCRIPTION
## What does this PR change?

Fix #2111 
Avoids map to be invisibile when closing the explore

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/minimap-invisible
2. Open explore with shortcuts
3. Close it
4. Verify minimap is still visible

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
