### PR TITLE
chore: reduce allocations from avatar system

### DIFF
--- a/unity-renderer/Assets/Rendering/Utils/GPUSkinning/SimpleGPUSkinning.cs
+++ b/unity-renderer/Assets/Rendering/Utils/GPUSkinning/SimpleGPUSkinning.cs
@@ -74,6 +74,9 @@ namespace GPUSkinning
 
             sharedMesh.SetTangents(bone01data);
             sharedMesh.SetUVs(1, bone23data);
+            
+            bone01data.Dispose();
+            bone23data.Dispose();
         }
         
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
@@ -127,13 +127,21 @@ namespace DCL
 
             finalMesh.bindposes = bindPoses;
 
-            (NativeArray<byte> bonesPerVertex, NativeArray<BoneWeight1> weights) = AvatarMeshCombinerUtils.ComputeBoneWeights(layers);
-            finalMesh.SetBoneWeights(bonesPerVertex, weights);
-
+            var bonesPerVertex = AvatarMeshCombinerUtils.CombineBonesPerVertex(layers);
+            var boneWeights = AvatarMeshCombinerUtils.CombineBonesWeights(layers);
+            finalMesh.SetBoneWeights(bonesPerVertex, boneWeights);
+            
+            bonesPerVertex.Dispose();
+            boneWeights.Dispose();
+            
             var flattenedMaterialsData = AvatarMeshCombinerUtils.FlattenMaterials( layers, materialAsset );
             finalMesh.SetUVs(EMISSION_COLORS_UV_CHANNEL_INDEX, flattenedMaterialsData.emissionColors);
             finalMesh.SetUVs(TEXTURE_POINTERS_UV_CHANNEL_INDEX, flattenedMaterialsData.texturePointers);
             finalMesh.SetColors(flattenedMaterialsData.colors);
+
+            flattenedMaterialsData.emissionColors.Dispose();
+            flattenedMaterialsData.texturePointers.Dispose();
+            flattenedMaterialsData.colors.Dispose();
 
             // Each layer corresponds with a subMesh. This is to take advantage of the sharedMaterials array.
             //

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Data.Common;
-using System.Linq;
 using Unity.Collections;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -124,8 +121,8 @@ namespace DCL
 
             finalMesh.bindposes = bindPoses;
 
-            var boneWeights = AvatarMeshCombinerUtils.ComputeBoneWeights( layers );
-            finalMesh.boneWeights = boneWeights;
+            (NativeArray<byte> bonesPerVertex, NativeArray<BoneWeight1> weights) = AvatarMeshCombinerUtils.ComputeNativeBoneWeights(layers);
+            finalMesh.SetBoneWeights(bonesPerVertex, weights);
 
             var flattenedMaterialsData = AvatarMeshCombinerUtils.FlattenMaterials( layers, materialAsset );
             finalMesh.SetUVs(EMISSION_COLORS_UV_CHANNEL_INDEX, flattenedMaterialsData.emissionColors);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
