### PR TITLE
feat: chat history iteration with up & down keys

### DIFF
--- a/unity-renderer/Assets/Resources/Prefabs/InputController.prefab
+++ b/unity-renderer/Assets/Resources/Prefabs/InputController.prefab
@@ -87,6 +87,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 4bc13df453704ca4c960cfa8af49991f, type: 2}
   - {fileID: 11400000, guid: 09d22c21282b4c54b93fa430c7eaefcb, type: 2}
   - {fileID: 11400000, guid: bf65a8845e8fc764a9314582d5d29a83, type: 2}
+  - {fileID: 11400000, guid: b5e17dbeae28f8748b3308516c99e26d, type: 2}
+  - {fileID: 11400000, guid: 963604f308a161b4daa2e9ad5a9beba4, type: 2}
   holdActions:
   - {fileID: 11400000, guid: 8eddef1fc072ec845aeb62f5e1041b52, type: 2}
   - {fileID: 11400000, guid: 0cfb8d150b7d6934d856665cf924d01d, type: 2}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -11,6 +11,7 @@ public class ChatHUDController : IDisposable
     private const int TEMPORARILY_MUTE_MINUTES = 10;
     private const int MAX_CONTINUOUS_MESSAGES = 6;
     private const int MIN_MILLISECONDS_BETWEEN_MESSAGES = 1500;
+    private const int MAX_HISTORY_ITERATION = 10;
 
     public event Action OnInputFieldSelected;
     public event Action OnInputFieldDeselected;
@@ -23,7 +24,9 @@ public class ChatHUDController : IDisposable
     private readonly IProfanityFilter profanityFilter;
     private readonly Regex whisperRegex = new Regex(@"(?i)^\/(whisper|w) (\S+)( *)(.*)");
     private readonly Dictionary<string, ulong> temporarilyMutedSenders = new Dictionary<string, ulong>();
