### PR TITLE
fix: friend request notification count, direct messages spinner for guests & chat window resizing on preview mode

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
@@ -14,6 +14,10 @@ public class FriendsController : MonoBehaviour, IFriendsController
 
     private const bool KERNEL_CAN_REMOVE_ENTRIES = false;
     public bool isInitialized { get; private set; } = false;
+
+    public int ReceivedRequestCount =>
+        friends.Values.Count(status => status.friendshipStatus == FriendshipStatus.REQUESTED_FROM);
+    
     public Dictionary<string, UserStatus> friends = new Dictionary<string, UserStatus>();
 
     [System.Serializable]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsController.cs
@@ -10,6 +10,7 @@ public interface IFriendsController
 
     int friendCount { get; }
     bool isInitialized { get; }
+    int ReceivedRequestCount { get; }
     Dictionary<string, FriendsController.UserStatus> GetFriends();
     FriendsController.UserStatus GetUserStatus(string userId);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/Helpers/FriendsController_Mock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/Helpers/FriendsController_Mock.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 public class FriendsController_Mock : IFriendsController
 {
@@ -13,6 +14,9 @@ public class FriendsController_Mock : IFriendsController
     public int friendCount => friends.Count;
 
     public bool isInitialized => true;
+
+    public int ReceivedRequestCount =>
+        friends.Values.Count(status => status.friendshipStatus == FriendshipStatus.REQUESTED_FROM);
 
     public Dictionary<string, FriendsController.UserStatus> GetFriends() { return friends; }
     

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDComponentView.cs
@@ -134,8 +134,6 @@ public class FriendsHUDComponentView : BaseComponentView, IFriendsHUDComponentVi
 
     public bool IsFriendListCreationReady() => friendsTab.DidDeferredCreationCompleted;
 
-    public int GetReceivedFriendRequestCount() => friendRequestsTab.ReceivedRequestsList.Count();
-
     public void Destroy() => Destroy(gameObject);
 
     public void Show()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDController.cs
@@ -194,7 +194,10 @@ public class FriendsHUDController : IHUD
         }
 
         if (shouldDisplay)
+        {
             View.Set(userId, newStatus.friendshipStatus, model);
+            UpdateNotificationsCounter();
+        }
         else
         {
             switch (newStatus.friendshipStatus)
@@ -282,10 +285,10 @@ public class FriendsHUDController : IHUD
         }
 
         var pendingFriendRequestsSO = NotificationScriptableObjects.pendingFriendRequests;
