### PR TITLE
style: coinbase added on the wallet illustration

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Textures/WalletIllustration.png
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Textures/WalletIllustration.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:087ee7558294a115aac988f8cb7f3cf21f6b1ab4a16cb6033758a6d277b48e81
-size 14302
+oid sha256:77052cf7d211f13701ed6ad7dcabbb04aab70f51313cf9fed4356bae7a47ce60
+size 103023


### PR DESCRIPTION
## What does this PR change?
Update of the wallet image for the skins and collectibles sections of the backpack when a player enters as a guest. Now it includes Coinbase as an option.
<img width="487" alt="Screenshot 2022-07-22 at 05 48 06" src="https://user-images.githubusercontent.com/51088292/180401536-0e3d5814-b4a3-4bac-bf4e-21eddcc5cdf7.png">

## How to test the changes?
1. Enter as a Guest here: https://play.decentraland.zone/?renderer-branch=style/ConnectWalletImage
2. Open the backpack in the sections skins and collectibles to see the new image.