### PR TITLE
chore: remove explorev2 feature flag

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
@@ -34,11 +34,11 @@ namespace DCL
             pluginSystem.Register<UUIDEventsPlugin>(() => new UUIDEventsPlugin());
             pluginSystem.Register<UIComponentsPlugin>(() => new UIComponentsPlugin());
             pluginSystem.Register<CoreComponentsPlugin>(() => new CoreComponentsPlugin());
+            pluginSystem.Register<PlacesAndEventsFeature>(() => new PlacesAndEventsFeature());
 
             pluginSystem.Register<SpawnPointsDisplayerPlugin>(() => new SpawnPointsDisplayerPlugin());
             pluginSystem.RegisterWithFlag<BuilderInWorldPlugin>(() => new BuilderInWorldPlugin(), "builder_in_world");
             pluginSystem.RegisterWithFlag<TutorialController>(() => new TutorialController(), "tutorial");
-            pluginSystem.RegisterWithFlag<PlacesAndEventsFeature>(() => new PlacesAndEventsFeature(), "explorev2");
             pluginSystem.RegisterWithFlag<ECS7Plugin>(() => new ECS7Plugin(), "ecs7");
             pluginSystem.Register<FriendsNotificationPlugin>(() => new FriendsNotificationPlugin(new DefaultPlayerPrefs(),
                 FriendsController.i,


### PR DESCRIPTION
## What does this PR change?

As the explorev2 feature has been on for 9 months, the explorev2 ff was removed. In the PluginSystemFactory.cs, the PlacesAndEventsFeature gets registered without the flag.


## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=chore/remove-explorev2-flag
2. Check that the Explore section is present in the StartMenu

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