@@ -39,9 +39,15 @@ namespace DCL
     public class FlattenedMaterialsData
     {
         public List<Material> materials = new List<Material>();
-        public Vector3[] texturePointers;
-        public Vector4[] colors;
-        public Vector4[] emissionColors;
+        public NativeArray<Vector3> texturePointers;
+        public NativeArray<Vector4> colors;
+        public NativeArray<Vector4> emissionColors;
+        public FlattenedMaterialsData(int vertexCount)
+        {
+            texturePointers = new NativeArray<Vector3>(vertexCount, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+            colors = new NativeArray<Vector4>(vertexCount, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+            emissionColors = new NativeArray<Vector4>(vertexCount, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+        }
     }
 
     /// <summary>
@@ -127,11 +133,8 @@ namespace DCL
             var flattenedMaterialsData = AvatarMeshCombinerUtils.FlattenMaterials( layers, materialAsset );
             finalMesh.SetUVs(EMISSION_COLORS_UV_CHANNEL_INDEX, flattenedMaterialsData.emissionColors);
             finalMesh.SetUVs(TEXTURE_POINTERS_UV_CHANNEL_INDEX, flattenedMaterialsData.texturePointers);
+            finalMesh.SetColors(flattenedMaterialsData.colors);
 
-            var tempArray = new NativeArray<Vector4>(flattenedMaterialsData.colors.Length, Allocator.Temp);
-            tempArray.CopyFrom(flattenedMaterialsData.colors);
-            finalMesh.SetColors(tempArray);
-            tempArray.Dispose();
             // Each layer corresponds with a subMesh. This is to take advantage of the sharedMaterials array.
             //
             // When a renderer has many sub-meshes, each materials array element correspond to the sub-mesh of

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombiner.cs
@@ -127,7 +127,7 @@ namespace DCL
 
             finalMesh.bindposes = bindPoses;
 
-            (NativeArray<byte> bonesPerVertex, NativeArray<BoneWeight1> weights) = AvatarMeshCombinerUtils.ComputeNativeBoneWeights(layers);
+            (NativeArray<byte> bonesPerVertex, NativeArray<BoneWeight1> weights) = AvatarMeshCombinerUtils.ComputeBoneWeights(layers);
             finalMesh.SetBoneWeights(bonesPerVertex, weights);
 
             var flattenedMaterialsData = AvatarMeshCombinerUtils.FlattenMaterials( layers, materialAsset );

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerUtils.cs
@@ -147,12 +147,11 @@ namespace DCL
         /// <returns>A FlattenedMaterialsData object. This object can be used to construct a combined mesh that has uniform data encoded in UV attributes.</returns>
         public static FlattenedMaterialsData FlattenMaterials(List<CombineLayer> layers, Material materialAsset)
         {
-            var result = new FlattenedMaterialsData();
             int layersCount = layers.Count;
 
             int finalVertexCount = 0;
             int currentVertexCount = 0;
-
+            
             for (int layerIndex = 0; layerIndex < layersCount; layerIndex++)
             {
                 CombineLayer layer = layers[layerIndex];
@@ -166,9 +165,7 @@ namespace DCL
                 }
             }
 
-            result.colors = new Vector4[finalVertexCount];
-            result.emissionColors = new Vector4[finalVertexCount];
-            result.texturePointers = new Vector3[finalVertexCount];
+            var result = new FlattenedMaterialsData(finalVertexCount);
 
             for (int layerIndex = 0; layerIndex < layersCount; layerIndex++)
             {
@@ -193,6 +190,7 @@ namespace DCL
 
                 for (int i = 0; i < layerRenderersCount; i++)
                 {
+
                     var renderer = layerRenderers[i];
 
                     // Bone Weights
@@ -221,7 +219,8 @@ namespace DCL
                         }
                         else
                         {
-                            logger.Log(LogType.Error, "FlattenMaterials", $"Base Map ID out of bounds! {baseMapId}");
+                            if (VERBOSE)
+                                logger.Log(LogType.Error, "FlattenMaterials", $"Base Map ID out of bounds! {baseMapId}");
                         }
                     }
 
@@ -234,7 +233,8 @@ namespace DCL
                         }
                         else
                         {
-                            logger.Log(LogType.Error, "FlattenMaterials", $"Emission Map ID out of bounds! {emissionMapId}");
+                            if (VERBOSE)
+                                logger.Log(LogType.Error, "FlattenMaterials", $"Emission Map ID out of bounds! {emissionMapId}");
                         }
                     }
 
@@ -252,10 +252,12 @@ namespace DCL
 
                     if (VERBOSE)
                         logger.Log($"Layer {i} - vertexCount: {vertexCount} - texturePointers: ({baseMapId}, {emissionMapId}, {cutoff}) - emissionColor: {emissionColor} - baseColor: {baseColor}");
+
                 }
 
                 SRPBatchingHelper.OptimizeMaterial(newMaterial);
-            }
+
+            }   
 
             return result;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/AvatarMeshCombinerUtils.cs
@@ -41,42 +41,7 @@ namespace DCL
         /// </summary>
         /// <param name="layers">A CombineLayer list. You can generate this array using CombineLayerUtils.Slice().</param>
         /// <returns>A list of BoneWeights that share the same skeleton.</returns>
