### PR TITLE
Fix: fixed explore being stuck in transitions

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -256,6 +256,9 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
     public void OnAfterShowAnimationCompleted()
     {
+        if(!DataStore.i.exploreV2.isOpen.Get())
+            return;
+
         DataStore.i.exploreV2.isInShowAnimationTransiton.Set(false);
         OnAfterShowAnimation?.Invoke();
     }


### PR DESCRIPTION
## What does this PR change?

Fix #2106
Avoids explore from being stuck between transitions

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/explore-stuck
2. Open and close the explore multiple times
3. Verify that it never gets stuck as in the screenshot attached to the issue #2106 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