-    private readonly List<ChatEntryModel> lastMessages = new List<ChatEntryModel>();
+    private readonly List<ChatEntryModel> spamMessages = new List<ChatEntryModel>();
+    private readonly List<string> lastMessagesSent = new List<string>();
+    private int currentHistoryIteration;
     private IChatHUDComponentView view;
 
     public ChatHUDController(DataStore dataStore,
@@ -42,6 +45,10 @@ public class ChatHUDController : IDisposable
     public void Initialize(IChatHUDComponentView view)
     {
         this.view = view;
+        this.view.OnIterateChatHistoryDown -= FillInputWithPreviousMessage;
+        this.view.OnIterateChatHistoryDown += FillInputWithPreviousMessage;
+        this.view.OnIterateChatHistoryUp -= FillInputWithNextMessage;
+        this.view.OnIterateChatHistoryUp += FillInputWithNextMessage;
         this.view.OnShowMenu -= ContextMenu_OnShowMenu;
         this.view.OnShowMenu += ContextMenu_OnShowMenu;
         this.view.OnInputFieldSelected -= HandleInputFieldSelected;
@@ -96,6 +103,8 @@ public class ChatHUDController : IDisposable
         view.OnSendMessage -= HandleSendMessage;
         view.OnInputFieldSelected -= HandleInputFieldSelected;
         view.OnInputFieldDeselected -= HandleInputFieldDeselected;
+        view.OnIterateChatHistoryDown -= FillInputWithPreviousMessage;
+        view.OnIterateChatHistoryUp -= FillInputWithNextMessage;
         OnSendMessage = null;
         OnMessageUpdated = null;
         OnInputFieldSelected = null;
@@ -179,10 +188,22 @@ public class ChatHUDController : IDisposable
     {
         var ownProfile = userProfileBridge.GetOwn();
         message.sender = ownProfile.userId;
+        RegisterMessageIteration(message);
+        currentHistoryIteration = 0;
         if (IsSpamming(message.sender)) return;
         if (IsSpamming(ownProfile.userName)) return;
         ApplyWhisperAttributes(message);
         OnSendMessage?.Invoke(message);
+    }
+
+    private void RegisterMessageIteration(ChatMessage message)
+    {
+        if (string.IsNullOrEmpty(message.body)) return;
+        
+        lastMessagesSent.Insert(0, message.body);
+
+        if (lastMessagesSent.Count > MAX_HISTORY_ITERATION)
+            lastMessagesSent.RemoveAt(lastMessagesSent.Count - 1);
     }
 
     private void ApplyWhisperAttributes(ChatMessage message)
@@ -199,9 +220,17 @@ public class ChatHUDController : IDisposable
         message.body = match.Groups[4].Value;
     }
 
-    private void HandleInputFieldSelected() => OnInputFieldSelected?.Invoke();
-    
-    private void HandleInputFieldDeselected() => OnInputFieldDeselected?.Invoke();
+    private void HandleInputFieldSelected()
+    {
+        currentHistoryIteration = 0;
+        OnInputFieldSelected?.Invoke();
+    }
+
+    private void HandleInputFieldDeselected()
+    {
+        currentHistoryIteration = 0;
+        OnInputFieldDeselected?.Invoke();
+    }
 
     private bool IsSpamming(string senderName)
     {
@@ -222,30 +251,30 @@ public class ChatHUDController : IDisposable
     
     private void UpdateSpam(ChatEntryModel model)
     {
-        if (lastMessages.Count == 0)
+        if (spamMessages.Count == 0)
         {
-            lastMessages.Add(model);
+            spamMessages.Add(model);
         }
-        else if (lastMessages[lastMessages.Count - 1].senderName == model.senderName)
+        else if (spamMessages[spamMessages.Count - 1].senderName == model.senderName)
         {
-            if (MessagesSentTooFast(lastMessages[lastMessages.Count - 1].timestamp, model.timestamp))
+            if (MessagesSentTooFast(spamMessages[spamMessages.Count - 1].timestamp, model.timestamp))
             {
-                lastMessages.Add(model);
+                spamMessages.Add(model);
 
-                if (lastMessages.Count == MAX_CONTINUOUS_MESSAGES)
+                if (spamMessages.Count == MAX_CONTINUOUS_MESSAGES)
                 {
                     temporarilyMutedSenders.Add(model.senderName, model.timestamp);
-                    lastMessages.Clear();
+                    spamMessages.Clear();
                 }
             }
             else
             {
-                lastMessages.Clear();
+                spamMessages.Clear();
             }
         }
         else
         {
-            lastMessages.Clear();
+            spamMessages.Clear();
         }
     }
 
@@ -259,5 +288,28 @@ public class ChatHUDController : IDisposable
     private DateTime CreateBaseDateTime()
     {
         return new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+    }
+    
+    private void FillInputWithNextMessage()
+    {
+        view.FocusInputField();
+        view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
+        currentHistoryIteration = (currentHistoryIteration + 1) % lastMessagesSent.Count;
+    }
+
+    private void FillInputWithPreviousMessage()
+    {
+        if (lastMessagesSent.Count == 0)
+        {
+            view.ResetInputField();
+            return;
+        }
+        
+        view.FocusInputField();
+        view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
+
+        currentHistoryIteration--;
+        if (currentHistoryIteration < 0)
+            currentHistoryIteration = lastMessagesSent.Count - 1;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -189,7 +189,7 @@ public class ChatHUDController : IDisposable
     {
         var ownProfile = userProfileBridge.GetOwn();
         message.sender = ownProfile.userId;
-        RegisterMessageIteration(message);
+        RegisterMessageHistory(message);
         currentHistoryIteration = 0;
         if (IsSpamming(message.sender)) return;
         if (IsSpamming(ownProfile.userName)) return;
@@ -197,7 +197,7 @@ public class ChatHUDController : IDisposable
         OnSendMessage?.Invoke(message);
     }
 
-    private void RegisterMessageIteration(ChatMessage message)
+    private void RegisterMessageHistory(ChatMessage message)
     {
         if (string.IsNullOrEmpty(message.body)) return;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -206,9 +206,6 @@ public class ChatHUDController : IDisposable
 
         if (lastMessagesSent.Count > MAX_HISTORY_ITERATION)
             lastMessagesSent.RemoveAt(lastMessagesSent.Count - 1);
-        
-        if (!lastMessagesSent.Last().Equals(""))
-            lastMessagesSent.Add("");
     }
 
     private void ApplyWhisperAttributes(ChatMessage message)
@@ -311,11 +308,11 @@ public class ChatHUDController : IDisposable
             return;
         }
         
-        view.FocusInputField();
-        view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
-
         currentHistoryIteration--;
         if (currentHistoryIteration < 0)
             currentHistoryIteration = lastMessagesSent.Count - 1;
+        
+        view.FocusInputField();
+        view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -85,6 +85,9 @@ public class ChatHUDView : BaseComponentView, IChatHUDComponentView
         }
     }
 
