### PR TITLE
fix: hologram renderer not being disabled after usage

### DIFF
--- a/unity-renderer/Assets/Rendering/LoadingAvatar/CrossSection/AvatarReveal.asmdef
+++ b/unity-renderer/Assets/Rendering/LoadingAvatar/CrossSection/AvatarReveal.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:49176a91bbf7f8a4aaf35f6df0643d1a"
+        "GUID:49176a91bbf7f8a4aaf35f6df0643d1a",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Rendering/LoadingAvatar/CrossSection/RevealAnimation.anim
+++ b/unity-renderer/Assets/Rendering/LoadingAvatar/CrossSection/RevealAnimation.anim
@@ -116,6 +116,34 @@ AnimationClip:
     path: Particles
     classID: 1
     script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: AvatarBase/Armature/M_Head_BaseMesh/Primitive
+    classID: 137
+    script: {fileID: 0}
   m_PPtrCurves: []
   m_SampleRate: 60
   m_WrapMode: 0
@@ -304,7 +332,42 @@ AnimationClip:
     path: Particles
     classID: 1
     script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Enabled
+    path: AvatarBase/Armature/M_Head_BaseMesh/Primitive
+    classID: 137
+    script: {fileID: 0}
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 1
+    functionName: OnRevealAnimationEnd
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
@@ -88,7 +88,7 @@ namespace AvatarSystem
                 gpuSkinningThrottler.Start();
 
                 status = IAvatar.Status.Loaded; 
-                baseAvatar.FadeOut(loader.combinedRenderer.GetComponent<MeshRenderer>(), lodLevel <= 1);
+                await baseAvatar.FadeOut(loader.combinedRenderer.GetComponent<MeshRenderer>(), lodLevel <= 1, linkedCt);
             }
             catch (OperationCanceledException)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/BaseAvatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/BaseAvatar.cs
@@ -1,5 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
 using UnityEngine;
 
 namespace AvatarSystem
@@ -44,13 +46,13 @@ namespace AvatarSystem
             meshRenderer = avatarRevealer.GetMainRenderer();
         }
 
-        public void FadeOut(MeshRenderer targetRenderer, bool playParticles) 
+        public async UniTask FadeOut(MeshRenderer targetRenderer, bool playParticles, CancellationToken cancellationToken) 
         {
             if (avatarRevealerContainer == null) 
                 return;
 
             avatarRevealer.AddTarget(targetRenderer);
-            avatarRevealer.StartAvatarRevealAnimation(playParticles);
+            await avatarRevealer.StartAvatarRevealAnimation(playParticles, cancellationToken);
         }
 
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IBaseAvatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IBaseAvatar.cs
@@ -1,5 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
 using UnityEngine;
 
 namespace AvatarSystem
@@ -12,6 +14,6 @@ namespace AvatarSystem
         void Initialize();
         SkinnedMeshRenderer GetMainRenderer();
         GameObject GetArmatureContainer();
-        void FadeOut(MeshRenderer targetRenderer, bool playParticles);
+        UniTask FadeOut(MeshRenderer targetRenderer, bool playParticles, CancellationToken cancellationToken);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IBaseAvatarRevealer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IBaseAvatarRevealer.cs
@@ -1,14 +1,16 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
 using DCL;
 using AvatarSystem;
+using Cysharp.Threading.Tasks;
 
 public interface IBaseAvatarRevealer
 {
     void InjectLodSystem(ILOD lod);
     void AddTarget(MeshRenderer newTarget);
-    void StartAvatarRevealAnimation(bool closeby);
+    UniTask StartAvatarRevealAnimation(bool instant, CancellationToken token);
     SkinnedMeshRenderer GetMainRenderer();
     void Reset();
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Tests/BaseAvatarShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Tests/BaseAvatarShould.cs
@@ -42,14 +42,17 @@ namespace Test.AvatarSystem
             Assert.AreEqual(baseAvatar.GetArmatureContainer(), armatureContainer);
         }
 
-        [Test]
-        public void StartRevealerFadeout()
+        [UnityTest]
+        public IEnumerator StartRevealerFadeout() => UniTask.ToCoroutine(async () =>
         {
             MeshRenderer testMesh = new MeshRenderer();
-            baseAvatar.FadeOut(testMesh, false);
+            CancellationToken cancellationToken = CancellationToken.None;
+            
+            await baseAvatar.FadeOut(testMesh, false, cancellationToken);
+            
             baseAvatarRevealer.Received().AddTarget(testMesh);
-            baseAvatarRevealer.Received().StartAvatarRevealAnimation(false);
-        }
+            baseAvatarRevealer.Received().StartAvatarRevealAnimation(false, cancellationToken);
+        });
 
     }
 }


### PR DESCRIPTION
## What does this PR change?

Disables hologram renderer after the animation ends.
The fadeOut method is now async

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
