### PR TITLE
Fix: null reference in skybox init

### DIFF
--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/Skybox3DElements/SkyboxElements.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/Skybox3DElements/SkyboxElements.cs
@@ -31,6 +31,9 @@ namespace DCL.Skybox
 
         internal void AssignCameraInstance(Transform currentTransform)
         {
+            if (currentTransform == null)
+                return;
+            
             domeElements.ResolveCameraDependency(currentTransform);
             satelliteElements.ResolveCameraDependency(currentTransform);
             planarElements.ResolveCameraDependency(currentTransform);


### PR DESCRIPTION
## What does this PR change?

Fix #2426
Fixes null reference in skybox initialization
...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/null-ref-skybox
2. Verify that Decentraland starts correctly
3. Verify the correct behaviour of the skybox

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
