### PR TITLE
fix: limited the amount of private chat channels & optimized loading hiccups

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDController.cs
@@ -437,7 +437,6 @@ public class FriendsHUDController : IHUD
         {
             foreach (var model in filteredFriends)
             {
-                // Display missing friends
                 if (View.ContainsFriend(model.userId)) return;
                 var status = friendsController.GetUserStatus(model.userId);
                 if (status == null) continue;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/Tabs/FriendsTabComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/Tabs/FriendsTabComponentView.cs
@@ -229,7 +229,6 @@ public class FriendsTabComponentView : BaseComponentView
             }
         }
 
-        SetMoreEntriesContainerAtBottomOfScroll();
         UpdateLayout();
         UpdateEmptyOrFilledState();
         UpdateCounterLabel();
@@ -365,7 +364,6 @@ public class FriendsTabComponentView : BaseComponentView
     private void ShowMoreFriendsToLoadHint()
     {
         loadMoreEntriesContainer.SetActive(true);
-        SetMoreEntriesContainerAtBottomOfScroll();
         UpdateLayout();
     }
 
@@ -491,17 +489,9 @@ public class FriendsTabComponentView : BaseComponentView
         
         if (searchResultsFriendList.IsSortingDirty)
             searchResultsFriendList.Sort();
-
-        SetMoreEntriesContainerAtBottomOfScroll();
     }
 
     private void RequestMoreFriendEntries() => OnRequireMoreFriends?.Invoke();
-
-    private void SetMoreEntriesContainerAtBottomOfScroll()
-    {
-        if (loadMoreEntriesContainer.activeSelf)
-            loadMoreEntriesContainer.transform.SetAsLastSibling();
-    }
 
     [Serializable]
     private struct FriendListComponents

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -221,8 +221,6 @@ public class HUDController : IHUDController
                         worldChatWindowHud.OnOpenPrivateChat += OpenPrivateChatWindow;
                         worldChatWindowHud.OnOpenPublicChannel -= OpenPublicChannelWindow;
                         worldChatWindowHud.OnOpenPublicChannel += OpenPublicChannelWindow;
-                        worldChatWindowHud.OnDeactivatePreview -= View_OnDeactivatePreview;
-                        worldChatWindowHud.OnDeactivatePreview += View_OnDeactivatePreview;
 
                         taskbarHud?.AddWorldChatWindow(worldChatWindowHud);
                     }
@@ -405,11 +403,6 @@ public class HUDController : IHUDController
         taskbarHud?.OpenPrivateChat(targetUserId);
     }
 
-    private void View_OnDeactivatePreview()
-    {
-        playerInfoCardHud?.CloseCard();
-    }
-
     private void PrivateChatWindowHud_OnPressBack()
     {
         PrivateChatWindow?.SetVisibility(false);
@@ -455,7 +448,6 @@ public class HUDController : IHUDController
         {
             worldChatWindowHud.OnOpenPrivateChat -= OpenPrivateChatWindow;
             worldChatWindowHud.OnOpenPublicChannel -= OpenPublicChannelWindow;
-            worldChatWindowHud.OnDeactivatePreview -= View_OnDeactivatePreview;
         }
 
         if (PrivateChatWindow != null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ConversationListHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ConversationListHUD.prefab
@@ -134,6 +134,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &564226951789914640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4477771477396242088}
+  - component: {fileID: 1452497600906007904}
+  - component: {fileID: 5497933249960973174}
+  m_Layer: 5
+  m_Name: Arrow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4477771477396242088
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 564226951789914640}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7200787093623502041}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 44.1, y: 0}
+  m_SizeDelta: {x: 12, y: 7.5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1452497600906007904
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 564226951789914640}
+  m_CullTransparentMesh: 1
+--- !u!114 &5497933249960973174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 564226951789914640}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 9879272c733ec44189c11c901f5b3500, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1477601900589003277
 GameObject:
   m_ObjectHideFlags: 0
@@ -981,9 +1056,9 @@ RectTransform:
   m_Father: {fileID: 6385060616518280574}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 205, y: -58}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 205, y: 0}
   m_SizeDelta: {x: 410, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &2525465837178415022
@@ -1047,6 +1122,140 @@ MonoBehaviour:
   entryPrefab: {fileID: 8915626932228566300, guid: dae9206e2bb6745ca85cdee7ca9c9e36,
     type: 3}
   userContextMenu: {fileID: 7544376168367412440}
+--- !u!1 &4195073284520279776
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3458026499158244162}
+  - component: {fileID: 1667305367637778847}
+  - component: {fileID: 3321790946023071022}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3458026499158244162
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4195073284520279776}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7200787093623502041}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -8.599998, y: 0}
+  m_SizeDelta: {x: 83, y: 32}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1667305367637778847
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4195073284520279776}
+  m_CullTransparentMesh: 1
+--- !u!114 &3321790946023071022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4195073284520279776}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: SHOW MORE
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4279768342
+  m_fontColor: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 13
+  m_fontSizeBase: 13
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4426213859173330826
 GameObject:
   m_ObjectHideFlags: 0
