### PR TITLE
chore: performance meter update

### DIFF
--- a/unity-renderer/Assets/Resources/ScriptableObjects/ForcePerformanceMeter.asset
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/ForcePerformanceMeter.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdae4528345114a1fa069b0a59dc53c7, type: 3}
+  m_Name: ForcePerformanceMeter
+  m_EditorClassIdentifier: 
+  value: 0

--- a/unity-renderer/Assets/Resources/ScriptableObjects/ForcePerformanceMeter.asset.meta
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/ForcePerformanceMeter.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 996802fba19fd8845bf86b5f5a503835
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scenes/InitialScene.unity
+++ b/unity-renderer/Assets/Scenes/InitialScene.unity
@@ -231,8 +231,9 @@ MonoBehaviour:
   enableTutorial: 0
   builderInWorld: 0
   soloScene: 0
-  multithreaded: 0
   debugPanelMode: 0
+  multithreaded: 0
+  runPerformanceMeterToolDuringLoading: 1
 --- !u!4 &1444882337
 Transform:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
@@ -149,6 +149,9 @@ public static class CommonScriptableObjects
 
     private static BooleanVariable playerInfoCardVisibleStateValue;
     public static BooleanVariable playerInfoCardVisibleState => GetOrLoad(ref playerInfoCardVisibleStateValue, "ScriptableObjects/PlayerInfoCardVisibleState");
+    
+    private static BooleanVariable forcePerformanceMeterValue;
+    public static BooleanVariable forcePerformanceMeter => GetOrLoad(ref forcePerformanceMeterValue, "ScriptableObjects/ForcePerformanceMeter");
 
     public static RendererState rendererState => GetOrLoad(ref rendererStateValue, "ScriptableObjects/RendererState");
     private static RendererState rendererStateValue;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/DebugBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/DebugBridge.cs
@@ -240,6 +240,12 @@ namespace DCL
         }
 
 #if UNITY_EDITOR
+        [ContextMenu("Run Performance Meter Tool for 10 seconds")]
+        public void ShortDebugPerformanceMeter()
+        {
+            RunPerformanceMeterTool(10);
+        }
+
         [ContextMenu("Run Performance Meter Tool for 30 seconds")]
         public void DebugPerformanceMeter()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/DebugBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/DebugBridge.cs
@@ -240,10 +240,10 @@ namespace DCL
         }
 
 #if UNITY_EDITOR
-        [ContextMenu("Run Performance Meter Tool for 10 seconds")]
+        [ContextMenu("Run Performance Meter Tool for 2 seconds")]
         public void ShortDebugPerformanceMeter()
         {
-            RunPerformanceMeterTool(10);
+            RunPerformanceMeterTool(2);
         }
 
         [ContextMenu("Run Performance Meter Tool for 30 seconds")]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugConfigComponent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugConfigComponent.cs
@@ -16,6 +16,7 @@ namespace DCL
             {
                 if (sharedInstance == null)
                     sharedInstance = FindObjectOfType<DebugConfigComponent>();
+
                 return sharedInstance;
             }
             private set => sharedInstance = value;
@@ -75,10 +76,14 @@ namespace DCL
         public bool enableTutorial = false;
         public bool builderInWorld = false;
         public bool soloScene = true;
-        public bool multithreaded = false;
-        public bool disableAssetBundles = false;
-        public bool disableGLTFDownloadThrottle = false;
         public DebugPanel debugPanelMode = DebugPanel.Off;
+        public bool disableAssetBundles = false;
+
+        [Header("Performance")]
+        public bool disableGLTFDownloadThrottle = false;
+        public bool multithreaded = false;
+        public bool runPerformanceMeterToolDuringLoading = false;
+        private PerformanceMeterController performanceMeterController;
 
         private void Awake()
         {
@@ -127,6 +132,19 @@ namespace DCL
 
             if (openBrowserWhenStart)
                 OpenWebBrowser();
+
+            if (runPerformanceMeterToolDuringLoading)
+            {
+                CommonScriptableObjects.forcePerformanceMeter.Set(true);
+                performanceMeterController = new PerformanceMeterController();
+                performanceMeterController.StartSampling(999);
+                CommonScriptableObjects.rendererState.OnChange += OnRendererStateChanged;
+            }
+        }
+        private void OnRendererStateChanged(bool current, bool previous)
+        {
+            CommonScriptableObjects.rendererState.OnChange -= OnRendererStateChanged;
+            performanceMeterController.StopSampling();
         }
 
         private void OpenWebBrowser()
@@ -146,15 +164,19 @@ namespace DCL
                     break;
                 case Environment.LOCAL:
                     debugString = "DEBUG_MODE&";
