### PR TITLE
feat: Avatar expression hearts get random pride-color

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionHeart.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionHeart.prefab
@@ -1614,25 +1614,27 @@ ParticleSystem:
     uvChannelMask: -1
     rowMode: 1
     sprites:
-    - sprite: {fileID: -1963845958742357998, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: -5678512871157408403, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: 2867782543290939051, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: -6134993809297719219, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: 7010944537311281634, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: -5653411428424605918, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: -4368468631126535990, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: -6234104402273833510, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: 6742681830430328498, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: -23437870716378929, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: -241883638187169623, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: 6726948905552063219, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: 8890448229390791921, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: 7065040574335784077, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: -8164254622701902531, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: -2592509462476873157, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: 5325486820111362789, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: 5026146890834185380, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
-    - sprite: {fileID: 7091995426309117335, guid: 85d6fa68939213d489bad857621e2796,
+    - sprite: {fileID: -5677250123261470903, guid: 442f06e710f18804e8fbbaae7286f8a7,
+        type: 3}
+    - sprite: {fileID: -924287825326529467, guid: 442f06e710f18804e8fbbaae7286f8a7,
         type: 3}
     flipU: 0
     flipV: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionHeart.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionHeart.prefab
@@ -1495,9 +1495,9 @@ ParticleSystem:
         m_NumAlphaKeys: 2
   UVModule:
     serializedVersion: 2
-    enabled: 0
-    mode: 0
-    timeMode: 0
+    enabled: 1
+    mode: 1
+    timeMode: 1
     fps: 30
     frameOverTime:
       serializedVersion: 2
@@ -1554,8 +1554,8 @@ ParticleSystem:
         m_RotationOrder: 4
     startFrame:
       serializedVersion: 2
-      minMaxState: 0
-      scalar: 0
+      minMaxState: 3
+      scalar: 0.9999
       minScalar: 0
       maxCurve:
         serializedVersion: 2
@@ -1605,7 +1605,7 @@ ParticleSystem:
         m_PreInfinity: 2
         m_PostInfinity: 2
         m_RotationOrder: 4
-    speedRange: {x: 0, y: 1}
+    speedRange: {x: 0, y: 0}
     tilesX: 1
     tilesY: 1
     animationType: 0
@@ -1614,7 +1614,26 @@ ParticleSystem:
     uvChannelMask: -1
     rowMode: 1
     sprites:
-    - sprite: {fileID: 0}
+    - sprite: {fileID: -1963845958742357998, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: 2867782543290939051, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: 7010944537311281634, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: -4368468631126535990, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: 6742681830430328498, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: -241883638187169623, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: 8890448229390791921, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: -8164254622701902531, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: 5325486820111362789, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
+    - sprite: {fileID: 7091995426309117335, guid: 85d6fa68939213d489bad857621e2796,
+        type: 3}
     flipU: 0
     flipV: 0
   VelocityModule:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Textures/AvatarParticleExpressionHeartPride.png
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Textures/AvatarParticleExpressionHeartPride.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd7dabf9b394542b931eb09cc3f85482b39b9759b32ae4a3c51c1b88ee8bbf39
+size 144660

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Textures/AvatarParticleExpressionHeartPride.png
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Textures/AvatarParticleExpressionHeartPride.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd7dabf9b394542b931eb09cc3f85482b39b9759b32ae4a3c51c1b88ee8bbf39
-size 144660
+oid sha256:1cb942ce5e888c4fe9c015193cca2d7042f95d671fb77fe0f98e94f6b16a8746
+size 161688

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Textures/AvatarParticleExpressionHeartPride.png.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Textures/AvatarParticleExpressionHeartPride.png.meta
@@ -1,0 +1,348 @@
+fileFormatVersion: 2
+guid: 85d6fa68939213d489bad857621e2796
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -1963845958742357998
+    second: AvatarParticleExpressionHeartPride_0
+  - first:
+      213: 2867782543290939051
+    second: AvatarParticleExpressionHeartPride_1
+  - first:
+      213: 7010944537311281634
+    second: AvatarParticleExpressionHeartPride_2
+  - first:
+      213: -4368468631126535990
+    second: AvatarParticleExpressionHeartPride_3
+  - first:
+      213: 6742681830430328498
+    second: AvatarParticleExpressionHeartPride_4
+  - first:
+      213: -241883638187169623
+    second: AvatarParticleExpressionHeartPride_5
+  - first:
+      213: 8890448229390791921
+    second: AvatarParticleExpressionHeartPride_6
+  - first:
+      213: -8164254622701902531
+    second: AvatarParticleExpressionHeartPride_7
+  - first:
+      213: 5325486820111362789
+    second: AvatarParticleExpressionHeartPride_8
+  - first:
+      213: 7091995426309117335
+    second: AvatarParticleExpressionHeartPride_9
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_0
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 218439361840fb4e0800000000000000
+      internalID: -1963845958742357998
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_1
+      rect:
+        serializedVersion: 2
+        x: 256
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ba63ce967096cc720800000000000000
+      internalID: 2867782543290939051
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_2
+      rect:
+        serializedVersion: 2
+        x: 512
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2e1876e39e0eb4160800000000000000
+      internalID: 7010944537311281634
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_3
+      rect:
+        serializedVersion: 2
+        x: 768
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ac01445dce41063c0800000000000000
+      internalID: -4368468631126535990
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_4
+      rect:
+        serializedVersion: 2
+        x: 1024
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2b6c7488661d29d50800000000000000
+      internalID: 6742681830430328498
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_5
+      rect:
+        serializedVersion: 2
+        x: 1280
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 9a8efd4dc18a4acf0800000000000000
+      internalID: -241883638187169623
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_6
+      rect:
+        serializedVersion: 2
+        x: 1536
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 1f4b6de9f87316b70800000000000000
+      internalID: 8890448229390791921
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_7
+      rect:
+        serializedVersion: 2
+        x: 1792
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d35230e3dadb2be80800000000000000
+      internalID: -8164254622701902531
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_8
+      rect:
+        serializedVersion: 2
+        x: 2048
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 5ea23c81c0ee7e940800000000000000
+      internalID: 5325486820111362789
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride_9
+      rect:
+        serializedVersion: 2
+        x: 2304
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 79599d5e344db6260800000000000000
+      internalID: 7091995426309117335
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 165a302ece90e1d4b8149e8929a0d213
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Textures/AvatarParticleExpressionHeartPride.png.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Textures/AvatarParticleExpressionHeartPride.png.meta
@@ -1,37 +1,40 @@
 fileFormatVersion: 2
-guid: 85d6fa68939213d489bad857621e2796
+guid: 442f06e710f18804e8fbbaae7286f8a7
 TextureImporter:
   internalIDToNameTable:
   - first:
-      213: -1963845958742357998
-    second: AvatarParticleExpressionHeartPride_0
+      213: -5678512871157408403
+    second: AvatarParticleExpressionHeartPride 1_0
   - first:
-      213: 2867782543290939051
-    second: AvatarParticleExpressionHeartPride_1
+      213: -6134993809297719219
+    second: AvatarParticleExpressionHeartPride 1_1
   - first:
-      213: 7010944537311281634
-    second: AvatarParticleExpressionHeartPride_2
+      213: -5653411428424605918
+    second: AvatarParticleExpressionHeartPride 1_2
   - first:
-      213: -4368468631126535990
-    second: AvatarParticleExpressionHeartPride_3
+      213: -6234104402273833510
+    second: AvatarParticleExpressionHeartPride 1_3
   - first:
-      213: 6742681830430328498
-    second: AvatarParticleExpressionHeartPride_4
+      213: -23437870716378929
+    second: AvatarParticleExpressionHeartPride 1_4
   - first:
-      213: -241883638187169623
-    second: AvatarParticleExpressionHeartPride_5
+      213: 6726948905552063219
+    second: AvatarParticleExpressionHeartPride 1_5
   - first:
-      213: 8890448229390791921
-    second: AvatarParticleExpressionHeartPride_6
+      213: 7065040574335784077
+    second: AvatarParticleExpressionHeartPride 1_6
   - first:
-      213: -8164254622701902531
-    second: AvatarParticleExpressionHeartPride_7
+      213: -2592509462476873157
+    second: AvatarParticleExpressionHeartPride 1_7
   - first:
-      213: 5325486820111362789
-    second: AvatarParticleExpressionHeartPride_8
+      213: 5026146890834185380
+    second: AvatarParticleExpressionHeartPride 1_8
   - first:
-      213: 7091995426309117335
-    second: AvatarParticleExpressionHeartPride_9
+      213: -5677250123261470903
+    second: AvatarParticleExpressionHeartPride 1_9
+  - first:
+      213: -924287825326529467
+    second: AvatarParticleExpressionHeartPride 1_10
   externalObjects: {}
   serializedVersion: 11
   mipmaps:
@@ -121,7 +124,7 @@ TextureImporter:
     serializedVersion: 2
     sprites:
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_0
+      name: AvatarParticleExpressionHeartPride 1_0
       rect:
         serializedVersion: 2
         x: 0
@@ -135,14 +138,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: 218439361840fb4e0800000000000000
-      internalID: -1963845958742357998
+      spriteID: d6ddd2631aed131b0800000000000000
+      internalID: -5678512871157408403
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_1
+      name: AvatarParticleExpressionHeartPride 1_1
       rect:
         serializedVersion: 2
         x: 256
@@ -156,14 +159,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: ba63ce967096cc720800000000000000
-      internalID: 2867782543290939051
+      spriteID: d40c69192af1cdaa0800000000000000
+      internalID: -6134993809297719219
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_2
+      name: AvatarParticleExpressionHeartPride 1_2
       rect:
         serializedVersion: 2
         x: 512
@@ -177,14 +180,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: 2e1876e39e0eb4160800000000000000
-      internalID: 7010944537311281634
+      spriteID: 22f1e97424c0b81b0800000000000000
+      internalID: -5653411428424605918
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_3
+      name: AvatarParticleExpressionHeartPride 1_3
       rect:
         serializedVersion: 2
         x: 768
@@ -198,14 +201,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: ac01445dce41063c0800000000000000
-      internalID: -4368468631126535990
+      spriteID: adde4c963130c79a0800000000000000
+      internalID: -6234104402273833510
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_4
+      name: AvatarParticleExpressionHeartPride 1_4
       rect:
         serializedVersion: 2
         x: 1024
@@ -219,14 +222,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: 2b6c7488661d29d50800000000000000
-      internalID: 6742681830430328498
+      spriteID: fc0a8a9716bbcaff0800000000000000
+      internalID: -23437870716378929
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_5
+      name: AvatarParticleExpressionHeartPride 1_5
       rect:
         serializedVersion: 2
         x: 1280
@@ -240,14 +243,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: 9a8efd4dc18a4acf0800000000000000
-      internalID: -241883638187169623
+      spriteID: 3fa22a1836cea5d50800000000000000
+      internalID: 6726948905552063219
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_6
+      name: AvatarParticleExpressionHeartPride 1_6
       rect:
         serializedVersion: 2
         x: 1536
@@ -261,14 +264,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: 1f4b6de9f87316b70800000000000000
-      internalID: 8890448229390791921
+      spriteID: d84910d58f01c0260800000000000000
+      internalID: 7065040574335784077
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_7
+      name: AvatarParticleExpressionHeartPride 1_7
       rect:
         serializedVersion: 2
         x: 1792
@@ -282,14 +285,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: d35230e3dadb2be80800000000000000
-      internalID: -8164254622701902531
+      spriteID: b322a3c216e850cd0800000000000000
+      internalID: -2592509462476873157
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_8
+      name: AvatarParticleExpressionHeartPride 1_8
       rect:
         serializedVersion: 2
         x: 2048
@@ -303,14 +306,14 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: 5ea23c81c0ee7e940800000000000000
-      internalID: 5325486820111362789
+      spriteID: 4ac0b11b7f570c540800000000000000
+      internalID: 5026146890834185380
       vertices: []
       indices: 
       edges: []
       weights: []
     - serializedVersion: 2
-      name: AvatarParticleExpressionHeartPride_9
+      name: AvatarParticleExpressionHeartPride 1_9
       rect:
         serializedVersion: 2
         x: 2304
@@ -324,8 +327,29 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: 79599d5e344db6260800000000000000
-      internalID: 7091995426309117335
+      spriteID: 94715fd971b5631b0800000000000000
+      internalID: -5677250123261470903
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: AvatarParticleExpressionHeartPride 1_10
+      rect:
+        serializedVersion: 2
+        x: 2560
+        y: 0
+        width: 256
+        height: 256
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 544a135be154c23f0800000000000000
+      internalID: -924287825326529467
       vertices: []
       indices: 
       edges: []
@@ -333,7 +357,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 165a302ece90e1d4b8149e8929a0d213
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 


### PR DESCRIPTION
## What does this PR change?

When a user does the "Kiss" avatar expression, it spawns hearts. This PR applies a random color from a set of colors, based on the pride flag - as celebration of pride month (June).

This is done by using the sprite sheet animation module in the particle system which is on the Kiss avatar expression prefab. There is a multi-sprite with 10 new heart sprites. Each sprite has a different color. The sheet animation module picks a random sprite every time it spawns a heart.

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=feat/heart-emotes-with-pride-colors
2. Open the Expressions menu
3. Select the "Kiss" expression
4. Notice the color of the hearts

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
