### PR TITLE
feat: bitmap loading

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromise.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromise.cs
@@ -161,8 +161,8 @@ namespace DCL
 
         protected virtual IEnumerator AddToLibrary(Action<bool> OnComplete)
         {
-            OnComplete(true);
             library.Add(asset);
+            OnComplete(true);
 
             yield return null;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/TextureResource/AssetPromise_TextureResource.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/TextureResource/AssetPromise_TextureResource.cs
@@ -66,9 +66,7 @@ namespace DCL
                     {
                         texture.wrapMode = unityWrap;
                         texture.filterMode = unitySamplingMode;
-                        var prev = texture.format;
                         texture.Compress(false);
-                        Debug.Log($"AssetPromise_TextureResource: {prev} -> {texture.format}");
                         texture.Apply(unitySamplingMode != FilterMode.Point, true);
                         asset.texture2D = texture;
                     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
@@ -310,7 +310,7 @@ public static class TextureHelpers
     public static byte[] GetChunkTextureData(byte[] target, int coordX, int coordY,
         int originalWidth, int chunkWidth, int chunkHeight, int byteLength)
     {
-        byte[] result = new byte[4 * chunkWidth * chunkHeight];
+        byte[] result = new byte[byteLength * chunkWidth * chunkHeight];
 
         for (int y = 0; y < chunkHeight; y++)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
@@ -1,17 +1,20 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
 using DCL;
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Profiling;
 using UnityEngine.Rendering;
+using Graphics = UnityEngine.Graphics;
 using Object = UnityEngine.Object;
 
 public static class TextureHelpers
 {
     // We if we allow bigger chunks, compressing those chunks may be slow
-    private const int MAX_CHUNK_SIZE = 256;
+    private const int MAX_CHUNK_SIZE = 128;
     private const bool DISABLE_THROTTLED_COMPRESSION = false;
     
     // Compression lookup table
@@ -20,6 +23,17 @@ public static class TextureHelpers
         { TextureFormat.ARGB32, TextureFormat.DXT5 },
         { TextureFormat.RGBA32, TextureFormat.DXT5 },
         { TextureFormat.RGB24, TextureFormat.DXT1 }
+    };
+    
+    private static readonly Dictionary<PixelFormat, TextureFormat> pixelFormatToTextureFormat = new Dictionary<PixelFormat, TextureFormat>()
+    {
+        { PixelFormat.Format32bppArgb, TextureFormat.RGBA32 },
+        { PixelFormat.Format24bppRgb, TextureFormat.RGB24 }
+    };
+    private static readonly Dictionary<PixelFormat, TextureFormat> supportedFormatsBmp = new Dictionary<PixelFormat, TextureFormat>()
+    {
+        { PixelFormat.Format32bppArgb, TextureFormat.DXT5 },
+        { PixelFormat.Format24bppRgb, TextureFormat.DXT1 }
     };
     
     // Compression lookup table
@@ -232,6 +246,159 @@ public static class TextureHelpers
 
         OnSuccess(finalTexture);
     }
+
+    /// <summary>
+    /// Compresses a texture of RGBA/RGB format into DXT5/1 by separating the original texture into chunks and compressing each chunk separatedly then using the resulting data to draw the final compressed texture
+    /// </summary>
+    /// <param name="texture"></param>
+    /// <param name="uploadToGPU"></param>
+    /// <param name="OnSuccess"></param>
+    /// <param name="OnFail"></param>
+    /// <param name="generateMimpaps"></param>
+    /// <param name="linear"></param>
+    /// <param name="wrapMode"></param>
+    /// <param name="filterMode"></param>
+    /// <returns></returns>
+    public static IEnumerator ThrottledCompressBmp(Bitmap bmp, bool uploadToGPU, Action<Texture2D> OnSuccess, Action<Exception> OnFail,
+        bool generateMimpaps = false,
+        bool linear = false,
+        TextureWrapMode wrapMode = TextureWrapMode.Clamp,
+        FilterMode filterMode = FilterMode.Bilinear)
+    {
+        // TODO: raise these up
+        /*if (!Application.isPlaying)
+        {
+            OnSuccess(texture);
+            yield break;
+        }
+        
+        // Already compressed? 
+        if (texture.format == TextureFormat.DXT5 || texture.format == TextureFormat.DXT1)
+        {
+            OnSuccess(texture);
+            yield break;
+        }
+
+        if (DISABLE_THROTTLED_COMPRESSION)
+        {
+            texture.Compress(true);
+            OnSuccess(texture);
+            yield break;
+        }
+        
+        
+        // small textures are not worth to throttle
+        if (bmp.Width < 32 || bmp.Height < 32)
+        {
+            texture.Compress(false);
+            OnSuccess(texture);
+            yield break;
+        }
+        
+        // other formats? 
+        if (!supportedFormatsBmp.ContainsKey(bmp.PixelFormat))
+        {
+            texture.Compress(false);
+            Debug.LogWarning($"Texture format: {texture.format} not compatible with this compression method");
+            OnSuccess(texture);
+            yield break;
+        }*/
+            
+        // we sacrifice up to ~3 pixels to make it divisible by 4
+        var targetTextureWidth = bmp.Width; //ReduceSizeUntilMultiplierOf4(bmp.Width);
+        var targetTextureHeight = bmp.Height; //ReduceSizeUntilMultiplierOf4(bmp.Height);
+        
+        // we get the most optimal chunk size
+        var chunkSizeWidth = targetTextureWidth; //GetBiggestChunkSizeFor(targetTextureWidth);
+        var chunkSizeHeight = targetTextureHeight; //GetBiggestChunkSizeFor(targetTextureHeight);
+
+        // At this point something went wrong
+        /*if (chunkSizeWidth < 0 || chunkSizeHeight < 0)
+        {
+            texture.Compress(false);
+            Debug.LogWarning($"Texture size: {texture.width}x{texture.height} not compatible with this compression method");
+            OnSuccess(texture);
+            yield break;
+        }*/
+        
+
+        var throttle = new SkipFrameIfDepletedTimeBudget();
+
+        var targetFormat = supportedFormatsBmp[bmp.PixelFormat];
+        /*Texture2D finalTexture = new Texture2D(targetTextureWidth, targetTextureHeight, targetFormat, generateMimpaps, linear)
+        {
+            wrapMode = wrapMode,
+            filterMode = filterMode
+        };*/
+
+        yield return throttle;
+
+        var xChunks = targetTextureWidth / chunkSizeWidth;
+        var yChunks = targetTextureHeight / chunkSizeHeight;
+
+        //var finalTextureData = finalTexture.GetRawTextureData<byte>();
+    
+        for (int y = 0; y < yChunks; y++)
+        {
+            for (int x = 0; x < xChunks; x++)
+            {
+                // TODO: Reuse this texture2D
+                TextureFormat textureFormat = pixelFormatToTextureFormat[bmp.PixelFormat];
+                Texture2D chunkTexture = new Texture2D(chunkSizeWidth, chunkSizeHeight, textureFormat, generateMimpaps, linear);
+                yield return throttle;
+                
+                Profiler.BeginSample($"[TextureHelperBmp] LockBits {x+y}");
+                BitmapData btmDt = bmp.LockBits(
+                    new Rectangle(0, 0, chunkSizeWidth, chunkSizeHeight),
+                    ImageLockMode.ReadWrite,
+                    bmp.PixelFormat
+                );
+                Profiler.EndSample();
+                
+                yield return throttle;
+                
+                // Get chunk texture from original texture
+                Profiler.BeginSample("[TextureHelperBmp] GetChunkTextureData");
+                var data = GetChunkTextureDataFromBmp(btmDt, x, y, bmp.Width, bmp.Height, chunkSizeWidth, chunkSizeHeight, formatByteLength[textureFormat]);
+                Profiler.EndSample();
+                
+                Profiler.BeginSample("[TextureHelperBmp] LoadRawTextureData");
+                chunkTexture.LoadRawTextureData(data);
+                Profiler.EndSample();
+
+                yield return throttle;
+
+                // Compress the chunk
+                Profiler.BeginSample("[TextureHelperBmp] Compress");
+                chunkTexture.Compress(false);
+                Profiler.EndSample();
+
+                chunkTexture.Apply(generateMimpaps, uploadToGPU);
+                OnSuccess(chunkTexture);
+                yield break;
+                
+                yield return throttle;
+
+                // Copy into final texture
+                //yield return WriteChunkTextureDataDXT5Throttled(finalTextureData, chunkTexture.GetRawTextureData<byte>(), x, y, chunkSizeWidth, chunkSizeHeight, targetTextureWidth, formatByteLength[chunkTexture.format] );
+
+                yield return throttle;
+                
+                Object.Destroy(chunkTexture);
+                
+                Profiler.BeginSample("[TextureHelperBmp] UnLockBits");
+                bmp.UnlockBits(btmDt);
+                Profiler.EndSample();
+
+                yield return throttle;
+            }
+        }
+
+
+        //finalTexture.Apply(generateMimpaps, uploadToGPU);
+
+        //OnSuccess(finalTexture);
+    }
     private static int ReduceSizeUntilMultiplierOf4(int size)
     {
         var result = -1;
@@ -293,7 +460,7 @@ public static class TextureHelpers
         var mult = 1;
         var biggest = -1;
 
-        while (current < value && current < MAX_CHUNK_SIZE)
+        while (current < value && current <= MAX_CHUNK_SIZE)
         {
             if (value % current == 0)
             {
@@ -330,6 +497,51 @@ public static class TextureHelpers
 
         return result;
     }
+    
+    public static byte[] GetChunkTextureDataFromBmp(BitmapData bmp, int coordX, int coordY,
+        int originalWidth, int originalHeight, int chunkWidth, int chunkHeight, int byteLength)
+    {
+        byte[] result = new byte[byteLength * chunkWidth * chunkHeight];
+
+        unsafe
+        {
+            byte* bitmapDataPointer = (byte*)bmp.Scan0;
+
+            if (bitmapDataPointer == null)
+            {
+                return null;
+            }
+
+            for (int y = 0; y < chunkHeight; y++)
+            {
+                for (int x = 0; x < chunkWidth; x++)
+                {
+                    var textureXIndex = coordX * chunkWidth * byteLength + x * byteLength;
+                    int height = coordY * originalWidth * chunkHeight * byteLength + (y+1) * byteLength * originalWidth;
+                    int offset = originalHeight * byteLength * originalWidth;
+                    var textureYIndex = offset - height;
+                    var textureIndex = textureXIndex + textureYIndex;
+                    var chunkIndex = chunkWidth * y * byteLength + x * byteLength;
+
+                    if (byteLength == 3)
+                    {
+                        result[chunkIndex + 2] = bitmapDataPointer[textureIndex];
+                        result[chunkIndex + 1] = bitmapDataPointer[textureIndex + 1];
+                        result[chunkIndex] = bitmapDataPointer[textureIndex + 2];
+                    }
+                    else
+                    {
+                        result[chunkIndex + 2] = bitmapDataPointer[textureIndex];
+                        result[chunkIndex + 1] = bitmapDataPointer[textureIndex + 1];
+                        result[chunkIndex] = bitmapDataPointer[textureIndex + 2];
+                        result[chunkIndex + 3] = bitmapDataPointer[textureIndex + 3];
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
 
     private static void WriteChunkTextureDataDXT5(NativeArray<byte> blankTexture,
         NativeArray<byte> chunkData,
@@ -360,6 +572,44 @@ public static class TextureHelpers
 
                 blankTexture[targetIndex] = chunkData[chunkIndex];
             }
+        }
+    }
+    
+    private static IEnumerator WriteChunkTextureDataDXT5Throttled(NativeArray<byte> blankTexture,
+        NativeArray<byte> chunkData,
+        int coordX, int coordY, int chunkSizeWidth, int chunkSizeHeight, int originalWidth, int byteLength)
+    {
+        var throttle = new SkipFrameIfDepletedTimeBudget();
+
+        // Number of bytes that a DXT chunk has ( 4x4 pixels )
+        var bytesPerPixelChunk = byteLength;
+        
+        // Number of DXT chunks that our chunk has
+        var dxtChunkSizeWidth = chunkSizeWidth / 4;
+        var dxtChunkSizeHeight = chunkSizeHeight / 4;
+        
+        // Chunk width in bytes
+        var chunkWidth = dxtChunkSizeWidth * bytesPerPixelChunk;
+        // Total width in bytes
+        var totalWidth = originalWidth / chunkSizeWidth * chunkWidth;
+
+        // Offsets by chunk coordinates
+        var xOffset = coordX * chunkWidth;
+        var yOffset = coordY * totalWidth * dxtChunkSizeHeight;
+
+        for (int y = 0; y < dxtChunkSizeHeight; y++)
+        {
+            yield return throttle;
+
+            Profiler.BeginSample("[TextureHelperBmp] WriteChunkTextureDataDXT5Throttled");
+            for (int x = 0; x < chunkWidth; x++)
+            {
+                int chunkIndex = x + y * chunkWidth;
+                int targetIndex = yOffset + xOffset + x + y * totalWidth;
+
+                blankTexture[targetIndex] = chunkData[chunkIndex];
+            }
+            Profiler.EndSample();
         }
     }
 }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -718,7 +718,7 @@ namespace UnityGLTF
             {
                 texture.wrapMode = settings.wrapMode;
                 texture.filterMode = settings.filterMode;
-                texture.Apply(false, settings.uploadToGpu);
+                texture.Apply(settings.generateMipmaps, settings.uploadToGpu);
 
                 // Resizing must be the last step to avoid breaking the texture when copying with Graphics.CopyTexture()
                 AddTextureToAssetCache(settings, imageCacheIndex, texture);

--- a/unity-renderer/Assets/csc.rsp
+++ b/unity-renderer/Assets/csc.rsp
@@ -1,0 +1,3 @@
+ 
+-r:System.Drawing.dll
+-unsafe

--- a/unity-renderer/Assets/csc.rsp.meta
+++ b/unity-renderer/Assets/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: add2a2fdfb828964285caf5209aeeb3f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR is a monster, don't look at it.


TLDR: Changed `.LoadImage` for C# Bitmap class to load JPG/PNG images to get their RGBA data, its also faster resizing them before converting it into a unity texture and then compressing it.


Test:  https://play.decentraland.zone/?renderer-branch=feat/bitmap-loading