+
                     break;
                 case Environment.ZONE:
                     debugString = "NETWORK=ropsten&";
+
                     break;
                 case Environment.TODAY:
                     debugString = "NETWORK=mainnet&";
+
                     break;
                 case Environment.ORG:
                     debugString = "NETWORK=mainnet&";
+
                     break;
             }
 
@@ -220,7 +242,9 @@ namespace DCL
                 {
                     Debug.LogError(
                         "play.decentraland.org only works with WebSocket SSL, please change the base URL to play.decentraland.zone");
+
                     QuitGame();
+
                     return;
                 }
             }
@@ -235,10 +259,7 @@ namespace DCL
 #endif
         }
 
-        private void OnDestroy()
-        {
-            DataStore.i.wsCommunication.communicationReady.OnChange -= OnCommunicationReadyChangedValue;
-        }
+        private void OnDestroy() { DataStore.i.wsCommunication.communicationReady.OnChange -= OnCommunicationReadyChangedValue; }
 
         private void QuitGame()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugParameters.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugParameters.asmdef
@@ -1,19 +1,21 @@
 {
-  "name": "DebugParameters",
-  "rootNamespace": "",
-  "references": [
-    "GUID:e555144732b726c4cba5b0f6337fea75",
-    "GUID:28f74c468a54948bfa9f625c5d428f56",
-    "GUID:50ec9ad5165784219ba1b15ab4e77d65",
-    "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "DebugParameters",
+    "rootNamespace": "",
+    "references": [
+        "GUID:e555144732b726c4cba5b0f6337fea75",
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:50ec9ad5165784219ba1b15ab4e77d65",
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
+        "GUID:86fc86d79514649949d189c1ef89260a",
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/BenchmarkResult.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/BenchmarkResult.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DCL
+{
+    [Serializable]
+    public class BenchmarkResult
+    {
+        // metrics based on this // https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L1912
+        private const double T_TABLE_INFINITY = 1.96;
+        private static readonly IReadOnlyDictionary<int, double> tTable = new Dictionary<int, double>()
+        {
+            { 01, 12.706 }, { 02, 4.303 }, { 03, 3.182 },
+            { 04, 02.776 }, { 05, 2.571 }, { 06, 2.447 },
+            { 07, 02.365 }, { 08, 2.306 }, { 09, 2.262 },
+            { 10, 02.228 }, { 11, 2.201 }, { 12, 2.179 },
+            { 13, 02.160 }, { 14, 2.145 }, { 15, 2.131 },
+            { 16, 02.120 }, { 17, 2.110 }, { 18, 2.101 },
+            { 19, 02.093 }, { 20, 2.086 }, { 21, 2.080 },
+            { 22, 02.074 }, { 23, 2.069 }, { 24, 2.064 },
+            { 25, 02.060 }, { 26, 2.056 }, { 27, 2.052 },
+            { 28, 02.048 }, { 29, 2.045 }, { 30, 2.042 }
+        };
+
+        public double min;
+        public double max;
+        public double moe; // Margin of error
+        public double rme = 0; // Relative Margin of Error
+        public double sem; // Mean standard error
+        public double stdDev;
+        public double mean;
+        public double variance;
+        private double[] samples;
+
+        public BenchmarkResult(double[] samples)
+        {
+            SetSamples(samples);
+        }
+
+        public void SetSamples(double[] samples)
+        {
+            this.samples = samples;
+            int sampleSize = samples.Length;
+
+            min = samples.Min();
+            max = samples.Max();
+            mean = samples.Average();
+            variance = Variance(samples);
+            stdDev = StdDev(variance);
+            sem = stdDev / Math.Sqrt(sampleSize);
+            // Compute the degrees of freedom.
+            int df = sampleSize - 1;
+            // Compute the critical value.
+            int tTableIndex = Math.Max(df, 1); //Minimum index is 1;
+            if (!tTable.TryGetValue(tTableIndex, out double critical))
+                critical = T_TABLE_INFINITY; // we take the infinity 
+
+            moe = sem * critical;
+            if (mean != 0)
+                rme = (moe / mean) * 100;
+        }
+
+        private static double Variance(double[] samples)
+        {
+            if (samples.Length <= 1)
+                return 0.0;
+
+            double avg = samples.Average();
+            double variance = samples.Sum(value => (value - avg) * (value - avg));
+            return variance / samples.Length;
+        }
+
+        private static double StdDev(double variance) { return Math.Sqrt(variance); }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/BenchmarkResult.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/BenchmarkResult.cs
@@ -38,6 +38,7 @@ namespace DCL
             SetSamples(samples);
         }
 
+        // Note (Kinerius): This code is lazy and performs poorly, please optimize if used outside our debugging tools
         public void SetSamples(double[] samples)
         {
             this.samples = samples;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/BenchmarkResult.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/BenchmarkResult.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8379b8a6d9184852bdffa7f479d60be8
+timeCreated: 1655908122

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
@@ -323,9 +323,9 @@ namespace DCL
         private int CalculatePerformanceScore()
         {
             double desiredFrameTime = Settings.i.qualitySettings.Data.fpsCap ? 1000/30.0 : 1000/60.0;
-            double fpsScore = Mathf.Min((float)(averageFrameTime / desiredFrameTime), 1); // from 0 to 1
+            double frameScore = Mathf.Min((float)(desiredFrameTime/ averageFrameTime), 1); // from 0 to 1
             double hiccupsScore = 1 - (float) totalHiccupFrames / samples.Count; // from 0 to 1
-            double performanceScore = (fpsScore + hiccupsScore) / 2 * 100; // scores sum / amount of scores * 100 to have a 0-100 scale
+            double performanceScore = (frameScore + hiccupsScore) / 2 * 100; // scores sum / amount of scores * 100 to have a 0-100 scale
 
             return Mathf.RoundToInt((float)performanceScore * 100f) / 100;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
@@ -321,7 +321,7 @@ namespace DCL
         }
 
         /// <summary>
-        /// Calculates a performance score from 0 to 100 based on the average FPS (compared to the max possible FPS) and the amount of hiccup frames (compared to the total amount of frames).
+        /// Calculates a performance score from 0 to 100 based on the average frame time (compared to the closest frame time to target 60 fps) and the amount of hiccup frames (compared to the total amount of frames).
         /// </summary>
         private int CalculatePerformanceScore()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using DCL.FPSDisplay;
 using DCL.SettingsCommon;
@@ -25,14 +26,14 @@ namespace DCL
             public float millisecondsConsumed;
             public bool isHiccup = false;
             public float currentTime;
-            public float fpsAtThisFrameInTime;
+            public float frameTimeMs;
 
             public override string ToString()
             {
                 return "frame number: " + frameNumber
                                         + "\n frame consumed milliseconds: " + millisecondsConsumed
                                         + "\n is hiccup: " + isHiccup
-                                        + "\n fps at this frame: " + fpsAtThisFrameInTime;
+                                        + "\n frame time: " + frameTimeMs;
             }
 
             public int CompareTo(object obj)
@@ -46,10 +47,10 @@ namespace DCL
                 if (otherSample == null)
                     return 1;
 
-                if (this.fpsAtThisFrameInTime == otherSample.fpsAtThisFrameInTime)
+                if (Math.Abs(this.frameTimeMs - otherSample.frameTimeMs) < float.Epsilon)
                     return 0;
 
-                return this.fpsAtThisFrameInTime > otherSample.fpsAtThisFrameInTime ? 1 : -1;
+                return this.frameTimeMs > otherSample.frameTimeMs ? 1 : -1;
             }
         }
 
@@ -60,14 +61,16 @@ namespace DCL
 
         // auxiliar data
         private SampleData lastSavedSample;
-        private float fpsSum = 0;
 
         // reported data
-        private float highestFPS;
-        private float lowestFPS;
-        private float averageFPS;
-        private float percentile50FPS;
-        private float percentile95FPS;
+        private double highestFrameTime;
+        private double lowestFrameTime;
+        private double averageFrameTime;
+        private double marginOfError;
+
+        private float percentile1FrameTime;
+        private float percentile50FrameTime;
+        private float percentile99FrameTime;
         private int totalHiccupFrames;
         private float totalHiccupsTimeInSeconds;
         private int totalFrames;
@@ -87,13 +90,12 @@ namespace DCL
             targetDurationInSeconds = 0f;
 
             lastSavedSample = null;
-            fpsSum = 0;
 
-            highestFPS = 0;
-            lowestFPS = 0;
-            averageFPS = 0;
-            percentile50FPS = 0;
-            percentile95FPS = 0;
+            highestFrameTime = 0;
+            lowestFrameTime = 0;
+            averageFrameTime = 0;
+            percentile50FrameTime = 0;
+            percentile99FrameTime = 0;
             totalHiccupFrames = 0;
             totalHiccupsTimeInSeconds = 0;
             totalFrames = 0;
@@ -163,15 +165,22 @@ namespace DCL
                 secondsConsumed = Time.timeSinceLevelLoad - lastSavedSample.currentTime;
             }
 
-            SampleData newSample = new SampleData()
+            float frameTimeMs = Time.deltaTime * 1000f;
+
+            if (frameTimeMs > 98f)
             {
+                Debug.Log(frameTimeMs);
+            }
+
+            SampleData newSample = new SampleData
+            {
+                frameTimeMs = frameTimeMs,
                 frameNumber = Time.frameCount,
-                fpsAtThisFrameInTime = newData.fpsCount,
                 millisecondsConsumed = secondsConsumed * 1000,
-                currentTime = Time.timeSinceLevelLoad
+                currentTime = Time.timeSinceLevelLoad,
+                isHiccup = secondsConsumed > FPSEvaluation.HICCUP_THRESHOLD_IN_SECONDS
             };
 
-            newSample.isHiccup = secondsConsumed > FPSEvaluation.HICCUP_THRESHOLD_IN_SECONDS;
             samples.Add(newSample);
             lastSavedSample = newSample;
 
@@ -181,8 +190,21 @@ namespace DCL
                 totalHiccupsTimeInSeconds += secondsConsumed;
             }
 
-            fpsSum += newData.fpsCount;
+            UpdateAllocations();
 
+            totalFrames++;
+
+            currentDurationInSeconds += Time.deltaTime;
+
+            if (currentDurationInSeconds > targetDurationInSeconds)
+            {
+                totalFramesTimeInSeconds = currentDurationInSeconds;
+                StopSampling();
+            }
+        }
+
+        private void UpdateAllocations()
+        {
             long lastAllocation = gcAllocatedInFrameRecorder.LastValue;
 
             if (highestAllocation < lastAllocation)
@@ -194,19 +216,8 @@ namespace DCL
             {
                 lowestAllocation = lastAllocation;
             }
-            
+
             totalAllocation += lastAllocation;
-            
-
-            totalFrames++;
-
-            currentDurationInSeconds += Time.deltaTime;
-
-            if (currentDurationInSeconds > targetDurationInSeconds)
-            {
-                totalFramesTimeInSeconds = currentDurationInSeconds;
-                StopSampling();
-            }
         }
 
         /// <summary>
