### PR TITLE
fix: rethrow OperationCancelled exception to be caught upstream

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -89,6 +89,7 @@ namespace AvatarSystem
             catch (OperationCanceledException)
             {
                 Dispose();
+                throw;
             }
             catch (Exception e)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
@@ -92,17 +92,29 @@ public class CharacterPreviewController : MonoBehaviour
     private async UniTaskVoid UpdateModelRoutine(AvatarModel newModel, Action onDone, CancellationToken ct)
     {
         currentAvatarModel.CopyFrom(newModel);
-        List<string> wearables = new List<string>(newModel.wearables);
-        wearables.Add(newModel.bodyShape);
-        await avatar.Load(wearables, new AvatarSettings
+        try
         {
-            bodyshapeId = newModel.bodyShape,
-            eyesColor = newModel.eyeColor,
-            hairColor = newModel.hairColor,
-            skinColor = newModel.skinColor
+            ct.ThrowIfCancellationRequested();
+            List<string> wearables = new List<string>(newModel.wearables);
+            wearables.Add(newModel.bodyShape);
+            await avatar.Load(wearables, new AvatarSettings
+            {
+                bodyshapeId = newModel.bodyShape,
+                eyesColor = newModel.eyeColor,
+                hairColor = newModel.hairColor,
+                skinColor = newModel.skinColor
 
-        }, ct);
-
+            }, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (Exception e)
+        {
+            Debug.LogException(e);
+            return;
+        }
         onDone?.Invoke();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
@@ -143,10 +143,10 @@ public class PlayerAvatarController : MonoBehaviour
             return;
         }
 
-        ct.ThrowIfCancellationRequested();
-        if (avatar.status != IAvatar.Status.Loaded || !profile.avatar.HaveSameWearablesAndColors(currentAvatar))
+        try
         {
-            try
+            ct.ThrowIfCancellationRequested();
+            if (avatar.status != IAvatar.Status.Loaded || !profile.avatar.HaveSameWearablesAndColors(currentAvatar))
             {
                 currentAvatar.CopyFrom(profile.avatar);
 
@@ -168,16 +168,16 @@ public class PlayerAvatarController : MonoBehaviour
                 if (avatar.lodLevel <= 1)
                     AvatarSystemUtils.SpawnAvatarLoadedParticles(avatarContainer.transform, loadingParticlesPrefab);
             }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-            catch (Exception e)
-            {
-                Debug.LogException(e);
-                WebInterface.ReportAvatarFatalError();
-                return;
-            }
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (Exception e)
+        {
+            Debug.LogException(e);
+            WebInterface.ReportAvatarFatalError();
+            return;
         }
 
         IAvatarAnchorPoints anchorPoints = new AvatarAnchorPoints();


### PR DESCRIPTION
The avatar loading was not rethrowing when cancelled and breaking some flows

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
