### PR TITLE
chore: ui camera is now always an overlay

### DIFF
--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxCamera.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxCamera.cs
@@ -51,7 +51,5 @@ namespace DCL.Skybox
 
             camBehavior.AssignCamera(mainCamComponent, skyboxCamera);
         }
-
-        public void SetCameraEnabledState(bool enabled) { skyboxCamera.enabled = enabled; }
     }
 }

--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxController.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxController.cs
@@ -102,11 +102,8 @@ namespace DCL.Skybox
 
             // Register for camera references
             DataStore.i.camera.transform.OnChange += AssignCameraReferences;
-            DataStore.i.camera.mainCamEnabled.OnChange += SkyboxCameraEnabled;
             AssignCameraReferences(DataStore.i.camera.transform.Get(), null);
         }
-
-        private void SkyboxCameraEnabled(bool current, bool previous) { skyboxCam.SetCameraEnabledState(current); }
 
         private void AssignCameraReferences(Transform currentTransform, Transform prevTransform)
         {
@@ -486,7 +483,6 @@ namespace DCL.Skybox
             DataStore.i.skyboxConfig.fixedTime.OnChange -= FixedTime_OnChange;
             DataStore.i.skyboxConfig.reflectionResolution.OnChange -= ReflectionResolution_OnChange;
             DataStore.i.camera.transform.OnChange -= AssignCameraReferences;
-            DataStore.i.camera.mainCamEnabled.OnChange -= SkyboxCameraEnabled;
 
             timeReporter.Dispose();
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
@@ -231,11 +231,6 @@ namespace DCL.Camera
         private void SetCameraEnabledState(bool enabled)
         {
             camera.enabled = enabled;
-
-            var hudsCameraData = hudsCamera.GetUniversalAdditionalCameraData();
-            hudsCameraData.renderType = enabled ?  CameraRenderType.Overlay : CameraRenderType.Base;
-
-            DataStore.i.camera.mainCamEnabled.Set(enabled);
         }
 
         private void OnDestroy()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Camera.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Camera.cs
@@ -9,7 +9,6 @@ namespace DCL
         public readonly BaseVariable<bool> panning = new BaseVariable<bool>();
         public readonly BaseVariable<RenderTexture> outputTexture = new BaseVariable<RenderTexture>(null);
         public readonly BaseVariable<bool> invertYAxis = new BaseVariable<bool>();
-        public readonly BaseVariable<bool> mainCamEnabled = new BaseVariable<bool>(true);
         public readonly BaseVariable<Camera> hudsCamera = new BaseVariable<Camera>();
     }
 }


### PR DESCRIPTION
Our current Camera Stack is:
```
- Skybox (Base)
   - World Camera (Overlay)
   - HUDs Camera (Overlay)
```
Going into a fullscreen HUD will disable the cameras for performance's sake. Since the HUDs are now in camera space, we were forced to change the camera mode of the HUD camera to Base (instead of Overlay) when in this mode. 

Now the skybox camera is never disabled, even if we are in a fullscreen HUD. The impact in performance is not even noticeable and simplyfies a lot the design.