@@ -1502,6 +1711,9 @@ MonoBehaviour:
     privateChats: []
     publicChannels: []
     isLoadingDirectChats: 0
+  loadMoreEntriesButton: {fileID: 4508800004620712082}
+  loadMoreEntriesContainer: {fileID: 8953413587729228697}
+  loadMoreEntriesLabel: {fileID: 335676906559043414}
 --- !u!1 &5214084149923899809
 GameObject:
   m_ObjectHideFlags: 0
@@ -1832,6 +2044,141 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6807604709821437271
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1486616107479674160}
+  - component: {fileID: 4475656656524039421}
+  - component: {fileID: 335676906559043414}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1486616107479674160
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6807604709821437271}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6296847833854330826}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 22.4}
+  m_SizeDelta: {x: 317, y: 36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4475656656524039421
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6807604709821437271}
+  m_CullTransparentMesh: 1
+--- !u!114 &335676906559043414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6807604709821437271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: '{0} chats hidden. Use the search bar to find them or click below to show
+    more.'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 6708c7eadd49b49f4ac3469e5104e7c9, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: dd1effe058ec94479a0dd10765262662, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 15
+  m_fontSizeBase: 15
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &6962653782954923093
 GameObject:
   m_ObjectHideFlags: 0
@@ -2155,6 +2502,128 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7914978557875723243
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7200787093623502041}
+  - component: {fileID: 151616857441447505}
+  - component: {fileID: 1157565987380936006}
+  - component: {fileID: 4508800004620712082}
+  m_Layer: 5
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7200787093623502041
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7914978557875723243}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3458026499158244162}
+  - {fileID: 4477771477396242088}
+  m_Father: {fileID: 6296847833854330826}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -23.6}
+  m_SizeDelta: {x: 124, y: 32}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &151616857441447505
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7914978557875723243}
+  m_CullTransparentMesh: 1
+--- !u!114 &1157565987380936006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7914978557875723243}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: f02af068e11cb4902a1a4faad10b890a, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 2
+--- !u!114 &4508800004620712082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7914978557875723243}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1157565987380936006}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &8242457001220167832
 GameObject:
   m_ObjectHideFlags: 0
@@ -2334,6 +2803,7 @@ RectTransform:
   - {fileID: 4257313855285611501}
   - {fileID: 8540575407798844873}
   - {fileID: 6388838176684646702}
+  - {fileID: 6296847833854330826}
   m_Father: {fileID: 2828657937425296497}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2567,9 +3037,9 @@ RectTransform:
   m_Father: {fileID: 6385060616518280574}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 205, y: -10}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 205, y: 0}
   m_SizeDelta: {x: 410, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &3064829855575657985
@@ -2632,6 +3102,43 @@ MonoBehaviour:
     isExpanded: 0
   entryPrefab: {fileID: 54474813580769298, guid: 0d953eabd7cb1462eaaf7235b09a0af4,
     type: 3}
+--- !u!1 &8953413587729228697
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6296847833854330826}
+  m_Layer: 5
+  m_Name: LoadMoreFriendsContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6296847833854330826
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8953413587729228697}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1486616107479674160}
+  - {fileID: 7200787093623502041}
+  m_Father: {fileID: 6385060616518280574}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 205, y: -116}
+  m_SizeDelta: {x: 410, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8999843318712220754
 GameObject:
   m_ObjectHideFlags: 0
@@ -3170,6 +3677,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: db08434be6dadc943b7e258f41869504, type: 3}
+--- !u!224 &6896061596910773713 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8158256326675281976, guid: db08434be6dadc943b7e258f41869504,
+    type: 3}
+  m_PrefabInstance: {fileID: 3351884956682182121}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8498673460815628759 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6590195516862157886, guid: db08434be6dadc943b7e258f41869504,
@@ -3182,12 +3695,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ae27d568eb9f4364ca12bdb6e11d0f52, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &6896061596910773713 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8158256326675281976, guid: db08434be6dadc943b7e258f41869504,
-    type: 3}
-  m_PrefabInstance: {fileID: 3351884956682182121}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6064852553117820040
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/WorldChatWindowViewMock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/WorldChatWindowViewMock.cs
@@ -8,8 +8,11 @@ public class WorldChatWindowViewMock : MonoBehaviour, IWorldChatWindowView
     public event Action<string> OnOpenPrivateChat;
     public event Action<string> OnOpenPublicChannel;
     public event Action<string> OnUnfriend;
