### PR TITLE
fix: layout updating when long messages are added to the chat

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -65,9 +65,9 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
         // Due to a TMPro bug in Unity 2020 LTS we have to wait several frames before setting the body.text to avoid a
         // client crash. More info at https://github.com/decentraland/unity-renderer/pull/2345#issuecomment-1155753538
         // TODO: Remove hack in a newer Unity/TMPro version 
-        await UniTask.NextFrame();
-        await UniTask.NextFrame();
-        await UniTask.NextFrame();
+        await UniTask.NextFrame(cancellationToken);
+        await UniTask.NextFrame(cancellationToken);
+        await UniTask.NextFrame(cancellationToken);
 
         if (!string.IsNullOrEmpty(userString) && showUserName)
             body.text = $"{userString} {chatEntryModel.bodyText}";
@@ -78,7 +78,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
 
         messageLocalDateTime = UnixTimeStampToLocalDateTime(chatEntryModel.timestamp).ToString();
 
-        Utils.ForceUpdateLayout(transform as RectTransform);
+        (transform as RectTransform).ForceUpdateLayout();
 
         PlaySfx(chatEntryModel);
     }


### PR DESCRIPTION
## What does this PR change?

It fixes a layout issue that was causing the chat messages to be trimmed when they are too long.

![image](https://user-images.githubusercontent.com/56365551/180284590-d37b12a2-7876-4bb2-89fd-245193590ff4.png)

## How to test the changes?

1. Open any chat window
2. Write very long messages
3. The scroll should behave correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
