### PR TITLE
avoid camera change if in no change zone

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
@@ -137,7 +137,7 @@ namespace DCL.Camera
 
         private void OnMouseWheelChangeValue(DCLAction_Measurable action, float value)
         {
-            if (value > -mouseWheelThreshold && value < mouseWheelThreshold) return;
+            if ((value > -mouseWheelThreshold && value < mouseWheelThreshold) || CommonScriptableObjects.cameraModeInputLocked.Get()) return;
             if (Utils.IsPointerOverUIElement()) return;
 
             if (CommonScriptableObjects.cameraMode == CameraMode.ModeId.FirstPerson && value < -mouseWheelThreshold)


### PR DESCRIPTION
## What does this PR change?

Fix #2133 
Removes the possibility of changing camera mode with mouse wheel in no camera change modifier areas

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/force-fp-wheel
2. Go to an area enforcing first person view
3. Try to change mode with mouse wheel or with the v key

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
