### PR TITLE
fix: Players' names in General Chat are not legible

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntry.cs
@@ -88,11 +88,11 @@ public class ChatEntry : MonoBehaviour, IPointerClickHandler, IPointerEnterHandl
 
         if (chatEntryModel.subType == Model.SubType.PRIVATE_FROM)
         {
-            userString = $"<b>From {chatEntryModel.senderName}:</b>";
+            userString = $"From {chatEntryModel.senderName}:";
         }
         else if (chatEntryModel.subType == Model.SubType.PRIVATE_TO)
         {
-            userString = $"<b>To {chatEntryModel.recipientName}:</b>";
+            userString = $"To {chatEntryModel.recipientName}:";
         }
 
         switch (chatEntryModel.messageType)
@@ -366,7 +366,7 @@ public class ChatEntry : MonoBehaviour, IPointerClickHandler, IPointerEnterHandl
     string GetDefaultSenderString(string sender)
     {
         if (!string.IsNullOrEmpty(sender))
-            return $"<b>{sender}:</b>";
+            return $"{sender}:";
 
         return "";
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatEntryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatEntryShould.cs
@@ -38,8 +38,8 @@ public class ChatEntryShould : IntegrationTestSuite_Legacy
         entry.Populate(message);
 
         Assert.AreEqual(entry.worldMessageColor, entry.body.color);
-        Assert.AreEqual("<b>user-test:</b>", entry.username.text);
-        Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
+        Assert.AreEqual("user-test:", entry.username.text);
+        Assert.AreEqual("user-test: test message", entry.body.text);
 
         message.messageType = ChatMessage.Type.PRIVATE;
         message.subType = ChatEntry.Model.SubType.PRIVATE_TO;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowHUDShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowHUDShould.cs
@@ -76,8 +76,8 @@ public class WorldChatWindowHUDShould : IntegrationTestSuite_Legacy
 
         ChatEntry entry = controller.view.chatHudView.entries[0];
 
-        Assert.AreEqual("<b>To TEST_USER:</b>", entry.username.text);
-        Assert.AreEqual("<b>To TEST_USER:</b> <noparse>test message</noparse>", entry.body.text);
+        Assert.AreEqual("To TEST_USER:", entry.username.text);
+        Assert.AreEqual("To TEST_USER: <noparse>test message</noparse>", entry.body.text);
 
         var receivedPM = new ChatMessage()
         {
@@ -91,8 +91,8 @@ public class WorldChatWindowHUDShould : IntegrationTestSuite_Legacy
 
         ChatEntry entry2 = controller.view.chatHudView.entries[1];
 
-        Assert.AreEqual("<b>From TEST_USER:</b>", entry2.username.text);
-        Assert.AreEqual("<b>From TEST_USER:</b> <noparse>test message</noparse>", entry2.body.text);
+        Assert.AreEqual("From TEST_USER:", entry2.username.text);
+        Assert.AreEqual("From TEST_USER: <noparse>test message</noparse>", entry2.body.text);
     }
 
     [Test]


### PR DESCRIPTION
## What does this PR change?
Fix #2134 

![Screen Shot 2022-04-05 at 13.11.45.png](https://images.zenhubusercontent.com/5d91f7e9df37660001a11578/06e011e3-5122-4394-bfbd-ee3d902d1451)

In this screenshoot we can appreciate how ilegible the player's name is. This is because in runtime the code is automatically adding the bold command when it is not necessary. See the screenshot bellow.

![Screen Shot 2022-04-05 at 13.11.19.png](https://images.zenhubusercontent.com/5d91f7e9df37660001a11578/d997246a-0ce6-441f-a81e-d8f74df60900)

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/players-names-in-general-chat-are-not-legible
2. Write something in the chat and notice the message is showed correctly legible.
3. Write a private message and notice the message is showed correctly legible (in both places general and private window).

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
