### PR TITLE
fix: gltf importer having undesired async calls when force sync was true

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -115,30 +115,37 @@ namespace UnityGLTF
         private GameObject CreateGLTFScene(string projectFilePath)
         {
             ILoader fileLoader = new GLTFFileLoader(Path.GetDirectoryName(projectFilePath));
-            using (var stream = File.OpenRead(projectFilePath))
-            {
-                GLTFRoot gLTFRoot;
-                GLTFParser.ParseJson(stream, out gLTFRoot);
+            using var stream = File.OpenRead(projectFilePath);
 
-                var loader = new GLTFSceneImporter(Path.GetFullPath(projectFilePath), gLTFRoot, fileLoader, null, stream);
-                loader.addImagesToPersistentCaching = false;
-                loader.addMaterialsToPersistentCaching = false;
-                loader.initialVisibility = true;
-                loader.useMaterialTransition = false;
-                loader.maxTextureSize = 512;
-                loader.maximumLod = _maximumLod;
-                loader.forceGPUOnlyMesh = false;
-                loader.forceGPUOnlyTex = false;
-                loader.forceSyncCoroutines = true;
+            GLTFRoot gLTFRoot;
+            GLTFParser.ParseJson(stream, out gLTFRoot);
 
-                Task task = loader.LoadScene(CancellationToken.None);
-                bool result = task.Wait(TimeSpan.FromSeconds(30));
+            var loader = new GLTFSceneImporter(Path.GetFullPath(projectFilePath), gLTFRoot, fileLoader, null, stream);
+            loader.addImagesToPersistentCaching = false;
+            loader.addMaterialsToPersistentCaching = false;
+            loader.initialVisibility = true;
+            loader.useMaterialTransition = false;
+            loader.maxTextureSize = 512;
+            loader.maximumLod = _maximumLod;
+            loader.forceGPUOnlyMesh = false;
+            loader.forceGPUOnlyTex = false;
+            loader.forceSyncCoroutines = true;
 
-                if (!result)
-                    throw new TimeoutException($"Importing {projectFilePath}");
+
+            Task task = loader.LoadScene(CancellationToken.None);
+            bool result = task.Wait(TimeSpan.FromSeconds(30));
                 
-                return loader.lastLoadedScene;
+            switch (result)
+            {
+                case false when task.Exception == null:
+                    throw new TimeoutException($"Importing {projectFilePath}");
+                case false when task.Exception != null:
+                    throw task.Exception;
             }
+
+            stream.Dispose();
+            return loader.lastLoadedScene;
+
         }
 
         private void ImportAsset(AssetImportContext ctx, GameObject gltfScene)


### PR DESCRIPTION
## What does this PR change?

Fixes GLTF importing in Editor throwing timeouts because of async calls that weren't correctly functioning and should have been ignored by the forceSyncCoroutines flag.

Fixes #2436

## How to test the changes?

Import #2436 example glb, it should be imported almost instantly.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
