### PR TITLE
fix: disabled freefall camera when standing on invisible colliders

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -23,6 +23,9 @@ public class DCLCharacterController : MonoBehaviour
 
     [Header("Collisions")]
     public LayerMask groundLayers;
+    
+    [Header("Additional Camera Layers")]
+    public LayerMask cameraLayers;
 
     [System.NonSerialized]
     public bool initialPositionAlreadySet = false;
@@ -471,7 +474,7 @@ public class DCLCharacterController : MonoBehaviour
 
     public bool CastGroundCheckingRays(float extraDistance, float scale, out RaycastHit hitInfo)
     {
-        if (CastGroundCheckingRays(transform, collider, extraDistance, scale, groundLayers, out hitInfo))
+        if (CastGroundCheckingRays(transform, collider, extraDistance, scale, groundLayers | cameraLayers , out hitInfo))
             return true;
 
         return IsLastCollisionGround();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
@@ -345,6 +345,9 @@ MonoBehaviour:
   groundLayers:
     serializedVersion: 2
     m_Bits: 1025
+  cameraLayers:
+    serializedVersion: 2
+    m_Bits: 131072
   jumpAction: {fileID: 11400000, guid: 8eddef1fc072ec845aeb62f5e1041b52, type: 2}
   sprintAction: {fileID: 11400000, guid: 0cfb8d150b7d6934d856665cf924d01d, type: 2}
   moveVelocity: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
## What does this PR change?

Avoids triggering freefall camera when standing on invisible colliders

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