+    public event Action<string> OnSearchChannelRequested;
+    public event Action OnRequireMorePrivateChats;
     public RectTransform Transform => (RectTransform) transform;
     public bool IsActive => gameObject.activeSelf;
+    public int PrivateChannelsCount { get; }
 
     private bool isDestroyed;
 
@@ -59,5 +62,21 @@ public class WorldChatWindowViewMock : MonoBehaviour, IWorldChatWindowView
     {
         if (isDestroyed) return;
         Destroy(gameObject);
+    }
+
+    public void ClearFilter()
+    {
+    }
+
+    public void HideMoreChatsToLoadHint()
+    {
+    }
+
+    public void ShowMoreChatsToLoadHint(int count)
+    {
+    }
+
+    public void Filter(Dictionary<string, PrivateChatModel> privateChats, Dictionary<string, PublicChatChannelModel> publicChannels)
+    {
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/CollapsableChatSearchListComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/CollapsableChatSearchListComponentView.cs
@@ -1,3 +1,4 @@
+using System;
 using UIComponents.CollapsableSortedList;
 using UnityEngine;
 
@@ -16,6 +17,19 @@ public class CollapsableChatSearchListComponentView : CollapsableSortedListCompo
     {
         directChatList.Filter(search);
         publicChannelList.Filter(search);
+    }
+
+    public void Filter(Func<PrivateChatEntry, bool> privateComparision,
+        Func<PublicChannelEntry, bool> publicComparision)
+    {
+        directChatList.Filter(privateComparision);
+        publicChannelList.Filter(publicComparision);
+    }
+
+    public override void Filter(Func<BaseComponentView, bool> comparision)
+    {
+        directChatList.Filter(comparision);
+        publicChannelList.Filter(comparision);
     }
 
     public override int Count()
@@ -51,6 +65,8 @@ public class CollapsableChatSearchListComponentView : CollapsableSortedListCompo
     {
         return (BaseComponentView) directChatList.Remove(key) ?? publicChannelList.Remove(key);
     }
+
+    public void Set(PrivateChatEntry.PrivateChatEntryModel model) => directChatList.Set(model.userId, model);
 
     public void Export(CollapsablePublicChannelListComponentView publicChannelList,
         CollapsableDirectChatListComponentView privateChatList)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IWorldChatWindowView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IWorldChatWindowView.cs
@@ -8,9 +8,12 @@ public interface IWorldChatWindowView
     event Action<string> OnOpenPrivateChat;
     event Action<string> OnOpenPublicChannel;
     event Action<string> OnUnfriend;
+    event Action<string> OnSearchChannelRequested;
+    event Action OnRequireMorePrivateChats;
     
     RectTransform Transform { get; }
     bool IsActive { get; }
+    int PrivateChannelsCount { get; }
 
     void Initialize(IChatController chatController, ILastReadMessagesService lastReadMessagesService);
     void Show();
@@ -22,4 +25,8 @@ public interface IWorldChatWindowView
     void HidePrivateChatsLoading();
     void RefreshBlockedDirectMessages(List<string> blockedUsers);
     void Dispose();
+    void ClearFilter();
+    void HideMoreChatsToLoadHint();
+    void ShowMoreChatsToLoadHint(int count);
+    void Filter(Dictionary<string,PrivateChatModel> privateChats, Dictionary<string,PublicChatChannelModel> publicChannels);
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PrivateChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PrivateChatEntry.cs
@@ -57,10 +57,14 @@ public class PrivateChatEntry : BaseComponentView, IComponentModelConfig
     {
         userNameLabel.text = model.userName;
         lastMessageLabel.text = model.lastMessage;
-        picture.Configure(new ImageComponentModel {uri = model.pictureUrl});
         SetBlockStatus(model.isBlocked);
         SetPresence(model.isOnline);
         unreadNotifications.Initialize(chatController, model.userId, lastReadMessagesService);
+        
+        if (model.imageFetchingEnabled)
+            EnableAvatarSnapshotFetching();
+        else
+            DisableAvatarSnapshotFetching();
     }
     
     private void HandleUserBlocked(string userId, bool blocked)
@@ -88,6 +92,26 @@ public class PrivateChatEntry : BaseComponentView, IComponentModelConfig
         menuTransform.pivot = userContextMenuPositionReference.pivot;
         menuTransform.position = userContextMenuPositionReference.position;
     }
