### PR TITLE
 fix: mac (12.3+) local web building

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,27 @@ When the steps are followed, you will be able to run the local Unity build by go
 
 1. Make sure you have the proper Unity version up and running
 2. Make sure you have [Kernel repository](https://github.com/decentraland/kernel) cloned.
-3. Make sure you are running kernel through `make watch` command in the cloned repo directory.
-4. Make sure you have the [explorer website repository](https://github.com/decentraland/explorer-website) cloned.
-5. Make sure you have the local website up and running by executing `npm run start:linked` in the cloned repo directory.
-6. Produce a Unity wasm targeted build using the Build menu.
-7. When the build finishes, copy all the files inside the resulting `/build` folder (`unity.loader.js` is not necessary as we use a modified loader) and paste them inside `explorer-website/node_modules/@dcl/unity-renderer`.
-8. Run the browser explorer through `localhost:3000`. Now, it should use your local Unity build.
-9. If you need a Unity re-build, you can just replace the files and reload the browser without restarting the `make watch` process nor the website.
+3. Make sure you are running kernel through `make watch` command in the cloned repo directory (`npm i` first just in case).
+4. Produce a Unity wasm targeted build using the Build menu.
+5. When the build finishes, copy all the files inside the resulting `/build` folder (`unity.loader.js` is not necessary as we use a modified loader) and paste them inside `kernel/node_modules/@dcl/unity-renderer`.
+6. Run the browser explorer through `localhost:8080&ENABLE_WEB3`. Now, it should use your local Unity build. Don't mind the white screen at the beginning, that's because the website repo is not being used and it's only loading Kernel with the build.
+7. If you need a Unity re-build, you can just replace the files and reload the browser without restarting the `make watch` process.
+
+Alternatively you can go through these 2 steps after step 3 and load the build locally using `localhost:3000` 
+1. Make sure you have the [explorer website repository](https://github.com/decentraland/explorer-website) cloned.
+2. Make sure you have the local website up and running by executing `npm run start:linked` in the cloned repo directory (`npm i` first just in case).
+3. When the WebGL build finishes, copy all the files inside the resulting `/build` folder (`unity.loader.js` is not necessary as we use a modified loader) and paste them inside `explorer-website/node_modules/@dcl/unity-renderer`.
+4. Access using using `localhost:3000`
+
+### Troubleshooting
+
+#### MacOS: Missing xcrun
+
+If you get the "missing xcrun" error when trying to run the `make watch` command, you should download the latest command line tools for macOS, either by downloading them from https://developer.apple.com/download/more/?=command%20line%20tools or by re-installing XCode
+
+#### MacOS: Build fails throwing `System.ComponentModel.Win32Exception (2): No such file or directory...`
+
+If the local WebGL build always fails with the error `System.ComponentModel.Win32Exception (2): No such file or directory...` it's because you are missing Python needed version (MacOS 12.3 onwards removes the previously-integrated python installation). So to solve this issue just install this [Python version](https://www.python.org/downloads/release/python-3105/).
 
 ## Technical how-to guides and explainers
 

--- a/unity-renderer/Assets/Scripts/Editor/PreBuildProcessing.cs
+++ b/unity-renderer/Assets/Scripts/Editor/PreBuildProcessing.cs
@@ -1,0 +1,21 @@
+#if UNITY_EDITOR && UNITY_EDITOR_OSX
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+// MacOS doesn't include Python anymore since macOS 12.3 (and removes the previously-existent version)
+// Emscripten build toolchain for WebGL builds on Unity 2020.3 depends on Python 2.7 or later. [WebGL builds on Unity 2021.2 and later require Python 3].
+// Solution for building locally for WebGL on macOS:
+// 1. Download Python 3+ at https://www.python.org/downloads/release/python-3105/
+// 2. Have this PreBuildProcessing script in place to re-map Python path when building. 
+// https://forum.unity.com/threads/case-1412113-builderror-osx-12-3-and-unity-2020-3-constant-build-errors.1255419/#post-7993017
+// https://answers.unity.com/questions/1893841/unity-2020328f1-webgl-build-failed-on-macos-monter.html
+
+public class PreBuildProcessing : IPreprocessBuildWithReport
+{
+    public int callbackOrder => 1;
+    public void OnPreprocessBuild(BuildReport report)
+    {
+        System.Environment.SetEnvironmentVariable("EMSDK_PYTHON", "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3");
+    }
+}
+#endif

--- a/unity-renderer/Assets/Scripts/Editor/PreBuildProcessing.cs.meta
+++ b/unity-renderer/Assets/Scripts/Editor/PreBuildProcessing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f16c91fc3553c4414a3f6fbf55c37a66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### WHY
- Emscripten build toolchain for WebGL builds on Unity 2020.3 depends on Python 2.7 or later. [WebGL builds on Unity 2021.2 and later require Python 3].
- MacOS doesn't include Python anymore since macOS 12.3 (and removes the previously-existent version). So making a WebGL build locally in Mac 12.3+ always fails because Python can't be found.

#### Solution for building locally for WebGL on macOS:
1. Download Python 3+ at https://www.python.org/downloads/release/python-3105/
2. Have a PreBuildProcessing script in place (added in this PR) to re-map Python path when building. 

Resources:
- https://forum.unity.com/threads/case-1412113-builderror-osx-12-3-and-unity-2020-3-constant-build-errors.1255419/#post-7993017
- https://answers.unity.com/questions/1893841/unity-2020328f1-webgl-build-failed-on-macos-monter.html

### WHAT
Added PreBuildProcessing script needed for building in MacOS 12.3 or later
