### PR TITLE
fix: GLTFImporter to generate a mesh when materials are ignored.

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -66,7 +66,7 @@ namespace DCL
         {
             DataStore.i.textureConfig.gltfMaxSize.Set(512);
             DataStore.i.textureConfig.generalMaxSize.Set(2048);
-            DataStore.i.avatarConfig.useHologramAvatar.Set(false);
+            DataStore.i.avatarConfig.useHologramAvatar.Set(true);
         }
 
         protected virtual void InitializeCommunication()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_AvatarConfig.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_AvatarConfig.cs
@@ -2,6 +2,6 @@ namespace DCL
 {
     public class DataStore_AvatarConfig
     {
-        public readonly BaseVariable<bool> useHologramAvatar = new BaseVariable<bool>(false);
+        public readonly BaseVariable<bool> useHologramAvatar = new BaseVariable<bool>(true);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_AvatarConfig.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_AvatarConfig.cs
@@ -2,6 +2,6 @@ namespace DCL
 {
     public class DataStore_AvatarConfig
     {
-        public readonly BaseVariable<bool> useHologramAvatar = new BaseVariable<bool>(true);
+        public readonly BaseVariable<bool> useHologramAvatar = new BaseVariable<bool>(false);
     }
 }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -130,7 +130,7 @@ namespace UnityGLTF
             loader.forceGPUOnlyMesh = false;
             loader.forceGPUOnlyTex = false;
             loader.forceSyncCoroutines = true;
-
+            loader.ignoreMaterials = !_importMaterials;
 
             Task task = loader.LoadScene(CancellationToken.None);
             bool result = task.Wait(TimeSpan.FromSeconds(30));
@@ -561,11 +561,13 @@ namespace UnityGLTF
                         }
                     }
 
-                    var rootObject = gltfScene.GetComponentInChildren<InstantiatedGLTFObject>();
 
-                    if (rootObject != null)
-                        DestroyImmediate(rootObject);
                 }
+                
+                var rootObject = gltfScene.GetComponentInChildren<InstantiatedGLTFObject>();
+
+                if (rootObject != null)
+                    DestroyImmediate(rootObject);
             }
             catch (Exception e)
             {

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -124,6 +124,8 @@ namespace UnityGLTF
         private bool useMaterialTransitionValue = true;
 
         public bool importSkeleton = true;
+        
+        public bool ignoreMaterials = false;
 
         public bool useMaterialTransition { get => useMaterialTransitionValue && !renderingIsDisabled; set => useMaterialTransitionValue = value; }
 
@@ -1639,6 +1641,14 @@ namespace UnityGLTF
             Renderer renderer = primitiveObj.GetComponent<Renderer>();
 
             cancellationToken.ThrowIfCancellationRequested();
+            
+            if (ignoreMaterials)
+            {
+                if (!(useMaterialTransition && initialVisibility) && LoadingTextureMaterial == null)
+                    primitiveObj.SetActive(true);
+                
+                return;
+            }
 
             //// NOTE(Brian): Texture loading
             if (useMaterialTransition && initialVisibility)


### PR DESCRIPTION
## What does this PR change?

Fixes the import of GLTF with Import Materials not checked.

**Important note**: Importing a GLTF with materials during the first import is still broken, this PR does not fix that, it just gives us an option.

## How to test the changes?

When starting Decentraland, the avatar should load correctly.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
