### PR TITLE
fix: update misleading text on signing request

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/TransactionHUD.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/TransactionHUD.cs
@@ -67,7 +67,9 @@ public class TransactionHUD : MonoBehaviour, ITransactionHUD
 
         if (scene != null)
         {
-            messageLabel.text = $"This scene {scene.sceneData.basePosition.ToString()} wants you to sign a message. Press ALLOW and then check your mobile wallet to confirm the transaction.";
+            messageLabel.text = $"This scene {scene.sceneData.basePosition.ToString()} is requesting the signature of a message. " +
+                                $"If you are interested, please click the Allow button to receive it in your Wallet Connect application. " +
+                                $"This action does not imply message approval.";
         }
     }
 


### PR DESCRIPTION
## What does this PR change?

Updated the text displayed when the user wants to sign a transaction. Now it should say "This scene is requesting the signature of a message. If you are interested, please click the Allow button to receive it in your Wallet Connect application. This action does not imply message approval."

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/update-misleading-text-on-pending-transactions
2. Login using WalletConnect
3. Teleport to (61,-27)
4. Try to start a transaction with any of the items there
5. The message that popups should say "This scene (61,-27) is requesting the signature of a message. If you are interested, please click the Allow button to receive it in your Wallet Connect application. This action does not imply message approval."

![image](https://user-images.githubusercontent.com/1999557/177408112-1d75e4db-06d1-4613-a120-ee3417c686df.png)


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
