### PR TITLE
Fix/nearby visible

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowComponentView.cs
@@ -3,9 +3,10 @@ using System.Collections;
 using SocialBar.UserThumbnail;
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-public class PrivateChatWindowComponentView : BaseComponentView, IPrivateChatComponentView
+public class PrivateChatWindowComponentView : BaseComponentView, IPrivateChatComponentView, IPointerDownHandler
 {
     [SerializeField] private Button backButton;
     [SerializeField] private Button closeButton;
@@ -30,11 +31,7 @@ public class PrivateChatWindowComponentView : BaseComponentView, IPrivateChatCom
         remove => userContextMenu.OnUnfriend -= value;
     }
 
-    public event Action<bool> OnFocused
-    {
-        add => onFocused += value;
-        remove => onFocused -= value;
-    }
+    public event Action<bool> OnFocused;
 
     public IChatHUDComponentView ChatHUD => chatView;
     public bool IsActive => gameObject.activeInHierarchy;
@@ -135,6 +132,14 @@ public class PrivateChatWindowComponentView : BaseComponentView, IPrivateChatCom
     public void Show() => gameObject.SetActive(true);
 
     public void Hide() => gameObject.SetActive(false);
+
+    public override void OnPointerExit(PointerEventData eventData)
+    {
+        base.OnPointerExit(eventData);
+        OnFocused?.Invoke(false);
+    }
+
+    public void OnPointerDown(PointerEventData eventData) => OnFocused?.Invoke(true);
 
     private void ShowOptions()
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -235,7 +235,10 @@ public class TaskbarHUDController : IHUD
         // view.ToggleAllOff();
         CloseFriendsWindow();
         CloseChatList();
-        OpenPublicChannelOnPreviewMode();
+        
+        if (!privateChatWindow.View.IsActive
+            && !publicChatChannel.View.IsActive)
+            OpenPublicChannelOnPreviewMode();
     }
 
     public void AddWorldChatWindow(WorldChatWindowController controller)
@@ -439,7 +442,8 @@ public class TaskbarHUDController : IHUD
         if (current)
             return;
 
-        view.experiencesButton.SetToggleState(false, false);
+        view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Experiences);
+        OpenPublicChannelOnPreviewMode();
     }
 
     private void NumOfLoadedExperiencesChanged(int current, int previous)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatChannelComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatChannelComponentView.cs
@@ -2,9 +2,10 @@
 using System.Collections;
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWindowView, IComponentModelConfig
+public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWindowView, IComponentModelConfig, IPointerDownHandler
 {
     [SerializeField] private Button closeButton;
     [SerializeField] private Button backButton;
@@ -18,11 +19,7 @@ public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWin
 
     public event Action OnClose;
     public event Action OnBack;
-    public event Action<bool> OnFocused
-    {
-        add => onFocused += value;
-        remove => onFocused -= value;
-    }
+    public event Action<bool> OnFocused;
 
     public bool IsActive => gameObject.activeInHierarchy;
     public IChatHUDComponentView ChatHUD => chatView;
@@ -105,6 +102,14 @@ public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWin
 
     public void Configure(BaseComponentModel newModel) => Configure((PublicChatChannelModel) newModel);
     
+    public void OnPointerDown(PointerEventData eventData) => OnFocused?.Invoke(true);
+
+    public override void OnPointerExit(PointerEventData eventData)
+    {
+        base.OnPointerExit(eventData);
+        OnFocused?.Invoke(false);
+    }
+
     private IEnumerator SetAlpha(float target, float duration)
     {
         var t = 0f;

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/BaseComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/BaseComponentView.cs
@@ -154,9 +154,9 @@ public abstract class BaseComponentView : MonoBehaviour, IBaseComponentView
             Destroy(gameObject);
     }
 
-    public void OnPointerEnter(PointerEventData eventData) { OnFocus(); }
+    public virtual void OnPointerEnter(PointerEventData eventData) { OnFocus(); }
 
-    public void OnPointerExit(PointerEventData eventData) { OnLoseFocus(); }
+    public virtual void OnPointerExit(PointerEventData eventData) { OnLoseFocus(); }
 
     private void OnDestroy()
     {


### PR DESCRIPTION
## What does this PR change?

Fixes an issue that happened whenever you locked the mouse while a private chat window was opened, the public channel window was getting on top of it.
Private & public chat windows only gets focus when clicking over them.
Public chat window is opened when experiences window is closed.

## How to test the changes?

1. Open a private chat window
2. Lock the mouse
3. Navigate through different chat windows, chat list and nearby channel.
4. Toggle on & off all the taskbar buttons

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
