### PR TITLE
fix: avatar modifier area for ECS7

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Handler/AvatarModifierAreaComponentHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Handler/AvatarModifierAreaComponentHandler.cs
@@ -55,11 +55,14 @@ namespace DCL.ECSComponents
             dataStore.otherPlayers.OnAdded -= OtherPlayersOnOnAdded;
             dataStore.otherPlayers.OnRemoved -= OnOtherPlayersRemoved;
 
-            updateEventHandler.RemoveListener(IUpdateEventHandler.EventType.LateUpdate, Update);
+            updateEventHandler.RemoveListener(IUpdateEventHandler.EventType.Update, Update);
         }
 
         public void OnComponentModelUpdated(IParcelScene scene, IDCLEntity entity, PBAvatarModifierArea model)
         {
+            if (model.Equals(this.model))
+                return;
+            
             // Clean up
             RemoveAllModifiers();
             OnAvatarEnter = null;
@@ -68,12 +71,12 @@ namespace DCL.ECSComponents
             this.entity = entity;
             ApplyCurrentModel(model);
         }
-        
+
         private void Update()
         {
             if (model == null)
                 return;
-            
+
             // Find avatars currently on the area
             HashSet<GameObject> newAvatarsInArea = DetectAllAvatarsInArea();
             if (AreSetEquals(avatarsInArea, newAvatarsInArea))
@@ -118,7 +121,7 @@ namespace DCL.ECSComponents
         private void RemoveAllModifiers()
         {
             RemoveAllModifiers(DetectAllAvatarsInArea());
-            avatarsInArea = null;
+            avatarsInArea.Clear();
         }
 
         private void RemoveAllModifiers(HashSet<GameObject> avatars)
@@ -146,7 +149,7 @@ namespace DCL.ECSComponents
                 foreach (PBAvatarModifierArea.Types.Modifier modifierKey in model.Modifiers)
                 {
                     var modifier = factory.GetOrCreateAvatarModifier(modifierKey);
-
+                    
                     OnAvatarEnter += modifier.ApplyModifier;
                     OnAvatarExit += modifier.RemoveModifier;
                 }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Utils/ECSAvatarUtils.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Utils/ECSAvatarUtils.cs
@@ -9,14 +9,16 @@ namespace DCL.ECSComponents.Utils
     
         public static HashSet<GameObject> DetectAvatars(in UnityEngine.Vector3 box, in UnityEngine.Vector3 center, in Quaternion rotation, in HashSet<Collider> excludeColliders = null)
         {
+            HashSet<GameObject> result = new HashSet<GameObject>();
+            
             Collider[] colliders = Physics.OverlapBox(center, box * 0.5f, rotation,
                 LayerMask.GetMask(AVATAR_TRIGGER_LAYER), QueryTriggerInteraction.Collide);
 
             if (colliders.Length == 0)
-                return null;
+                return result;
 
             bool hasExcludeList = excludeColliders != null;
-            HashSet<GameObject> result = new HashSet<GameObject>();
+
             foreach (Collider collider in colliders)
             {
                 if (hasExcludeList && excludeColliders.Contains(collider))


### PR DESCRIPTION
## What does this PR change?

This fixes the Avatar modifier area component for ECS 7


## How to test the changes?

1.- Download the scene https://github.com/decentraland/ecs7-template (recommended branch: feat/cube-spawner)
2.- Follow the instructions and install this SDK version `npm install "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/readd-avatar-modifier-area/dcl-sdk-7.0.0-2718342601.commit-6cf89b2.tgz"`
3.- start the scene with npm start
4.- Use this URL: http://127.0.0.1:8000/?position=0%2C0&ENABLE_ECS7&renderer-branch=fix/avatar-modifier-area&kernel-branch=main&SCENE_DEBUG_PANEL=&realm=v1%7E127.0.0.1%3A8000
5.- Change the code to see if everything works as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