+    public event Action OnIterateChatHistoryDown;
+    public event Action OnIterateChatHistoryUp;
+
     public event Action<ChatMessage> OnSendMessage;
 
     public int EntryCount => entries.Count;
@@ -111,6 +114,19 @@ public class ChatHUDView : BaseComponentView, IChatHUDComponentView
     {
         base.OnEnable();
         Utils.ForceUpdateLayout(transform as RectTransform);
+    }
+
+    public override void Update()
+    {
+        base.Update();
+        
+        if (!inputField.isFocused) return;
+        
+        if (Input.GetKeyDown(KeyCode.DownArrow))
+            OnIterateChatHistoryDown?.Invoke();
+        
+        if (Input.GetKeyDown(KeyCode.UpArrow))
+            OnIterateChatHistoryUp?.Invoke();
     }
 
     public void ResetInputField(bool loseFocus = false)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
@@ -8,8 +8,8 @@ public interface IChatHUDComponentView
     event Action OnShowMenu;
     event Action OnInputFieldSelected;
     event Action OnInputFieldDeselected;
-    event Action OnIterateChatHistoryDown;
-    event Action OnIterateChatHistoryUp;
+    event Action OnPreviousChatInHistory;
+    event Action OnNextChatInHistory;
     
     int EntryCount { get; }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
@@ -8,6 +8,8 @@ public interface IChatHUDComponentView
     event Action OnShowMenu;
     event Action OnInputFieldSelected;
     event Action OnInputFieldDeselected;
+    event Action OnIterateChatHistoryDown;
+    event Action OnIterateChatHistoryUp;
     
     int EntryCount { get; }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -195,6 +195,54 @@ public class ChatHUDControllerShould : IntegrationTestSuite_Legacy
             .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
     });
 