-        public static BoneWeight[] ComputeBoneWeights( List<CombineLayer> layers )
-        {
-            int layersCount = layers.Count;
-
-            int resultSize = 0;
-
-            List<BoneWeight[]> boneWeightArrays = new List<BoneWeight[]>(10);
-
-            for (int layerIndex = 0; layerIndex < layersCount; layerIndex++)
-            {
-                CombineLayer layer = layers[layerIndex];
-                var layerRenderers = layer.renderers;
-
-                int layerRenderersCount = layerRenderers.Count;
-
-                for (int i = 0; i < layerRenderersCount; i++)
-                {
-                    var boneWeights = layerRenderers[i].sharedMesh.boneWeights;
-                    boneWeightArrays.Add(boneWeights);
-                    resultSize += boneWeights.Length;
-                }
-            }
-
-            BoneWeight[] result = new BoneWeight[resultSize];
-
-            int copyOffset = 0;
-            for ( int i = 0; i < boneWeightArrays.Count; i++ )
-            {
-                Array.Copy(boneWeightArrays[i], 0, result, copyOffset, boneWeightArrays[i].Length);
-                copyOffset += boneWeightArrays[i].Length;
-            }
-
-            return result;
-        }
-        
-        public static (NativeArray<byte> bonesPerVertex, NativeArray<BoneWeight1> weights) ComputeNativeBoneWeights( List<CombineLayer> layers )
+        public static (NativeArray<byte> bonesPerVertex, NativeArray<BoneWeight1> weights) ComputeBoneWeights( List<CombineLayer> layers )
         {
             int layersCount = layers.Count;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
@@ -7,7 +7,7 @@ using DCL;
 using DCL.Helpers;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
-using UnityEditor;
+using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.TestTools;
@@ -184,7 +184,7 @@ public class AvatarMeshCombinerUtilsCan
         FlattenedMaterialsData result = AvatarMeshCombinerUtils.FlattenMaterials(layers, material);
 
         // Assert
-        FlattenedMaterialsData expected = new FlattenedMaterialsData();
+        FlattenedMaterialsData expected = new FlattenedMaterialsData(24);
 
         var colors = new List<Vector4>();
         var texturePointers = new List<Vector3>();
@@ -198,9 +198,9 @@ public class AvatarMeshCombinerUtilsCan
         emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.white, 24));
         texturePointers.AddRange(Enumerable.Repeat(new Vector3(4, 10, 0.5f), 24));
 
-        expected.colors = colors.ToArray();
-        expected.emissionColors = emissionColors.ToArray();
-        expected.texturePointers = texturePointers.ToArray();
+        expected.colors = new NativeArray<Vector4>(colors.ToArray(), Allocator.Temp);
+        expected.emissionColors = new NativeArray<Vector4>(emissionColors.ToArray(), Allocator.Temp);
+        expected.texturePointers = new NativeArray<Vector3>(texturePointers.ToArray(), Allocator.Temp);
 
         CollectionAssert.AreEquivalent(expected.colors, result.colors);
         CollectionAssert.AreEquivalent(expected.texturePointers, result.texturePointers);
@@ -225,7 +225,7 @@ public class AvatarMeshCombinerUtilsCan
         FlattenedMaterialsData result = AvatarMeshCombinerUtils.FlattenMaterials(layers, material);
 
         // Assert
-        FlattenedMaterialsData expected = new FlattenedMaterialsData();
+        FlattenedMaterialsData expected = new FlattenedMaterialsData(24);
 
         var colors = new List<Vector4>();
         var texturePointers = new List<Vector3>();
@@ -239,9 +239,9 @@ public class AvatarMeshCombinerUtilsCan
         emissionColors.AddRange(Enumerable.Repeat((Vector4)Color.white, 24));
         texturePointers.AddRange(Enumerable.Repeat(new Vector3(4, 10, 0.5f), 24));
 
-        expected.colors = colors.ToArray();
-        expected.emissionColors = emissionColors.ToArray();
-        expected.texturePointers = texturePointers.ToArray();
+        expected.colors = new NativeArray<Vector4>(colors.ToArray(), Allocator.Temp);
+        expected.emissionColors = new NativeArray<Vector4>(emissionColors.ToArray(), Allocator.Temp);
+        expected.texturePointers = new NativeArray<Vector3>(texturePointers.ToArray(), Allocator.Temp);
 
         CollectionAssert.AreEquivalent(expected.colors, result.colors);
         CollectionAssert.AreEquivalent(expected.texturePointers, result.texturePointers);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
@@ -154,14 +154,15 @@ public class AvatarMeshCombinerUtilsCan
         var result = AvatarMeshCombinerUtils.ComputeBoneWeights(layers);
 
         // Assert
-        Assert.That(result.Count, Is.EqualTo(96));
+        Assert.That(result.weights, Is.EqualTo(96));
 
         int assertCounter = 0;
 
