### PR TITLE
Fix: adds a small offset to avoid controller drift induced movements

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -8,6 +8,8 @@ public class DCLCharacterController : MonoBehaviour
 {
     public static DCLCharacterController i { get; private set; }
 
+    private const float CONTROLLER_DRIFT_OFFSET = 0.15f;
+
     [Header("Movement")]
     public float minimumYPosition = 1f;
 
@@ -299,14 +301,14 @@ public class DCLCharacterController : MonoBehaviour
 
                 Vector3 forwardTarget = Vector3.zero;
 
-                if (characterYAxis.GetValue() > 0)
+                if (characterYAxis.GetValue() > CONTROLLER_DRIFT_OFFSET)
                     forwardTarget += xzPlaneForward;
-                if (characterYAxis.GetValue() < 0)
+                if (characterYAxis.GetValue() < -CONTROLLER_DRIFT_OFFSET)
                     forwardTarget -= xzPlaneForward;
 
-                if (characterXAxis.GetValue() > 0)
+                if (characterXAxis.GetValue() > CONTROLLER_DRIFT_OFFSET)
                     forwardTarget += xzPlaneRight;
-                if (characterXAxis.GetValue() < 0)
+                if (characterXAxis.GetValue() < -CONTROLLER_DRIFT_OFFSET)
                     forwardTarget -= xzPlaneRight;
 
 


### PR DESCRIPTION
## What does this PR change?

Possibly fixes #1900
Adds a small offset for movements input to avoid unwanted movements caused by controller drift

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/controller-drift
2. Move around
3. Move around with a controller plugged to the pc
4. Verify that there are no unwanted movements

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
