### PR TITLE
fix: debug mode and chat coords are fixed

### DIFF
--- a/unity-renderer/Assets/Prefabs/FPSPanel.prefab
+++ b/unity-renderer/Assets/Prefabs/FPSPanel.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 5238879484207625851}
   - component: {fileID: 3227257210199013863}
   - component: {fileID: 1619290350810090377}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: Label
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -154,7 +154,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -163,6 +163,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -191,7 +192,7 @@ GameObject:
   - component: {fileID: 3860873241709818942}
   - component: {fileID: 1994528194573935870}
   - component: {fileID: 5012294344041377517}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: LabelBackground
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -268,7 +269,7 @@ GameObject:
   - component: {fileID: 891051229449626258}
   - component: {fileID: 1052222339156527546}
   - component: {fileID: 1592760362493093889}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: FPSPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -182,7 +182,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
     {
         if (pointerEventData.button == PointerEventData.InputButton.Left)
         {
-            int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, null);
+            int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, DataStore.i.camera.hudsCamera.Get());
             if (linkIndex != -1)
             {
                 DataStore.i.HUDs.gotoPanelVisible.Set(true);
@@ -221,7 +221,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
             return;
 
         hoverPanelTimer = 0f;
-        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, null);
+        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, DataStore.i.camera.hudsCamera.Get());
         if (linkIndex == -1)
         {
             isOverCoordinates = false;
@@ -353,7 +353,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
         if (isOverCoordinates)
             return;
 
-        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, Input.mousePosition, null);
+        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, Input.mousePosition, DataStore.i.camera.hudsCamera.Get());
 
         if (linkIndex == -1)
             return;


### PR DESCRIPTION
Some items inside the DebugView prefab were not in the UI Layer.

Additionally the camera was not being used for the TMPro utility to check the mouse over the link

# Test

Using `DEBUG_MODE` should make the FPS panel visible.
Hovering coordinates in chat should show a toast
Clicking coordinates in chat should open a popup.