### PR TITLE
fix: remove bodyshape from hides lists

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
@@ -112,6 +112,7 @@ public class CatalogController : MonoBehaviour
         {
             if (!wearableCatalog.ContainsKey(wearableItem.id))
             {
+                wearableItem.SanitizeHidesLists();
                 wearableCatalog.Add(wearableItem.id, wearableItem);
 
                 if (!wearablesInUseCounters.ContainsKey(wearableItem.id))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/Tests/WearableItemShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/Tests/WearableItemShould.cs
@@ -51,6 +51,20 @@ namespace AvatarAssets_Test
                 Assert.IsTrue(wearable.DoesHide(category, BODY_SHAPE));
         }
 
+        [Test]
+        public void RemoveBodyshapeFromHidesWhenSanitizing()
+        {
+            var wearable = GivenSkinWearable(new [] { WearableLiterals.Categories.BODY_SHAPE });
+
+            wearable.SanitizeHidesLists();
+
+            Assert.IsFalse(wearable.data.hides.Contains(WearableLiterals.Categories.BODY_SHAPE));
+            foreach (WearableItem.Representation representation in wearable.data.representations)
+            {
+                Assert.IsFalse(representation.overrideHides.Contains(WearableLiterals.Categories.BODY_SHAPE));
+            }
+        }
+
         private WearableItem GivenSkinWearable(string[] customHides)
         {
             var wearable = new WearableItem
@@ -58,7 +72,14 @@ namespace AvatarAssets_Test
                 data = new WearableItem.Data
                 {
                     category = WearableLiterals.Categories.SKIN,
-                    representations = new[] {new WearableItem.Representation {bodyShapes = new[] {BODY_SHAPE}}},
+                    representations = new[]
+                    {
+                        new WearableItem.Representation
+                        {
+                            bodyShapes = new[] { BODY_SHAPE },
+                            overrideHides = customHides
+                        }
+                    },
                     hides = customHides
                 }
             };

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -184,6 +184,20 @@ public class WearableItem
         return hides;
     }
 
+    public void SanitizeHidesLists()
+    {
+        //remove bodyshape from hides list 
+        if (data.hides != null)
+            data.hides = data.hides.Except(new [] { WearableLiterals.Categories.BODY_SHAPE }).ToArray();
+        for (int i = 0; i < data.representations.Length; i++)
+        {
+            Representation representation = data.representations[i];
+            if (representation.overrideHides != null)
+                representation.overrideHides = representation.overrideHides.Except(new [] { WearableLiterals.Categories.BODY_SHAPE }).ToArray();
+
+        }
+    }
+
     public bool DoesHide(string category, string bodyShape) => GetHidesList(bodyShape).Any(s => s == category);
 
     public bool IsCollectible() { return !string.IsNullOrEmpty(rarity); }


### PR DESCRIPTION
Some wearables contain "body-shape" in their hides lists. This breaks our avatar loading process because the bodyshape is never retrieved.

You can test this wearable in this url

https://play.decentraland.zone/?WITH_ITEMS=urn%3Adecentraland%3Amatic%3Acollections-thirdparty%3Acryptoavatars%3A0x28ccbe824455a3b188c155b434e4e628babb6ffa%3A673&CATALYST=peer.decentraland.org&DEBUG=true&NETWORK=ropsten&realm=v2%7Epeer.decentraland.org&renderer-branch=fix/wearables-hidding-bodyshapes

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
