### PR TITLE
fix: emote animation loader tests async

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationLoader.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationLoader.cs
@@ -13,20 +13,16 @@ namespace DCL.Emotes
 
         public EmoteAnimationLoader(IWearableRetriever retriever) { this.retriever = retriever; }
 
-        internal readonly string MISSING_CONTAINER_ERROR = "Container cannot be null";
-        internal readonly string MISSING_EMOTE_ERROR = "Emote cannot be null";
-        internal readonly string MISSING_BODYSHAPE_ERROR = "bodyShapeId cannot be null or empty";
-
         public async UniTask LoadEmote(GameObject container, WearableItem emote, string bodyShapeId, CancellationToken ct = default)
         {
             if (container == null)
-                throw new NullReferenceException(MISSING_CONTAINER_ERROR);
+                throw new NullReferenceException("Container cannot be null");
 
             if (emote == null)
-                throw new NullReferenceException(MISSING_EMOTE_ERROR);
+                throw new NullReferenceException("Emote cannot be null");
 
             if (string.IsNullOrEmpty(bodyShapeId))
-                throw new NullReferenceException(MISSING_BODYSHAPE_ERROR);
+                throw new NullReferenceException("bodyShapeId cannot be null or empty");
 
             ct.ThrowIfCancellationRequested();
 

--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationLoader.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationLoader.cs
@@ -13,16 +13,20 @@ namespace DCL.Emotes
 
         public EmoteAnimationLoader(IWearableRetriever retriever) { this.retriever = retriever; }
 
+        internal readonly string MISSING_CONTAINER_ERROR = "Container cannot be null";
+        internal readonly string MISSING_EMOTE_ERROR = "Emote cannot be null";
+        internal readonly string MISSING_BODYSHAPE_ERROR = "bodyShapeId cannot be null or empty";
+
         public async UniTask LoadEmote(GameObject container, WearableItem emote, string bodyShapeId, CancellationToken ct = default)
         {
             if (container == null)
-                throw new NullReferenceException("Container cannot be null");
+                throw new NullReferenceException(MISSING_CONTAINER_ERROR);
 
             if (emote == null)
-                throw new NullReferenceException("Emote cannot be null");
+                throw new NullReferenceException(MISSING_EMOTE_ERROR);
 
             if (string.IsNullOrEmpty(bodyShapeId))
-                throw new NullReferenceException("bodyShapeId cannot be null or empty");
+                throw new NullReferenceException(MISSING_BODYSHAPE_ERROR);
 
             ct.ThrowIfCancellationRequested();
 

--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/Tests/EmoteAnimationLoaderShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/Tests/EmoteAnimationLoaderShould.cs
@@ -30,28 +30,43 @@ namespace DCL.Emotes
         [TearDown]
         public void TearDown() { Object.Destroy(container); }
 
-        [Test]
-        public void ThrowIfNullContainer() { TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(null, new WearableItem(), "female")); }
+        [UnityTest]
+        public IEnumerator ThrowIfNullContainer() => UniTask.ToCoroutine(async () =>
+        { 
+            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(null, new WearableItem(), "female"));
+        });
 
-        [Test]
-        public void ThrowIfNullEmote() { TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, null, "female")); }
+        [UnityTest]
+        public IEnumerator ThrowIfNullEmote() => UniTask.ToCoroutine(async () =>
+        {
+            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, null, "female"));
+        });
 
-        [Test]
-        public void ThrowIfNullBodyShape() { TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), null)); }
+        [UnityTest]
+        public IEnumerator ThrowIfNullBodyShape() => UniTask.ToCoroutine(async () =>
+        {
+            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), null));
+        });
 
-        [Test]
-        public void ThrowIfEmptyBodyShape() { TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), "")); }
+        [UnityTest]
+        public IEnumerator ThrowIfEmptyBodyShape() => UniTask.ToCoroutine(async () =>
+        {
+            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), ""));
+        });
 
-        [Test]
-        public void ThrowIfNoRepresentationForBodyShape() { TestUtils.ThrowsAsync<Exception>(loader.LoadEmote(container, new WearableItem { id = "emote0" }, "female"), $"No representation for female of emote: emote0"); }
+        [UnityTest]
+        public IEnumerator ThrowIfNoRepresentationForBodyShape() => UniTask.ToCoroutine(async () =>
+        {
+            await TestUtils.ThrowsAsync<Exception>(loader.LoadEmote(container, new WearableItem { id = "emote0" }, "female"), $"No representation for female of emote: emote0");
+        });
 
-        [Test]
-        public void ThrowIfCancelledTokenProvided()
+        [UnityTest]
+        public IEnumerator ThrowIfCancelledTokenProvided() => UniTask.ToCoroutine(async () =>
         {
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
-            TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), "female", cts.Token));
-        }
+            // await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), "female", cts.Token));
+        });
 
         [UnityTest]
         public IEnumerator ProvideTheRetrieverAnimation() => UniTask.ToCoroutine(async () =>
@@ -88,6 +103,5 @@ namespace DCL.Emotes
 
             Assert.AreEqual(clip, loader.animation);
         });
