### PR TITLE
fix: portable experience lifecycle issues

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/UUIDEventsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
@@ -372,10 +372,9 @@ namespace DCL
                 worldState.currentSceneId);
 
             // Raycast for global pointer events (for each PE scene)
-            List<string>
-                currentPortableExperienceIds =
-                    Environment.i.world.state
-                        .portableExperienceIds; //PortableExperienceUtils.GetActivePortableExperienceIds();
+            List<string> currentPortableExperienceIds =
+                DataStore.i.Get<DataStore_World>().portableExperienceIds.Get().ToList();
+
             for (int i = 0; i < currentPortableExperienceIds.Count; i++)
             {
                 raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
@@ -10,7 +10,6 @@ namespace DCL
         Dictionary<string, IParcelScene> loadedScenes { get; set; }
         List<IParcelScene> scenesSortedByDistance { get; set; }
         List<string> globalSceneIds { get; set; }
-        List<string> portableExperienceIds { get; set; }
         string currentSceneId { get; set; }
         bool TryGetScene(string id, out IParcelScene scene);
         bool TryGetScene<T>(string id, out T scene) where T : class, IParcelScene;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
@@ -55,7 +55,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
             "IsInsideSceneBoundaries() should always return true.");
         Assert.IsTrue(globalScene.IsInsideSceneBoundaries(new Vector2Int(-1000, -1000)),
             "IsInsideSceneBoundaries() should always return true.");
-
+        
         yield return null;
 
         // Position character inside parcel (0,0)
@@ -70,26 +70,60 @@ public class SceneTests : IntegrationTestSuite_Legacy
             "Scene not in loaded dictionary when far! GlobalScenes must not be unloaded by distance!");
     }
 
-    [Test]
-    public void ParcelScene_TrackDisposables_AfterInitDone()
+    [UnityTest]
+    public IEnumerator UnloadGlobalScene()
     {
-        TestUtils.CreateEntityWithBoxShape(scene, Vector3.zero, true);
-        TestUtils.CreateEntityWithBoxShape(scene, Vector3.zero, true);
-        TestUtils.CreateEntityWithBoxShape(scene, Vector3.zero, true);
+        string sceneId = "Test Global Scene";
 
-        scene.sceneLifecycleHandler.SetInitMessagesDone();
+        sceneController.CreateGlobalScene(JsonUtility.ToJson(new CreateGlobalSceneMessage() {id = sceneId}));
 
-        Assert.AreEqual(0, scene.sceneLifecycleHandler.disposableNotReadyCount);
+        Assert.IsTrue(Environment.i.world.state.Contains(sceneId), "Scene not in loaded dictionary!");
+
+        sceneController.UnloadParcelSceneExecute(sceneId);
+
+        Assert.IsFalse(Environment.i.world.state.Contains(sceneId), "Scene not unloaded correctly!");
+
+        yield break;
     }
 
-    [Test]
-    public void ParcelScene_TrackDisposables_Empty()
-    {
-        Assert.AreEqual(0, scene.sceneLifecycleHandler.disposableNotReadyCount);
-    }
 
     [UnityTest]