+    [Test]
+    public void DisplayNextMessageInHistory()
+    {
+        const string body = "hey";
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        
+        view.Received(1).SetInputFieldText(body);
+    }
+    
+    [Test]
+    public void DisplayPreviousMessageInHistory()
+    {
+        const string body = "hey";
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
+        view.OnPreviousChatInHistory += Raise.Event<Action>();
+        
+        view.Received(1).SetInputFieldText(body);
+    }
+
+    [Test]
+    public void ResetInputWhenAllMessagesInHistoryWereIterated()
+    {
+        const string body = "hey";
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        
+        view.Received(1).SetInputFieldText(body);
+        view.Received(1).SetInputFieldText("");
+    }
+    
+    [Test]
+    public void DoNotDuplicateMessagesInHistory()
+    {
+        const string body = "hey";
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "bleh"));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
+        view.OnPreviousChatInHistory += Raise.Event<Action>();
+        view.OnPreviousChatInHistory += Raise.Event<Action>();
+        view.OnPreviousChatInHistory += Raise.Event<Action>();
+        
+        view.Received(1).SetInputFieldText(body);
+        view.Received(1).SetInputFieldText("bleh");
+        view.Received(1).SetInputFieldText("");
+    }
+
     private RegexProfanityFilter GivenProfanityFilter()
     {
         var wordProvider = Substitute.For<IProfanityWordProvider>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -198,49 +198,51 @@ public class ChatHUDControllerShould : IntegrationTestSuite_Legacy
     [Test]
     public void DisplayNextMessageInHistory()
     {
-        const string body = "hey";
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
+        view.OnNextChatInHistory += Raise.Event<Action>();
         view.OnNextChatInHistory += Raise.Event<Action>();
         
-        view.Received(1).SetInputFieldText(body);
+        Received.InOrder(() =>
+        {
+            view.SetInputFieldText("sup");
+            view.SetInputFieldText("hey");
+        });
     }
     
     [Test]
     public void DisplayPreviousMessageInHistory()
     {
-        const string body = "hey";
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
+        view.OnPreviousChatInHistory += Raise.Event<Action>();
         view.OnPreviousChatInHistory += Raise.Event<Action>();
         
-        view.Received(1).SetInputFieldText(body);
-    }
-
-    [Test]
-    public void ResetInputWhenAllMessagesInHistoryWereIterated()
-    {
-        const string body = "hey";
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
-        view.OnNextChatInHistory += Raise.Event<Action>();
-        view.OnNextChatInHistory += Raise.Event<Action>();
-        
-        view.Received(1).SetInputFieldText(body);
-        view.Received(1).SetInputFieldText("");
+        Received.InOrder(() =>
+        {
+            view.SetInputFieldText("hey");
+            view.SetInputFieldText("sup");
+        });
     }
     
     [Test]
     public void DoNotDuplicateMessagesInHistory()
     {
-        const string body = "hey";
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "bleh"));
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", body));
-        view.OnPreviousChatInHistory += Raise.Event<Action>();
-        view.OnPreviousChatInHistory += Raise.Event<Action>();
-        view.OnPreviousChatInHistory += Raise.Event<Action>();
+        const string repeatedMessage = "hey";
         
-        view.Received(1).SetInputFieldText(body);
-        view.Received(1).SetInputFieldText("bleh");
-        view.Received(1).SetInputFieldText("");
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "bleh"));
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        
+        Received.InOrder(() =>
+        {
+            view.SetInputFieldText("bleh");
+            view.SetInputFieldText(repeatedMessage);
+            view.SetInputFieldText("bleh");
+        });
     }
 
     private RegexProfanityFilter GivenProfanityFilter()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ChatHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ChatHUD.prefab
@@ -1093,7 +1093,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -0.000024681574}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -483}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &3956694658099104561
 MonoBehaviour:
@@ -1807,6 +1807,10 @@ MonoBehaviour:
     inputFieldText: 
     enableFadeoutMode: 0
     entries: []
+  nextChatInHistoryInput: {fileID: 11400000, guid: b5e17dbeae28f8748b3308516c99e26d,
+    type: 2}
+  previousChatInHistoryInput: {fileID: 11400000, guid: 963604f308a161b4daa2e9ad5a9beba4,
+    type: 2}
 --- !u!1 &8305413179443684899
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatHUD.prefab
@@ -118,6 +118,10 @@ MonoBehaviour:
     inputFieldText: 
     enableFadeoutMode: 0
     entries: []
+  nextChatInHistoryInput: {fileID: 11400000, guid: b5e17dbeae28f8748b3308516c99e26d,
+    type: 2}
+  previousChatInHistoryInput: {fileID: 11400000, guid: 963604f308a161b4daa2e9ad5a9beba4,
+    type: 2}
   separatorEntryPrefab: {fileID: 717124712886577979, guid: 66a008a71d1e6d043a1066b0e45db3ca,
     type: 3}
 --- !u!225 &4634647665024068242

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -48,6 +48,8 @@ public enum DCLAction_Trigger
     ToggleEmoteShortcut7 = 149,
     ToggleEmoteShortcut8 = 150,
     ToggleEmoteShortcut9 = 151,