@@ -220,14 +231,18 @@ namespace DCL
 
             int samplesCount = sortedSamples.Count;
 
-            highestFPS = sortedSamples[samplesCount - 1].fpsAtThisFrameInTime;
-            lowestFPS = sortedSamples[0].fpsAtThisFrameInTime;
+            var benchmark = new BenchmarkResult(sortedSamples.Select(sample => (double)sample.frameTimeMs).ToArray());
 
-            averageFPS = fpsSum / sortedSamples.Count;
+            highestFrameTime = benchmark.max;
+            lowestFrameTime = benchmark.min;
+            averageFrameTime = benchmark.mean;
+            marginOfError = benchmark.moe;
+            
+            percentile1FrameTime = sortedSamples[Mathf.CeilToInt(samplesCount * 0.01f)].frameTimeMs;
+            percentile50FrameTime = sortedSamples[Mathf.CeilToInt(samplesCount * 0.5f)].frameTimeMs;
+            percentile99FrameTime = sortedSamples[Mathf.CeilToInt(samplesCount * 0.99f)].frameTimeMs;
+            
             averageAllocation = totalAllocation / sortedSamples.Count;
-
-            percentile50FPS = sortedSamples[Mathf.CeilToInt(samplesCount * 0.5f)].fpsAtThisFrameInTime;
-            percentile95FPS = sortedSamples[Mathf.CeilToInt(samplesCount * 0.95f)].fpsAtThisFrameInTime;
         }
 
         /// <summary>
