### PR TITLE
Fix: Skybox Controller double instance

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
@@ -35,7 +35,6 @@ namespace DCL
             pluginSystem.RegisterWithFlag(() => new BuilderInWorldPlugin(), "builder_in_world");
             pluginSystem.RegisterWithFlag(() => new TutorialController(), "tutorial");
             pluginSystem.RegisterWithFlag(() => new PlacesAndEventsFeature(), "explorev2");
-            pluginSystem.RegisterWithFlag(() => new SkyboxController(), "procedural_skybox");
 
             pluginSystem.SetFeatureFlagsData(DataStore.i.featureFlags.flags);
 


### PR DESCRIPTION
## What does this PR change?

Fixes: Fixed double instance issue of skybox controller. Skybox controller with flag feature is removed. Now procedural skybox will be default skybox.


## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?renderer=https://glob-dland-s3-unity-renderer.s3.amazonaws.com/branch/fix/skybox-controller-double-instance
2. Check if skybox is moving and all features of procedural skybox is working from settings panel.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