-    public IEnumerator SceneLoading()
+    public IEnumerator TrackPortableExperiencesInDataStore()
+    {
+        DataStore_World worldData = DataStore.i.Get<DataStore_World>();
+        string sceneId = "Test Global Scene";
+
+        GameObject experiencesViewerMockedGo = new GameObject();
+        DataStore.i.experiencesViewer.isInitialized.Set(experiencesViewerMockedGo.transform);
+
+        // Ensure its added to DataStore when created
+        sceneController.CreateGlobalScene(JsonUtility.ToJson(new CreateGlobalSceneMessage()
+            {id = sceneId, isPortableExperience = true}));
+        Assert.IsTrue(worldData.portableExperienceIds.Contains(sceneId));
+
+        // Ensure its removed from DataStore when unloaded
+        sceneController.UnloadParcelSceneExecute(sceneId);
+        Assert.IsFalse(worldData.portableExperienceIds.Contains(sceneId));
+
+        // If re-added when isPortableExperience is false, then it shouldn't be in the data store
+        sceneController.CreateGlobalScene(JsonUtility.ToJson(new CreateGlobalSceneMessage()
+            {id = sceneId, isPortableExperience = false}));
+        Assert.IsFalse(worldData.portableExperienceIds.Contains(sceneId));
+
+        // Whe re-added with isPortableExperience as true, it should work again
+        sceneController.UnloadParcelSceneExecute(sceneId);
+        sceneController.CreateGlobalScene(JsonUtility.ToJson(new CreateGlobalSceneMessage()
+            {id = sceneId, isPortableExperience = true}));
+        Assert.IsTrue(worldData.portableExperienceIds.Contains(sceneId));
+
+        Object.Destroy(experiencesViewerMockedGo);
+        DataStore.i.experiencesViewer.isInitialized.Set(null);
+        yield break;
+    }
+
+
+    [UnityTest]
+    public IEnumerator LoadScene()
     {
         sceneController.LoadParcelScenes((Resources.Load("TestJSON/SceneLoadingTest") as TextAsset).text);
         yield return new WaitForAllMessagesProcessed();
@@ -101,7 +135,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
     }
 
     [UnityTest]
-    public IEnumerator SceneUnloading()
+    public IEnumerator UnloadScene()
     {
         sceneController.LoadParcelScenes((Resources.Load("TestJSON/SceneLoadingTest") as TextAsset).text);
 
@@ -137,7 +171,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
     }
 
     [UnityTest]
-    public IEnumerator SeveralParcelsFromJSON()
+    public IEnumerator LoadManyParcelsFromJSON()
     {
         string severalParcelsJson = (Resources.Load("TestJSON/TestSceneSeveralParcels") as TextAsset).text;
 
@@ -178,6 +212,24 @@ public class SceneTests : IntegrationTestSuite_Legacy
 
         sceneController.UnloadAllScenes(includePersistent: true);
         yield return null;
+    }
+
+    [Test]
+    public void ParcelScene_TrackDisposables_AfterInitDone()
+    {
+        TestUtils.CreateEntityWithBoxShape(scene, Vector3.zero, true);
+        TestUtils.CreateEntityWithBoxShape(scene, Vector3.zero, true);
+        TestUtils.CreateEntityWithBoxShape(scene, Vector3.zero, true);
+
+        scene.sceneLifecycleHandler.SetInitMessagesDone();
+
+        Assert.AreEqual(0, scene.sceneLifecycleHandler.disposableNotReadyCount);
+    }
+
+    [Test]
+    public void ParcelScene_TrackDisposables_Empty()
+    {
+        Assert.AreEqual(0, scene.sceneLifecycleHandler.disposableNotReadyCount);
     }
 
     [UnityTest]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
@@ -11,8 +11,6 @@ namespace DCL
         public Dictionary<string, IParcelScene> loadedScenes { get; set; } = new Dictionary<string, IParcelScene>();
         public List<IParcelScene> scenesSortedByDistance { get; set; } = new List<IParcelScene>();
         public List<string> globalSceneIds { get; set; } = new List<string>();
-
-        public List<string> portableExperienceIds { get; set; } = new List<string>();
         public string currentSceneId { get; set; } = null;
 
         public IParcelScene GetScene(string id)


### PR DESCRIPTION

## What does this PR change?

This PR cover the following fixes:
- fix: experiences viewer not showing pex as it should
- fix: global scene unloading not working at all, including pexs

Tests added to ensure coverage.

## How to test the changes?

For the first fix, ensure your portable experience is showing up in the pex viewer.

Not sure how to reproduce the unload global scenes, because this never worked at all!. The code to unload global scenes was gated under a `!isPersistent` check. We have to just make sure the avatar scene and pex are never unloaded by kernel after teleports?

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