-        foreach ( var b in result )
+        for (int i = 0; i < result.bonesPerVertex.Length; i++)
         {
-            Assert.That(b.weight0, Is.EqualTo(assertCounter));
-            Assert.That(b.boneIndex1, Is.EqualTo(assertCounter));
+            var boneWeight1 = result.weights[i];
+            Assert.That(boneWeight1.weight, Is.EqualTo(assertCounter));
+            Assert.That(boneWeight1.boneIndex, Is.EqualTo(assertCounter));
             assertCounter++;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
@@ -121,18 +121,18 @@ public class AvatarMeshCombinerUtilsCan
             SkinnedMeshRenderer renderer = DCL.Helpers.SkinnedMeshRenderer.Create(mat);
 
             int vertexCount = renderer.sharedMesh.vertexCount;
-            var boneWeights = new BoneWeight[vertexCount];
 
-            for (int i = 0; i < boneWeights.Length; i++)
+            var nativeBonesPerVertex = new NativeArray<byte>(vertexCount, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+            var nativeBones = new NativeArray<BoneWeight1>(vertexCount, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+
+            for (int i = 0; i < vertexCount; i++)
             {
-                var b = new BoneWeight();
-                b.weight0 = counter;
-                b.boneIndex1 = counter;
-                boneWeights[i] = b;
+                nativeBonesPerVertex[i] = 1;
+                nativeBones[i] = new BoneWeight1() { boneIndex = counter, weight = counter };
                 counter++;
             }
 
-            renderer.sharedMesh.boneWeights = boneWeights;
+            renderer.sharedMesh.SetBoneWeights(nativeBonesPerVertex, nativeBones);
             return renderer;
         }
 
@@ -154,15 +154,17 @@ public class AvatarMeshCombinerUtilsCan
         var result = AvatarMeshCombinerUtils.ComputeBoneWeights(layers);
 
         // Assert
-        Assert.That(result.weights, Is.EqualTo(96));
+        Assert.That(result.weights.Length, Is.EqualTo(96));
 
         int assertCounter = 0;
 
-        for (int i = 0; i < result.bonesPerVertex.Length; i++)
+        int bonesPerVertex = result.bonesPerVertex.Length;
+
+        for (int i = 0; i < bonesPerVertex; i++)
         {
-            var boneWeight1 = result.weights[i];
-            Assert.That(boneWeight1.weight, Is.EqualTo(assertCounter));
-            Assert.That(boneWeight1.boneIndex, Is.EqualTo(assertCounter));
+            var boneWeight1 = result.weights[assertCounter];
+            Assert.That(boneWeight1.weight, Is.EqualTo(1), "Bone Weight");
+            Assert.That(boneWeight1.boneIndex, Is.EqualTo(assertCounter), "Bone index");
             assertCounter++;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMeshCombiner/Tests/AvatarMeshCombinerUtilsCan.cs
@@ -151,18 +151,19 @@ public class AvatarMeshCombinerUtilsCan
         }
 
         // Act
-        var result = AvatarMeshCombinerUtils.ComputeBoneWeights(layers);
+        var weights = AvatarMeshCombinerUtils.CombineBonesWeights(layers);
+        var bonesPerVertex = AvatarMeshCombinerUtils.CombineBonesPerVertex(layers);
 
         // Assert
-        Assert.That(result.weights.Length, Is.EqualTo(96));
+        Assert.That(weights.Length, Is.EqualTo(96));
 
         int assertCounter = 0;
 
-        int bonesPerVertex = result.bonesPerVertex.Length;
+        int count = bonesPerVertex.Length;
 
-        for (int i = 0; i < bonesPerVertex; i++)
+        for (int i = 0; i < count; i++)
         {
-            var boneWeight1 = result.weights[assertCounter];
+            var boneWeight1 = weights[assertCounter];
             Assert.That(boneWeight1.weight, Is.EqualTo(1), "Bone Weight");
             Assert.That(boneWeight1.boneIndex, Is.EqualTo(assertCounter), "Bone index");
             assertCounter++;
@@ -173,6 +174,9 @@ public class AvatarMeshCombinerUtilsCan
         layers.SelectMany( (x) => x.renderers ).ToList().ForEach(
             DCL.Helpers.SkinnedMeshRenderer.DestroyAndUnload
         );
+
+        weights.Dispose();
+        bonesPerVertex.Dispose();
     }
 
     [Test]


### PR DESCRIPTION
## Why?

When a lot of avatars spawn, the GarbageCollector causes hiccups very frequently, this is caused by very large allocations every time an avatar is spawned. 

## What changed?

Reduced the allocations of copying arrays by using Unity's NativeArray which provides allocation-free management of arrays.

## Results

Performance Score incremented from `68,78` to `73,87`
Allocations over 30 seconds lowered from `544.585,61` to `509.632,536`

(results might differ because genesis plaza is chaotic and people move, the test started when the first avatar was about to spawn)

For more information, read the comments below.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
