### PR TITLE
fix: Close Experiences Viewer when the mouse locks

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -247,7 +247,9 @@ public class TaskbarHUDController : IHUD
         // view.ToggleAllOff();
         CloseFriendsWindow();
         CloseChatList();
-        
+        isExperiencesViewerOpen.Set(false);
+
+
         if (!privateChatWindow.View.IsActive
             && !publicChatChannel.View.IsActive)
             OpenPublicChannelOnPreviewMode();


### PR DESCRIPTION
## What does this PR change?
This PR makes the Experiences Viewer close after we lock the mouse. Keeping the HUD open was provoking an issue with the chat HUD because it was appearing behind and we shouldn't have this situation. The taskbar should always be showing only a window at the same time.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/close-experiences-viewer-when-mouse-lock
2. Open the backpack and equip some smart wearable that includes any portable experience.
3. Go to the taskbar and click on the Experiences button.
4. Once the Experiences window is open, click on the world in order to lock the mouse.
5. Notice the Experiences window closes.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
