### PR TITLE
fix: NFTShape not being removed

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShape.cs
@@ -71,7 +71,6 @@ namespace DCL.Components
                 return;
 
             entity.OnShapeUpdated -= UpdateBackgroundColor;
-            Environment.i.world.state.RemoveLoaderForEntity(entity);
 
             base.DetachShape(entity);
         }


### PR DESCRIPTION
NFTShape was not being removed on `removeComponent`
This snipped of code was not removing the component

```
const entity = new Entity()
const shapeComponent = new NFTShape(
  "ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/558536"
)
entity.addComponent(shapeComponent)
entity.addComponent(
  new Transform({
    position: new Vector3(4, 1.5, 4),
  })
)
engine.addEntity(entity)
entity.removeComponent(NFTShape)
```