-        int receivedRequestsCount = View.GetReceivedFriendRequestCount();
-
+        
         if (pendingFriendRequestsSO != null)
         {
+            var receivedRequestsCount = friendsController.ReceivedRequestCount;
             pendingFriendRequestsSO.Set(receivedRequestsCount);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/IFriendsHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/IFriendsHUDComponentView.cs
@@ -26,7 +26,6 @@ public interface IFriendsHUDComponentView
     FriendEntryBase GetEntry(string userId);
     void DisplayFriendUserNotFound();
     bool IsFriendListCreationReady();
-    int GetReceivedFriendRequestCount();
     void Destroy();
     void Show();
     void Hide();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/Tabs/FriendRequestsTabComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/Tabs/FriendRequestsTabComponentView.cs
@@ -52,8 +52,6 @@ public class FriendRequestsTabComponentView : BaseComponentView
     private bool isLayoutDirty;
 
     public Dictionary<string, FriendRequestEntry> Entries => entries;
-
-    public CollapsableSortedFriendEntryList ReceivedRequestsList => receivedRequestsList;
     public int Count => Entries.Count + creationQueue.Count;
 
     public event Action<FriendRequestEntry> OnCancelConfirmation;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowComponentView.cs
@@ -19,8 +19,10 @@ public class PrivateChatWindowComponentView : BaseComponentView, IPrivateChatCom
     [SerializeField] private Button optionsButton;
     [SerializeField] private Model model;
     [SerializeField] private CanvasGroup[] previewCanvasGroup;
+    [SerializeField] private Vector2 previewModeSize;
     
     private Coroutine alphaRoutine;
+    private Vector2 originalSize;
 
     public event Action OnPressBack;
     public event Action OnMinimize;
@@ -46,6 +48,7 @@ public class PrivateChatWindowComponentView : BaseComponentView, IPrivateChatCom
     public override void Awake()
     {
         base.Awake();
+        originalSize = ((RectTransform) transform).sizeDelta;
         backButton.onClick.AddListener(() => OnPressBack?.Invoke());
         closeButton.onClick.AddListener(() => OnClose?.Invoke());
         optionsButton.onClick.AddListener(ShowOptions);
@@ -84,6 +87,7 @@ public class PrivateChatWindowComponentView : BaseComponentView, IPrivateChatCom
             StopCoroutine(alphaRoutine);
         
         alphaRoutine = StartCoroutine(SetAlpha(alphaTarget, 0.5f));
+        ((RectTransform) transform).sizeDelta = previewModeSize;
     }
 
     public void DeactivatePreview()
@@ -102,6 +106,7 @@ public class PrivateChatWindowComponentView : BaseComponentView, IPrivateChatCom
             StopCoroutine(alphaRoutine);
         
         alphaRoutine = StartCoroutine(SetAlpha(alphaTarget, 0.5f));
+        ((RectTransform) transform).sizeDelta = originalSize;
     }
 
     public override void RefreshControl()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/GeneralChatChannelHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/GeneralChatChannelHUD.prefab
@@ -82,6 +82,7 @@ MonoBehaviour:
   - {fileID: 1841170242913198830}
   - {fileID: 1465780631268768265}
   - {fileID: 2676580422195266286}
+  previewModeSize: {x: 410, y: 400}
 --- !u!225 &3013135254997361945
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -824,9 +825,9 @@ RectTransform:
   m_Father: {fileID: 4540070755932127706}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 9.5, y: 564}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 9.5, y: -59}
   m_SizeDelta: {x: 382.42, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5822956738923906067
@@ -1082,10 +1083,10 @@ RectTransform:
   m_Father: {fileID: 4540070755932127706}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 623}
-  m_SizeDelta: {x: 410, y: 50}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 410, y: 51}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &3408665687965099177
 CanvasRenderer:
@@ -1409,7 +1410,7 @@ PrefabInstance:
     - target: {fileID: 7497584698789204027, guid: bac007ac4ef98284c8cf05867a35ee0f,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7497584698789204027, guid: bac007ac4ef98284c8cf05867a35ee0f,
         type: 3}
@@ -1429,7 +1430,7 @@ PrefabInstance:
     - target: {fileID: 7497584698789204027, guid: bac007ac4ef98284c8cf05867a35ee0f,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 573
+      value: -51
       objectReference: {fileID: 0}
     - target: {fileID: 7497584698789204027, guid: bac007ac4ef98284c8cf05867a35ee0f,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/GeneralChatChannelHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/GeneralChatChannelHUD.prefab
@@ -82,7 +82,7 @@ MonoBehaviour:
   - {fileID: 1841170242913198830}
   - {fileID: 1465780631268768265}
   - {fileID: 2676580422195266286}
-  previewModeSize: {x: 410, y: 330}
+  previewModeSize: {x: 410, y: 350}
 --- !u!225 &3013135254997361945
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/GeneralChatChannelHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/GeneralChatChannelHUD.prefab
@@ -82,7 +82,7 @@ MonoBehaviour:
   - {fileID: 1841170242913198830}
   - {fileID: 1465780631268768265}
   - {fileID: 2676580422195266286}
-  previewModeSize: {x: 410, y: 400}
+  previewModeSize: {x: 410, y: 330}
 --- !u!225 &3013135254997361945
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -139,10 +139,10 @@ RectTransform:
   m_Father: {fileID: 1176892910673695435}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 191.21, y: -35.915}
+  m_SizeDelta: {x: 366.42, y: 53.83}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3805798685388041355
 CanvasRenderer:
@@ -828,7 +828,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 9.5, y: -59}
-  m_SizeDelta: {x: 382.42, y: 0}
+  m_SizeDelta: {x: 382.42, y: 71.83}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5822956738923906067
 CanvasRenderer:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatHUD.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   - {fileID: 869161738090150756}
   - {fileID: 8449268174740436361}
   - {fileID: 8365916295481987895}