+    
+    public bool IsVisible(RectTransform container)
+    {
+        if (!gameObject.activeSelf) return false;
+        return ((RectTransform) transform).CountCornersVisibleFrom(container) > 0;
+    }
+
+    public void EnableAvatarSnapshotFetching()
+    {
+        if (model.imageFetchingEnabled) return;
+        picture.Configure(new ImageComponentModel {uri = model.pictureUrl});
+        model.imageFetchingEnabled = true;
+    }
+
+    public void DisableAvatarSnapshotFetching()
+    {
+        if (!model.imageFetchingEnabled) return;
+        picture.SetImage((string) null);
+        model.imageFetchingEnabled = false;
+    }
 
     [Serializable]
     public class PrivateChatEntryModel : BaseComponentModel
@@ -99,6 +123,7 @@ public class PrivateChatEntry : BaseComponentView, IComponentModelConfig
         public string pictureUrl;
         public bool isBlocked;
         public bool isOnline;
+        public bool imageFetchingEnabled;
 
         public PrivateChatEntryModel(string userId, string userName, string lastMessage, string pictureUrl, bool isBlocked, bool isOnline,
             ulong lastMessageTimestamp)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
@@ -7,6 +7,8 @@ using UnityEngine.UI;
 
 public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowView, IComponentModelConfig
 {
+    private const int CREATION_AMOUNT_PER_FRAME = 5;
+
     [SerializeField] private CollapsablePublicChannelListComponentView publicChannelList;
     [SerializeField] private CollapsableDirectChatListComponentView directChatList;
     [SerializeField] private CollapsableChatSearchListComponentView searchResultsList;
@@ -21,8 +23,16 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
     [SerializeField] private SearchBarComponentView searchBar;
     [SerializeField] private WorldChatWindowModel model;
 
-    private string lastSearch;
-    private bool privateChatsSortingDirty;
+    [Header("Load More Entries")] [SerializeField]
+    private Button loadMoreEntriesButton;
+
+    [SerializeField] private GameObject loadMoreEntriesContainer;
+    [SerializeField] private TMP_Text loadMoreEntriesLabel;
+
+    private readonly Queue<PrivateChatModel> creationQueue = new Queue<PrivateChatModel>();
+    private bool isSortingDirty;
+    private bool isLayoutDirty;
+    private Dictionary<string, PrivateChatModel> filteredPrivateChats;
 
     public event Action OnClose;
     public event Action<string> OnOpenPrivateChat;
@@ -34,8 +44,12 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
         remove => directChatList.OnUnfriend -= value;
     }
 
+    public event Action<string> OnSearchChannelRequested;
+    public event Action OnRequireMorePrivateChats;
+
     public RectTransform Transform => (RectTransform) transform;
     public bool IsActive => gameObject.activeInHierarchy;
+    public int PrivateChannelsCount => directChatList.Count() + creationQueue.Count;
 
     public static WorldChatWindowComponentView Create()
     {
@@ -49,7 +63,8 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
         directChatList.SortingMethod = (a, b) => b.Model.lastMessageTimestamp.CompareTo(a.Model.lastMessageTimestamp);
         directChatList.OnOpenChat += entry => OnOpenPrivateChat?.Invoke(entry.Model.userId);
         publicChannelList.OnOpenChat += entry => OnOpenPublicChannel?.Invoke(entry.Model.channelId);
-        searchBar.OnSearchText += Filter;
+        searchBar.OnSearchText += text => OnSearchChannelRequested?.Invoke(text);
+        loadMoreEntriesButton.onClick.AddListener(() => OnRequireMorePrivateChats?.Invoke());
         UpdateHeaders();
     }
 
@@ -69,32 +84,28 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
     public override void Update()
     {
         base.Update();
-        
-        if (privateChatsSortingDirty)
+
+        if (isSortingDirty)
+        {
             directChatList.Sort();
-        privateChatsSortingDirty = false;
+            searchResultsList.Sort();
+            publicChannelList.Sort();
+        }
+
+        isSortingDirty = false;
+
+        if (isLayoutDirty)
+            ((RectTransform) scroll.transform).ForceUpdateLayout();
+        isLayoutDirty = false;
+
+        SetQueuedEntries();
     }
 
     public void Show() => gameObject.SetActive(true);
 
     public void Hide() => gameObject.SetActive(false);
 
-    public void SetPrivateChat(PrivateChatModel model)
-    {
-        var user = model.user;
-        directChatList.Set(user.userId, new PrivateChatEntry.PrivateChatEntryModel(
-            user.userId,
-            user.userName,
-            model.recentMessage.body,
-            user.face256SnapshotURL,
-            model.isBlocked,
-            model.isOnline,
-            model.recentMessage.timestamp));
-        directChatList.Sort();
-        UpdateHeaders();
-        UpdateLayout();
-        privateChatsSortingDirty = true;
-    }
+    public void SetPrivateChat(PrivateChatModel model) => creationQueue.Enqueue(model);
 
     public void RemovePrivateChat(string userId)
     {
@@ -126,6 +137,64 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
         directChatList.RefreshBlockedEntries(blockedUsers);
     }
 
