### PR TITLE
minor fixes in minimap new panel

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUD.asmdef
@@ -16,7 +16,9 @@
         "GUID:81f3218b29e049144b175dad2ebbac1b",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:320f1c61ad4373b4f9ffa3075e1f3d48",
-        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
+        "GUID:858f845923fcab3448cf8b66614b41a1",
+        "GUID:bd51ff2b035ce4ab4be7c38c43c88889"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDView.cs
@@ -89,6 +89,6 @@ public class MinimapHUDView : MonoBehaviour
 
     private void OnDestroy()
     {
-        mouseCatcher.OnMouseLock -= OnMouseLocked;
+        mouseCatcher?.OnMouseLock -= OnMouseLocked;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDView.cs
@@ -15,6 +15,8 @@ public class MinimapHUDView : MonoBehaviour
     private TextMeshProUGUI sceneNameText;
 
     [SerializeField] private TextMeshProUGUI playerPositionText;
+    [SerializeField] internal ShowHideAnimator mainShowHideAnimator;
+    [SerializeField] private Button openNavmapButton;
 
     [Header("Options")] [SerializeField] private Button optionsButton;
     [SerializeField] private GameObject sceneOptionsPanel;
@@ -25,15 +27,15 @@ public class MinimapHUDView : MonoBehaviour
 
     [Header("Map Renderer")] public RectTransform mapRenderContainer;
     public RectTransform mapViewport;
-    [SerializeField] private Button openNavmapButton;
 
     public static System.Action<MinimapHUDModel> OnUpdateData;
     public static System.Action OnOpenNavmapClicked;
     public InputAction_Trigger toggleNavMapAction;
-    [SerializeField] internal ShowHideAnimator mainShowHideAnimator;
+    private IMouseCatcher mouseCatcher;
 
     public void Initialize(MinimapHUDController controller)
     {
+        mouseCatcher = SceneReferences.i?.mouseCatcher;
         gameObject.name = VIEW_OBJECT_NAME;
         sceneOptionsPanel.SetActive(false);
 
@@ -42,6 +44,9 @@ public class MinimapHUDView : MonoBehaviour
         addBookmarkButton.onClick.AddListener(controller.AddBookmark);
         reportSceneButton.onClick.AddListener(controller.ReportScene);
         openNavmapButton.onClick.AddListener(toggleNavMapAction.RaiseOnTriggered);
+
+        if (mouseCatcher != null)
+            mouseCatcher.OnMouseLock += OnMouseLocked;
 
         var renderer = MapRenderer.i;
 
@@ -52,6 +57,11 @@ public class MinimapHUDView : MonoBehaviour
             renderer.transform.SetAsFirstSibling();
         }
         usersAroundListHudButton.gameObject.SetActive(false);
+    }
+
+    internal void OnMouseLocked() 
+    {
+        sceneOptionsPanel.SetActive(false);
     }
 
     internal static MinimapHUDView Create(MinimapHUDController controller)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDView.cs
@@ -89,6 +89,7 @@ public class MinimapHUDView : MonoBehaviour
 
     private void OnDestroy()
     {
-        mouseCatcher?.OnMouseLock -= OnMouseLocked;
+        if(mouseCatcher != null)
+            mouseCatcher.OnMouseLock -= OnMouseLocked;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDView.cs
@@ -86,4 +86,9 @@ public class MinimapHUDView : MonoBehaviour
         else if (!visible && mainShowHideAnimator.isVisible)
             mainShowHideAnimator.Hide();
     }
+
+    private void OnDestroy()
+    {
+        mouseCatcher.OnMouseLock -= OnMouseLocked;
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/Resources/MinimapHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/Resources/MinimapHUD.prefab
@@ -430,6 +430,7 @@ GameObject:
   - component: {fileID: 3774863987792430947}
   - component: {fileID: 5126883592997258683}
   - component: {fileID: 2827894067568205290}
+  - component: {fileID: 5297831391194203415}
   m_Layer: 5
   m_Name: Options
   m_TagString: Untagged
@@ -550,6 +551,22 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+--- !u!114 &5297831391194203415
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1235273549235105683}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &1406223747237966313
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?

Fix #2120 
Adds sound effects to three dots button, closes the new panel when the cursor gets locked again (same behavior as taskbar panels)

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/minimap-menu-improvs
2. Verify the sound effects on the minimap menu button
3. Lock the mouse and verify that the panel closes itself

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
