### PR TITLE
fix: chat messages crashing desktop client

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -74,6 +74,8 @@ public class ChatHUDController : IDisposable
                 chatEntryModel.recipientName = await profanityFilter.Filter(chatEntryModel.recipientName);
         }
 
+        await UniTask.SwitchToMainThread();
+        
         view.AddEntry(chatEntryModel, setScrollPositionToBottom);
 
         if (view.entries.Count > MAX_CHAT_ENTRIES)


### PR DESCRIPTION
## What does this PR change?

Fixes a crash caused by opening a thread to process Regexes and not going back to the main thread.

## How to test the changes?

Desktop Client shouldn't crash.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