+    public void HideMoreChatsToLoadHint()
+    {
+        loadMoreEntriesContainer.SetActive(false);
+        UpdateLayout();
+    }
+
+    public void ShowMoreChatsToLoadHint(int count)
+    {
+        loadMoreEntriesLabel.SetText(
+            $"{count} chats hidden. Use the search bar to find them or click below to show more.");
+        ShowMoreChatsToLoadHint();
+    }
+
+    public void ClearFilter()
+    {
+        filteredPrivateChats = null;
+        searchResultsList.Export(publicChannelList, directChatList);
+        searchResultsList.Hide();
+        publicChannelList.Show();
+        publicChannelList.Sort();
+        directChatList.Show();
+        directChatList.Sort();
+        directChannelHeader.SetActive(true);
+        searchResultsHeader.SetActive(false);
+
+        directChatList.Filter(entry => true);
+        publicChannelList.Filter(entry => true);
+
+        UpdateHeaders();
+    }
+
+    public void Filter(Dictionary<string, PrivateChatModel> privateChats,
+        Dictionary<string, PublicChatChannelModel> publicChannels)
+    {
+        filteredPrivateChats = privateChats;
+
+        foreach (var chat in privateChats)
+            if (!directChatList.Contains(chat.Key))
+                SetPrivateChat(chat.Value);
+
+        foreach (var channel in publicChannels)
+            if (!publicChannelList.Contains(channel.Key))
+                SetPublicChannel(channel.Value);
+
+        searchResultsList.Import(publicChannelList, directChatList);
+        searchResultsList.Show();
+        searchResultsList.Sort();
+        publicChannelList.Hide();
+        directChatList.Hide();
+        directChannelHeader.SetActive(false);
+        searchResultsHeader.SetActive(true);
+
+        searchResultsList.Filter(entry => privateChats.ContainsKey(entry.Model.userId),
+            entry => publicChannels.ContainsKey(entry.Model.channelId));
+
+        UpdateHeaders();
+    }
+
     public override void RefreshControl()
     {
         publicChannelList.Clear();
@@ -137,36 +206,40 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
         SetPrivateChatLoadingVisibility(model.isLoadingDirectChats);
     }
 
-    private void Filter(string search)
+    private void Set(PrivateChatModel model)
     {
-        if (string.IsNullOrEmpty(search) && !string.IsNullOrEmpty(lastSearch))
-        {
-            searchResultsList.Export(publicChannelList, directChatList);
-            searchResultsList.Hide();
-            publicChannelList.Show();
-            publicChannelList.Sort();
-            directChatList.Show();
-            directChatList.Sort();
-            directChannelHeader.SetActive(true);
-            searchResultsHeader.SetActive(false);
-        }
+        var user = model.user;
+        var userId = user.userId;
+        
+        var entry = new PrivateChatEntry.PrivateChatEntryModel(
+            user.userId,
+            user.userName,
+            model.recentMessage.body,
+            user.face256SnapshotURL,
+            model.isBlocked,
+            model.isOnline,
+            model.recentMessage.timestamp);
 
-        if (!string.IsNullOrEmpty(search) && string.IsNullOrEmpty(lastSearch))
+        if (filteredPrivateChats?.ContainsKey(userId) ?? false)
         {
-            searchResultsList.Import(publicChannelList, directChatList);
-            searchResultsList.Show();
-            searchResultsList.Sort();
-            publicChannelList.Hide();
-            directChatList.Hide();
-            directChannelHeader.SetActive(false);
-            searchResultsHeader.SetActive(true);
+            directChatList.Remove(userId);
+            publicChannelList.Remove(userId);
+            searchResultsList.Set(entry);
         }
-
-        searchResultsList.Filter(search);
-        publicChannelList.Filter(search);
-        directChatList.Filter(search);
-        lastSearch = search;
+        else
+            directChatList.Set(userId, entry);
+        
         UpdateHeaders();
+        UpdateLayout();
+        SortLists();
+    }
+
+    private void SortLists() => isSortingDirty = true;
+
+    private void ShowMoreChatsToLoadHint()
+    {
+        loadMoreEntriesContainer.SetActive(true);
+        UpdateLayout();
     }
 
     private void SetPrivateChatLoadingVisibility(bool visible)
@@ -182,6 +255,14 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
         directChatsHeaderLabel.text = $"Direct Messages ({directChatList.Count()})";
         searchResultsHeaderLabel.text = $"Results ({searchResultsList.Count()})";
     }
