### PR TITLE
fix: GLTF hot reload for new ECS

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GLTFShape/Handler/GLTFShapeComponentHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GLTFShape/Handler/GLTFShapeComponentHandler.cs
@@ -126,8 +126,6 @@ namespace DCL.ECSComponents
         {
             if (entity != null)
                 dataStore.RemoveShapeReady(entity.entityId);
-            if (meshesInfo != null)
-                ECSComponentsUtils.DisposeMeshInfo(meshesInfo);
             if (rendereable != null)
                 ECSComponentsUtils.RemoveRendereableFromDataStore( scene.sceneData.id, rendereable);
             if (model != null)


### PR DESCRIPTION
## What does this PR change?

This PR removes the GLTF component erasing all the renderer component when it is destryoed. This way the hot reload work as expected since we are not removing the renderers from the pool

## How to test the changes?

Can't be tested

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
