### PR TITLE
fix: Tutorial not starting on new user

### DIFF
--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
@@ -177,10 +177,8 @@ namespace DCL.Tutorial
             NotificationsController.disableWelcomeNotification = true;
 
             WebInterface.SetDelightedSurveyEnabled(false);
-            
-            IWorldState worldState = Environment.i.world.state;
-            
-            if ((!CommonScriptableObjects.rendererState.Get()) || worldState?.currentSceneId == null)
+
+            if (!CommonScriptableObjects.rendererState.Get())
                 CommonScriptableObjects.rendererState.OnChange += OnRenderingStateChanged;
             else
                 OnRenderingStateChanged(true, false);
@@ -244,6 +242,10 @@ namespace DCL.Tutorial
                 GameObject.Destroy(runningStep.gameObject);
                 runningStep = null;
             }
+
+            yield return new WaitUntil(IsPlayerInScene);
+
+            playerIsInGenesisPlaza = playerIsInGenesisPlaza || IsPlayerInsideGenesisPlaza();
 
             switch (tutorialType)
             {
@@ -438,8 +440,6 @@ namespace DCL.Tutorial
 
             CommonScriptableObjects.rendererState.OnChange -= OnRenderingStateChanged;
 
-            playerIsInGenesisPlaza = IsPlayerInsideGenesisPlaza();
-
             if (configuration.debugRunTutorial)
                 currentStepIndex = configuration.debugStartingStepIndex >= 0 ? configuration.debugStartingStepIndex : 0;
             else
@@ -592,6 +592,16 @@ namespace DCL.Tutorial
                 fromDeepLink = false.ToString(),
                 enableNewTutorialCamera = false.ToString()
             }));
+        }
+
+        internal bool IsPlayerInScene()
+        {
+            IWorldState worldState = Environment.i.world.state;
+
+            if (worldState == null || worldState.currentSceneId == null)
+                return false;
+
+            return true;
         }
 
         internal static bool IsPlayerInsideGenesisPlaza()

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
@@ -178,7 +178,12 @@ namespace DCL.Tutorial
 
             WebInterface.SetDelightedSurveyEnabled(false);
             
-            CommonScriptableObjects.rendererState.OnChange += OnRenderingStateChanged;
+            IWorldState worldState = Environment.i.world.state;
+            
+            if ((!CommonScriptableObjects.rendererState.Get()) || worldState?.currentSceneId == null)
+                CommonScriptableObjects.rendererState.OnChange += OnRenderingStateChanged;
+            else
+                OnRenderingStateChanged(true, false);
 
             OnTutorialEnabled?.Invoke();
         }

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
@@ -177,11 +177,8 @@ namespace DCL.Tutorial
             NotificationsController.disableWelcomeNotification = true;
 
             WebInterface.SetDelightedSurveyEnabled(false);
-
-            if (!CommonScriptableObjects.rendererState.Get())
-                CommonScriptableObjects.rendererState.OnChange += OnRenderingStateChanged;
-            else
-                OnRenderingStateChanged(true, false);
+            
+            CommonScriptableObjects.rendererState.OnChange += OnRenderingStateChanged;
 
             OnTutorialEnabled?.Invoke();
         }

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
@@ -245,7 +245,7 @@ namespace DCL.Tutorial
 
             yield return new WaitUntil(IsPlayerInScene);
 
-            playerIsInGenesisPlaza = playerIsInGenesisPlaza || IsPlayerInsideGenesisPlaza();
+            playerIsInGenesisPlaza = IsPlayerInsideGenesisPlaza();
 
             switch (tutorialType)
             {

--- a/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
+++ b/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
@@ -107,6 +107,7 @@ namespace DCL.Tutorial_Tests
 
             // Act
             yield return tutorialController.StartTutorialFromStep(0);
+            yield return  null;
 
             // Assert
             Assert.IsFalse(DataStore.i.common.isTutorialRunning.Get());
@@ -115,12 +116,13 @@ namespace DCL.Tutorial_Tests
             Assert.AreEqual(TutorialPath.FromGenesisPlaza, tutorialController.currentPath);
         }
 
