### PR TITLE
chore: change peer load balancer url

### DIFF
--- a/unity-renderer/Assets/ABConverter/Tests/ABConverterCoreShould.cs
+++ b/unity-renderer/Assets/ABConverter/Tests/ABConverterCoreShould.cs
@@ -41,7 +41,7 @@ namespace DCL.ABConverter.Tests
 
         string basePath = @"C:\test-path\";
         string hash1 = "QmHash1", hash2 = "QmHash2", hash3 = "QmHash3", hash4 = "QmHash4";
-        string baseUrl = @"https://peer-lb.decentraland.org/lambdas/contentv2/contents/";
+        string baseUrl = @"https://peer.decentraland.org/lambdas/contentv2/contents/";
         private string contentData1 = "TestContent1 - guid: 14e357df3f3b75940b5d59e1035255b1\n";
         private string contentData2 = "TestContent2 - guid: 14e357df3f3b75940b5d59e1035255b2\n";
         private string contentData3 = "TestContent3 - guid: 14e357df3f3b75940b5d59e1035255b3\n";

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Scripts/BuilderMainPanelController.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/HUD/ProjectsPanelHUD/Scripts/BuilderMainPanelController.cs
@@ -467,8 +467,8 @@ public class BuilderMainPanelController : IHUD, IBuilderMainPanelController
             network = TESTING_TLD;
             DataStore.i.realm.playerRealm.Set(new CurrentRealmModel()
             {
-                domain = $"https://peer-lb.decentraland.{TESTING_TLD}",
-                contentServerUrl = $"https://peer-lb.decentraland.{TESTING_TLD}/content",
+                domain = $"https://peer.decentraland.{TESTING_TLD}",
+                contentServerUrl = $"https://peer.decentraland.{TESTING_TLD}/content",
             });
         }
 #endif

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Editor/TestScene/ECSTestScene.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Editor/TestScene/ECSTestScene.cs
@@ -28,7 +28,7 @@ public class ECSTestScene : MonoBehaviour
 
     private static void AddGLTFShapeComponent(string sceneId, IECSComponentWriter componentWriter)
     {
-        Environment.i.world.state.scenesSortedByDistance[0].contentProvider.baseUrl = "https://peer-lb.decentraland.org/content/contents/";
+        Environment.i.world.state.scenesSortedByDistance[0].contentProvider.baseUrl = "https://peer.decentraland.org/content/contents/";
         Environment.i.world.state.scenesSortedByDistance[0].contentProvider.fileToHash.Add("models/SCENE.glb".ToLower(), "QmQgQtuAg9qsdrmLwnFiLRAYZ6Du4Dp7Yh7bw7ELn7AqkD");
             
         componentWriter.PutComponent(sceneId, 2, ComponentID.GLTF_SHAPE,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/ContentServerUtils/ContentServerUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/ContentServerUtils/ContentServerUtils.cs
@@ -73,7 +73,7 @@ namespace DCL
         public static string GetBaseUrl(ApiTLD tld)
         {
             if (tld != ApiTLD.NONE)
-                return $"https://peer-lb.decentraland.{GetTldString(tld)}/lambdas/contentv2";
+                return $"https://peer.decentraland.{GetTldString(tld)}/lambdas/contentv2";
 
             return customBaseUrl;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.cs
@@ -15,8 +15,8 @@ public class Catalyst : ICatalyst
     public string contentUrl => realmContentServerUrl;
     public string lambdasUrl => $"{realmDomain}/lambdas";
 
-    private string realmDomain = "https://peer-lb.decentraland.org";
-    private string realmContentServerUrl = "https://peer-lb.decentraland.org/content";
+    private string realmDomain = "https://peer.decentraland.org";
+    private string realmContentServerUrl = "https://peer.decentraland.org/content";
 
     private readonly IDataCache<CatalystSceneEntityPayload[]> deployedScenesCache = new DataCache<CatalystSceneEntityPayload[]>();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Wearables/WearablesAPIData.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Wearables/WearablesAPIData.cs
@@ -53,7 +53,7 @@ public class WearablesAPIData
     }
 
     // TODO: dinamically use ICatalyst.contentUrl, content server is not a const
-    private const string WEARABLES_CONTENT_BASE_URL = "https://peer-lb.decentraland.org/content/contents/";
+    private const string WEARABLES_CONTENT_BASE_URL = "https://peer.decentraland.org/content/contents/";
 
     public List<Wearable> wearables;
     public PaginationData pagination;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Wearables/WearablesFetchingHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Wearables/WearablesFetchingHelper.cs
@@ -15,7 +15,7 @@ namespace DCL.Helpers
 
         // TODO: change fetching logic to allow for auto-pagination
         // The https://nft-api.decentraland.org/v1/ endpoint doesn't fetch L1 wearables right now, if those need to be re-converted we should use that old endpoint again and change the WearablesAPIData structure again for that response.
-        // public const string COLLECTIONS_FETCH_URL = "https://peer-lb.decentraland.org/lambdas/collections"; 
+        // public const string COLLECTIONS_FETCH_URL = "https://peer.decentraland.org/lambdas/collections"; 
         public const string COLLECTIONS_FETCH_URL = "https://nft-api.decentraland.org/v1/collections?sortBy=newest&first=1000"; 
         private static Collection[] collections;
 


### PR DESCRIPTION
## What does this PR change?

Change "peer-lb.decentraland.org" in code base and change to "peer.decentraland.org"
The new load balancer is located at peer.decentraland.org

## How to test the changes?

Nothing to test. All "peer-lb.decentraland.org" urls should now point to "peer.decentraland.org"

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
