### PR TITLE
Fix: emote wheel no longer opens on shortcut usage

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesWheelHUD/EmotesWheelController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesWheelHUD/EmotesWheelController.cs
@@ -8,6 +8,7 @@ namespace DCL.EmotesWheel
     {
         internal EmotesWheelView view;
         private BaseVariable<bool> emotesVisible => DataStore.i.HUDs.emotesVisible;
+        private BaseVariable<bool> emoteJustTriggeredFromShortcut => DataStore.i.HUDs.emoteJustTriggeredFromShortcut;
         private BaseVariable<bool> isAvatarEditorVisible => DataStore.i.HUDs.avatarEditorVisible;
         private BaseVariable<bool> isStartMenuOpen => DataStore.i.exploreV2.isOpen;
         private BaseVariable<bool> canStartMenuBeOpened => DataStore.i.exploreV2.isSomeModalOpen;
@@ -38,7 +39,6 @@ namespace DCL.EmotesWheel
         private InputAction_Trigger auxShortcut7InputAction;
         private InputAction_Trigger auxShortcut8InputAction;
         private InputAction_Trigger auxShortcut9InputAction;
-        private bool emoteJustTriggeredFromShortcut = false;
         private UserProfile userProfile;
         private BaseDictionary<string, WearableItem> catalog;
         private bool ownedWearablesAlreadyRequested = false;
@@ -163,9 +163,8 @@ namespace DCL.EmotesWheel
             if (isStartMenuOpen.Get())
                 return;
 
-            if (emoteJustTriggeredFromShortcut)
+            if (emoteJustTriggeredFromShortcut.Get())
             {
-                emoteJustTriggeredFromShortcut = false;
                 emotesVisible.Set(false);
                 return;
             }
@@ -319,43 +318,43 @@ namespace DCL.EmotesWheel
             {
                 case DCLAction_Trigger.ToggleEmoteShortcut0:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[0]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut1:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[1]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut2:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[2]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut3:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[3]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut4:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[4]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut5:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[5]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut6:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[6]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut7:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[7]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut8:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[8]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleEmoteShortcut9:
                     PlayEmote(emotesCustomizationDataStore.equippedEmotes[9]?.id, UserProfile.EmoteSource.Shortcut);
-                    emoteJustTriggeredFromShortcut = true;
+                    emoteJustTriggeredFromShortcut.Set(true);
                     break;
                 case DCLAction_Trigger.ToggleShortcut0:
                     if (emotesVisible.Get())

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -34,6 +34,7 @@ public class TaskbarHUDController : IHUD
 
     internal BaseVariable<bool> isEmotesWheelInitialized => DataStore.i.emotesCustomization.isWheelInitialized;
     internal BaseVariable<bool> isEmotesVisible => DataStore.i.HUDs.emotesVisible;
+    internal BaseVariable<bool> emoteJustTriggeredFromShortcut => DataStore.i.HUDs.emoteJustTriggeredFromShortcut;
     internal BaseVariable<Transform> isExperiencesViewerInitialized => DataStore.i.experiencesViewer.isInitialized;
     internal BaseVariable<bool> isExperiencesViewerOpen => DataStore.i.experiencesViewer.isOpen;
     internal BaseVariable<int> numOfLoadedExperiences => DataStore.i.experiencesViewer.numOfLoadedExperiences;
@@ -106,6 +107,12 @@ public class TaskbarHUDController : IHUD
 
     private void HandleEmotesToggle(bool show)
     {
+        if (show && emoteJustTriggeredFromShortcut.Get())
+        {
+            emoteJustTriggeredFromShortcut.Set(false);
+            return;
+        }
+
         if (show)
         {
             OpenPublicChannelOnPreviewMode();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_HUDs.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_HUDs.cs
@@ -11,6 +11,7 @@ namespace DCL
         public readonly BaseVariable<bool> isAvatarEditorInitialized = new BaseVariable<bool>(false);
         public readonly BaseVariable<bool> avatarEditorVisible = new BaseVariable<bool>(false);
         public readonly BaseVariable<bool> emotesVisible = new BaseVariable<bool>(false);
+        public readonly BaseVariable<bool> emoteJustTriggeredFromShortcut = new BaseVariable<bool>(false);
         public readonly BaseVariable<bool> isNavMapInitialized = new BaseVariable<bool>(false);
         public readonly BaseVariable<bool> navmapVisible = new BaseVariable<bool>(false);
         public readonly BaseVariable<bool> chatInputVisible = new BaseVariable<bool>(false);


### PR DESCRIPTION
## What does this PR change?

Fix #2430 
Avoids emote wheel from opening on emote shortcut usage

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/emote-wheel
2. Open the emote wheel
3. Use Emotes
4. Use emotes with the shortcuts and verify that the wheel doesn't open
5. Use the wheel in combination with the taskbar button

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
