### PR TITLE
fix: update friends entries when the profile changes

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDComponentView.cs
@@ -223,7 +223,11 @@ public class FriendsHUDComponentView : BaseComponentView, IFriendsHUDComponentVi
         }
     }
 
-    public void Populate(string userId, FriendEntryModel model) => friendsTab.Populate(userId, model);
+    public void Populate(string userId, FriendEntryModel model)
+    {
+        friendsTab.Populate(userId, model);
+        friendRequestsTab.Populate(userId, (FriendRequestEntryModel) model);
+    }
 
     public bool IsActive() => gameObject.activeInHierarchy;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Tests/PrivateChatWindowHUDShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Tests/PrivateChatWindowHUDShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f71cfc802bf52ef41a108e61db0511ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?

`FriendsHUDController` listens to friend profile changes and updates the view with latest changes.
This change attempts to fix a problem when sometimes you cannot see the user names of your friends correctly displayed in the list.

![Screen Shot 2022-06-14 at 15 06 55](https://user-images.githubusercontent.com/56365551/173704745-9095c023-11ae-4224-9330-8c1d9c0d6342.png)

## How to test the changes?

1. Wait until all friends are loaded
2. Open the friend list, all friends should be displayed correctly
3. If any of your friends changes its name, it should be replicated into the list

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