-
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/Tests/EmoteAnimationLoaderShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/Tests/EmoteAnimationLoaderShould.cs
@@ -31,74 +31,19 @@ namespace DCL.Emotes
         public void TearDown() { Object.Destroy(container); }
 
         [UnityTest]
-        public IEnumerator ThrowIfNullContainer() => UniTask.ToCoroutine(async () =>
-        {
-            try
-            {
-                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(null, new WearableItem(), "female"));
-            }
-            catch (Exception e)
-            {
-                // We don't 'throw' the exception because it makes the test fail
-                Assert.IsTrue(e.Message.Contains(loader.MISSING_CONTAINER_ERROR));
-            }
-        });
+        public IEnumerator ThrowIfNullContainer() => UniTask.ToCoroutine(async () => await TestUtils.ThrowsAsync<NullReferenceException>(loader.LoadEmote(null, new WearableItem(), "female")));
 
         [UnityTest]
-        public IEnumerator ThrowIfNullEmote() => UniTask.ToCoroutine(async () =>
-        {
-            try 
-            {
-                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, null, "female"));
-            }
-            catch (Exception e)
-            {
-                // We don't 'throw' the exception because it makes the test fail
-                Assert.IsTrue(e.Message.Contains(loader.MISSING_EMOTE_ERROR));
-            }
-        });
+        public IEnumerator ThrowIfNullEmote() => UniTask.ToCoroutine(async () => await TestUtils.ThrowsAsync<NullReferenceException>(loader.LoadEmote(container, null, "female")));
 
         [UnityTest]
-        public IEnumerator ThrowIfNullBodyShape() => UniTask.ToCoroutine(async () =>
-        {
-            try
-            {
-                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), null));
-            }
-            catch (Exception e)
-            {
-                // We don't 'throw' the exception because it makes the test fail
-                Assert.IsTrue(e.Message.Contains(loader.MISSING_BODYSHAPE_ERROR));
-            }
-        });
+        public IEnumerator ThrowIfNullBodyShape() => UniTask.ToCoroutine(async () => await TestUtils.ThrowsAsync<NullReferenceException>(loader.LoadEmote(container, new WearableItem(), null)));
 
         [UnityTest]
-        public IEnumerator ThrowIfEmptyBodyShape() => UniTask.ToCoroutine(async () =>
-        {
-            try
-            {
-                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), ""));
-            }
-            catch (Exception e)
-            {
-                // We don't 'throw' the exception because it makes the test fail
-                Assert.IsTrue(e.Message.Contains(loader.MISSING_BODYSHAPE_ERROR));
-            }
-        });
+        public IEnumerator ThrowIfEmptyBodyShape() => UniTask.ToCoroutine(async () => await TestUtils.ThrowsAsync<NullReferenceException>(loader.LoadEmote(container, new WearableItem(), "")));
 
         [UnityTest]
-        public IEnumerator ThrowIfNoRepresentationForBodyShape() => UniTask.ToCoroutine(async () =>
-        {
-            try
-            {
-                await TestUtils.ThrowsAsync<Exception>(loader.LoadEmote(container, new WearableItem { id = "emote0" }, "female"), $"No representation for female of emote: emote0");
-            }
-            catch (Exception e)
-            {
-                // We don't 'throw' the exception because it makes the test fail
-                Assert.IsTrue(e.Message.Contains("No representation"));
-            }
-        });
+        public IEnumerator ThrowIfNoRepresentationForBodyShape() => UniTask.ToCoroutine(async () => await TestUtils.ThrowsAsync<Exception>(loader.LoadEmote(container, new WearableItem { id = "emote0" }, "female"), $"No representation for female of emote: emote0"));
 
         [UnityTest]
         public IEnumerator ThrowIfCancelledTokenProvided() => UniTask.ToCoroutine(async () =>
@@ -106,14 +51,7 @@ namespace DCL.Emotes
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
 
-            try
-            {
-                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), "female", cts.Token));
-            }
-            catch (Exception e)
-            {
-                // We don't 'throw' the exception because it makes the test fail
-            }
+            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), "female", cts.Token));
         });
 
         [UnityTest]