-    
-    private void UpdateLayout() => ((RectTransform) scroll.transform).ForceUpdateLayout();
+
+    private void UpdateLayout() => isLayoutDirty = true;
+
+    private void SetQueuedEntries()
+    {
+        if (creationQueue.Count == 0) return;
+
+        for (var i = 0; i < CREATION_AMOUNT_PER_FRAME && creationQueue.Count > 0; i++)
+            Set(creationQueue.Dequeue());
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -166,7 +166,10 @@ public class WorldChatWindowController : IHUD
         if (ShouldDisplayPrivateChat(message))
             view.SetPrivateChat(CreatePrivateChatModel(message, profile));
         else if (!pendingPrivateChats.Contains(profile.userId))
+        {
             pendingPrivateChats.Enqueue(profile.userId);
+            UpdateMoreChannelsToLoadHint();
+        }
     }
 
     private bool ShouldDisplayPrivateChat(ChatMessage message)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -1,19 +1,25 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using DCL.Interface;
 
 public class WorldChatWindowController : IHUD
 {
     private const string GENERAL_CHANNEL_ID = "general";
+    private const int MAX_SEARCHED_CHANNELS = 100;
+    private const int LOAD_PRIVATE_CHATS_ON_DEMAND_COUNT = 30;
+    private const int INITIAL_DISPLAYED_PRIVATE_CHAT_COUNT = 50;
     
     private readonly IUserProfileBridge userProfileBridge;
     private readonly IFriendsController friendsController;
     private readonly IChatController chatController;
     private readonly ILastReadMessagesService lastReadMessagesService;
-
-    private Dictionary<string, UserProfile> recipientsFromPrivateChats = new Dictionary<string, UserProfile>();
-    private Dictionary<string, ChatMessage> lastPrivateMessages = new Dictionary<string, ChatMessage>();
+    private readonly Queue<string> pendingPrivateChats = new Queue<string>();
+    private readonly Dictionary<string, PublicChatChannelModel> publicChannels = new Dictionary<string, PublicChatChannelModel>();
+    private readonly Dictionary<string, UserProfile> recipientsFromPrivateChats = new Dictionary<string, UserProfile>();
+    private readonly Dictionary<string, ChatMessage> lastPrivateMessages = new Dictionary<string, ChatMessage>();
+    
     private IWorldChatWindowView view;
     private UserProfile ownUserProfile;
 
@@ -21,7 +27,6 @@ public class WorldChatWindowController : IHUD
 
     public event Action<string> OnOpenPrivateChat;
     public event Action<string> OnOpenPublicChannel;
-    public event Action OnDeactivatePreview;
     public event Action OnOpen;
 
     public WorldChatWindowController(
@@ -44,22 +49,29 @@ public class WorldChatWindowController : IHUD
         view.OnOpenPrivateChat += OpenPrivateChat;
         view.OnOpenPublicChannel += OpenPublicChannel;
         view.OnUnfriend += HandleUnfriend;
+        view.OnSearchChannelRequested += SearchChannels;
+        view.OnRequireMorePrivateChats += ShowMorePrivateChats;
+        
         ownUserProfile = userProfileBridge.GetOwn();
+        if (ownUserProfile != null)
+            ownUserProfile.OnUpdate += OnUserProfileUpdate;
+        
         // TODO: this data should come from the chat service when channels are implemented
-        view.SetPublicChannel(new PublicChatChannelModel(GENERAL_CHANNEL_ID, "nearby",
-            "Talk to the people around you. If you move far away from someone you will lose contact. All whispers will be displayed."));
-        var privateChatsByRecipient = GetLastPrivateChatByRecipient(chatController.GetEntries());
-        lastPrivateMessages = privateChatsByRecipient.ToDictionary(pair => pair.Key.userId, pair => pair.Value);
-        recipientsFromPrivateChats = privateChatsByRecipient.Keys.ToDictionary(profile => profile.userId);
-        ShowPrivateChats(privateChatsByRecipient);
-        if (privateChatsByRecipient.Count == 0)
+        publicChannels[GENERAL_CHANNEL_ID] = new PublicChatChannelModel(GENERAL_CHANNEL_ID, "nearby",
+            "Talk to the people around you. If you move far away from someone you will lose contact. All whispers will be displayed.");
+        view.SetPublicChannel(publicChannels[GENERAL_CHANNEL_ID]);
+        
+        foreach (var value in chatController.GetEntries())
+            HandleMessageAdded(value);
+        
+        if (!friendsController.isInitialized)
             view.ShowPrivateChatsLoading();
+        
         chatController.OnAddMessage += HandleMessageAdded;
         friendsController.OnUpdateUserStatus += HandleUserStatusChanged;
         friendsController.OnInitialized += HandleFriendsControllerInitialization;
 
-        if (ownUserProfile != null)
-            ownUserProfile.OnUpdate += OnUserProfileUpdate;
+        UpdateMoreChannelsToLoadHint();
     }
 
     public void Dispose()
@@ -68,6 +80,8 @@ public class WorldChatWindowController : IHUD
         view.OnOpenPrivateChat -= OpenPrivateChat;
         view.OnOpenPublicChannel -= OpenPublicChannel;
         view.OnUnfriend -= HandleUnfriend;
+        view.OnSearchChannelRequested -= SearchChannels;
+        view.OnRequireMorePrivateChats -= ShowMorePrivateChats;
         view.Dispose();
         chatController.OnAddMessage -= HandleMessageAdded;
         friendsController.OnUpdateUserStatus -= HandleUserStatusChanged;
@@ -80,7 +94,10 @@ public class WorldChatWindowController : IHUD
     public void SetVisibility(bool visible)
     {
         if (visible)
+        {
             view.Show();
+            OnOpen?.Invoke();
+        }
         else
             view.Hide();
     }
@@ -110,6 +127,7 @@ public class WorldChatWindowController : IHUD
     {
         if (!recipientsFromPrivateChats.ContainsKey(userId)) return;
         if (!lastPrivateMessages.ContainsKey(userId)) return;
+        if (pendingPrivateChats.Contains(userId)) return;
         if (status.friendshipStatus == FriendshipStatus.FRIEND)
         {
             var profile = recipientsFromPrivateChats[userId];
@@ -128,59 +146,112 @@ public class WorldChatWindowController : IHUD
         }
     }
 
-    private void ShowPrivateChats(Dictionary<UserProfile, ChatMessage> privateChatsByRecipient)
-    {
-        // TODO: throttle in case of hiccups
-        foreach (var pair in privateChatsByRecipient)
-        {
-            var user = pair.Key;
-            var message = pair.Value;
-            view.SetPrivateChat(new PrivateChatModel
-            {
-                user = user,
-                recentMessage = message,
-                isBlocked = ownUserProfile.IsBlocked(user.userId),
-                isOnline = friendsController.GetUserStatus(user.userId).presence == PresenceStatus.ONLINE
-            });
-        }
-    }
-
     private void HandleMessageAdded(ChatMessage message)
     {
         if (message.messageType != ChatMessage.Type.PRIVATE) return;
         var profile = ExtractRecipient(message);
         if (profile == null) return;
         if (friendsController.isInitialized && !friendsController.IsFriend(profile.userId)) return;
-        lastPrivateMessages[profile.userId] = message;
-        recipientsFromPrivateChats[profile.userId] = profile;
-        view.SetPrivateChat(new PrivateChatModel
+
+        if (lastPrivateMessages.ContainsKey(profile.userId))
         {
-            user = profile,
-            recentMessage = message,
-            isBlocked = ownUserProfile.IsBlocked(profile.userId),
-            isOnline = friendsController.GetUserStatus(profile.userId).presence == PresenceStatus.ONLINE
-        });
+            if (message.timestamp > lastPrivateMessages[profile.userId].timestamp)
+                lastPrivateMessages[profile.userId] = message;
+        }
+        else
+            lastPrivateMessages[profile.userId] = message;
+        
+        recipientsFromPrivateChats[profile.userId] = profile;
+
+        if (ShouldDisplayPrivateChat(message))
+            view.SetPrivateChat(CreatePrivateChatModel(message, profile));
+        else if (!pendingPrivateChats.Contains(profile.userId))
+            pendingPrivateChats.Enqueue(profile.userId);
     }
 
