### PR TITLE
fix: desktop crash due to multithreading issues

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDController.cs
@@ -162,8 +162,12 @@ public class PlayerInfoCardHUDController : IHUD
     }
     private async UniTask AsyncSetUserProfile(UserProfile userProfile)
     {
-        view.SetName(await FilterName(userProfile));
-        view.SetDescription(await FilterDescription(userProfile));
+        string filterName = await FilterName(userProfile);
+        string filterDescription = await FilterDescription(userProfile);
+        await UniTask.SwitchToMainThread();
+
+        view.SetName(filterName);
+        view.SetDescription(filterDescription);
         view.ClearCollectibles();
         view.SetIsBlocked(IsBlocked(userProfile.userId));
         LoadAndShowWearables(userProfile);


### PR DESCRIPTION
## What does this PR change?

Fixed a crash that was caused by doing unity stuff while on a worker thread, whoops.

This fixes https://github.com/decentraland/explorer-desktop/issues/278

## How to test the changes?

Open a user profile in desktop client, it shouldn't crash.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
