### PR TITLE
fix: player positions in minimap is not unclamped

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapUserIcon.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapUserIcon.cs
@@ -13,6 +13,6 @@ public class MapUserIcon : MonoBehaviour
             return;
 
         var gridPosition = Utils.WorldToGridPositionUnclamped(trackedPlayer.worldPosition + CommonScriptableObjects.worldOffset.Get());
-        transform.localPosition = MapUtils.CoordsToPosition(Vector2Int.RoundToInt(gridPosition));
+        transform.localPosition = MapUtils.CoordsToPositionUnclamped(gridPosition);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapUtils.cs
@@ -18,6 +18,8 @@ namespace DCL.Helpers
             return result;
         }
 
+        public static Vector2 CoordsToPositionUnclamped(Vector2 coords) => CoordsToPositionUnclamped(coords, PARCEL_SIZE);
+        public static Vector2 CoordsToPositionUnclamped(Vector2 coords, int parcelSize) { return coords * parcelSize; }
         public static Vector2 CoordsToPosition(Vector2Int coords) => CoordsToPosition(coords, PARCEL_SIZE);
         public static Vector2 CoordsToPosition(Vector2Int coords, int parcelSize) { return ((Vector2)coords) * parcelSize; }
         public static Vector2 CoordsToPosition(Vector2 coords) => CoordsToPosition(coords, PARCEL_SIZE);


### PR DESCRIPTION
Player positions in minimap was being clamped into integers.

# Test

Go to a crowded place, player position should correspond to its representation in the minimap