### PR TITLE
Fix: allow user to play emotes on moving platforms

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -134,13 +134,9 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         flattenedVelocity.y = 0;
 
         if (isOwnPlayer)
-        {
             blackboard.movementSpeed = flattenedVelocity.magnitude - DCLCharacterController.i.movingPlatformSpeed;
-        }
         else
-        {
             blackboard.movementSpeed = flattenedVelocity.magnitude;
-        }
 
         Vector3 rayOffset = Vector3.up * RAY_OFFSET_LENGTH;
         
@@ -327,9 +323,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         return true;
     }
 
-    public void PlayEmote(string emoteId, long timestamps) {
-        SetExpressionValues(emoteId, timestamps); 
-    }
+    public void PlayEmote(string emoteId, long timestamps) { SetExpressionValues(emoteId, timestamps); }
 
     public void EquipEmote(string emoteId, AnimationClip clip)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -231,7 +231,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         var animationInfo = animation[bb.expressionTriggerId];
         animation.CrossFade(bb.expressionTriggerId, EXPRESSION_TRANSITION_TIME, PlayMode.StopAll);
         //Introduced the isMoving variable that is true if there is user input, substituted the old Math.Abs(bb.movementSpeed) > Mathf.Epsilon that relies of too much precision
-        var mustExit = DCLCharacterController.i.isMoving || animationInfo.length - animationInfo.time < EXPRESSION_TRANSITION_TIME || !bb.isGrounded;
+        var mustExit = DCLCharacterController.i.isMovingByUserInput || animationInfo.length - animationInfo.time < EXPRESSION_TRANSITION_TIME || !bb.isGrounded;
         if (mustExit)
         {
             animation.Blend(bb.expressionTriggerId, 0, EXPRESSION_TRANSITION_TIME);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -230,8 +230,14 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
     {
         var animationInfo = animation[bb.expressionTriggerId];
         animation.CrossFade(bb.expressionTriggerId, EXPRESSION_TRANSITION_TIME, PlayMode.StopAll);
+        bool mustExit;
+
         //Introduced the isMoving variable that is true if there is user input, substituted the old Math.Abs(bb.movementSpeed) > Mathf.Epsilon that relies of too much precision
-        var mustExit = DCLCharacterController.i.isMovingByUserInput || animationInfo.length - animationInfo.time < EXPRESSION_TRANSITION_TIME || !bb.isGrounded;
+        if (isOwnPlayer) 
+            mustExit = DCLCharacterController.i.isMovingByUserInput || animationInfo.length - animationInfo.time < EXPRESSION_TRANSITION_TIME || !bb.isGrounded;
+        else
+            mustExit = Math.Abs(bb.movementSpeed) > 0.07f || animationInfo.length - animationInfo.time < EXPRESSION_TRANSITION_TIME || !bb.isGrounded;
+
         if (mustExit)
         {
             animation.Blend(bb.expressionTriggerId, 0, EXPRESSION_TRANSITION_TIME);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -134,9 +134,13 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         flattenedVelocity.y = 0;
 
         if (isOwnPlayer)
+        {
             blackboard.movementSpeed = flattenedVelocity.magnitude - DCLCharacterController.i.movingPlatformSpeed;
+        }
         else
+        {
             blackboard.movementSpeed = flattenedVelocity.magnitude;
+        }
 
         Vector3 rayOffset = Vector3.up * RAY_OFFSET_LENGTH;
         
@@ -154,7 +158,6 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
             DCLCharacterController.i.groundLayers);
 
         blackboard.isGrounded = isGroundedByCharacterController || isGroundedByVelocity || isGroundedByRaycast;
-
 #if UNITY_EDITOR
         Debug.DrawRay(target.transform.position + rayOffset, Vector3.down * (RAY_OFFSET_LENGTH - ELEVATION_OFFSET), blackboard.isGrounded ? Color.green : Color.red);
 #endif
@@ -231,8 +234,8 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
     {
         var animationInfo = animation[bb.expressionTriggerId];
         animation.CrossFade(bb.expressionTriggerId, EXPRESSION_TRANSITION_TIME, PlayMode.StopAll);
-
-        var mustExit = Math.Abs(bb.movementSpeed) > Mathf.Epsilon || animationInfo.length - animationInfo.time < EXPRESSION_TRANSITION_TIME || !bb.isGrounded;
+        //Introduced the isMoving variable that is true if there is user input, substituted the old Math.Abs(bb.movementSpeed) > Mathf.Epsilon that relies of too much precision
+        var mustExit = DCLCharacterController.i.isMoving || animationInfo.length - animationInfo.time < EXPRESSION_TRANSITION_TIME || !bb.isGrounded;
         if (mustExit)
         {
             animation.Blend(bb.expressionTriggerId, 0, EXPRESSION_TRANSITION_TIME);
@@ -262,7 +265,6 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
             return;
 
         var mustTriggerAnimation = !string.IsNullOrEmpty(expressionTriggerId) && blackboard.expressionTriggerTimestamp != expressionTriggerTimestamp;
-
         blackboard.expressionTriggerId = expressionTriggerId;
         blackboard.expressionTriggerTimestamp = expressionTriggerTimestamp;
 
@@ -272,7 +274,6 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
             {
                 animation.Stop(expressionTriggerId);
             }
-
             currentState = State_Expression;
             Update();
         }
@@ -326,7 +327,9 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         return true;
     }
 
-    public void PlayEmote(string emoteId, long timestamps) { SetExpressionValues(emoteId, timestamps); }
+    public void PlayEmote(string emoteId, long timestamps) {
+        SetExpressionValues(emoteId, timestamps); 
+    }
 
     public void EquipEmote(string emoteId, AnimationClip clip)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -49,7 +49,7 @@ public class DCLCharacterController : MonoBehaviour
     Vector3 velocity = Vector3.zero;
 
     public bool isWalking { get; private set; } = false;
-    public bool isMoving { get; private set; } = false;
+    public bool isMovingByUserInput { get; private set; } = false;
     public bool isJumping { get; private set; } = false;
     public bool isGrounded { get; private set; }
     public bool isOnMovingPlatform { get; private set; }
@@ -308,9 +308,9 @@ public class DCLCharacterController : MonoBehaviour
                     forwardTarget -= xzPlaneRight;
 
                 if (forwardTarget.Equals(Vector3.zero))
-                    isMoving = false;
+                    isMovingByUserInput = false;
                 else
-                    isMoving = true;
+                    isMovingByUserInput = true;
 
 
                 forwardTarget.Normalize();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -49,6 +49,7 @@ public class DCLCharacterController : MonoBehaviour
     Vector3 velocity = Vector3.zero;
 
     public bool isWalking { get; private set; } = false;
+    public bool isMoving { get; private set; } = false;
     public bool isJumping { get; private set; } = false;
     public bool isGrounded { get; private set; }
     public bool isOnMovingPlatform { get; private set; }
@@ -305,6 +306,11 @@ public class DCLCharacterController : MonoBehaviour
                     forwardTarget += xzPlaneRight;
                 if (characterXAxis.GetValue() < -CONTROLLER_DRIFT_OFFSET)
                     forwardTarget -= xzPlaneRight;
+
+                if (forwardTarget.Equals(Vector3.zero))
+                    isMoving = false;
+                else
+                    isMoving = true;
 
 
                 forwardTarget.Normalize();


### PR DESCRIPTION
## What does this PR change?

Fix #2251
Users can now play emotes on moving platforms

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/platform-anim
2. In genesis plaza go on the air balloon
3. Try to play emotes on it and verify it works
4. Play emotes in other contexts and verify a regular behavior

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