@@ -267,22 +282,25 @@ namespace DCL
             );
 
             // Step 2 - report processed data
-            Log("Data report step 2 - Processed values:"
-                + "\n * PERFORMANCE SCORE (0-100) -> " + CalculatePerformanceScore()
-                + "\n * average FPS -> " + averageFPS
-                + "\n * highest FPS -> " + highestFPS
-                + "\n * lowest FPS -> " + lowestFPS
-                + "\n * 50 percentile (median) FPS -> " + percentile50FPS
-                + "\n * 95 percentile FPS -> " + percentile95FPS
-                + $"\n * total hiccups (>{FPSEvaluation.HICCUP_THRESHOLD_IN_SECONDS}ms frames) -> {totalHiccupFrames} ({CalculateHiccupsPercentage()}% of frames were hiccups)"
-                + "\n * total hiccups time (seconds) -> " + totalHiccupsTimeInSeconds
-                + "\n * total frames -> " + totalFrames
-                + "\n * total frames time (seconds) -> " + totalFramesTimeInSeconds
-                + "\n * lowest allocations (kb) -> " + lowestAllocation/1000.0
-                + "\n * highest allocations (kb) -> " + highestAllocation/1000.0
-                + "\n * average allocations (kb) -> " + averageAllocation/1000.0
-                + "\n * total allocations (kb) -> " + totalAllocation/1000.0
+            string format = "F3";
 
+            Log($"Data report step 2 - Processed values:" +
+                $"\n * PERFORMANCE SCORE (0-100) -> {CalculatePerformanceScore()}" +
+                $"\n * average frame time -> {averageFrameTime.ToString(format)}ms" +
+                $"\n * highest frame time -> {highestFrameTime.ToString(format)}ms" +
+                $"\n * lowest frame time -> {lowestFrameTime.ToString(format)}ms" +
+                $"\n * error percentage -> ±{marginOfError.ToString(format)}%" +
+                $"\n * 1 percentile frame time -> {percentile1FrameTime.ToString(format)}ms" +
+                $"\n * 50 percentile frame time -> {percentile50FrameTime.ToString(format)}ms" +
+                $"\n * 99 percentile frame time -> {percentile99FrameTime.ToString(format)}ms" +
+                $"\n * total hiccups (>{FPSEvaluation.HICCUP_THRESHOLD_IN_SECONDS}ms frames) -> {totalHiccupFrames} ({CalculateHiccupsPercentage()}% of frames were hiccups)" +
+                $"\n * total hiccups time (seconds) -> {totalHiccupsTimeInSeconds}" +
+                $"\n * total frames -> {totalFrames}" +
+                $"\n * total frames time (seconds) -> {totalFramesTimeInSeconds}" +
+                $"\n * lowest allocations (kb) -> {lowestAllocation / 1000.0}" +
+                $"\n * highest allocations (kb) -> {highestAllocation / 1000.0}" +
+                $"\n * average allocations (kb) -> {averageAllocation / 1000.0}" +
+                $"\n * total allocations (kb) -> {totalAllocation / 1000.0}"
             );
 
             // Step 3 - report all samples data
@@ -302,18 +320,14 @@ namespace DCL
         /// <summary>
         /// Calculates a performance score from 0 to 100 based on the average FPS (compared to the max possible FPS) and the amount of hiccup frames (compared to the total amount of frames).
         /// </summary>
-        private float CalculatePerformanceScore()
+        private int CalculatePerformanceScore()
         {
-            float topFPS = Settings.i.qualitySettings.Data.fpsCap ? 30f : 60f;
-            float fpsScore = Mathf.Min(averageFPS / topFPS, 1); // from 0 to 1
-            float hiccupsScore = 1 - ((float) totalHiccupFrames / samples.Count); // from 0 to 1
+            double desiredFrameTime = Settings.i.qualitySettings.Data.fpsCap ? 1000/30.0 : 1000/60.0;
+            double fpsScore = Mathf.Min((float)(averageFrameTime / desiredFrameTime), 1); // from 0 to 1
+            double hiccupsScore = 1 - (float) totalHiccupFrames / samples.Count; // from 0 to 1
+            double performanceScore = (fpsScore + hiccupsScore) / 2 * 100; // scores sum / amount of scores * 100 to have a 0-100 scale
 
-            float performanceScore =
-                (fpsScore + hiccupsScore) / 2 * 100; // scores sum / amount of scores * 100 to have a 0-100 scale
-
-            performanceScore = Mathf.Round(performanceScore * 100f) / 100f; // to save only 2 decimals
-
-            return performanceScore;
+            return Mathf.RoundToInt((float)performanceScore * 100f) / 100;
         }
 
         private float CalculateHiccupsPercentage()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMeterController/PerformanceMeterController.cs
@@ -282,7 +282,7 @@ namespace DCL
             );
 
             // Step 2 - report processed data
-            string format = "F3";
+            string format = "F1";
 
             Log($"Data report step 2 - Processed values:" +
                 $"\n * PERFORMANCE SCORE (0-100) -> {CalculatePerformanceScore()}" +

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMetricsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMetricsController.cs
@@ -59,7 +59,7 @@ namespace DCL
             if (!CommonScriptableObjects.focusState.Get())
                 return;
 #endif
-            if (!CommonScriptableObjects.rendererState.Get())
+            if (!CommonScriptableObjects.rendererState.Get() && !CommonScriptableObjects.forcePerformanceMeter.Get())
                 return;
 
             var deltaInMs = Time.deltaTime * 1000;


### PR DESCRIPTION
## What does this PR change?

Updated the performance meter tool to give us frame data instead of fps, also added error margins

Fixes #2460

## How to test the changes?

run `clientDebug.RunPerformanceMeterTool(30)` in the browser console an wait for the results

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