+  previewModeSize: {x: 410, y: 400}
 --- !u!114 &6801816554211203788
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -969,9 +970,9 @@ RectTransform:
   m_Father: {fileID: 4540070755932127706}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 9.5, y: 563}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 9.5, y: -60}
   m_SizeDelta: {x: 382.42, y: 60}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5822956738923906067
@@ -1201,10 +1202,10 @@ RectTransform:
   m_Father: {fileID: 4540070755932127706}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 623}
-  m_SizeDelta: {x: 410, y: 50}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 410, y: 51}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &3408665687965099177
 CanvasRenderer:
@@ -3619,7 +3620,7 @@ PrefabInstance:
     - target: {fileID: 7497584698789204027, guid: bac007ac4ef98284c8cf05867a35ee0f,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7497584698789204027, guid: bac007ac4ef98284c8cf05867a35ee0f,
         type: 3}
@@ -3639,7 +3640,7 @@ PrefabInstance:
     - target: {fileID: 7497584698789204027, guid: bac007ac4ef98284c8cf05867a35ee0f,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 573
+      value: -51
       objectReference: {fileID: 0}
     - target: {fileID: 7497584698789204027, guid: bac007ac4ef98284c8cf05867a35ee0f,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatHUD.prefab
@@ -89,7 +89,7 @@ MonoBehaviour:
   - {fileID: 869161738090150756}
   - {fileID: 8449268174740436361}
   - {fileID: 8365916295481987895}
-  previewModeSize: {x: 410, y: 400}
+  previewModeSize: {x: 410, y: 330}
 --- !u!114 &6801816554211203788
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatHUD.prefab
@@ -89,7 +89,7 @@ MonoBehaviour:
   - {fileID: 869161738090150756}
   - {fileID: 8449268174740436361}
   - {fileID: 8365916295481987895}
-  previewModeSize: {x: 410, y: 330}
+  previewModeSize: {x: 410, y: 350}
 --- !u!114 &6801816554211203788
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatChannelComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatChannelComponentView.cs
@@ -14,8 +14,10 @@ public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWin
     [SerializeField] private ChatHUDView chatView;
     [SerializeField] private PublicChatChannelModel model;
     [SerializeField] private CanvasGroup[] previewCanvasGroup;
+    [SerializeField] private Vector2 previewModeSize;
     
     private Coroutine alphaRoutine;
+    private Vector2 originalSize;
 
     public event Action OnClose;
     public event Action OnBack;
@@ -34,6 +36,7 @@ public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWin
     public override void Awake()
     {
         base.Awake();
+        originalSize = ((RectTransform) transform).sizeDelta;
         backButton.onClick.AddListener(() => OnBack?.Invoke());
         closeButton.onClick.AddListener(() => OnClose?.Invoke());
     }
@@ -70,6 +73,7 @@ public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWin
             StopCoroutine(alphaRoutine);
         
         alphaRoutine = StartCoroutine(SetAlpha(alphaTarget, 0.5f));
+        ((RectTransform) transform).sizeDelta = previewModeSize;
     }
 
     public void ActivatePreviewInstantly()
@@ -80,6 +84,8 @@ public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWin
         const float alphaTarget = 0f;
         foreach (var group in previewCanvasGroup)
             group.alpha = alphaTarget;
+
+        ((RectTransform) transform).sizeDelta = previewModeSize;
     }
 
     public void DeactivatePreview()
