### PR TITLE
fix: increase performance in hot code path

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
@@ -1411,6 +1411,7 @@ namespace Tests
             sceneEvent.payload = onPointerDownEvent;
             sceneEvent.eventType = "uuidEvent";
             EntityIdHelper idHelper = new EntityIdHelper();
+            
 
             // Check if target entity is hit behind other entity
             bool targetEntityHit = false;
@@ -1453,11 +1454,10 @@ namespace Tests
                 {
                     if (pointerEvent.eventType == "uuidEvent" &&
                         pointerEvent.payload.uuid == onPointerId &&
-                        pointerEvent.payload.payload.hit.entityId == clickTargetEntity.entityId.ToString())
+                        pointerEvent.payload.payload.hit.entityId == idHelper.GetOriginalId(clickTargetEntity.entityId))
                     {
                         targetEntityHit = true;
                     }
-
                     return true;
                 });
 
@@ -1655,7 +1655,7 @@ namespace Tests
                 {
                     if (pointerEvent.eventType == "uuidEvent" &&
                         pointerEvent.payload.uuid == onPointerId &&
-                        pointerEvent.payload.payload.hit.entityId == clickTargetEntity.entityId.ToString())
+                        pointerEvent.payload.payload.hit.entityId == idHelper.GetOriginalId(clickTargetEntity.entityId))
                     {
                         targetEntityHit = true;
                     }

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
@@ -1824,7 +1824,7 @@ namespace Tests
             sceneEvent.sceneId = scene.sceneData.id;
             sceneEvent.payload = onPointerDownEvent;
             sceneEvent.eventType = "uuidEvent";