-    private Dictionary<UserProfile, ChatMessage> GetLastPrivateChatByRecipient(IEnumerable<ChatMessage> messages)
+    private bool ShouldDisplayPrivateChat(ChatMessage message)
     {
-        var chatsByRecipient = new Dictionary<UserProfile, ChatMessage>();
+        if (view.PrivateChannelsCount < INITIAL_DISPLAYED_PRIVATE_CHAT_COUNT) return true;
+        var messageTimestamp = DateTimeOffset.FromUnixTimeMilliseconds((long) message.timestamp);
+        return (DateTime.UtcNow - messageTimestamp).TotalDays <= 1;
+    }
 
-        foreach (var message in messages)
+    private PrivateChatModel CreatePrivateChatModel(ChatMessage recentMessage, UserProfile profile)
+    {
+        return new PrivateChatModel
         {
-            if (message.messageType != ChatMessage.Type.PRIVATE) continue;
-            var profile = ExtractRecipient(message);
-            if (!chatsByRecipient.ContainsKey(profile))
-                chatsByRecipient.Add(profile, message);
-            else if (message.timestamp > chatsByRecipient[profile].timestamp)
-                chatsByRecipient[profile] = message;
-        }
-
-        return chatsByRecipient;
+            user = profile,
+            recentMessage = recentMessage,
+            isBlocked = ownUserProfile.IsBlocked(profile.userId),
+            isOnline = friendsController.GetUserStatus(profile.userId).presence == PresenceStatus.ONLINE
+        };
     }
 
     private UserProfile ExtractRecipient(ChatMessage message) =>
         userProfileBridge.Get(message.sender != ownUserProfile.userId ? message.sender : message.recipient);
 
