### PR TITLE
chore: Removed gpu-only-meshes ff

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -180,8 +180,6 @@ namespace DCL
 
         private void UploadMeshesToGPU(HashSet<Mesh> meshesList)
         {
-            var uploadToGPU = DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(FeatureFlag.GPU_ONLY_MESHES);
-
             foreach ( Mesh mesh in meshesList )
             {
                 if ( !mesh.isReadable )
@@ -189,12 +187,6 @@ namespace DCL
 
                 asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
                 asset.meshes.Add(mesh);
-
-                if (uploadToGPU)
-                {
-                    Physics.BakeMesh(mesh.GetInstanceID(), false);
-                    mesh.UploadMeshData(true);
-                }
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/FeatureFlags/Data/FeatureFlag.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/FeatureFlags/Data/FeatureFlag.cs
@@ -5,8 +5,6 @@ using UnityEngine;
 
 public class FeatureFlag
 {
-    public const string GPU_ONLY_MESHES = "use-gpu-only-meshes";
-
     public readonly Dictionary<string, bool> flags  = new Dictionary<string, bool>();
     public readonly Dictionary<string, FeatureFlagVariant> variants  = new Dictionary<string, FeatureFlagVariant>();
 

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -348,8 +348,7 @@ namespace UnityGLTF
             sceneImporter.initialVisibility = initialVisibility;
             sceneImporter.addMaterialsToPersistentCaching = addMaterialsToPersistentCaching;
 
-            sceneImporter.forceGPUOnlyMesh = settings.forceGPUOnlyMesh
-                                             && DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(FeatureFlag.GPU_ONLY_MESHES);
+            sceneImporter.forceGPUOnlyMesh = false;
 
             sceneImporter.OnMeshCreated += meshCreatedCallback;
             sceneImporter.OnRendererCreated += rendererCreatedCallback;


### PR DESCRIPTION
### WHY
The gpu-only-meshes ff was present in the FeatureFlag.cs class, but was inaccessible since there was no flag in Unleash. 

### WHAT
The flag was removed, and in the places that it was used, it was set as false or removed. The logic that was directly dependent on this flag was removed.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