--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/Tests/EmoteAnimationLoaderShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/Tests/EmoteAnimationLoaderShould.cs
@@ -32,32 +32,72 @@ namespace DCL.Emotes
 
         [UnityTest]
         public IEnumerator ThrowIfNullContainer() => UniTask.ToCoroutine(async () =>
-        { 
-            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(null, new WearableItem(), "female"));
+        {
+            try
+            {
+                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(null, new WearableItem(), "female"));
+            }
+            catch (Exception e)
+            {
+                // We don't 'throw' the exception because it makes the test fail
+                Assert.IsTrue(e.Message.Contains(loader.MISSING_CONTAINER_ERROR));
+            }
         });
 
         [UnityTest]
         public IEnumerator ThrowIfNullEmote() => UniTask.ToCoroutine(async () =>
         {
-            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, null, "female"));
+            try 
+            {
+                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, null, "female"));
+            }
+            catch (Exception e)
+            {
+                // We don't 'throw' the exception because it makes the test fail
+                Assert.IsTrue(e.Message.Contains(loader.MISSING_EMOTE_ERROR));
+            }
         });
 
         [UnityTest]
         public IEnumerator ThrowIfNullBodyShape() => UniTask.ToCoroutine(async () =>
         {
-            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), null));
+            try
+            {
+                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), null));
+            }
+            catch (Exception e)
+            {
+                // We don't 'throw' the exception because it makes the test fail
+                Assert.IsTrue(e.Message.Contains(loader.MISSING_BODYSHAPE_ERROR));
+            }
         });
 
         [UnityTest]
         public IEnumerator ThrowIfEmptyBodyShape() => UniTask.ToCoroutine(async () =>
         {
-            await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), ""));
+            try
+            {
+                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), ""));
+            }
+            catch (Exception e)
+            {
+                // We don't 'throw' the exception because it makes the test fail
+                Assert.IsTrue(e.Message.Contains(loader.MISSING_BODYSHAPE_ERROR));
+            }
         });
 
         [UnityTest]
         public IEnumerator ThrowIfNoRepresentationForBodyShape() => UniTask.ToCoroutine(async () =>
         {
-            await TestUtils.ThrowsAsync<Exception>(loader.LoadEmote(container, new WearableItem { id = "emote0" }, "female"), $"No representation for female of emote: emote0");
+            try
+            {
+                await TestUtils.ThrowsAsync<Exception>(loader.LoadEmote(container, new WearableItem { id = "emote0" }, "female"), $"No representation for female of emote: emote0");
+            }
+            catch (Exception e)
+            {
+                // We don't 'throw' the exception because it makes the test fail
+                Assert.IsTrue(e.Message.Contains("No representation"));
+            }
         });
 
         [UnityTest]
@@ -65,7 +105,15 @@ namespace DCL.Emotes
         {
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
-            // await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), "female", cts.Token));
+
+            try
+            {
+                await TestUtils.ThrowsAsync<OperationCanceledException>(loader.LoadEmote(container, new WearableItem(), "female", cts.Token));
+            }
+            catch (Exception e)
+            {
+                // We don't 'throw' the exception because it makes the test fail
+            }
         });
 
         [UnityTest]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventCardComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventCardComponentViewTests.cs
@@ -344,20 +344,14 @@ public class EventCardComponentViewTests
         Assert.IsFalse(eventCardModalComponent.isVisible);
     }
 
-    [UnityTest]
-    public IEnumerator RaiseOnCloseActionTriggeredCorrectly()
+    [Test]
+    public void RaiseOnCloseActionTriggeredCorrectly()
     {
         // Arrange
         eventCardModalComponent.Show();
 
         // Act
         eventCardModalComponent.OnCloseActionTriggered(new DCLAction_Trigger());
-
-        // TODO: until we remove the PopulateTask.PopulateTask() 3-frame wait we should keep this 3-frame wait hack,
-        // otherwise this test always fails in the desktop client CI.
-        yield return null;
-        yield return null;
-        yield return null;
         
         // Assert
         Assert.IsFalse(eventCardModalComponent.isVisible);


### PR DESCRIPTION
### WHY
explorer-desktop repo always fail several tests due to the `EmoteAnimationLoader` tests being async: they are not awaited during the test run and their expected exceptions are thrown later while other tests are running, making those other tests fail.

These are 3 examples, notice that the error has nothing to do with the failed tests:
- [First unity version update in desktop client playmode tests fail](https://app.circleci.com/pipelines/github/decentraland/explorer-desktop/1185/workflows/7b96c093-8b23-4ce2-a1a1-1736ebfd6b0e/jobs/6122)
![Screen Shot 2022-06-22 at 13 31 44](https://user-images.githubusercontent.com/1031741/175132749-ee725996-c2a7-46c3-932c-dbb590120d8b.png)

- [Second unity version update in desktop client playmode tests fail](https://app.circleci.com/pipelines/github/decentraland/explorer-desktop/1185/workflows/e40b1bcf-18aa-4ddb-8f97-2bad4ff682f6/jobs/6129)
![Screen Shot 2022-06-22 at 13 31 58](https://user-images.githubusercontent.com/1031741/175132805-900ca5da-6936-48a6-a060-da32cfc1c606.png)

- [Third uniy version update in desktop client playmode tests fail](https://app.circleci.com/pipelines/github/decentraland/explorer-desktop/1185/workflows/d1aa6a1d-b64f-47ca-9555-d1becd16e0d5/jobs/6132)
![Screen Shot 2022-06-22 at 13 32 06](https://user-images.githubusercontent.com/1031741/175132838-155f34c5-f975-412c-a5db-d553ecd3c67d.png)

### WHAT

Handled `EmoteAnimationLoader` tests as coroutines so that they are awaited until finished before continuing with the following tests.

### TEST
[This 'test' draft PR](https://github.com/decentraland/explorer-desktop/pull/340) from explorer-desktop (born from [the unity version update branch](https://github.com/decentraland/explorer-desktop/pull/307)) that points to this branch latest commit proves that this PR fixes the problem.