+    ChatPreviousInHistory = 152,
+    ChatNextInHistory = 153,
 
     Expression_Wave = 201,
     Expression_FistPump = 202,
@@ -319,6 +321,12 @@ public class InputController : MonoBehaviour
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut9:
                     InputProcessor.FromKey(action, KeyCode.Alpha9, modifiers: InputProcessor.Modifier.FocusNotInInput, modifierKeys: new KeyCode[] { KeyCode.B });
+                    break;
+                case DCLAction_Trigger.ChatNextInHistory:
+                    InputProcessor.FromKey(action, KeyCode.UpArrow, modifiers: InputProcessor.Modifier.OnlyWithInputFocused);
+                    break;
+                case DCLAction_Trigger.ChatPreviousInHistory:
+                    InputProcessor.FromKey(action, KeyCode.DownArrow, modifiers: InputProcessor.Modifier.OnlyWithInputFocused);
                     break;
                 case DCLAction_Trigger.Expression_Wave:
                     InputProcessor.FromKey(action, KeyCode.Alpha1,
@@ -592,7 +600,8 @@ public static class InputProcessor
         None = 0b0000000, // No modifier needed
         NeedsPointerLocked = 0b0000001, // The pointer must be locked to the game
         FocusNotInInput = 0b0000010, // The game focus cannot be in an input field
-        NotInStartMenu = 0b0000100 // The game focus cannot be in full-screen start menu
+        NotInStartMenu = 0b0000100, // The game focus cannot be in full-screen start menu
+        OnlyWithInputFocused = 0b0001000 // The game focus must be in an input field
     }
 
     /// <summary>
@@ -632,7 +641,12 @@ public static class InputProcessor
         if (IsModifierSet(modifiers, Modifier.NeedsPointerLocked) && !DCL.Helpers.Utils.IsCursorLocked)
             return false;
 
-        if (IsModifierSet(modifiers, Modifier.FocusNotInInput) && FocusIsInInputField())
+        var isInputFieldFocused = FocusIsInInputField();
+        
+        if (IsModifierSet(modifiers, Modifier.FocusNotInInput) && isInputFieldFocused)
+            return false;
+        
+        if (IsModifierSet(modifiers, Modifier.OnlyWithInputFocused) && !isInputFieldFocused)
             return false;
 
         if (IsModifierSet(modifiers, Modifier.NotInStartMenu) && IsStartMenuVisible())

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ChatNextInHistory.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ChatNextInHistory.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8ba04a041474be2a7ac981e4fff73ef, type: 3}
+  m_Name: ChatNextInHistory
+  m_EditorClassIdentifier: 
+  dclAction: 153
+  blockTrigger: {fileID: 11400000, guid: 184d6891e429a8f4e978d2d25e50b36e, type: 2}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ChatNextInHistory.asset.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ChatNextInHistory.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5e17dbeae28f8748b3308516c99e26d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ChatPreviousInHistory.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ChatPreviousInHistory.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8ba04a041474be2a7ac981e4fff73ef, type: 3}
+  m_Name: ChatPreviousInHistory
+  m_EditorClassIdentifier: 
+  dclAction: 152
+  blockTrigger: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ChatPreviousInHistory.asset.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ChatPreviousInHistory.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 963604f308a161b4daa2e9ad5a9beba4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?

`Closes #1666 `

Press `UP arrow key` or `DOWN arrow key` to set the previous messages sent in the chat input field.

## How to test the changes?

1. Send any message in the chat
2. Pressing `UP arrow key` the last message should be set in the input field
3. Keep sending messages
4. When `UP arrow key` or `DOWN arrow key` should iterate over the whole chat history
5. The last history iteration should be filled with an empty text
6. Messages should not be duplicated in the history

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
