### PR TITLE
fix: invisible character preview

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
@@ -41,16 +41,24 @@ namespace AvatarSystem
             return (mainTextureUrl, maskTextureUrl);
         }
 
-        public static void CopyBones(SkinnedMeshRenderer source, IEnumerable<SkinnedMeshRenderer> targets)
+        public static void CopyBones(Transform rootBone, Transform[] bones, IEnumerable<SkinnedMeshRenderer> targets)
         {
-            if (source == null)
+            if (rootBone == null || bones == null)
                 return;
 
             foreach (SkinnedMeshRenderer skinnedMeshRenderer in targets)
             {
-                skinnedMeshRenderer.rootBone = source.rootBone;
-                skinnedMeshRenderer.bones = source.bones;
+                CopyBones(rootBone, bones, skinnedMeshRenderer);
             }
+        }
+
+        public static void CopyBones(Transform rootBone, Transform[] bones, SkinnedMeshRenderer skinnedMeshRenderer)
+        {
+            if (rootBone == null || bones == null)
+                return;
+
+            skinnedMeshRenderer.rootBone = rootBone;
+            skinnedMeshRenderer.bones = bones;
         }
 
         public static void PrepareMaterialColors(Rendereable rendereable, Color skinColor, Color hairColor)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/LoaderDefinitions/IWearableLoader.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/LoaderDefinitions/IWearableLoader.cs
@@ -20,5 +20,6 @@ namespace AvatarSystem
         Rendereable rendereable { get; }
         Status status { get; }
         UniTask Load(GameObject container, AvatarSettings avatarSettings, CancellationToken ct = default);
+        void SetBones(Transform rootBone, Transform[] bones);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/Loader.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/Loader.cs
@@ -54,10 +54,16 @@ namespace AvatarSystem
                 if (status == ILoader.Status.Failed_Major)
                     throw new Exception($"Couldnt load (nor fallback) wearables with required category: {string.Join(", ", ConstructRequiredFailedWearablesList(loaders.Values))}");
 
-                AvatarSystemUtils.CopyBones(skinnedContainer, loaders.Values.SelectMany(x => x.rendereable.renderers).OfType<SkinnedMeshRenderer>());
+
+                foreach (IWearableLoader wearableLoader in loaders.Values)
+                {
+                    wearableLoader.SetBones(skinnedContainer.rootBone, skinnedContainer.bones);
+                }
 
                 if (bodyshapeLoader.rendereable != null)
-                    AvatarSystemUtils.CopyBones(skinnedContainer, bodyshapeLoader.rendereable.renderers.OfType<SkinnedMeshRenderer>());
+                {
+                    bodyshapeLoader.SetBones(skinnedContainer.rootBone, skinnedContainer.bones);
+                }
 
                 (bool headVisible, bool upperBodyVisible, bool lowerBodyVisible, bool feetVisible) = AvatarSystemUtils.GetActiveBodyParts(settings.bodyshapeId, wearables);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/WearableLoader.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/WearableLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL;
@@ -84,6 +85,8 @@ namespace AvatarSystem
                 throw;
             }
         }
+
+        public void SetBones(Transform rootBone, Transform[] bones) { AvatarSystemUtils.CopyBones(rootBone, bones, rendereable.renderers.OfType<SkinnedMeshRenderer>()); }
 
         private async UniTask FallbackToDefault(GameObject container, CancellationToken ct)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/CharacterPreview.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/CharacterPreview.prefab
@@ -261,7 +261,6 @@ MonoBehaviour:
   bodySnapshotTemplate: {fileID: 4122678849617202556}
   avatarContainer: {fileID: 6856622359626919856}
   avatarRevealContainer: {fileID: 6693538414670061813}
-  armatureContainer: {fileID: 6856622359626919856}
 --- !u!1 &5657874010593393711
 GameObject:
   m_ObjectHideFlags: 0
@@ -452,7 +451,7 @@ Camera:
   field of view: 40
   orthographic: 0
   orthographic size: 5
-  m_Depth: 0
+  m_Depth: -100
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 49152


### PR DESCRIPTION
When using an Avatar with a Hologram all the renderers (including the Bodyshape's ones) point its bones to the BaseAvatar (the hologram). This is done to have smooth transitions from hologram to real avatar.

The bug goes as follow:

- Spawn in Genesis Plaza with more people
- Avatars with holograms are rendered
- Bunch of bodyshapes are pointing its bones to their corresponding BaseAvatar
- You teleport to another location,  avatars from other people are disposed (renderers are returned to the library to be reused)
- Open Backpack
- CharacterPreview loads an AvatarWithoutHologram, that means using the upperbody as the bones orchestator)
- Most wearables are retrieved from the library because they are already loaded, bodyshape included.
- All wearables use the upperbody bones to animate themselves but upperbody bones are pointing to the `BaseAvatar` of its previous "life".
- Wearables are now being animated in MORDOR (where the assets in the library live) and therefore invisible


# Test
- Do multiple visits to crowded places and then teleport before opening the backpack. The Character Preview should work