### PR TITLE
test: enable third party wearables endpoint usage

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -717,9 +717,9 @@ public class AvatarEditorHUDController : IHUD
         if (isOn)
         {
             // TODO (Santi): Use CatalogController.RequestThirdPartyWearablesByCollection(...) when the endpoint is available by platform!
-            //CatalogController.RequestThirdPartyWearablesByCollection(userProfile.userId, collectionId)
             view.BlockCollectionsDropdown(true);
-            WearablesFetchingHelper.GetThirdPartyWearablesByCollection(collectionId)
+            // WearablesFetchingHelper.GetThirdPartyWearablesByCollection(collectionId)
+            CatalogController.RequestThirdPartyWearablesByCollection(userProfile.userId, collectionId)
                 .Then((wearables) =>
                 {
                     foreach (WearableItem wearable in wearables)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Wearables/WearablesFetchingHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Wearables/WearablesFetchingHelper.cs
@@ -17,8 +17,8 @@ namespace DCL.Helpers
         // public const string COLLECTIONS_FETCH_URL = "https://peer-lb.decentraland.org/lambdas/collections"; 
         public const string COLLECTIONS_FETCH_URL = "https://nft-api.decentraland.org/v1/collections?sortBy=newest&first=1000"; 
         private static Collection[] collections;
-
-        public const string THIRD_PARTY_COLLECTIONS_FETCH_URL = "https://nft-api.decentraland.org/v1/collections?sortBy=newest&first=30";
+        
+        public const string THIRD_PARTY_COLLECTIONS_FETCH_URL = "third-party-integrations";
         public const string THIRD_PARTY_WEARABLES_FETCH_URL = "collections/wearables?";
 
         private static IEnumerator EnsureCollectionsData()
@@ -117,9 +117,10 @@ namespace DCL.Helpers
         public static Promise<Collection[]> GetThirdPartyCollections()
         {
             Promise<Collection[]> promiseResult = new Promise<Collection[]>();
-
+            
+            // Until the TPCs fetching lambda is present in all catalysts, we have to test the client with '&CATALYST=peer.decentraland.zone'
             Environment.i.platform.webRequest.Get(
-                url: THIRD_PARTY_COLLECTIONS_FETCH_URL,
+                url: $"{Environment.i.platform.serviceProviders.catalyst.lambdasUrl}/{THIRD_PARTY_COLLECTIONS_FETCH_URL}",
                 downloadHandler: new DownloadHandlerBuffer(),
                 timeout: 5000,
                 OnFail: (webRequest) =>


### PR DESCRIPTION
Base PR: https://github.com/decentraland/unity-renderer/pull/1814

- updated third party wearables endpoint url 
- updated endpoint usage following Santi's comments

### TESTING
The build must be tested with `&CATALYST=peer.decentraland.zone` URL param until the Third Party Wearable Collections fetching lambda is implemente in all catalysts.
- Test Link: https://play.decentraland.zone/?renderer-branch=test/EnableThirdPartyWearablesEndpointUsage&CATALYST=peer.decentraland.zone&kernel-branch=test/DisableWearablesFetchFilters

### NOTES
- ~Right now the only collection in [the endpoint](https://peer.decentraland.zone/lambdas/third-party-integrations) used to fetch all third party collections doesn't have a `name` property in its data so the client won't display it's name but its toggle can be seen and used~
![Screen Shot 2022-04-01 at 17 15 01](https://user-images.githubusercontent.com/1031741/161337746-47e959d6-75a6-4127-aa02-a27b9555a9e0.png)

<img width="291" alt="Screen Shot 2022-04-01 at 17 17 10" src="https://user-images.githubusercontent.com/1031741/161337750-82559702-7334-4cc7-88a8-9eaec70b0515.png">

**edit: This has been solved from the endpoint-side.**


- ~Currently when the collection is toggled, Kernel throws a [`You must set one and only one filter for V1. Also, the only collection id allowed is 'urn:decentraland:off-chain:base-avatars'`](https://github.com/decentraland/kernel/blob/9b51f8e6cadf0de7e99116d4474baea0cdec3646/packages/shared/catalogs/sagas.ts#L84) error~ **edit: connected to a [test branch in kernel](https://github.com/decentraland/kernel/pull/256) to avoid the error**