-    private void OnUserProfileUpdate(UserProfile profile) { view.RefreshBlockedDirectMessages(profile.blocked); }
+    private void OnUserProfileUpdate(UserProfile profile) => view.RefreshBlockedDirectMessages(profile.blocked);
+    
+    private void ShowOrHideMoreFriendsToLoadHint()
+    {
+        if (pendingPrivateChats.Count == 0)
+            View.HideMoreChatsToLoadHint();
+        else
+            View.ShowMoreChatsToLoadHint(pendingPrivateChats.Count);
+    }
+    
+    private void SearchChannels(string search)
+    {
+        if (string.IsNullOrEmpty(search))
+        {
+            View.ClearFilter();
+            ShowOrHideMoreFriendsToLoadHint();
+            return;
+        }
+
+        Dictionary<string, PrivateChatModel> FilterPrivateChannelsByUserName(string search)
+        {
+            var regex = new Regex(search, RegexOptions.IgnoreCase);
+
+            return recipientsFromPrivateChats.Values.Where(profile =>
+                !string.IsNullOrEmpty(profile.userName) && regex.IsMatch(profile.userName))
+                .Take(MAX_SEARCHED_CHANNELS)
+                .ToDictionary(model => model.userId, profile => CreatePrivateChatModel(lastPrivateMessages[profile.userId], profile));
+        }
+
+        Dictionary<string, PublicChatChannelModel> FilterPublicChannelsByName(string search)
+        {
+            var regex = new Regex(search, RegexOptions.IgnoreCase);
+
+            return publicChannels.Values
+                .Where(model => !string.IsNullOrEmpty(model.name) && regex.IsMatch(model.name))
+                .Take(MAX_SEARCHED_CHANNELS)
+                .ToDictionary(model => model.channelId, model => model);
+        }
+
+        View.Filter(FilterPrivateChannelsByUserName(search), FilterPublicChannelsByName(search));
+    }
+    
+    private void ShowMorePrivateChats()
+    {
+        for (var i = 0; i < LOAD_PRIVATE_CHATS_ON_DEMAND_COUNT && pendingPrivateChats.Count > 0; i++)
+        {
+            var userId = pendingPrivateChats.Dequeue();
+            if (!lastPrivateMessages.ContainsKey(userId)) continue;
+            if (!recipientsFromPrivateChats.ContainsKey(userId)) continue;
+            var recentMessage = lastPrivateMessages[userId];
+            var profile = recipientsFromPrivateChats[userId];
+            View.SetPrivateChat(CreatePrivateChatModel(recentMessage, profile));
+        }
+
+        UpdateMoreChannelsToLoadHint();
+    }
+    
+    private void UpdateMoreChannelsToLoadHint()
+    {
+        if (pendingPrivateChats.Count == 0)
+            View.HideMoreChatsToLoadHint();
+        else
+            View.ShowMoreChatsToLoadHint(pendingPrivateChats.Count);
+    }
 }

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/CollapsableSortedList/CollapsableSortedListComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/CollapsableSortedList/CollapsableSortedListComponentView.cs
@@ -122,7 +122,7 @@ namespace UIComponents.CollapsableSortedList
             UpdateLayout();
         }
 
-        public void Filter(Func<V, bool> comparision)
+        public virtual void Filter(Func<V, bool> comparision)
         {
             filteredCount = 0;
 


### PR DESCRIPTION
## What does this PR change?

`Closes #2344 `

## How to test the changes?

### With less than 50 direct message entries
1. check that list is displayed correctly
2. check the search bar works as expected
3. all profile pictures of the visible entries should be displayed correctly

### With more than 50 direct message entries
1. a max of 50 entries should be loaded at start
2. when you scroll to the bottom an option saying "show more" should be displayed with label indicating how many entries are hidden
3. click the "show more" button, it should display another 30 entries
4. use the search bar. All entries should be displayed matching your input, no matter if they were displayed or not
5. check that all profile pictures of the visible entries are displayed correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
