### PR TITLE
chore: remove avatar lods feature flag

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -69,7 +69,13 @@ namespace DCL
             player.onPointerDownCollider.SetColliderEnabled(false);
         }
 
-        public void SetAnimationThrottling(int framesBetweenUpdates) { player.avatar.SetAnimationThrottling(framesBetweenUpdates); }
+        public void SetAnimationThrottling(int framesBetweenUpdates)
+        {
+            if (player?.avatar == null)
+                return;
+            
+            player.avatar.SetAnimationThrottling(framesBetweenUpdates);
+        }
 
         public void SetNameVisible(bool visible)
         {
@@ -78,7 +84,13 @@ namespace DCL
             else
                 player?.playerName.Hide();
         }
-        public void UpdateImpostorTint(float distanceToMainPlayer) { player.avatar.SetImpostorTint(AvatarRendererHelpers.CalculateImpostorTint(distanceToMainPlayer)); }
+        public void UpdateImpostorTint(float distanceToMainPlayer)
+        {
+            if (player?.avatar == null)
+                return;
+            
+            player.avatar.SetImpostorTint(AvatarRendererHelpers.CalculateImpostorTint(distanceToMainPlayer));
+        }
 
         public void Dispose() { }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/Tests/AvatarsLODControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/Tests/AvatarsLODControllerShould.cs
@@ -32,17 +32,6 @@ namespace Tests.AvatarsLODController
         [Test]
         public void BeCreatedProperly()
         {
-            Assert.IsFalse(controller.enabled);
-            Assert.AreEqual(0, controller.lodControllers.Count);
-        }
-
-        [Test]
-        public void BeInitializedProperly()
-        {
-            FeatureFlag flag =  TestUtils.CreateFeatureFlag(new List<string>() { DCL.AvatarsLODController.AVATAR_LODS_FLAG_NAME });
-            controller.Initialize(flag);
-
-            Assert.IsTrue(controller.enabled);
             Assert.AreEqual(0, controller.lodControllers.Count);
         }
 
@@ -53,9 +42,7 @@ namespace Tests.AvatarsLODController
             controller.Configure().CreateLodController(Arg.Any<Player>()).Returns(lodController);
 
             otherPlayers.Add("player0", new Player { name = "player0", id = "player0", avatar = Substitute.For<IAvatar>() });
-            controller.Initialize( TestUtils.CreateFeatureFlag(new List<string>() { DCL.AvatarsLODController.AVATAR_LODS_FLAG_NAME }));
 
-            Assert.IsTrue(controller.enabled);
             Assert.AreEqual(1, controller.lodControllers.Count);
             Assert.AreEqual(lodController, controller.lodControllers["player0"]);
         }
@@ -65,7 +52,6 @@ namespace Tests.AvatarsLODController
         {
             IAvatarLODController lodController = Substitute.For<IAvatarLODController>();
             controller.Configure().CreateLodController(Arg.Any<Player>()).Returns(lodController);
-            controller.Initialize( TestUtils.CreateFeatureFlag(new List<string>() { DCL.AvatarsLODController.AVATAR_LODS_FLAG_NAME }));
 
             otherPlayers.Add("player0", CreateMockPlayer("player0"));
 
@@ -79,7 +65,6 @@ namespace Tests.AvatarsLODController
             IAvatarLODController lodController = Substitute.For<IAvatarLODController>();
             controller.Configure().CreateLodController(Arg.Any<Player>()).Returns(lodController);
             otherPlayers.Add("player0", CreateMockPlayer("player0"));
-            controller.Initialize( TestUtils.CreateFeatureFlag(new List<string>() { DCL.AvatarsLODController.AVATAR_LODS_FLAG_NAME }));
 
             otherPlayers.Remove("player0");
 
@@ -97,7 +82,6 @@ namespace Tests.AvatarsLODController
                           lodController = Substitute.For<IAvatarLODController>();
                           return lodController;
                       });
-            controller.enabled = true;
 
             controller.RegisterAvatar("player0", CreateMockPlayer("player0"));
 