-
+            
             // Check if target entity is triggered by hitting the parent entity
             bool targetEntityHit = false;
             yield return TestUtils.ExpectMessageToKernel(targetEventType, sceneEvent,
@@ -1837,7 +1837,7 @@ namespace Tests
                 {
                     if (pointerEvent.eventType == "uuidEvent" &&
                         pointerEvent.payload.uuid == onPointerId &&
-                        pointerEvent.payload.payload.hit.entityId == clickTargetEntity.entityId.ToString())
+                        pointerEvent.payload.payload.hit.entityId == idHelper.GetOriginalId(clickTargetEntity.entityId))
                     {
                         targetEntityHit = true;
                     }

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
@@ -1865,7 +1865,7 @@ namespace Tests
                 {
                     if (pointerEvent.eventType == "uuidEvent" &&
                         pointerEvent.payload.uuid == onPointerId &&
-                        pointerEvent.payload.payload.hit.entityId == clickTargetEntity.entityId.ToString())
+                        pointerEvent.payload.payload.hit.entityId == idHelper.GetOriginalId(clickTargetEntity.entityId))
                     {
                         targetEntityHit = true;
                     }

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
@@ -1410,6 +1410,7 @@ namespace Tests
             sceneEvent.sceneId = scene.sceneData.id;
             sceneEvent.payload = onPointerDownEvent;
             sceneEvent.eventType = "uuidEvent";
+            EntityIdHelper idHelper = new EntityIdHelper();
 
             // Check if target entity is hit behind other entity
             bool targetEntityHit = false;
@@ -1423,7 +1424,7 @@ namespace Tests
                 {
                     if (pointerEvent.eventType == "uuidEvent" &&
                         pointerEvent.payload.uuid == onPointerId &&
-                        pointerEvent.payload.payload.hit.entityId == clickTargetEntity.entityId.ToString())
+                        pointerEvent.payload.payload.hit.entityId == idHelper.GetOriginalId(clickTargetEntity.entityId))
                     {
                         targetEntityHit = true;
                     }
@@ -1613,7 +1614,7 @@ namespace Tests
             sceneEvent.sceneId = scene.sceneData.id;
             sceneEvent.payload = onPointerDownEvent;
             sceneEvent.eventType = "uuidEvent";
-
+            EntityIdHelper idHelper = new EntityIdHelper();
             // Check the target entity is not hit behind the 'isPointerBlocker' shape
             bool targetEntityHit = false;
             yield return TestUtils.ExpectMessageToKernel(targetEventType, sceneEvent,
@@ -1626,7 +1627,7 @@ namespace Tests
                 {
                     if (pointerEvent.eventType == "uuidEvent" &&
                         pointerEvent.payload.uuid == onPointerId &&
-                        pointerEvent.payload.payload.hit.entityId == clickTargetEntity.entityId.ToString())
+                        pointerEvent.payload.payload.hit.entityId == idHelper.GetOriginalId(clickTargetEntity.entityId))
                     {
                         targetEntityHit = true;
                     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -18,7 +18,8 @@ namespace DCL
         public string GetOriginalId(long entityId)
         {
             // if the entityId is less than 512, then it is considered well-known.
-            if (entityId < 512) {
+            if (entityId < 512) 
+            {
                 switch (entityId)
                 {
                     case (long)SpecialEntityId.SCENE_ROOT_ENTITY:
@@ -39,7 +40,8 @@ namespace DCL
             }
             
             // if it has the 0x8000_0000 mask, then it *should* be stored in the entityIdToLegacyId map
-            if ((entityId & 0x80000000) != 0 && entityIdToLegacyId.ContainsKey(entityId)) {
+            if ((entityId & 0x80000000) != 0 && entityIdToLegacyId.ContainsKey(entityId)) 
+            {
                 // the entity has the 0x80000000 mask signaling it was an invalid ID
                 return entityIdToLegacyId[entityId];
             }
@@ -68,7 +70,7 @@ namespace DCL
             // E prefix for entities
             sb.Insert(0, "E");
 
-	          return sb.ToString();
+            return sb.ToString();
         }
         
         public long EntityFromLegacyEntityString(string entityId)
@@ -77,7 +79,8 @@ namespace DCL
             return entityIdLong;
         }
 
-        long GetConvertedEntityId(string entityId) {
+        private long GetConvertedEntityId(string entityId)
+        {
             // entity Ids in base36 start with E
             if (entityId[0] == 'E')
             {
@@ -86,29 +89,27 @@ namespace DCL
                 for (var i = entityId.Length - 1; i > 0; i--)
                 {
                     char charCode = entityId[i];
-                    bool isBase36Number = charCode >= '0' && charCode <= '9';
+                    bool isNumber = charCode >= '0' && charCode <= '9';
                     bool isBase36Letter = charCode >= 'a' && charCode <= 'z';
-                    if (isBase36Number)
-                    {
+                    if (isNumber)
                         result += (charCode - '0') * power;
-                    } else if (isBase36Letter)
-                    {
+                    else if (isBase36Letter)
                         result += (10 + (charCode - 'a')) * power;
-                    } else {
-                        // non base36, fallback to entityIdFromDictionary
+                    else // non base36, fallback to entityIdFromDictionary
                         return entityIdFromDictionary(entityId);
-                    }
+
                     power *= 36;
                 }
                 // reserve 512 entity ids (<<9)
                 return result << 9;
-            } else {
-                // non standard entity, fallback to entityIdFromDictionary
-                return entityIdFromDictionary(entityId);
             }
+            
+            // non standard entity, fallback to entityIdFromDictionary
+            return entityIdFromDictionary(entityId);
         }
 
-        long entityIdFromDictionary(string entityId) {
+        private long entityIdFromDictionary(string entityId)
+        {
             // first we try against well known and lesser used entities
             switch (entityId)
             {
@@ -129,9 +130,12 @@ namespace DCL
             }
 
             // secondly, test if it was already seen in invalidEntities
-            if (invalidEntities.ContainsKey(entityId)) {
+            if (invalidEntities.ContainsKey(entityId)) 
+            {
                 return invalidEntities[entityId];
-            } else {
+            }
+            else 
+            {
                 // generate the new ID, uses the mask 0x8000_0000
                 var newEntityIdLong = ++invalidEntityCounter | 0x80000000;
 				
@@ -146,45 +150,4 @@ namespace DCL
             }
         }
     }
-    /*
-    // test cases
-    
-	public void test(string s, long expected) {
-		Console.WriteLine("For string {0}", s);
-		var	r = GetConvertedEntityId(s);
-		if (r != expected) 
-			Console.WriteLine("  ERROR! Num expected={0} (0x{0:X}) given={1} (0x{1:X})", expected, r);
-		else
-			Console.WriteLine("  OK     Num expected={0} (0x{0:X}) given={1} (0x{1:X})", expected, r);
-
-		var gen = GetOriginalId(r);
-		if (gen != s) 
-			Console.WriteLine("  ERROR! Gen expected={0} given={1}", s, gen);
-		else
-			Console.WriteLine("  OK     Gen expected={0} given={1}", s, gen);
-	}
-    
-    t.test("0", 0);
-		t.test("AvatarEntityReference", 1);
-		t.test("AvatarPositionEntityReference", 2);
-		t.test("FirstPersonCameraEntityReference", 3);
-		t.test("PlayerEntityReference", 4);
-		t.test("1", 0x80000000);
-		t.test("2", 0x80000001);
-		t.test("1", 0x80000000);
-		t.test("E0", 1 << 9);		
-		t.test("E1", 2 << 9);
-		t.test("Eb", 12 << 9);
-		t.test("E33", 112 << 9);
-		t.test("Euv", 1112 << 9);
-		t.test("E8kn", 11112 << 9);
-		t.test("E2dqf",111112 << 9);
-		t.test("Ea", 11 << 9);
-		t.test("Eaa", 371 << 9);
-		t.test("Eaaa", 13331 << 9);
-		//repeated:
-        t.test("E1", 2 << 9);
-		t.test("Eijealm", 0x85A1505600);
-    
-    */
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -50,7 +50,7 @@ namespace DCL
             return ToBase36EntityId(entityId);
         }
         
-        private static string ToBase36EntityId(long value)
+        private string ToBase36EntityId(long value)
         {
             // TODO(mendez): the string builder approach can be better. It does use more allocations
             //               than the optimal. The ideal scenario would use a `stackalloc char[13]` instead 
@@ -100,8 +100,15 @@ namespace DCL
 
                     power *= 36;
                 }
+                
                 // reserve 512 entity ids (<<9)
-                return result << 9;
+                long newEntityIdLong = result << 9;
+                
+                // // store the mapping from newEntityIdLong->original
+                // if (!entityIdToLegacyId.ContainsKey(newEntityIdLong))
+                //     entityIdToLegacyId[newEntityIdLong] = entityId;
+                
+                return newEntityIdLong;
             }
             
             // non standard entity, fallback to entityIdFromDictionary

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -14,6 +14,12 @@ namespace DCL
         internal Dictionary<string, long> negativeValues = new Dictionary<string, long>();
 
         private int negativeCounter = -1;
+        private Regex regex;
+
+        public EntityIdHelper()
+        {
+            regex = new Regex("^*[A-Z]",RegexOptions.Compiled);
+        }
         
         public string GetOriginalId(long entityId)
         {
@@ -22,9 +28,78 @@ namespace DCL
 
             return entityIdToLegacyId[entityId];
         }
-
+        
         public long EntityFromLegacyEntityString(string entityId)
         {
+
+            long entityIdLong = GetConvertedEntityId(entityId);
+            return entityIdLong;
+        }
+
+        // public long GetConvertedEntityId(string entityId)
+        // {
+        //     long entityIdLong = 0;
+        //    
+        //     string entityIdExtracted = entityId.Substring(1);
+        //     
+        //     // It is not base 36, so we assign a negative number for it
+        //     if (regex.IsMatch(entityIdExtracted))
+        //     {
+        //         if (negativeValues.ContainsKey(entityIdExtracted))
+        //         {
+        //             entityIdLong = negativeValues[entityIdExtracted];
+        //         }
+        //         else
+        //         {
+        //             entityIdLong = negativeCounter;
+        //             negativeValues.Add(entityIdExtracted,negativeCounter);
+        //             negativeCounter--;
+        //         }
+        //     }
+        //     else
+        //     {
+        //         entityIdLong = DecodeBase36(entityIdExtracted) << 9;
+        //     }
+        //
+        //     if (!entityIdToLegacyId.ContainsKey(entityIdLong))
+        //         entityIdToLegacyId[entityIdLong] = entityId;
+        //
+        //     return entityIdLong;
+        // }
+        
+        long GetConvertedEntityId(string entityId) {
+            // entity Ids in base36 start with E
+            if (entityId[0] == 'E')
+            {
+                long result = 0;
+                long power = 1;
+                for (var i = entityId.Length - 1; i > 0; i--)
+                {
+                    char charCode = entityId[i];
+                    bool isBase36Number = charCode >= '0' /*'0'*/ && charCode <= '9'; /*'9'*/
+                    bool isBase36Letter = charCode >= 'a' /*'a'*/ && charCode <= 'z'; /*'z'*/
+                    if (isBase36Number)
+                    {
+                        result += (charCode - 48) /*'0'*/ * power;
+                    } else if (isBase36Letter)
+                    {
+                        result += (charCode - 97) /*'a'*/ * power;
+                    } else {
+                        // non base36, fallback to entityIdFromDictionary
+                        return entityIdFromDictionary(entityId);
+                    }
+                    power *= 36;
+                    // this is slow result += charList.IndexOf(input[i]) * (long)Math.Pow(36, pos);
+                }
+                // reserve 512 entity ids (<<9)
+                return result << 9;
+            } else {
+                // non standard entity, fallback to entityIdFromDictionary
+                return entityIdFromDictionary(entityId);
+            }
+        }
+
+        long entityIdFromDictionary(string entityId) {
             switch (entityId)
             {
                 case SpecialEntityIdLegacyLiteral.SCENE_ROOT_ENTITY:
@@ -43,39 +118,17 @@ namespace DCL
                     return (long) SpecialEntityId.THIRD_PERSON_CAMERA_ENTITY_REFERENCE;
             }
             
-            long entityIdLong = GetConvertedEntityId(entityId);
-            return entityIdLong;
-        }
-
-        public long GetConvertedEntityId(string entityId)
-        {
-            long entityIdLong = 0;
-            var regex = new Regex("^*[A-Z]");
-            string entityIdExtracted = entityId.Substring(1);
-            
             // It is not base 36, so we assign a negative number for it
-            if (regex.IsMatch(entityIdExtracted))
+            if (negativeValues.ContainsKey(entityId))
             {
-                if (negativeValues.ContainsKey(entityIdExtracted))
-                {
-                    entityIdLong = negativeValues[entityIdExtracted];
-                }
-                else
-                {
-                    entityIdLong = negativeCounter;
-                    negativeValues.Add(entityIdExtracted,negativeCounter);
-                    negativeCounter--;
-                }
-            }
-            else
+                return negativeValues[entityId];
+            } else
             {
-                entityIdLong = DecodeBase36(entityIdExtracted) << 9;
+                
+                var newEntityIdLong = -negativeValues.Count -1;
+                negativeValues.Add(entityId, newEntityIdLong);
+                return newEntityIdLong;
             }
-
-            if (!entityIdToLegacyId.ContainsKey(entityIdLong))
-                entityIdToLegacyId[entityIdLong] = entityId;
-
-            return entityIdLong;
         }
         
         public long DecodeBase36(string input)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,85 +11,85 @@ namespace DCL
     public class EntityIdHelper
     {
         internal Dictionary<long, string> entityIdToLegacyId = new Dictionary<long, string>();
-        internal Dictionary<string, long> negativeValues = new Dictionary<string, long>();
+        internal Dictionary<string, long> invalidEntities = new Dictionary<string, long>();
 
-        private int negativeCounter = -1;
-        private Regex regex;
-
-        public EntityIdHelper()
-        {
-            regex = new Regex("^*[A-Z]",RegexOptions.Compiled);
-        }
+        private int invalidEntityCounter = -1;
         
         public string GetOriginalId(long entityId)
         {
-            if (!entityIdToLegacyId.ContainsKey(entityId))
-                return SpecialEntityIdLegacyLiteral.SCENE_ROOT_ENTITY;
+            if (entityId < 512) {
+                switch (entityId)
+                {
+                    case (long)SpecialEntityId.SCENE_ROOT_ENTITY:
+                        return SpecialEntityIdLegacyLiteral.SCENE_ROOT_ENTITY;
 
-            return entityIdToLegacyId[entityId];
+                    case (long)SpecialEntityId.FIRST_PERSON_CAMERA_ENTITY_REFERENCE:
+                        return SpecialEntityIdLegacyLiteral.FIRST_PERSON_CAMERA_ENTITY_REFERENCE;
+
+                    case (long)SpecialEntityId.AVATAR_ENTITY_REFERENCE:
+                        return SpecialEntityIdLegacyLiteral.AVATAR_ENTITY_REFERENCE;
+
+                    case (long)SpecialEntityId.AVATAR_POSITION_REFERENCE:
+                        return SpecialEntityIdLegacyLiteral.AVATAR_POSITION_REFERENCE;
+
+                    case (long)SpecialEntityId.THIRD_PERSON_CAMERA_ENTITY_REFERENCE:
+                        return SpecialEntityIdLegacyLiteral.THIRD_PERSON_CAMERA_ENTITY_REFERENCE;
+                }
+            }
+            
+            if ((entityId & 0x80000000) != 0 && entityIdToLegacyId.ContainsKey(entityId)) {
+                // the entity has the 0x80000000 mask signaling it was an invalid ID
+                return entityIdToLegacyId[entityId];
+            }
+
+            return ToBase36EntityId(entityId);
+        }
+        
+        private static string ToBase36EntityId(long value)
+        {
+            const string base36 = "0123456789abcdefghijklmnopqrstuvwxyz";
+            // this can be static in the class
+            var sb = new StringBuilder(13);
+
+            value = value >> 9;
+            value -= 1;
+            do
+            {
+                sb.Insert(0, base36[(byte)(value % 36)]);
+                value /= 36;
+            } while (value != 0);
+            sb.Insert(0, "E"); // E prefix for entities
+			return sb.ToString();
         }
         
         public long EntityFromLegacyEntityString(string entityId)
         {
-
             long entityIdLong = GetConvertedEntityId(entityId);
             return entityIdLong;
         }
 
-        // public long GetConvertedEntityId(string entityId)
-        // {
-        //     long entityIdLong = 0;
-        //    
-        //     string entityIdExtracted = entityId.Substring(1);
-        //     
-        //     // It is not base 36, so we assign a negative number for it
-        //     if (regex.IsMatch(entityIdExtracted))
-        //     {
-        //         if (negativeValues.ContainsKey(entityIdExtracted))
-        //         {
-        //             entityIdLong = negativeValues[entityIdExtracted];
-        //         }
-        //         else
-        //         {
-        //             entityIdLong = negativeCounter;
-        //             negativeValues.Add(entityIdExtracted,negativeCounter);
-        //             negativeCounter--;
-        //         }
-        //     }
-        //     else
-        //     {
-        //         entityIdLong = DecodeBase36(entityIdExtracted) << 9;
-        //     }
-        //
-        //     if (!entityIdToLegacyId.ContainsKey(entityIdLong))
-        //         entityIdToLegacyId[entityIdLong] = entityId;
-        //
-        //     return entityIdLong;
-        // }
-        
         long GetConvertedEntityId(string entityId) {
             // entity Ids in base36 start with E
             if (entityId[0] == 'E')
             {
-                long result = 0;
+                long result = 1;
                 long power = 1;
                 for (var i = entityId.Length - 1; i > 0; i--)
                 {
                     char charCode = entityId[i];
-                    bool isBase36Number = charCode >= '0' /*'0'*/ && charCode <= '9'; /*'9'*/
-                    bool isBase36Letter = charCode >= 'a' /*'a'*/ && charCode <= 'z'; /*'z'*/
+                    bool isBase36Number = charCode >= '0' && charCode <= '9';
+                    bool isBase36Letter = charCode >= 'a' && charCode <= 'z';
                     if (isBase36Number)
                     {
-                        result += (charCode - 48) /*'0'*/ * power;
+                        result += (charCode - '0') * power;
                     } else if (isBase36Letter)
                     {
-                        result += (charCode - 97) /*'a'*/ * power;
+                        result += (10 + (charCode - 'a')) * power;
                     } else {
                         // non base36, fallback to entityIdFromDictionary
                         return entityIdFromDictionary(entityId);
                     }
                     power *= 36;
-                    // this is slow result += charList.IndexOf(input[i]) * (long)Math.Pow(36, pos);
                 }
                 // reserve 512 entity ids (<<9)
                 return result << 9;
@@ -119,29 +119,58 @@ namespace DCL
             }
             
             // It is not base 36, so we assign a negative number for it
-            if (negativeValues.ContainsKey(entityId))
-            {
-                return negativeValues[entityId];
-            } else
-            {
-                
-                var newEntityIdLong = -negativeValues.Count -1;
-                negativeValues.Add(entityId, newEntityIdLong);
+            if (invalidEntities.ContainsKey(entityId)) {
+                return invalidEntities[entityId];
+            } else {
+                var newEntityIdLong = ++invalidEntityCounter | 0x80000000;
+				
+                if (!entityIdToLegacyId.ContainsKey(newEntityIdLong))
+                    entityIdToLegacyId[newEntityIdLong] = entityId;
+					
+                invalidEntities.Add(entityId, newEntityIdLong);
                 return newEntityIdLong;
             }
         }
-        
-        public long DecodeBase36(string input)
-        {
-            const string charList = "0123456789abcdefghijklmnopqrstuvwxyz";
-            long result = 0;
-            int pos = 0;
-            for(int i = input.Length-1;i >= 0; i--)
-            {
-                result += charList.IndexOf(input[i]) * (long)Math.Pow(36, pos);
-                pos++;
-            }
-            return result;
-        }
     }
+    /*
+    // test cases
+    
+	public void test(string s, long expected) {
+		Console.WriteLine("For string {0}", s);
+		var	r = GetConvertedEntityId(s);
+		if (r != expected) 
+			Console.WriteLine("  ERROR! Num expected={0} (0x{0:X}) given={1} (0x{1:X})", expected, r);
+		else
+			Console.WriteLine("  OK     Num expected={0} (0x{0:X}) given={1} (0x{1:X})", expected, r);
+
+		var gen = GetOriginalId(r);
+		if (gen != s) 
+			Console.WriteLine("  ERROR! Gen expected={0} given={1}", s, gen);
+		else
+			Console.WriteLine("  OK     Gen expected={0} given={1}", s, gen);
+	}
+    
+    t.test("0", 0);
+		t.test("AvatarEntityReference", 1);
+		t.test("AvatarPositionEntityReference", 2);
+		t.test("FirstPersonCameraEntityReference", 3);
+		t.test("PlayerEntityReference", 4);
+		t.test("1", 0x80000000);
+		t.test("2", 0x80000001);
+		t.test("1", 0x80000000);
+		t.test("E0", 1 << 9);		
+		t.test("E1", 2 << 9);
+		t.test("Eb", 12 << 9);
+		t.test("E33", 112 << 9);
+		t.test("Euv", 1112 << 9);
+		t.test("E8kn", 11112 << 9);
+		t.test("E2dqf",111112 << 9);
+		t.test("Ea", 11 << 9);
+		t.test("Eaa", 371 << 9);
+		t.test("Eaaa", 13331 << 9);
+		//repeated:
+        t.test("E1", 2 << 9);
+		t.test("Eijealm", 0x85A1505600);
+    
+    */
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/EntityIdHelper.cs
@@ -103,11 +103,7 @@ namespace DCL
                 
                 // reserve 512 entity ids (<<9)
                 long newEntityIdLong = result << 9;
-                
-                // // store the mapping from newEntityIdLong->original
-                // if (!entityIdToLegacyId.ContainsKey(newEntityIdLong))
-                //     entityIdToLegacyId[newEntityIdLong] = entityId;
-                
+
                 return newEntityIdLong;
             }
             

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Messaging/MessagingControllersManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Messaging/MessagingControllersManager.cs
@@ -9,8 +9,7 @@ namespace DCL
     public class MessagingControllersManager : IMessagingControllersManager
     {
         public static bool VERBOSE = false;
-
-        // Note(Adrian): This value was on 0.006f before the perfomance regresion
+        
         private const float MAX_GLOBAL_MSG_BUDGET = 0.006f;
         private const float MAX_SYSTEM_MSG_BUDGET_FOR_FAR_SCENES = 0.003f;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Messaging/MessagingControllersManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Messaging/MessagingControllersManager.cs
@@ -11,7 +11,7 @@ namespace DCL
         public static bool VERBOSE = false;
 
         // Note(Adrian): This value was on 0.006f before the perfomance regresion
-        private const float MAX_GLOBAL_MSG_BUDGET = 0.010f;
+        private const float MAX_GLOBAL_MSG_BUDGET = 0.006f;
         private const float MAX_SYSTEM_MSG_BUDGET_FOR_FAR_SCENES = 0.003f;
 
         private const float GLTF_BUDGET_MAX = 0.033f;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs
@@ -15,48 +15,36 @@ public class EntityIdHelperShould
     {
         helper = new EntityIdHelper();
     }
-    
+
     [Test]
-    public void ConvertLegacyEntityIdsCorrectly()
+    public void ReturnTheSameEntityIdsCorrectly()
     {
         // Arrange
-        string legacyEntityId = "Eed";
+        string legacyEntityId = "E1";
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
 
         // Act
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        long result2 = helper.EntityFromLegacyEntityString(legacyEntityId);
         
         // Assert
-        Assert.AreEqual(result,264704);
-        Assert.AreEqual(result,helper.DecodeBase36(legacyEntityId.Substring(1)) << 9);
+        Assert.AreEqual(result,result2);
+        Assert.AreEqual(result,2 << 9);
     }
     
     [Test]
     public void ReserveThe512FirstEntitiesCorrectly()
     {
         // Arrange
-        string legacyEntityId = "Eed";
+        string legacyEntityId = "E0";
         
         // Act
         long result = helper.EntityFromLegacyEntityString(legacyEntityId);
         
         // Assert
-        Assert.AreNotEqual(result,-779);
-        Assert.AreNotEqual(result,helper.DecodeBase36(legacyEntityId));
+        Assert.AreNotEqual(result, 0);
+        Assert.AreEqual(result,512);
     }
-    
-    [Test]
-    public void ConvertNotBase36EntityIdsCorrectly()
-    {
-        // Arrange
-        string legacyEntityId = "EFDE";
-        
-        // Act
-        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
-        
-        // Assert
-        Assert.AreEqual(result,-1);
-    }
-    
+
     [Test]
     public void ConvertNotBase36EntityIdsOnlyOneTime()
     {
@@ -72,7 +60,7 @@ public class EntityIdHelperShould
     }
     
     [Test]
-    public void ConvertSeveralNotBase36EntityIdsCorrectly()
+    public void ConvertSeveralNotBase36EntityIdsConsecutevylyCorrectly()
     {
         // Arrange
         string legacyEntityId = "GEFDE";
@@ -85,13 +73,84 @@ public class EntityIdHelperShould
         result = helper.EntityFromLegacyEntityString(legacyEntityId);
         long result2 = helper.EntityFromLegacyEntityString(legacyEntityId2);
         long result3 = helper.EntityFromLegacyEntityString(legacyEntityId3);
-        long result4 = helper.EntityFromLegacyEntityString(legacyEntityId4);
         
         // Assert
-        Assert.AreEqual(-1,result);
-        Assert.AreEqual(-2,result2);
-        Assert.AreEqual(-3,result3);
-        Assert.AreEqual(-4,result4);
+        Assert.AreEqual( 2147483648,result);
+        Assert.AreEqual( 2147483649,result2);
+        Assert.AreEqual( 2147483650,result3);
+        Assert.AreNotEqual(result,result2);
+    }
+
+    [Test]
+    public void ConvertTwoNotBased36EntitiesConsecutevily()
+    {
+        // Arrange
+        string legacyEntityId = "1";
+        string legacyEntityId2 = "2";
+        
+        // Act
+        long result = helper.EntityFromLegacyEntityString(legacyEntityId);
+        long result2 = helper.EntityFromLegacyEntityString(legacyEntityId2);
+        
+        // Assert
+        Assert.AreEqual(result, 0x80000000);
+        Assert.AreEqual(result2, 0x80000001);
+    }
+    
+    [TestCase("1",ExpectedResult =  0x80000000)]
+    [TestCase("2",ExpectedResult =  0x80000000)]
+    [TestCase("E0",ExpectedResult =  1 << 9)]
+    [TestCase("E1",ExpectedResult =  2 << 9)]
+    [TestCase("Eed",ExpectedResult =  518 << 9)]
+    [TestCase("Eb",ExpectedResult =  12 << 9)]
+    [TestCase("E33",ExpectedResult =  112 << 9)]
+    [TestCase("E444",ExpectedResult =  5333 << 9)]
+    [TestCase("Euv",ExpectedResult =  1112 << 9)]
+    [TestCase("E8kn",ExpectedResult =  11112 << 9)]
+    [TestCase("E2dqf",ExpectedResult =  111112 << 9)]
+    [TestCase("Ea",ExpectedResult =  11 << 9)]
+    [TestCase("Eaa",ExpectedResult =  371 << 9)]
+    [TestCase("Eaaa",ExpectedResult =  13331 << 9)]
+    [TestCase("Eijealm",ExpectedResult =  0x85A1505600)]
+    public long ConvertSeveralEntitysIdsCorrectly(string input)
+    {
+        // Act
+        long result = helper.EntityFromLegacyEntityString(input);
+
+        // Assert
+        return result;
+    }
+    
+    [TestCase("0")]
+    [TestCase("AvatarEntityReference")]
+    [TestCase("AvatarPositionEntityReference")]
+    [TestCase("PlayerEntityReference")]
+    [TestCase("FirstPersonCameraEntityReference")]
+    [TestCase("1")]
+    [TestCase("2")]
+    [TestCase("E0")]
+    [TestCase("E1")]
+    [TestCase("Eed")]
+    [TestCase("Eb")]
+    [TestCase("E33")]
+    [TestCase("E444")]
+    [TestCase("Euv")]
+    [TestCase("E8kn")]
+    [TestCase("E2dqf")]
+    [TestCase("Ea")]
+    [TestCase("Eaa")]
+    [TestCase("Eaaa")]
+    [TestCase("Eijealm")]
+    public void GetOriginalIdInAllCasesCorrectly(string input)
+    {
+        // Arrange
+        long result = helper.EntityFromLegacyEntityString(input);
+        
+        // Act
+        string entityId = helper.GetOriginalId(result);
+
+        // Assert
+        Assert.AreEqual(entityId,input);
     }
     
     [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/EntityIdHelperShould.cs
@@ -75,20 +75,23 @@ public class EntityIdHelperShould
     public void ConvertSeveralNotBase36EntityIdsCorrectly()
     {
         // Arrange
-        string legacyEntityId = "EFDE";
-        string legacyEntityId2 = "EFDEFG";
-        string legacyEntityId3 = "EFDEEE";
+        string legacyEntityId = "GEFDE";
+        string legacyEntityId2 = "GEFDEFG";
+        string legacyEntityId3 = "GEFDEEE";
+        string legacyEntityId4 = "noBase36-d|";
         long result = helper.EntityFromLegacyEntityString(legacyEntityId);
         
         // Act
         result = helper.EntityFromLegacyEntityString(legacyEntityId);
         long result2 = helper.EntityFromLegacyEntityString(legacyEntityId2);
         long result3 = helper.EntityFromLegacyEntityString(legacyEntityId3);
+        long result4 = helper.EntityFromLegacyEntityString(legacyEntityId4);
         
         // Assert
         Assert.AreEqual(-1,result);
         Assert.AreEqual(-2,result2);
         Assert.AreEqual(-3,result3);
+        Assert.AreEqual(-4,result4);
     }
     
     [Test]

--- a/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
+++ b/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
@@ -42,7 +42,7 @@ namespace DCL.Helpers
 
         public static string CreateSceneMessage(string sceneId, string tag, string method, string payload) { return $"{sceneId}\t{method}\t{payload}\t{tag}\n"; }
 
-        static int entityCounter = 123;
+        static int entityCounter = 513;
         static int disposableIdCounter = 123;
 
         public static PB_Transform GetPBTransform(Vector3 position, Quaternion rotation, Vector3 scale)


### PR DESCRIPTION
Test link: https://play.decentraland.zone/?renderer-branch=fix/entity-dissapear

Increases the performance of the entity id back and forth conversion.

My tools for C# are limited and I couldn't get Unity + IDE to work in time. So here are the tests that need to be added:

```c#
public void test(string s, long expected) {
  Console.WriteLine("For string {0}", s);
  var	r = GetConvertedEntityId(s);
  if (r != expected) {
    Console.WriteLine("  ERROR! Num expected={0} (0x{0:X}) given={1} (0x{1:X})", expected, r);
    throw new Exception("failed");
  } else {
    Console.WriteLine("  OK     Num expected={0} (0x{0:X}) given={1} (0x{1:X})", expected, r);
  }
  var gen = GetOriginalId(r);
  if (gen != s) {
    Console.WriteLine("  ERROR! Gen expected={0} given={1}", s, gen);
    throw new Exception("failed");
  } else {
    Console.WriteLine("  OK     Gen expected={0} given={1}", s, gen);
  }
}
    
t.test("0", 0);
t.test("AvatarEntityReference", 1);
t.test("AvatarPositionEntityReference", 2);
t.test("FirstPersonCameraEntityReference", 3);
t.test("PlayerEntityReference", 4);
t.test("1", 0x80000000);
t.test("2", 0x80000001);
t.test("1", 0x80000000);
t.test("E0", 1 << 9);		
t.test("E1", 2 << 9);
t.test("Eb", 12 << 9);
t.test("E33", 112 << 9);
t.test("Euv", 1112 << 9);
t.test("E8kn", 11112 << 9);
t.test("E2dqf",111112 << 9);
t.test("Ea", 11 << 9);
t.test("Eaa", 371 << 9);
t.test("Eaaa", 13331 << 9);
//repeated:
t.test("E1", 2 << 9);
t.test("Eijealm", 0x85A1505600);
    
```