### PR TITLE
fix: mana counter value not being correctly parsed

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ManaCounterView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ManaCounterView.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -18,7 +19,8 @@ internal class ManaCounterView : MonoBehaviour
     public void SetBalance(string balance)
     {
         double manaBalance = 0;
-        if (double.TryParse(balance, out manaBalance))
+        
+        if (double.TryParse(balance, NumberStyles.Number, CultureInfo.InvariantCulture, out manaBalance))
             SetBalance(manaBalance);
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Tests/ProfileHUDTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Tests/ProfileHUDTests.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using System;
 using System.Collections;
 using NSubstitute;
 using UnityEngine.TestTools;
@@ -109,10 +108,10 @@ public class ProfileHUDTests : IntegrationTestSuite_Legacy
     [Test]
     public void SetManaBalanceCorrectly()
     {
-        string balance = "5";
+        string balance = "123456.123456";
 
         controller.SetManaBalance(balance);
-        Assert.AreEqual(Convert.ToDouble(balance), Convert.ToDouble(controller.view.manaCounterView.balanceText.text));
+        Assert.AreEqual("123,5K", controller.view.manaCounterView.balanceText.text);
     }
 
     [Test]
@@ -217,4 +216,6 @@ public class ProfileHUDTests : IntegrationTestSuite_Legacy
 
         Assert.AreEqual(controller.view.descriptionContainer.activeSelf, isWalletConnected);
     }
+
+    
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Tests/ProfileHUDTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Tests/ProfileHUDTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System.Collections;
+using System.Globalization;
 using NSubstitute;
 using UnityEngine.TestTools;
 
@@ -109,9 +110,12 @@ public class ProfileHUDTests : IntegrationTestSuite_Legacy
     public void SetManaBalanceCorrectly()
     {
         string balance = "123456.123456";
-
+        double.TryParse(balance, NumberStyles.Number, CultureInfo.InvariantCulture, out double manaBalance);
+        string formattedManaBalance = (manaBalance / 1000D).ToString("0.#K");
+        
         controller.SetManaBalance(balance);
-        Assert.AreEqual("123,5K", controller.view.manaCounterView.balanceText.text);
+        
+        Assert.AreEqual(formattedManaBalance, controller.view.manaCounterView.balanceText.text);
     }
 
     [Test]


### PR DESCRIPTION
## What does this PR change?

Fixed mana counter parser to use Culture invariant parses.

Fixes https://github.com/decentraland/explorer-desktop/issues/125

## How to test the changes?

Log in with a wallet with mana, the counter should be correctly parsed.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
