### PR TITLE
chore: set passport's canvas in camera space

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUD.asmdef
@@ -27,7 +27,8 @@
         "GUID:2fe81fa47ac9ca345860b544ce917241",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:8aa60ff897c74401cb96cdbc583fed0d",
-        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca"
+        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca",
+        "GUID:bb3eef89092f71f44aa2449a9cf7879c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
@@ -58,6 +58,9 @@ public class PlayerInfoCardHUDView : MonoBehaviour
     private UnityAction<bool> toggleChangedDelegate => (x) => UpdateTabs();
 
     private MouseCatcher mouseCatcher;
+    private HUDCanvasCameraModeController hudCanvasCameraModeController;
+
+    private void Awake() { hudCanvasCameraModeController = new HUDCanvasCameraModeController(GetComponent<Canvas>(), DataStore.i.camera.hudsCamera); }
 
     public static PlayerInfoCardHUDView CreateView()
     {
@@ -263,6 +266,7 @@ public class PlayerInfoCardHUDView : MonoBehaviour
 
     private void OnDestroy()
     {
+        hudCanvasCameraModeController?.Dispose();
         if (mouseCatcher != null)
             mouseCatcher.OnMouseDown -= OnPointerDown;
     }


### PR DESCRIPTION
Passport was not set in camera space canvas

# Test
Open the passport and then other UI's on top, it should be behind them.