### PR TITLE
chore: improve character ground check extra distance

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -11,7 +11,7 @@ public class DCLCharacterController : MonoBehaviour
     [Header("Movement")]
     public float minimumYPosition = 1f;
 
-    public float groundCheckExtraDistance = 0.25f;
+    public float groundCheckExtraDistance = 0.1f;
     public float gravity = -55f;
     public float jumpForce = 12f;
     public float movementSpeed = 8f;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
@@ -336,7 +336,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   minimumYPosition: 0
-  groundCheckExtraDistance: 0.25
+  groundCheckExtraDistance: 0.1
   gravity: -55
   jumpForce: 12
   movementSpeed: 11


### PR DESCRIPTION
Tried other solutions to fix the problem we get on **the desktop client** character controller getting "floaty" for a second when reaching the ground but since those other solutions (like using `FixedUpdate()`) require to re-balance gravity, etc. I went for the simpler solution that doesn't affect the web client and solves the issue at the desktop client: decreasing a bit the ground check extra distance value.

In case you want to test that the character controller jump height and slope walking keeps working as expected you can enter this scene at ropsten network:
https://play.decentraland.zone/?NETWORK=ropsten&position=59%2C-67&realm=thor&renderer-branch=chore%2FImproveCharacterGroundCheckExtraDistance
![chrome_z8HENOj61g](https://user-images.githubusercontent.com/1031741/161754982-acdc2b72-119a-4cb6-be1b-6d6430070d20.png)

And test that the last slope (47.5º) cannot be "walked on" (all the previous can):
![chrome_V0VFWSnZ92](https://user-images.githubusercontent.com/1031741/161755222-abb28b7c-df89-46b2-bf4b-3cd9676ba60f.png)

And the 190cm and 200cm columns shouldn't be reachable by jumping from the ground (the other 2 should):
![chrome_2kz6hQBzmv](https://user-images.githubusercontent.com/1031741/161756361-39904302-79ae-4462-a3a8-6f9398195b97.png)

