### PR TITLE
fix: discard pixels below Y plane

### DIFF
--- a/unity-renderer/Assets/Rendering/Shaders/URP/FadeDithering.hlsl
+++ b/unity-renderer/Assets/Rendering/Shaders/URP/FadeDithering.hlsl
@@ -5,8 +5,7 @@ float4 fadeDithering(float4 color, float3 positionWS, float4 positionSS)
 {
 	bool insideFadeThreshold;
 	float3 worldPos = positionWS;
-    if(worldPos.y < 0)
-        clip(-1);
+    clip(worldPos.y + 0.1f);
 
 	if ( _FadeDirection == 0 )
 		insideFadeThreshold = worldPos.y < _CullYPlane;

--- a/unity-renderer/Assets/Rendering/Shaders/URP/FadeDithering.hlsl
+++ b/unity-renderer/Assets/Rendering/Shaders/URP/FadeDithering.hlsl
@@ -5,6 +5,8 @@ float4 fadeDithering(float4 color, float3 positionWS, float4 positionSS)
 {
 	bool insideFadeThreshold;
 	float3 worldPos = positionWS;
+    if(worldPos.y < 0)
+        clip(-1);
 
 	if ( _FadeDirection == 0 )
 		insideFadeThreshold = worldPos.y < _CullYPlane;


### PR DESCRIPTION
Due to some camera tricks for the new floor, the objects hidden in the negative Y of the world were being displayed. This fixes it by discarding the pixels directly.

Test below the floor is rendered. Also take a look at the world, GLTF transition effect and such.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