-        [Test]
-        public void SkipTutorialStepsFromGenesisPlazaCorrectly()
+        [UnityTest]
+        public IEnumerator SkipTutorialStepsFromGenesisPlazaCorrectly()
         {
             ConfigureTutorialForGenesisPlaza();
 
             tutorialController.SkipTutorial();
+            yield return null;
 
             Assert.IsFalse(DataStore.i.common.isTutorialRunning.Get());
             Assert.IsNull(tutorialController.runningStep);
@@ -140,12 +142,13 @@ namespace DCL.Tutorial_Tests
             Assert.AreEqual(TutorialPath.FromDeepLink, tutorialController.currentPath);
         }
 
-        [Test]
-        public void SkipTutorialStepsFromDeepLinkCorrectly()
+        [UnityTest]
+        public IEnumerator SkipTutorialStepsFromDeepLinkCorrectly()
         {
             ConfigureTutorialForDeepLink();
 
             tutorialController.SkipTutorial();
+            yield return  null;
 
             Assert.IsFalse(DataStore.i.common.isTutorialRunning.Get());
             Assert.IsNull(tutorialController.runningStep);
@@ -166,12 +169,13 @@ namespace DCL.Tutorial_Tests
             Assert.AreEqual(TutorialPath.FromResetTutorial, tutorialController.currentPath);
         }
 
-        [Test]
-        public void SkipTutorialStepsForResetTutorialCorrectly()
+        [UnityTest]
+        public IEnumerator SkipTutorialStepsForResetTutorialCorrectly()
         {
             ConfigureTutorialForResetTutorial();
 
             tutorialController.SkipTutorial();
+            yield return null;
 
             Assert.IsFalse(DataStore.i.common.isTutorialRunning.Get());
             Assert.IsNull(tutorialController.runningStep);
@@ -185,6 +189,7 @@ namespace DCL.Tutorial_Tests
             ConfigureTutorialForUserThatAlreadyDidTheTutorial();
 
             yield return tutorialController.StartTutorialFromStep(0);
+            yield return null;
 
             Assert.IsFalse(DataStore.i.common.isTutorialRunning.Get());
             Assert.IsNull(tutorialController.runningStep);
@@ -192,12 +197,13 @@ namespace DCL.Tutorial_Tests
             Assert.AreEqual(TutorialPath.FromUserThatAlreadyDidTheTutorial, tutorialController.currentPath);
         }
 
-        [Test]
-        public void SkipTutorialStepsFromUserThatAlreadyDidTheTutorialCorrectly()
+        [UnityTest]
+        public IEnumerator SkipTutorialStepsFromUserThatAlreadyDidTheTutorialCorrectly()
         {
             ConfigureTutorialForUserThatAlreadyDidTheTutorial();
 
             tutorialController.SkipTutorial();
+            yield return null;
 
             Assert.IsFalse(DataStore.i.common.isTutorialRunning.Get());
             Assert.IsNull(tutorialController.runningStep);
@@ -220,12 +226,13 @@ namespace DCL.Tutorial_Tests
             Assert.AreEqual(TutorialPath.FromBuilderInWorld, tutorialController.currentPath);
         }
 
