### PR TITLE
fix: wearable change failure

### DIFF
--- a/unity-renderer/Assets/Rendering/LoadingAvatar/CrossSection/BaseAvatarReveal.cs
+++ b/unity-renderer/Assets/Rendering/LoadingAvatar/CrossSection/BaseAvatarReveal.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
@@ -6,6 +7,7 @@ using DCL.Helpers;
 using DCL;
 using AvatarSystem;
 using Cysharp.Threading.Tasks;
+using Random = UnityEngine.Random;
 
 public class BaseAvatarReveal : MonoBehaviour, IBaseAvatarRevealer
 {
@@ -108,15 +110,22 @@ public class BaseAvatarReveal : MonoBehaviour, IBaseAvatarRevealer
 
     public async UniTask StartAvatarRevealAnimation(bool instant, CancellationToken cancellationToken)
     {
-        if (!instant)
+        try
+        {
+            if (!instant)
+            {
+                SetFullRendered();
+                return;
+            }
+
+            isRevealing = true;
+            animation.Play();
+            await UniTask.WaitUntil(() => !isRevealing, cancellationToken: cancellationToken);
+        }
+        catch(OperationCanceledException)
         {
             SetFullRendered();
-            return;
         }
-
-        isRevealing = true;
-        animation.Play();
-        await UniTask.WaitUntil(() => !isRevealing, cancellationToken: cancellationToken);
     }
 
     public void OnRevealAnimationEnd()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
@@ -88,7 +88,9 @@ namespace AvatarSystem
                 gpuSkinningThrottler.Start();
 
                 status = IAvatar.Status.Loaded; 
-                baseAvatar.FadeOut(loader.combinedRenderer.GetComponent<MeshRenderer>(), lodLevel <= 1, linkedCt);
+                
+                await baseAvatar.FadeOut(loader.combinedRenderer.GetComponent<MeshRenderer>(), lodLevel <= 1, linkedCt);
+                
             }
             catch (OperationCanceledException)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
@@ -88,7 +88,7 @@ namespace AvatarSystem
                 gpuSkinningThrottler.Start();
 
                 status = IAvatar.Status.Loaded; 
-                await baseAvatar.FadeOut(loader.combinedRenderer.GetComponent<MeshRenderer>(), lodLevel <= 1, linkedCt);
+                baseAvatar.FadeOut(loader.combinedRenderer.GetComponent<MeshRenderer>(), lodLevel <= 1, linkedCt);
             }
             catch (OperationCanceledException)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/BaseAvatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/BaseAvatar.cs
@@ -50,6 +50,8 @@ namespace AvatarSystem
         {
             if (avatarRevealerContainer == null) 
                 return;
+            
+            cancellationToken.ThrowIfCancellationRequested();
 
             avatarRevealer.AddTarget(targetRenderer);
             await avatarRevealer.StartAvatarRevealAnimation(playParticles, cancellationToken);


### PR DESCRIPTION
## What does this PR change?

Fixes a bug where the avatar failed to stay visible when changing wearables by fixing how the FadeOut cancellation is being handled.

## How to test the changes?

Change a wearable and press done, the avatar should go through the hologram phase and should work correctly.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
