### PR TITLE
fix: chat messages order

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -65,16 +65,17 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
 
     internal async UniTask PopulateTask(ChatEntryModel chatEntryModel, CancellationToken cancellationToken)
     {
-        // Due to a TMPro bug in Unity 2020 LTS we have to wait several frames before setting the body.text to avoid a
-        // client crash. More info at https://github.com/decentraland/unity-renderer/pull/2345#issuecomment-1155753538
-        await UniTask.NextFrame();
-        await UniTask.NextFrame();
-        await UniTask.NextFrame();
-        
         model = chatEntryModel;
 
         chatEntryModel.bodyText = RemoveTabs(chatEntryModel.bodyText);
         var userString = GetUserString(chatEntryModel);
+        
+        // Due to a TMPro bug in Unity 2020 LTS we have to wait several frames before setting the body.text to avoid a
+        // client crash. More info at https://github.com/decentraland/unity-renderer/pull/2345#issuecomment-1155753538
+        // TODO: Remove hack in a newer Unity/TMPro version 
+        await UniTask.NextFrame();
+        await UniTask.NextFrame();
+        await UniTask.NextFrame();
         
         if (!string.IsNullOrEmpty(userString) && showUserName)
             body.text = $"{userString} {chatEntryModel.bodyText}";

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Resources/ChatEntrySeparator.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Resources/ChatEntrySeparator.prefab
@@ -66,7 +66,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Today
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -109,7 +109,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -118,6 +118,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -237,6 +238,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   title: {fileID: 354067051564857684}
+  previewBackgroundImage: {fileID: 0}
+  previewBackgroundColor: {r: 0, g: 0, b: 0, a: 0}
+  previewFontColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!114 &7718504158943562904
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Resources/ChatEntryReceived.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Resources/ChatEntryReceived.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: djkdjdjdkjd
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -108,7 +108,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -117,6 +117,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -198,18 +199,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeToFade: 10
   fadeDuration: 5
-  username: {fileID: 0}
   body: {fileID: 354067051564857684}
-  worldMessageColor: {r: 0, g: 0, b: 0, a: 1}
-  privateToMessageColor: {r: 0, g: 0, b: 0, a: 1}
-  privateFromMessageColor: {r: 0, g: 0, b: 0, a: 1}
-  systemColor: {r: 0.4669811, g: 1, b: 0.9846577, a: 1}
-  playerNameColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
-  nonPlayerNameColor: {r: 1, g: 1, b: 1, a: 1}
   group: {fileID: 354067052109101190}
   timeToHoverPanel: 1
+  timeToHoverGotoPanel: 1
+  showUserName: 1
   hoverPanelPositionReference: {fileID: 3024181970000382523}
   contextMenuPositionReference: {fileID: 0}
+  previewBackgroundImage: {fileID: 0}
+  previewBackgroundColor: {r: 0, g: 0, b: 0, a: 0}
+  previewFontColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!225 &354067052109101190
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Resources/ChatEntrySent.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Resources/ChatEntrySent.prefab
@@ -64,18 +64,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeToFade: 10
   fadeDuration: 5
-  username: {fileID: 0}
   body: {fileID: 150487733643597186}
-  worldMessageColor: {r: 0, g: 0, b: 0, a: 1}
-  privateToMessageColor: {r: 0, g: 0, b: 0, a: 1}
-  privateFromMessageColor: {r: 0, g: 0, b: 0, a: 1}
-  systemColor: {r: 0.4669811, g: 1, b: 0.9846577, a: 1}
-  playerNameColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
-  nonPlayerNameColor: {r: 1, g: 1, b: 1, a: 1}
   group: {fileID: 150487731994969879}
   timeToHoverPanel: 1
+  timeToHoverGotoPanel: 1
+  showUserName: 1
   hoverPanelPositionReference: {fileID: 2464393378482792029}
   contextMenuPositionReference: {fileID: 0}
+  previewBackgroundImage: {fileID: 0}
+  previewBackgroundColor: {r: 0, g: 0, b: 0, a: 0}
+  previewFontColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!225 &150487731994969879
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -193,7 +191,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Test 1 2 3 4 5 6 7 8
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -236,7 +234,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -245,6 +243,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Chat/ChatEntry.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Chat/ChatEntry.prefab
@@ -311,7 +311,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Name: The worlds '
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -354,7 +354,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -363,6 +363,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ChatEntrySeparator.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ChatEntrySeparator.prefab
@@ -66,7 +66,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Today
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -109,7 +109,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -118,6 +118,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatEntryReceived.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatEntryReceived.prefab
@@ -49,6 +49,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4315294092968244398, guid: c419563788ffdbc44a53495651162084,
         type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4315294092968244398, guid: c419563788ffdbc44a53495651162084,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -220,7 +225,7 @@ PrefabInstance:
     - target: {fileID: 8068759164719752186, guid: c419563788ffdbc44a53495651162084,
         type: 3}
       propertyPath: m_text
-      value: 'The worlds '
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c419563788ffdbc44a53495651162084, type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatEntrySent.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PrivateChatEntrySent.prefab
@@ -115,7 +115,7 @@ PrefabInstance:
     - target: {fileID: 4919932192753732469, guid: c419563788ffdbc44a53495651162084,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 837
+      value: 1223
       objectReference: {fileID: 0}
     - target: {fileID: 4919932192753732469, guid: c419563788ffdbc44a53495651162084,
         type: 3}
@@ -300,7 +300,7 @@ PrefabInstance:
     - target: {fileID: 8068759164719752186, guid: c419563788ffdbc44a53495651162084,
         type: 3}
       propertyPath: m_text
-      value: 'The worlds '
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 8068759164719752186, guid: c419563788ffdbc44a53495651162084,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PublicChatEntrySent.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/PublicChatEntrySent.prefab
@@ -132,7 +132,7 @@ PrefabInstance:
     - target: {fileID: 4919932192753732469, guid: c419563788ffdbc44a53495651162084,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 1223
       objectReference: {fileID: 0}
     - target: {fileID: 4919932192753732469, guid: c419563788ffdbc44a53495651162084,
         type: 3}
@@ -317,7 +317,7 @@ PrefabInstance:
     - target: {fileID: 8068759164719752186, guid: c419563788ffdbc44a53495651162084,
         type: 3}
       propertyPath: m_text
-      value: 'The worlds '
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 8068759164719752186, guid: c419563788ffdbc44a53495651162084,
         type: 3}


### PR DESCRIPTION
After we updated the project's unity version with a hacky fix (3-frame wait when populating a chat entry) for a crash that happened in the web client build, that same hack provoked a problem with chat entries positioning.

This PR moves that hack to the closest point to the crash-provoking code (the body.text manipulation as explained [here](https://github.com/decentraland/unity-renderer/pull/2345#issuecomment-1155753538)) and that solves the problem with the chat entries positioning.

I also removed all the placeholder texts that we had in several chat entry prefabs (as that placeholder text can be seen by a quick eye during the 3-frame wait)

**master branch build**
![Screen Shot 2022-06-21 at 20 55 58](https://user-images.githubusercontent.com/1031741/174916722-e716d68b-0d3b-4ada-8425-65e16d8df659.png)

**This PR build**
![Screen Shot 2022-06-21 at 21 21 22](https://user-images.githubusercontent.com/1031741/174917543-7736d250-7d51-4306-9af7-eba343627913.png)

### TEST
- Test that opening the main menu -> Places and clicking in Wondermine -> Jump In doesn't freeze/crash the client
- Test that writting consecutive messages they are positioned correctly