### PR TITLE
chore: avatar should face same direction as spawn point after teleport

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
@@ -192,8 +192,7 @@ namespace DCL.Camera
             var yValue = Mathf.InverseLerp(-90, 90, eulerDir.x);
             defaultVirtualCameraAsFreeLook.m_YAxis.Value = yValue;
             
-            var xzPlaneForward = Vector3.Scale(verticalAxisLookAt, new Vector3(1, 0, 1));
-            characterForward.Set(xzPlaneForward); 
+            characterForward.Set(verticalAxisLookAt); 
         }
 
         public override void OnBlock(bool blocked)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
@@ -173,13 +173,14 @@ namespace DCL.Camera
         public override void OnSetRotation(CameraController.SetRotationPayload payload)
         {
             var eulerDir = Vector3.zero;
+            var verticalAxisLookAt = Vector3.zero;
 
             if (payload.cameraTarget.HasValue)
             {
                 var cameraTarget = payload.cameraTarget.GetValueOrDefault();
 
                 var horizontalAxisLookAt = payload.y - cameraTarget.y;
-                var verticalAxisLookAt = new Vector3(cameraTarget.x - payload.x, 0, cameraTarget.z - payload.z);
+                verticalAxisLookAt = new Vector3(cameraTarget.x - payload.x, 0, cameraTarget.z - payload.z);
 
                 eulerDir.y = Vector3.SignedAngle(Vector3.forward, verticalAxisLookAt, Vector3.up);
                 eulerDir.x = Mathf.Atan2(horizontalAxisLookAt, verticalAxisLookAt.magnitude) * Mathf.Rad2Deg;
@@ -190,6 +191,9 @@ namespace DCL.Camera
             //value range 0 to 1, being 0 the bottom orbit and 1 the top orbit
             var yValue = Mathf.InverseLerp(-90, 90, eulerDir.x);
             defaultVirtualCameraAsFreeLook.m_YAxis.Value = yValue;
+            
+            var xzPlaneForward = Vector3.Scale(verticalAxisLookAt, new Vector3(1, 0, 1));
+            characterForward.Set(xzPlaneForward); 
         }
 
         public override void OnBlock(bool blocked)


### PR DESCRIPTION
## What does this PR change?

When in _third person mode_, after a teleport to a new location, the avatar was facing always north and not the direction of the camera forward. With this PR, the avatar now looks to the same direction as the camera forward.

## How to test the changes?

1) Keep _third person mode_
1) Teleport to -74,53
2) Check that the avatar is looking west

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
