### PR TITLE
fix: memory leak

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
@@ -26,7 +26,7 @@ namespace DCL.Components
 
         protected Model previousModel = new Model();
 
-        protected static Dictionary<GameObject, LoadWrapper> attachedLoaders = new Dictionary<GameObject, LoadWrapper>();
+        private static readonly Dictionary<GameObject, LoadWrapper> attachedLoaders = new Dictionary<GameObject, LoadWrapper>();
 
         public static LoadWrapper GetLoaderForEntity(IDCLEntity entity)
         {
@@ -50,6 +50,11 @@ namespace DCL.Components
             }
 
             return result as T;
+        }
+
+        public static void RemoveLoaderForEntity(IDCLEntity entity)
+        {
+            attachedLoaders.Remove(entity.meshRootGameObject);
         }
 
         public LoadableShape() { model = new Model(); }
@@ -279,9 +284,8 @@ namespace DCL.Components
                 return;
 
             LoadWrapper loadWrapper = GetLoaderForEntity(entity);
-
             loadWrapper?.Unload();
-
+            RemoveLoaderForEntity(entity);
             entity.meshesInfo.CleanReferences();
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
@@ -40,7 +40,7 @@ namespace DCL.Components
             return result;
         }
 
-        public static T GetOrAddLoaderForEntity<T>(IDCLEntity entity)
+        protected static T GetOrAddLoaderForEntity<T>(IDCLEntity entity)
             where T : LoadWrapper, new()
         {
             if (!attachedLoaders.TryGetValue(entity.meshRootGameObject, out LoadWrapper result))
@@ -52,12 +52,12 @@ namespace DCL.Components
             return result as T;
         }
 
-        public static void RemoveLoaderForEntity(IDCLEntity entity)
+        protected static void RemoveLoaderForEntity(IDCLEntity entity)
         {
             attachedLoaders.Remove(entity.meshRootGameObject);
         }
 
-        public LoadableShape() { model = new Model(); }
+        protected LoadableShape() { model = new Model(); }
 
         public override int GetClassId() { return -1; }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShape.cs
@@ -71,6 +71,7 @@ namespace DCL.Components
                 return;
 
             entity.OnShapeUpdated -= UpdateBackgroundColor;
+            RemoveLoaderForEntity(entity);
 
             base.DetachShape(entity);
         }


### PR DESCRIPTION
## What does this PR change?

Fixed memory leaks caused by references in a dictionary that was holding objects with references that should be cleaned up.

This should fix #2082 

## How this change was measured?

I ran some tests with this steps:
- I made use of the `LOCAL_COMMS` URL parameter that prevents the loading of other avatars, this removes "noise" from the profiling.
- The first snapshot is taken at 0,0 (Genesis Plaza) when the boards finish loading.
- The second snapshot is taken after I teleport to 100,100 (mostly barren land) and go back to 0,0 and repeat this process 2 times. So when the snapshot is taken, Genesis plaza was loaded and destroyed 3 times in total.
- Between A and B I've closed unity to prevent the profiler to have garbage

Snapshots A has the fix
Snapshots B doesn't.

![image](https://user-images.githubusercontent.com/7646450/163213660-f576c619-4332-4ffa-be99-8e4348363fb3.png)

Although Unity memory profiler has its issues, it still gives us some info to measure.

## How to test the changes?

As always, run through the world, teleport to popular places a bunch of times and it should be less likely for a crash to occur.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
