### PR TITLE
feat: nearby channel always active

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -231,23 +231,19 @@ public class HUDController : IHUDController
                 if (PublicChatChannelHud == null)
                 {
                     CreateHudElement(configuration, HUDElementID.PUBLIC_CHAT_CHANNEL);
-                    if (PublicChatChannelHud != null)
-                    {
-                        PublicChatChannelHud.Initialize();
-                        PublicChatChannelHud.OnBack -= HandlePublicChatChannelBacked;
-                        PublicChatChannelHud.OnBack += HandlePublicChatChannelBacked;
-                        PublicChatChannelHud.OnClosed -= HandlePublicChatChannelClosed;
-                        PublicChatChannelHud.OnClosed += HandlePublicChatChannelClosed;
-                        PublicChatChannelHud.SetVisibility(false);
-                    }
+                    PublicChatChannelHud.Initialize();
+                    PublicChatChannelHud.OnBack -= HandlePublicChatChannelBacked;
+                    PublicChatChannelHud.OnBack += HandlePublicChatChannelBacked;
+                    PublicChatChannelHud.OnClosed -= HandlePublicChatChannelClosed;
+                    PublicChatChannelHud.OnClosed += HandlePublicChatChannelClosed;
                     taskbarHud?.AddPublicChatChannel(PublicChatChannelHud);
                     // TODO: this call should be removed when chat notifications are implemented
-                    taskbarHud?.OpenPublicChatChannel("general");
+                    taskbarHud?.OpenPublicChatChannel("general", false);
                     PublicChatChannelHud.ActivatePreviewModeInstantly();
                 }
                 else
                     UpdateHudElement(configuration, HUDElementID.PUBLIC_CHAT_CHANNEL);
-                
+
                 if (PrivateChatWindow == null)
                 {
                     CreateHudElement(configuration, HUDElementID.PRIVATE_CHAT_WINDOW);
@@ -395,7 +391,7 @@ public class HUDController : IHUDController
 
     private void OpenPublicChannelWindow(string channelId)
     {
-        taskbarHud?.OpenPublicChatChannel(channelId);
+        taskbarHud?.OpenPublicChatChannel(channelId, true);
     }
 
     private void OpenPrivateChatWindow(string targetUserId)
@@ -458,7 +454,7 @@ public class HUDController : IHUDController
             PublicChatChannelHud.OnClosed -= HandlePublicChatChannelClosed;
             PublicChatChannelHud.OnBack -= HandlePublicChatChannelBacked;
         }
-            
+
 
         if (friendsHud != null)
             friendsHud.OnPressWhisper -= OpenPrivateChatWindow;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -158,7 +158,10 @@ public class TaskbarHUDController : IHUD
             OpenFriendsWindow();
         }
         else
+        {
             CloseFriendsWindow();
+            OpenPublicChannelOnPreviewMode();
+        }
     }
 
     private void ToggleWorldChatTrigger_OnTriggered(DCLAction_Trigger action)
@@ -183,11 +186,10 @@ public class TaskbarHUDController : IHUD
         if (mouseCatcher.isLocked) return;
         worldChatWindowHud.SetVisibility(false);
         privateChatWindow.SetVisibility(false);
-        publicChatChannel.SetVisibility(false);
         friendsHud?.SetVisibility(false);
         isEmotesVisible.Set(false);
         isExperiencesViewerOpen.Set(false);
-        view.ToggleAllOff();
+        OpenPublicChannelOnPreviewMode();
     }
 
     private void HandleChatToggle(bool show)
@@ -198,7 +200,10 @@ public class TaskbarHUDController : IHUD
             OpenLastActiveChatWindow(chatToggleTargetWindow);
         }
         else
+        {
             CloseAnyChatWindow();
+            OpenPublicChannelOnPreviewMode();
+        }
         
         OnAnyTaskbarButtonClicked?.Invoke();
     }
@@ -217,6 +222,7 @@ public class TaskbarHUDController : IHUD
         // view.ToggleAllOff();
         CloseFriendsWindow();
         CloseChatList();
+        OpenPublicChannelOnPreviewMode();
     }
 
     public void AddWorldChatWindow(WorldChatWindowController controller)
