### PR TITLE
fix: metrics feature flag rename

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMetricsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMetricsController.cs
@@ -13,7 +13,7 @@ namespace DCL
     public class PerformanceMetricsController
     {
         private const int SAMPLES_SIZE = 1000; // Send performance report every 1000 samples
-        private const string PROFILER_METRICS_FEATURE_FLAG = "SendProfilerMetrics";
+        private const string PROFILER_METRICS_FEATURE_FLAG = "explorer-profiler-metrics";
 
         private readonly LinealBufferHiccupCounter tracker = new LinealBufferHiccupCounter();
         private readonly char[] encodedSamples = new char[SAMPLES_SIZE];


### PR DESCRIPTION
## What does this PR change?

Changed `SendProfilerMetrics` to `explorer-profiler-metrics`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