-        [Test]
-        public void SkipTutorialStepsFromBuilderInWorldCorrectly()
+        [UnityTest]
+        public IEnumerator SkipTutorialStepsFromBuilderInWorldCorrectly()
         {
             ConfigureTutorialForBuilderInWorld();
 
             tutorialController.SkipTutorial();
+            yield return null;
 
             Assert.IsFalse(DataStore.i.common.isTutorialRunning.Get());
             Assert.IsNull(tutorialController.runningStep);

--- a/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
+++ b/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
@@ -1,5 +1,4 @@
 using DCL.Tutorial;
-using DCL;
 using NUnit.Framework;
 using System;
 using System.Collections;
@@ -15,25 +14,23 @@ using Object = UnityEngine.Object;
 
 namespace DCL.Tutorial_Tests
 {
-    public class TutorialControllerShould : IntegrationTestSuite_Legacy
+    public class TutorialControllerShould : IntegrationTestSuite
     {
-        private ParcelScene scene;
-
         private TutorialView tutorialView;
         private TutorialController tutorialController;
         private int currentStepIndex = 0;
         private List<TutorialStep> currentSteps = new List<TutorialStep>();
         private Coroutine stepCoroutine;
-        
-        private ISceneController sceneController => DCL.Environment.i.world.sceneController;
-
+        private ParcelScene genesisPlazaSimulator;
+        private readonly Vector2Int genesisPlazaLocation = new Vector2Int(-9, -9);
 
         protected override IEnumerator SetUp()
         {
             yield return base.SetUp();
-            scene = TestUtils.CreateTestScene();
-            sceneController.LoadParcelScenes((Resources.Load("TestJSON/SceneLoadingTest") as TextAsset).text);
-            yield return new WaitForAllMessagesProcessed();
+            Environment.i.world.state.loadedScenes = new Dictionary<string, IParcelScene>();
+            genesisPlazaSimulator = TestUtils.CreateTestScene();
+            Environment.i.world.state.currentSceneId = genesisPlazaSimulator.sceneData.id;
+            genesisPlazaSimulator.parcels.Add(genesisPlazaLocation);
             CreateAndConfigureTutorial();
         }
 
@@ -598,11 +595,11 @@ namespace DCL.Tutorial_Tests
 
             currentStepIndex = 0;
             currentSteps = tutorialController.configuration.stepsOnGenesisPlaza;
-            
+
             tutorialController.tutorialType = TutorialType.Initial;
             tutorialController.userAlreadyDidTheTutorial = false;
             tutorialController.playerIsInGenesisPlaza = true;
-            if(!scene.parcels.Contains(new Vector2Int(-9, -9)))scene.parcels.Add(new Vector2Int(-9, -9));
+            if(!genesisPlazaSimulator.parcels.Contains(genesisPlazaLocation)) genesisPlazaSimulator.parcels.Add(genesisPlazaLocation);
             tutorialController.tutorialReset = false;
             DataStore.i.common.isTutorialRunning.Set(true);
             tutorialController.runningStep = new GameObject().AddComponent<TutorialStep>();
@@ -624,7 +621,7 @@ namespace DCL.Tutorial_Tests
             tutorialController.tutorialType = TutorialType.Initial;
             tutorialController.userAlreadyDidTheTutorial = false;
             tutorialController.playerIsInGenesisPlaza = false;
-            if(scene.parcels.Contains(new Vector2Int(-9, -9)))scene.parcels.Remove(new Vector2Int(-9, -9));
+            if(genesisPlazaSimulator.parcels.Contains(genesisPlazaLocation)) genesisPlazaSimulator.parcels.Remove(genesisPlazaLocation);
             tutorialController.tutorialReset = false;
             tutorialController.openedFromDeepLink = true;
             DataStore.i.common.isTutorialRunning.Set(true);
@@ -648,7 +645,7 @@ namespace DCL.Tutorial_Tests
             tutorialController.userAlreadyDidTheTutorial = false;
             tutorialController.tutorialReset = true;
             tutorialController.playerIsInGenesisPlaza = false;
-            if(scene.parcels.Contains(new Vector2Int(-9, -9)))scene.parcels.Remove(new Vector2Int(-9, -9));
+            if(genesisPlazaSimulator.parcels.Contains(genesisPlazaLocation)) genesisPlazaSimulator.parcels.Remove(genesisPlazaLocation);
             DataStore.i.common.isTutorialRunning.Set(true);
             tutorialController.runningStep = new GameObject().AddComponent<TutorialStep>();
             CommonScriptableObjects.tutorialActive.Set(true);
@@ -744,7 +741,7 @@ namespace DCL.Tutorial_Tests
             tutorialController.tutorialType = TutorialType.Initial;
             tutorialController.userAlreadyDidTheTutorial = false;
             tutorialController.playerIsInGenesisPlaza = true;
-            if(!scene.parcels.Contains(new Vector2Int(-9, -9)))scene.parcels.Add(new Vector2Int(-9, -9));
+            if(!genesisPlazaSimulator.parcels.Contains(genesisPlazaLocation)) genesisPlazaSimulator.parcels.Add(genesisPlazaLocation);
             tutorialController.tutorialReset = false;
             DataStore.i.common.isTutorialRunning.Set(true);
             tutorialController.runningStep = null;

--- a/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
+++ b/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
@@ -1,8 +1,12 @@
 using DCL.Tutorial;
+using DCL;
 using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using DCL.Controllers;
+using DCL.Helpers;
+using DCL.Models;
 using Tests;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -11,17 +15,25 @@ using Object = UnityEngine.Object;
 
 namespace DCL.Tutorial_Tests
 {
-    public class TutorialControllerShould : IntegrationTestSuite
+    public class TutorialControllerShould : IntegrationTestSuite_Legacy
     {
+        private ParcelScene scene;
+
         private TutorialView tutorialView;
         private TutorialController tutorialController;
         private int currentStepIndex = 0;
         private List<TutorialStep> currentSteps = new List<TutorialStep>();
         private Coroutine stepCoroutine;
+        
+        private ISceneController sceneController => DCL.Environment.i.world.sceneController;
+
 
         protected override IEnumerator SetUp()
         {
             yield return base.SetUp();
+            scene = TestUtils.CreateTestScene();
+            sceneController.LoadParcelScenes((Resources.Load("TestJSON/SceneLoadingTest") as TextAsset).text);
+            yield return new WaitForAllMessagesProcessed();
             CreateAndConfigureTutorial();
         }
 
@@ -586,10 +598,11 @@ namespace DCL.Tutorial_Tests
 
             currentStepIndex = 0;
             currentSteps = tutorialController.configuration.stepsOnGenesisPlaza;
-
+            
             tutorialController.tutorialType = TutorialType.Initial;
             tutorialController.userAlreadyDidTheTutorial = false;
             tutorialController.playerIsInGenesisPlaza = true;
+            if(!scene.parcels.Contains(new Vector2Int(-9, -9)))scene.parcels.Add(new Vector2Int(-9, -9));
             tutorialController.tutorialReset = false;
             DataStore.i.common.isTutorialRunning.Set(true);
             tutorialController.runningStep = new GameObject().AddComponent<TutorialStep>();
@@ -611,6 +624,7 @@ namespace DCL.Tutorial_Tests
             tutorialController.tutorialType = TutorialType.Initial;
             tutorialController.userAlreadyDidTheTutorial = false;
             tutorialController.playerIsInGenesisPlaza = false;
+            if(scene.parcels.Contains(new Vector2Int(-9, -9)))scene.parcels.Remove(new Vector2Int(-9, -9));
             tutorialController.tutorialReset = false;
             tutorialController.openedFromDeepLink = true;
             DataStore.i.common.isTutorialRunning.Set(true);
@@ -634,6 +648,7 @@ namespace DCL.Tutorial_Tests
             tutorialController.userAlreadyDidTheTutorial = false;
             tutorialController.tutorialReset = true;
             tutorialController.playerIsInGenesisPlaza = false;
+            if(scene.parcels.Contains(new Vector2Int(-9, -9)))scene.parcels.Remove(new Vector2Int(-9, -9));
             DataStore.i.common.isTutorialRunning.Set(true);
             tutorialController.runningStep = new GameObject().AddComponent<TutorialStep>();
             CommonScriptableObjects.tutorialActive.Set(true);
@@ -729,6 +744,7 @@ namespace DCL.Tutorial_Tests
             tutorialController.tutorialType = TutorialType.Initial;
             tutorialController.userAlreadyDidTheTutorial = false;
             tutorialController.playerIsInGenesisPlaza = true;
+            if(!scene.parcels.Contains(new Vector2Int(-9, -9)))scene.parcels.Add(new Vector2Int(-9, -9));
             tutorialController.tutorialReset = false;
             DataStore.i.common.isTutorialRunning.Set(true);
             tutorialController.runningStep = null;

--- a/unity-renderer/Assets/Tutorial/Tests/TutorialControllerTests.asmdef
+++ b/unity-renderer/Assets/Tutorial/Tests/TutorialControllerTests.asmdef
@@ -1,33 +1,40 @@
 {
-  "name": "TutorialControllerTests",
-  "rootNamespace": "",
-  "references": [
-    "GUID:27619889b8ba8c24980f49ee34dbb44a",
-    "GUID:0acc523941302664db1f4e527237feb3",
-    "GUID:8e14059e964ca49aeb55d0e7b2b14c3c",
-    "GUID:3bdb7fe910cce8d4888137cded3ba4a2",
-    "GUID:760a1d365aad58044916992b072cf2a6",
-    "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
-    "GUID:4307f53044263cf4b835bd812fc161a4",
-    "GUID:28f74c468a54948bfa9f625c5d428f56",
-    "GUID:70aa308435753374584c7061e4b89ef2",
-    "GUID:98bf3bf29030cbf4092d89a7cc28b7fb",
-    "GUID:858f845923fcab3448cf8b66614b41a1",
-    "GUID:c9fbb75c15a4cd042b731877ede4a5c1",
-    "GUID:7fe146b43e76fe745aeaf2020feb54b7",
-    "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": true,
-  "precompiledReferences": [
-    "nunit.framework.dll"
-  ],
-  "autoReferenced": false,
-  "defineConstraints": [
-    "UNITY_INCLUDE_TESTS"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "TutorialControllerTests",
+    "rootNamespace": "",
+    "references": [
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:8e14059e964ca49aeb55d0e7b2b14c3c",
+        "GUID:3bdb7fe910cce8d4888137cded3ba4a2",
+        "GUID:760a1d365aad58044916992b072cf2a6",
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
+        "GUID:4307f53044263cf4b835bd812fc161a4",
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:70aa308435753374584c7061e4b89ef2",
+        "GUID:98bf3bf29030cbf4092d89a7cc28b7fb",
+        "GUID:858f845923fcab3448cf8b66614b41a1",
+        "GUID:c9fbb75c15a4cd042b731877ede4a5c1",
+        "GUID:7fe146b43e76fe745aeaf2020feb54b7",
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
+        "GUID:ef84d7ce90ba34f07be26ace428e9bc8",
+        "GUID:97d8897529779cb49bebd400c7f402a6",
+        "GUID:fbcc413e192ef9048811d47ab0aca0c0",
+        "GUID:3047fd2f05bcaae498a99a3f9321f9a8",
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
+        "GUID:44a9db8f655ab05409802e5476cf9dd3",
+        "GUID:a881b57670b1d2747a6d7f9e32b63230"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
## What does this PR change?

The tutorial was not starting because there was a check on `CommonScriptableObjects.rendererState.Get()` before subscribing the `OnRenderingStateChanged` method, which eventually triggered the tutorial. If the user went first to the avatar customization scene, renderState was true, and the event was not subscribed when the user got to Genesis Plaza. 

This was fixed by removing the check.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Delete cookies or start Incognito Window to have a fresh start
2. Go to: https://play.decentraland.zone/?renderer-branch=fix/tutorial-not-starting
3. Check that the tutorial appears after avatar customization

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