@@ -236,12 +242,14 @@ public class TaskbarHUDController : IHUD
         worldChatWindowHud = controller;
 
         view.ShowChatButton();
-        worldChatWindowHud.View.OnClose += () =>
-        {
-            if (!privateChatWindow.View.IsActive
-                && !publicChatChannel.View.IsActive)
-                view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
-        };
+        worldChatWindowHud.View.OnClose += OpenPublicChannelOnPreviewMode;
+    }
+
+    private void OpenPublicChannelOnPreviewMode()
+    {
+        publicChatChannel.SetVisibility(true);
+        publicChatChannel.ActivatePreviewModeInstantly();
+        view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
     }
 
     private void OpenFriendsWindow()
@@ -298,7 +306,6 @@ public class TaskbarHUDController : IHUD
         worldChatWindowHud.SetVisibility(false);
         privateChatWindow.SetVisibility(false);
         publicChatChannel.SetVisibility(false);
-        view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
     }
 
     public void OpenPublicChatChannel(string channelId)
@@ -352,9 +359,9 @@ public class TaskbarHUDController : IHUD
 
         controller.OnClosed += () =>
         {
-            if (!worldChatWindowHud.View.IsActive
-                && !publicChatChannel.View.IsActive)
-                view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
+            publicChatChannel.SetVisibility(true);
+            publicChatChannel.ActivatePreviewModeInstantly();
+            view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
         };
     }
 
@@ -373,12 +380,7 @@ public class TaskbarHUDController : IHUD
         
         publicChatChannel = controller;
 
-        controller.OnClosed += () =>
-        {
-            if (!worldChatWindowHud.View.IsActive
-                && !privateChatWindow.View.IsActive)
-                view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
-        };
+        controller.OnClosed += OpenPublicChannelOnPreviewMode;
     }
 
     public void AddFriendsWindow(FriendsHUDController controller)
@@ -397,7 +399,11 @@ public class TaskbarHUDController : IHUD
 
         friendsHud = controller;
         view.ShowFriendsButton();
-        friendsHud.View.OnClose += () => view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Friends);
+        friendsHud.View.OnClose += () =>
+        {
+            view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Friends);
+            OpenPublicChannelOnPreviewMode();
+        };
     }
 
     private void InitializeEmotesSelector(bool current, bool previous) 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -96,16 +96,26 @@ public class TaskbarHUDController : IHUD
         if (show)
             OpenFriendsWindow();
         else
+        {
             friendsHud?.SetVisibility(false);
+            OpenPublicChannelOnPreviewMode();
+        }
+            
         OnAnyTaskbarButtonClicked?.Invoke();
     }
 
     private void HandleEmotesToggle(bool show)
     {
         if (show)
+        {
+            OpenPublicChannelOnPreviewMode();
             ShowEmotes();
+        }
         else
+        {
             isEmotesVisible.Set(false);
+            OpenPublicChannelOnPreviewMode();
+        }
         OnAnyTaskbarButtonClicked?.Invoke();
     }
 
@@ -113,7 +123,6 @@ public class TaskbarHUDController : IHUD
     {
         worldChatWindowHud.SetVisibility(false);
         privateChatWindow.SetVisibility(false);
-        publicChatChannel.SetVisibility(false);
         friendsHud?.SetVisibility(false);
         isExperiencesViewerOpen.Set(false);
         isEmotesVisible.Set(true);
@@ -125,7 +134,11 @@ public class TaskbarHUDController : IHUD
         if (show)
             ShowExperiences();
         else
+        {
             isExperiencesViewerOpen.Set(false);
+            OpenPublicChannelOnPreviewMode();
+        }
+            
         OnAnyTaskbarButtonClicked?.Invoke();
     }
 
@@ -233,8 +246,7 @@ public class TaskbarHUDController : IHUD
             return;
         }
 
-        if (controller.View.Transform.parent == view.leftWindowContainer)
-            return;
+        if (controller.View.Transform.parent == view.leftWindowContainer) return;
 
         controller.View.Transform.SetParent(view.leftWindowContainer, false);
         experiencesViewerTransform?.SetAsLastSibling();
