### PR TITLE
fix: react to updates in player profiles

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -229,6 +229,8 @@ namespace DCL
                 player = new Player();
             }
 
+            bool isNameDirty = player.name != model.name;
+
             player.id = model.id;
             player.name = model.name;
             player.isTalking = model.talking;
@@ -240,7 +242,6 @@ namespace DCL
             if (isNew)
             {
                 player.playerName = playerName;
-                player.playerName.SetName(player.name);
                 player.playerName.Show();
                 player.anchorPoints = anchorPoints;
                 if (isGlobalSceneAvatar)
@@ -258,6 +259,8 @@ namespace DCL
 
             player.playerName.SetIsTalking(model.talking);
             player.playerName.SetYOffset(Mathf.Max(MINIMUM_PLAYERNAME_HEIGHT, height));
+            if (isNameDirty)
+                player.playerName.SetName(model.name);
         }
 
         private void Update()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
@@ -66,7 +66,9 @@ public class UserProfileController : MonoBehaviour
 
     public void AddUserProfileToCatalog(UserProfileModel model)
     {
-        var userProfile = ScriptableObject.CreateInstance<UserProfile>();
+        if (!userProfilesCatalog.TryGetValue(model.userId, out UserProfile userProfile))
+            userProfile = ScriptableObject.CreateInstance<UserProfile>();
+
         userProfile.UpdateData(model);
         userProfilesCatalog.Add(model.userId, userProfile);
     }


### PR DESCRIPTION
Player profiles update were not being tracked and therefore names in the AvatarShape or the chat.


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