@@ -98,6 +104,7 @@ public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWin
             StopCoroutine(alphaRoutine);
         
         alphaRoutine = StartCoroutine(SetAlpha(alphaTarget, 0.5f));
+        ((RectTransform) transform).sizeDelta = originalSize;
     }
 
     public void Configure(BaseComponentModel newModel) => Configure((PublicChatChannelModel) newModel);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
@@ -36,6 +36,7 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
     private bool isLayoutDirty;
     private Dictionary<string, PrivateChatModel> filteredPrivateChats;
     private int currentAvatarSnapshotIndex;
+    private bool isLoadingPrivateChannels;
 
     public event Action OnClose;
     public event Action<string> OnOpenPrivateChat;
@@ -162,9 +163,14 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
         searchResultsList.Hide();
         publicChannelList.Show();
         publicChannelList.Sort();
-        directChatList.Show();
-        directChatList.Sort();
-        directChannelHeader.SetActive(true);
+        
+        if (!isLoadingPrivateChannels)
+        {
+            directChatList.Show();
+            directChatList.Sort();
+            directChannelHeader.SetActive(true);    
+        }
+        
         searchResultsHeader.SetActive(false);
 
         directChatList.Filter(entry => true);
@@ -255,6 +261,7 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
         directChatsLoadingContainer.SetActive(visible);
         directChatsContainer.SetActive(!visible);
         scroll.enabled = !visible;
+        isLoadingPrivateChannels = visible;
     }
 
     private void UpdateHeaders()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -65,7 +65,8 @@ public class WorldChatWindowController : IHUD
             HandleMessageAdded(value);
         
         if (!friendsController.isInitialized)
-            view.ShowPrivateChatsLoading();
+            if (ownUserProfile != null && ownUserProfile.isGuest)
+                view.ShowPrivateChatsLoading();
         
         chatController.OnAddMessage += HandleMessageAdded;
         friendsController.OnUpdateUserStatus += HandleUserStatusChanged;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -65,7 +65,7 @@ public class WorldChatWindowController : IHUD
             HandleMessageAdded(value);
         
         if (!friendsController.isInitialized)
-            if (ownUserProfile != null && ownUserProfile.isGuest)
+            if (ownUserProfile?.hasConnectedWeb3 ?? false)
                 view.ShowPrivateChatsLoading();
         
         chatController.OnAddMessage += HandleMessageAdded;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -207,8 +207,14 @@ public class WorldChatWindowController : IHUD
     private UserProfile ExtractRecipient(ChatMessage message) =>
         userProfileBridge.Get(message.sender != ownUserProfile.userId ? message.sender : message.recipient);
 
-    private void OnUserProfileUpdate(UserProfile profile) => view.RefreshBlockedDirectMessages(profile.blocked);
-    
+    private void OnUserProfileUpdate(UserProfile profile)
+    {
+        view.RefreshBlockedDirectMessages(profile.blocked);
+        
+        if (!profile.hasConnectedWeb3)
+            view.HidePrivateChatsLoading();
+    }
+
     private void ShowOrHideMoreFriendsToLoadHint()
     {
         if (pendingPrivateChats.Count == 0)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/WebInterfaceFriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/WebInterfaceFriendsController.cs
@@ -34,6 +34,7 @@ namespace DCL.Interface
         
         public int friendCount => friendsController.friendCount;
         public bool isInitialized => friendsController.isInitialized;
+        public int ReceivedRequestCount => friendsController.ReceivedRequestCount;
 
         public WebInterfaceFriendsController(IFriendsController friendsController)
         {


### PR DESCRIPTION
## What does this PR change?

- private & public chat windows are resized to avoid overlapping with scene UIs
- hide direct chats loading spinner when the user is a guest
- received friend request notifications count at taskbar

## How to test the changes?

1. Authenticate as a guest, open the chat list window, search for a friend. No UI components should be overlapped.
2. Go to ice poker scenes, check that the chat in transparent mode does not overlap with their UI.
3. Receive a friend request, the notification count should be updated correctly in the taskbar.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