@@ -247,7 +259,7 @@ public class TaskbarHUDController : IHUD
 
     private void OpenPublicChannelOnPreviewMode()
     {
-        publicChatChannel.SetVisibility(true);
+        publicChatChannel.SetVisibility(true, false);
         publicChatChannel.ActivatePreviewModeInstantly();
         view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
     }
@@ -306,9 +318,10 @@ public class TaskbarHUDController : IHUD
         worldChatWindowHud.SetVisibility(false);
         privateChatWindow.SetVisibility(false);
         publicChatChannel.SetVisibility(false);
+        view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
     }
 
-    public void OpenPublicChatChannel(string channelId)
+    public void OpenPublicChatChannel(string channelId, bool focusInputField)
     {
         publicChatChannel?.Setup(channelId);
         worldChatWindowHud?.SetVisibility(false);
@@ -316,7 +329,7 @@ public class TaskbarHUDController : IHUD
         friendsHud?.SetVisibility(false);
         isExperiencesViewerOpen?.Set(false);
         isEmotesVisible?.Set(false);
-        publicChatChannel?.SetVisibility(true);
+        publicChatChannel?.SetVisibility(true, focusInputField);
         view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
         chatToggleTargetWindow = publicChatChannel;
         chatInputTargetWindow = publicChatChannel;
@@ -357,12 +370,7 @@ public class TaskbarHUDController : IHUD
 
         privateChatWindow = controller;
 
-        controller.OnClosed += () =>
-        {
-            publicChatChannel.SetVisibility(true);
-            publicChatChannel.ActivatePreviewModeInstantly();
-            view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
-        };
+        controller.OnClosed += OpenPublicChannelOnPreviewMode;
     }
 
     public void AddPublicChatChannel(PublicChatChannelController controller)
@@ -412,13 +420,7 @@ public class TaskbarHUDController : IHUD
         view.ShowEmotesButton(); 
     }
 
-    private void IsEmotesVisibleChanged(bool current, bool previous)
-    {
-        if (current && !isEmotesVisible.Get())
-            return;
-
-        view.emotesButton.SetToggleState(current, false);
-    }
+    private void IsEmotesVisibleChanged(bool current, bool previous) => HandleEmotesToggle(current);
 
     private void InitializeExperiencesViewer(Transform currentViewTransform, Transform previousViewTransform)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDView.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -27,7 +26,7 @@ public class TaskbarHUDView : MonoBehaviour
     private readonly Dictionary<TaskbarButtonType, TaskbarButton> buttonsByType =
         new Dictionary<TaskbarButtonType, TaskbarButton>();
 
-    private TaskbarButtonType lastToggledOnButton = TaskbarButtonType.None;
+    private TaskbarButton lastToggledOnButton;
 
     public event System.Action<bool> OnChatToggle;
     public event System.Action<bool> OnFriendsToggle;
@@ -111,61 +110,55 @@ public class TaskbarHUDView : MonoBehaviour
         experiencesContainer.SetActive(visible);
     }
 
-    public void ToggleAllOff()
-    {
-        lastToggledOnButton = GetToggledOnButtonType();
-        foreach (var button in buttonsByType.Keys)
-            ToggleOff(button);
-    }
-
     public void ToggleOn(TaskbarButtonType buttonType) => ToggleOn(buttonsByType[buttonType], false);
 
     public void ToggleOff(TaskbarButtonType buttonType) => ToggleOff(buttonsByType[buttonType], false);
     
     private void ToggleOn(TaskbarButton obj) => ToggleOn(obj, true);
 
