### PR TITLE
fix: change to decode instead of GetHashCode for entity ids

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -64,7 +64,7 @@ namespace DCL
                 {
                     entityIdLong = negativeCounter;
                     negativeValues.Add(entityId,negativeCounter);
-                    negativeCounter++;
+                    negativeCounter--;
                 }
             }
             else
@@ -78,7 +78,7 @@ namespace DCL
             return entityIdLong;
         }
         
-        public Int64 DecodeBase36(string input)
+        public long DecodeBase36(string input)
         {
             const string charList = "0123456789abcdefghijklmnopqrstuvwxyz";
             var reversed = input;
@@ -89,37 +89,6 @@ namespace DCL
                 result += charList.IndexOf(reversed[i]) * (long)Math.Pow(36, pos);
                 pos++;
             }
-            return result;
-        }
-        
-        public string ToBase36(long decimalNumber, int radix)
-        {
-            const int bitsInLong = 64;
-            const string digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-            if (radix < 2 || radix > digits.Length)
-                throw new ArgumentException("The radix must be >= 2 and <= " + digits.Length);
-
-            if (decimalNumber == 0)
-                return "0";
-
-            int index = bitsInLong - 1;
-            long currentNumber = Math.Abs(decimalNumber);
-            char[] charArray = new char[bitsInLong];
-
-            while (currentNumber != 0)
-            {
-                int remainder = (int)(currentNumber % radix);
-                charArray[index--] = digits[remainder];
-                currentNumber = currentNumber / radix;
-            }
-
-            string result = new String(charArray, index + 1, bitsInLong - index - 1);
-            if (decimalNumber < 0)
-            {
-                result = "-" + result;
-            }
-
             return result;
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -81,12 +81,11 @@ namespace DCL
         public long DecodeBase36(string input)
         {
             const string charList = "0123456789abcdefghijklmnopqrstuvwxyz";
-            var reversed = input;
             long result = 0;
             int pos = 0;
-            for(int i = reversed.Length-1;i >= 0; i--)
+            for(int i = input.Length-1;i >= 0; i--)
             {
-                result += charList.IndexOf(reversed[i]) * (long)Math.Pow(36, pos);
+                result += charList.IndexOf(input[i]) * (long)Math.Pow(36, pos);
                 pos++;
             }
             return result;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -39,19 +39,10 @@ namespace DCL
                     return (long) SpecialEntityId.THIRD_PERSON_CAMERA_ENTITY_REFERENCE;
             }
 
-            
             long entityIdLong = DecodeBase36(entityId) << 9;
-
+            
             if (!entityIdToLegacyId.ContainsKey(entityIdLong))
                 entityIdToLegacyId[entityIdLong] = entityId;
-            else
-            {
-                if (entityId != entityIdToLegacyId[entityIdLong])
-                {
-                    // long result = Convert.ToInt64(entityId, 32);
-                    Debug.Log("Entity already exist " + entityId + "   colliding with " + entityIdToLegacyId[entityIdLong] + "   converted ");
-                }
-            }
 
             return entityIdLong;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using DCL.Models;
+using UnityEngine;
 
 namespace DCL
 {
@@ -35,12 +39,66 @@ namespace DCL
                     return (long) SpecialEntityId.THIRD_PERSON_CAMERA_ENTITY_REFERENCE;
             }
 
-            long entityIdLong = entityId.GetHashCode() << 9;
+            
+            long entityIdLong = DecodeBase36(entityId) << 9;
 
             if (!entityIdToLegacyId.ContainsKey(entityIdLong))
                 entityIdToLegacyId[entityIdLong] = entityId;
+            else
+            {
+                if (entityId != entityIdToLegacyId[entityIdLong])
+                {
+                    // long result = Convert.ToInt64(entityId, 32);
+                    Debug.Log("Entity already exist " + entityId + "   colliding with " + entityIdToLegacyId[entityIdLong] + "   converted ");
+                }
+            }
 
             return entityIdLong;
+        }
+        
+        public Int64 DecodeBase36(string input)
+        {
+            string charList = "0123456789abcdefghijklmnopqrstuvwxyz";
+            var reversed = input.ToLower().Reverse();
+            long result = 0;
+            int pos = 0;
+            foreach (char c in reversed)
+            {
+                result += charList.IndexOf(c) * (long)Math.Pow(36, pos);
+                pos++;
+            }
+            return result;
+        }
+        
+        public string ToBase36(long decimalNumber, int radix)
+        {
+            const int bitsInLong = 64;
+            const string digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+            if (radix < 2 || radix > digits.Length)
+                throw new ArgumentException("The radix must be >= 2 and <= " + digits.Length.ToString());
+
+            if (decimalNumber == 0)
+                return "0";
+
+            int index = bitsInLong - 1;
+            long currentNumber = Math.Abs(decimalNumber);
+            char[] charArray = new char[bitsInLong];
+
+            while (currentNumber != 0)
+            {
+                int remainder = (int)(currentNumber % radix);
+                charArray[index--] = digits[remainder];
+                currentNumber = currentNumber / radix;
+            }
+
+            string result = new String(charArray, index + 1, bitsInLong - index - 1);
+            if (decimalNumber < 0)
+            {
+                result = "-" + result;
+            }
+
+            return result;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using DCL;
+using DCL.Models;
+using NUnit.Framework;
+using UnityEngine;
+
+public class EntityIdHelperShould
+{
+    private EntityIdHelper helper;
+    
+    [SetUp]
+    public void Setup()
+    {
+        helper = new EntityIdHelper();
+    }
+    
+    [Test]
+    public void ConvertLegacyEntityIdsCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "Eed";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreEqual(result,264704);
+        Assert.AreEqual(result,helper.DecodeBase36(legacyEntityId) << 9);
+    }
+    
+    [Test]
+    public void ReserveThe512FirstEntitiesCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "Eed";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreNotEqual(result,-779);
+        Assert.AreNotEqual(result,helper.DecodeBase36(legacyEntityId));
+    }
+    
+    [Test]
+    public void ConvertNotBase36EntityIdsCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "EFDE";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreEqual(result,-1);
+    }
+    
+    [Test]
+    public void ConvertNotBase36EntityIdsOnlyOneTime()
+    {
+        // Arrange
+        string legacyEntityId = "EFDE";
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Act
+        long result2 = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreEqual(result,result2);
+    }
+    
+    [Test]
+    public void ConvertSeveralNotBase36EntityIdsCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "EFDE";
+        string legacyEntityId2 = "EFDEFG";
+        string legacyEntityId3 = "EFDEEE";
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Act
+        result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        long result2 = helper.EntityFromLegacyEntityString(legacyEntityId2);
+        long result3 = helper.EntityFromLegacyEntityString(legacyEntityId3);
+        
+        // Assert
+        Assert.AreEqual(-1,result);
+        Assert.AreEqual(-2,result2);
+        Assert.AreEqual(-3,result3);
+    }
+    
+    [Test]
+    public void EntityLegacyGiveRootCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "0";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreEqual(result, (long) SpecialEntityId.SCENE_ROOT_ENTITY);
+    }
+    
+    [Test]
+    public void EntityLegacyGiveThirdPersonCameraEntityCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "PlayerEntityReference";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreEqual(result, (long) SpecialEntityId.THIRD_PERSON_CAMERA_ENTITY_REFERENCE);
+    }
+        
+    [Test]
+    public void EntityLegacyGiveFirstPersonCameraEntityCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "FirstPersonCameraEntityReference";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreEqual(result, (long) SpecialEntityId.FIRST_PERSON_CAMERA_ENTITY_REFERENCE);
+    }
+    
+    [Test]
+    public void EntityLegacyGiveAvatarPositionEntityCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "AvatarPositionEntityReference";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreEqual(result, (long) SpecialEntityId.AVATAR_POSITION_REFERENCE);
+    }
+    
+    [Test]
+    public void EntityLegacyGiveAvatarEntityCorrectly()
+    {
+        // Arrange
+        string legacyEntityId = "AvatarEntityReference";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        
+        // Assert
+        Assert.AreEqual(result, (long) SpecialEntityId.AVATAR_ENTITY_REFERENCE);
+    }
+    
+    [Test]
+    public void TestUntilWhatId()
+    {
+        EntityIdHelper entityIdHelper = new EntityIdHelper();
+        string lastEntityId = null;
+        int numberOfEntities = 0;
+        try
+        {
+            while(true)
+            {
+                numberOfEntities++;
+                lastEntityId = entityIdHelper.ToBase36(numberOfEntities, 36);
+                entityIdHelper.EntityFromLegacyEntityString(lastEntityId);
+            }
+        }
+        catch(Exception e)
+        {
+            Debug.Log("Found! " + numberOfEntities + " lastENtityId "+ lastEntityId);
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs
@@ -21,13 +21,13 @@ public class EntityIdHelperShould
     {
         // Arrange
         string legacyEntityId = "Eed";
-        
+
         // Act
         long result = helper.EntityFromLegacyEntityString(legacyEntityId);
         
         // Assert
         Assert.AreEqual(result,264704);
-        Assert.AreEqual(result,helper.DecodeBase36(legacyEntityId) << 9);
+        Assert.AreEqual(result,helper.DecodeBase36(legacyEntityId.Substring(1)) << 9);
     }
     
     [Test]
@@ -154,26 +154,5 @@ public class EntityIdHelperShould
         
         // Assert
         Assert.AreEqual(result, (long) SpecialEntityId.AVATAR_ENTITY_REFERENCE);
-    }
-    
-    [Test]
-    public void TestUntilWhatId()
-    {
-        EntityIdHelper entityIdHelper = new EntityIdHelper();
-        string lastEntityId = null;
-        int numberOfEntities = 0;
-        try
-        {
-            while(true)
-            {
-                numberOfEntities++;
-                lastEntityId = entityIdHelper.ToBase36(numberOfEntities, 36);
-                entityIdHelper.EntityFromLegacyEntityString(lastEntityId);
-            }
-        }
-        catch(Exception e)
-        {
-            Debug.Log("Found! " + numberOfEntities + " lastENtityId "+ lastEntityId);
-        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51832d47d4fa4ac4590f0575ec11ff89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
@@ -1,3 +1,4 @@
+using System;
 using DCL;
 using DCL.Components;
 using DCL.Configuration;
@@ -11,6 +12,8 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.TestTools;
+using Environment = DCL.Environment;
+using Object = UnityEngine.Object;
 
 public class SceneTests : IntegrationTestSuite_Legacy
 {
@@ -369,105 +372,5 @@ public class SceneTests : IntegrationTestSuite_Legacy
         TestUtils.SetEntityParent(scene, entityId, (long) SpecialEntityId.SCENE_ROOT_ENTITY);
         Assert.IsNull(entity.parent);
         Assert.IsFalse(Environment.i.world.sceneBoundsChecker.WasAddedAsPersistent(entity));
-    }
-
-    [Test]
-    public void ConvertLegacyEntityIdsCorrectly()
-    {
-        // Arrange
-        string legacyEntityId = "Eed";
-        
-        // Act
-        EntityIdHelper helper = new EntityIdHelper();
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
-        
-        // Assert
-        Assert.AreEqual(result,9554432);
-        Assert.AreEqual(result,helper.DecodeBase36(legacyEntityId) << 9);
-    }
-    
-    [Test]
-    public void ReserveThe512FirstEntitiesCorrectly()
-    {
-        // Arrange
-        string legacyEntityId = "Eed";
-        
-        // Act
-        EntityIdHelper helper = new EntityIdHelper();
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
-        
-        // Assert
-        Assert.AreNotEqual(result,-1273338300);
-        Assert.AreNotEqual(result,helper.DecodeBase36(legacyEntityId));
-    }
-
-    [Test]
-    public void EntityLegacyGiveRootCorrectly()
-    {
-        // Arrange
-        string legacyEntityId = "0";
-        
-        // Act
-        EntityIdHelper helper = new EntityIdHelper();
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
-        
-        // Assert
-        Assert.AreEqual(result, (long) SpecialEntityId.SCENE_ROOT_ENTITY);
-    }
-    
-    [Test]
-    public void EntityLegacyGiveThirdPersonCameraEntityCorrectly()
-    {
-        // Arrange
-        string legacyEntityId = "PlayerEntityReference";
-        
-        // Act
-        EntityIdHelper helper = new EntityIdHelper();
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
-        
-        // Assert
-        Assert.AreEqual(result, (long) SpecialEntityId.THIRD_PERSON_CAMERA_ENTITY_REFERENCE);
-    }
-        
-    [Test]
-    public void EntityLegacyGiveFirstPersonCameraEntityCorrectly()
-    {
-        // Arrange
-        string legacyEntityId = "FirstPersonCameraEntityReference";
-        
-        // Act
-        EntityIdHelper helper = new EntityIdHelper();
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
-        
-        // Assert
-        Assert.AreEqual(result, (long) SpecialEntityId.FIRST_PERSON_CAMERA_ENTITY_REFERENCE);
-    }
-    
-    [Test]
-    public void EntityLegacyGiveAvatarPositionEntityCorrectly()
-    {
-        // Arrange
-        string legacyEntityId = "AvatarPositionEntityReference";
-        
-        // Act
-        EntityIdHelper helper = new EntityIdHelper();
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
-        
-        // Assert
-        Assert.AreEqual(result, (long) SpecialEntityId.AVATAR_POSITION_REFERENCE);
-    }
-    
-    [Test]
-    public void EntityLegacyGiveAvatarEntityCorrectly()
-    {
-        // Arrange
-        string legacyEntityId = "AvatarEntityReference";
-        
-        // Act
-        EntityIdHelper helper = new EntityIdHelper();
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
-        
-        // Assert
-        Assert.AreEqual(result, (long) SpecialEntityId.AVATAR_ENTITY_REFERENCE);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
@@ -382,8 +382,8 @@ public class SceneTests : IntegrationTestSuite_Legacy
         long result = helper.EntityFromLegacyEntityString(legacyEntityId);
         
         // Assert
-        Assert.AreEqual(result,885819392);
-        Assert.AreEqual(result,legacyEntityId.GetHashCode() << 9);
+        Assert.AreEqual(result,9554432);
+        Assert.AreEqual(result,helper.DecodeBase36(legacyEntityId) << 9);
     }
     
     [Test]
@@ -398,7 +398,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
         
         // Assert
         Assert.AreNotEqual(result,-1273338300);
-        Assert.AreNotEqual(result,legacyEntityId.GetHashCode());
+        Assert.AreNotEqual(result,helper.DecodeBase36(legacyEntityId));
     }
 
     [Test]


### PR DESCRIPTION
## What does this PR change?

This PR changes the way we get the long number for an entity id from a string, we were using the GetHashCode approach but since that approach can make some iDs to collide I have changed it to decode the base36 string

I also has done some perfomance benchmark to ensure that we are not losing too much perfomance with this changes.

For the benchmark I just stay at the casino while everthing is loading. Since a lots of messages are sent in the casino scene, we can meassure if there is an impact when a lot of entityIds are converted

Testing in the casino , we lose 0.01 seconds (in total) when you are standing in the casino for 30 seconds with the conversion . The GetHashCode approach lose less than 0.00001 seconds


## How to test the changes?


1. Go to: https://play.decentraland.org/?renderer-branch=fix/entity-collision&position=-75,78
2. Everything work as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