@@ -111,7 +95,6 @@ namespace Tests.AvatarsLODController
         {
             IAvatarLODController lodController = Substitute.For<IAvatarLODController>();
             controller.Configure().CreateLodController(Arg.Any<Player>()).Returns(lodController);
-            controller.enabled = true;
             Player player0 = CreateMockPlayer("player0");
             controller.lodControllers.Add("player0", lodController);
 
@@ -126,7 +109,6 @@ namespace Tests.AvatarsLODController
         {
             Player player = CreateMockPlayer("player0");
             IAvatarLODController lodController = Substitute.For<IAvatarLODController>();
-            controller.enabled = true;
             controller.lodControllers.Add("player0", lodController);
 
             controller.UnregisterAvatar("player0", player);
@@ -139,7 +121,6 @@ namespace Tests.AvatarsLODController
         public void UnregisterPlayerProperly_NotRegistered()
         {
             Player player = CreateMockPlayer("player0");
-            controller.enabled = true;
 
             controller.UnregisterAvatar("player0", player);
 
@@ -181,7 +162,6 @@ namespace Tests.AvatarsLODController
             invisibleAvatarPlayer.worldPosition = -Vector3.forward * 10f; //player behind camera => Invisible
 
             DataStore.i.avatarsLOD.maxAvatars.Set(2);
-            controller.enabled = true;
             controller.Update();
 
             fullAvatarPlayerController.Received().SetLOD0();
@@ -194,7 +174,6 @@ namespace Tests.AvatarsLODController
         public void HideCharacterClippingAvatars()
         {
             DataStore.i.avatarsLOD.maxAvatars.Set(2);
-            controller.enabled = true;
 
             Vector3 cameraPosition = Vector3.zero;
             CommonScriptableObjects.cameraForward.Set(Vector3.forward);
@@ -242,7 +221,6 @@ namespace Tests.AvatarsLODController
             impostorAvatarPlayer.worldPosition = Vector3.forward * tintMinDistance;
 
             DataStore.i.avatarsLOD.maxAvatars.Set(1);
-            controller.enabled = true;
             controller.Update();
 
             impostorAvatarPlayerController.ReceivedWithAnyArgs().UpdateImpostorTint(default);
@@ -268,7 +246,7 @@ namespace Tests.AvatarsLODController
             Player invisibleAvatarPlayer = CreateMockPlayer("impostorPlayer");
             IAvatarLODController invisibleAvatarPlayerController = Substitute.For<IAvatarLODController>();
             invisibleAvatarPlayerController.player.Returns(invisibleAvatarPlayer);
-            otherPlayers.Add(invisibleAvatarPlayer.id, invisibleAvatarPlayer);
+            //otherPlayers.Add(invisibleAvatarPlayer.id, invisibleAvatarPlayer);
             controller.lodControllers.Add(invisibleAvatarPlayer.id, invisibleAvatarPlayerController);
             invisibleAvatarPlayer.worldPosition = cameraPosition - Vector3.forward * 5;
 
@@ -283,12 +261,11 @@ namespace Tests.AvatarsLODController
             otherPlayers.Add("player0", CreateMockPlayer("player0", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 0.91f));
             otherPlayers.Add("player1", CreateMockPlayer("player1", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 0.92f));
             otherPlayers.Add("player2", CreateMockPlayer("player2", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 0.93f));
-            controller.lodControllers.Add("player0", CreateMockLODController(otherPlayers["player0"]));
-            controller.lodControllers.Add("player1", CreateMockLODController(otherPlayers["player1"]));
-            controller.lodControllers.Add("player2", CreateMockLODController(otherPlayers["player2"]));
+            controller.lodControllers["player0"] = CreateMockLODController(otherPlayers["player0"]);
+            controller.lodControllers["player1"] = CreateMockLODController(otherPlayers["player1"]);
+            controller.lodControllers["player2"] = CreateMockLODController(otherPlayers["player2"]);
 
             DataStore.i.avatarsLOD.maxAvatars.Set(2);
-            controller.enabled = true;
             controller.Update();
 
             controller.lodControllers["player0"].Received().SetLOD0();
@@ -302,12 +279,11 @@ namespace Tests.AvatarsLODController
             otherPlayers.Add("player0", CreateMockPlayer("player0", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 1.01f));
             otherPlayers.Add("player1", CreateMockPlayer("player1", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 1.02f));
             otherPlayers.Add("player2", CreateMockPlayer("player2", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 1.03f));
-            controller.lodControllers.Add("player0", CreateMockLODController(otherPlayers["player0"]));
-            controller.lodControllers.Add("player1", CreateMockLODController(otherPlayers["player1"]));
-            controller.lodControllers.Add("player2", CreateMockLODController(otherPlayers["player2"]));
+            controller.lodControllers["player0"] = CreateMockLODController(otherPlayers["player0"]);
+            controller.lodControllers["player1"] = CreateMockLODController(otherPlayers["player1"]);
+            controller.lodControllers["player2"] = CreateMockLODController(otherPlayers["player2"]);
 
             DataStore.i.avatarsLOD.maxAvatars.Set(2);
-            controller.enabled = true;
             controller.Update();
 
             controller.lodControllers["player0"].Received().SetLOD1();
@@ -321,12 +297,11 @@ namespace Tests.AvatarsLODController
             otherPlayers.Add("player0", CreateMockPlayer("player0", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 1.01f));
             otherPlayers.Add("player1", CreateMockPlayer("player1", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 0.92f));
             otherPlayers.Add("player2", CreateMockPlayer("player2", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 0.93f));
-            controller.lodControllers.Add("player0", CreateMockLODController(otherPlayers["player0"]));
-            controller.lodControllers.Add("player1", CreateMockLODController(otherPlayers["player1"]));
-            controller.lodControllers.Add("player2", CreateMockLODController(otherPlayers["player2"]));
+            controller.lodControllers["player0"] = CreateMockLODController(otherPlayers["player0"]);
+            controller.lodControllers["player1"] = CreateMockLODController(otherPlayers["player1"]);
+            controller.lodControllers["player2"] = CreateMockLODController(otherPlayers["player2"]);
 
             DataStore.i.avatarsLOD.maxAvatars.Set(2);
-            controller.enabled = true;
             controller.Update();
 
             controller.lodControllers["player0"].Received().SetLOD2();
@@ -342,15 +317,14 @@ namespace Tests.AvatarsLODController
             otherPlayers.Add("player2", CreateMockPlayer("player2", Vector3.forward * DataStore.i.avatarsLOD.simpleAvatarDistance.Get() * 0.93f));
             otherPlayers.Add("player3", CreateMockPlayer("player3", Vector3.forward * DataStore.i.avatarsLOD.LODDistance.Get() * 1.02f));
             otherPlayers.Add("player4", CreateMockPlayer("player4", Vector3.forward * DataStore.i.avatarsLOD.LODDistance.Get() * 1.04f));
-            controller.lodControllers.Add("player0", CreateMockLODController(otherPlayers["player0"]));
-            controller.lodControllers.Add("player1", CreateMockLODController(otherPlayers["player1"]));
-            controller.lodControllers.Add("player2", CreateMockLODController(otherPlayers["player2"]));
-            controller.lodControllers.Add("player3", CreateMockLODController(otherPlayers["player3"]));
-            controller.lodControllers.Add("player4", CreateMockLODController(otherPlayers["player4"]));
+            controller.lodControllers["player0"] = CreateMockLODController(otherPlayers["player0"]);
+            controller.lodControllers["player1"] = CreateMockLODController(otherPlayers["player1"]);
+            controller.lodControllers["player2"] = CreateMockLODController(otherPlayers["player2"]);
+            controller.lodControllers["player3"] = CreateMockLODController(otherPlayers["player3"]);
+            controller.lodControllers["player4"] = CreateMockLODController(otherPlayers["player4"]);
 
             DataStore.i.avatarsLOD.maxAvatars.Set(3);
             DataStore.i.avatarsLOD.maxImpostors.Set(1);
-            controller.enabled = true;
             controller.Update();
 
             controller.lodControllers["player0"].Received().SetLOD1(); //Takes one of the free avatar spots 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifierAreaShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifierAreaShould.cs
@@ -146,6 +146,17 @@ public class AvatarModifierAreaShould : IntegrationTestSuite_Legacy
         
         mockAvatarModifier.Received().ApplyModifier(player2.gameObject);
 
+        yield return null;
+        
+        DataStore.i.player.otherPlayers.Remove(player2.player.id);
+        DataStore.i.player.otherPlayers.Remove(player3.player.id);
+        DataStore.i.player.otherPlayers.Remove(player4.player.id);
+        
+        Object.Destroy(((PlayerName)player1.player.playerName).gameObject);
+        Object.Destroy(((PlayerName)player2.player.playerName).gameObject);
+        Object.Destroy(((PlayerName)player3.player.playerName).gameObject);
+        Object.Destroy(((PlayerName)player4.player.playerName).gameObject);
+
         Object.Destroy(player1.gameObject);
         Object.Destroy(player2.gameObject);
         Object.Destroy(player3.gameObject);
@@ -194,7 +205,8 @@ public class AvatarModifierAreaShould : IntegrationTestSuite_Legacy
         Player player = new Player()
         {
             id = playerId,
-            collider = gameObject.GetComponentInChildren<Collider>()
+            collider = gameObject.GetComponentInChildren<Collider>(),
+            playerName = GameObject.Instantiate(Resources.Load<GameObject>("PlayerName")).GetComponent<PlayerName>()
         };
         return (player, gameObject);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifiersTest.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifiersTest.asmdef
@@ -12,7 +12,9 @@
         "GUID:a78c5d8dad39efe45ab1b21901f8db0f",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:44a9db8f655ab05409802e5476cf9dd3",
-        "GUID:9a16a75a9de4ba2458b50ed374f1b28f"
+        "GUID:9a16a75a9de4ba2458b50ed374f1b28f",
+        "GUID:e620e543132e94e4fb43a2bd6f324cbf",
+        "GUID:896ac1ef7dceedf49b9a9b0f3c8e798d"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/UsersAroundListHUD/Tests/UsersAroundListHUDShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/UsersAroundListHUD/Tests/UsersAroundListHUDShould.cs
@@ -70,12 +70,11 @@ public class UsersAroundListHUDShould : IntegrationTestSuite_Legacy
             userId = users[2]
         });
 
-        otherPlayers.Add(users[0], new Player { id = users[0], name = users[0], worldPosition = Vector3.zero });
-        otherPlayers.Add(users[1], new Player { id = users[1], name = users[1], worldPosition = Vector3.zero });
+        otherPlayers.Add(users[0], new Player { id = users[0], name = users[0], worldPosition = Vector3.zero,  playerName = GameObject.Instantiate(Resources.Load<GameObject>("PlayerName")).GetComponent<PlayerName>() });
+        otherPlayers.Add(users[1], new Player { id = users[1], name = users[1], worldPosition = Vector3.zero,  playerName = GameObject.Instantiate(Resources.Load<GameObject>("PlayerName")).GetComponent<PlayerName>() });
 
         Assert.IsTrue(GetVisibleChildren(listView.contentPlayers) == 2, "listView.content.childCount != 2");
         Assert.IsTrue(listView.availableElements.Count == 0, "listView.availableElements.Count != 0");
-
 
         otherPlayers.Remove(users[1]);
         Assert.IsTrue(GetVisibleChildren(listView.contentPlayers) == 1, "listView.content.childCount != 1");
@@ -85,8 +84,7 @@ public class UsersAroundListHUDShould : IntegrationTestSuite_Legacy
         Assert.IsTrue(GetVisibleChildren(listView.contentPlayers) == 0, "listView.content.childCount != 0");
         Assert.IsTrue(listView.availableElements.Count == 2, "listView.availableElements.Count != 2");
 
-
-        otherPlayers.Add(users[2], new Player { id = users[2], name = users[2], worldPosition = Vector3.zero });
+        otherPlayers.Add(users[2], new Player { id = users[2], name = users[2], worldPosition = Vector3.zero,  playerName = GameObject.Instantiate(Resources.Load<GameObject>("PlayerName")).GetComponent<PlayerName>() });
         Assert.IsTrue(GetVisibleChildren(listView.contentPlayers) == 1, "listView.content.childCount != 1");
         Assert.IsTrue(listView.availableElements.Count == 1, "listView.availableElements.Count != 1");
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/UsersAroundListHUD/Tests/UsersAroundListHUDTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/UsersAroundListHUD/Tests/UsersAroundListHUDTests.asmdef
@@ -12,7 +12,9 @@
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:c34e38f41494f834abff029ddf82af43",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
-        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca"
+        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca",
+        "GUID:e620e543132e94e4fb43a2bd6f324cbf",
+        "GUID:896ac1ef7dceedf49b9a9b0f3c8e798d"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?

Removed the avatars lod feature flag. Also removed the enabled bool attribute, since it was redundant without the flag's presence. Moved the flag initialization code into the Initialize method.

Some tests started failing since they were dependent on the enabled bool. Modified these tests accordingly to the modified code.

## How to test the changes?

Go to: https://play.decentraland.zone/?renderer-branch=chore/remove-avatar-lods-feature-flag
Go to WonderMine scene
Check that the avatar lods are present when the number of avatars exceeds the Max HQ Avatars setting

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