-    private TaskbarButtonType GetToggledOnButtonType()
-    {
-        return buttonsByType.Any(pair => pair.Value.toggledOn)
-            ? buttonsByType.First(pair => pair.Value.toggledOn).Key
-            : TaskbarButtonType.None;
-    }
-
     private void ToggleOn(TaskbarButton obj, bool useCallback)
     {
-        if (useCallback)
-        {
-            if (obj == friendsButton)
-                OnFriendsToggle?.Invoke(true);
-            if (obj == emotesButton)
-                OnEmotesToggle?.Invoke(true);
-            else if (obj == chatButton)
-                OnChatToggle?.Invoke(true);
-            else if (obj == experiencesButton)
-                OnExperiencesToggle?.Invoke(true);    
-        }
-
+        var wasToggled = lastToggledOnButton == obj;
+        lastToggledOnButton = obj;
+        
         foreach (var btn in buttonsByType.Values)
             btn.SetToggleState(btn == obj, useCallback);
+
+        if (!useCallback) return;
+        if (wasToggled) return;
+        
+        if (obj == friendsButton)
+            OnFriendsToggle?.Invoke(true);
+        if (obj == emotesButton)
+            OnEmotesToggle?.Invoke(true);
+        else if (obj == chatButton)
+            OnChatToggle?.Invoke(true);
+        else if (obj == experiencesButton)
+            OnExperiencesToggle?.Invoke(true);
     }
 
     private void ToggleOff(TaskbarButton obj) => ToggleOff(obj, true);
 
     private void ToggleOff(TaskbarButton obj, bool useCallback)
     {
-        if (useCallback)
-        {
-            if (obj == friendsButton)
-                OnFriendsToggle?.Invoke(false);
-            if (obj == emotesButton)
-                OnEmotesToggle?.Invoke(false);
-            else if (obj == chatButton)
-                OnChatToggle?.Invoke(false);
-            else if (obj == experiencesButton)
-                OnExperiencesToggle?.Invoke(false);    
-        }
-            
+        var wasToggled = lastToggledOnButton == obj;
+        
+        if (wasToggled)
+            lastToggledOnButton = null;
+        
         obj.SetToggleState(false, useCallback);
+
+        if (!useCallback) return;
+        if (!wasToggled) return;
+        
+        if (obj == friendsButton)
+            OnFriendsToggle?.Invoke(false);
+        if (obj == emotesButton)
+            OnEmotesToggle?.Invoke(false);
+        else if (obj == chatButton)
+            OnChatToggle?.Invoke(false);
+        else if (obj == experiencesButton)
+            OnExperiencesToggle?.Invoke(false);
     }
 
     internal void ShowChatButton()
@@ -200,12 +193,6 @@ public class TaskbarHUDView : MonoBehaviour
             taskbarAnimator.Show(instant);
         else
             taskbarAnimator.Hide(instant);
-    }
-
-    public void RestoreLastToggle()
-    {
-        if (lastToggledOnButton == TaskbarButtonType.None) return;
-        ToggleOn(lastToggledOnButton);
     }
 
     public enum TaskbarButtonType

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatChannelController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatChannelController.cs
@@ -23,7 +23,6 @@ public class PublicChatChannelController : IHUD
     private double initTimeInSeconds;
     private string channelId;
     private CancellationTokenSource deactivatePreviewCancellationToken = new CancellationTokenSource();
-    private bool isFirstFocusSkipped;
     private bool skipChatInputTrigger;
     internal string lastPrivateMessageRecipient = string.Empty;
 
@@ -145,18 +144,16 @@ public class PublicChatChannelController : IHUD
         chatController.Send(message);
         socialAnalytics.SendChannelMessageSent(message.sender, message.body.Length, channelId);
     }
-
-    public void SetVisibility(bool visible)
+    
+    public void SetVisibility(bool visible, bool focusInputField)
     {
         if (visible)
         {
             View.Show();
             MarkChatMessagesAsRead();
-            // this is a terrible patch to keep preview mode activated at the start of the session
-            // the root of the problem comes from race conditions from input field's event triggers
-            if (isFirstFocusSkipped)
+            
+            if (focusInputField)
                 chatHudController.FocusInputField();
-            isFirstFocusSkipped = true;
         }
         else
         {
@@ -164,6 +161,8 @@ public class PublicChatChannelController : IHUD
             View.Hide();
         }
     }
+
+    public void SetVisibility(bool visible) => SetVisibility(visible, false);
 
     private async UniTaskVoid ReloadAllChats()
     {


### PR DESCRIPTION
## What does this PR change?

`closes #2368 `

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Toggle all buttons in the taskbar. Whenever any window closes, the nearby channel should be opened in "unfocused" mode
2. Press `B`, `ESC`, `L`. It should toggle different feature windows. When they are closed, the nearby chanell should be opened in "unfocused" mode
3. At the start of the session, the nearby channel should be open in "unfocused" mode

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
