### PR TITLE
chore: autoassign action for reviewers

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -1,0 +1,13 @@
+addAssignees: author
+numberOfAssignees: 1
+
+addReviewers: true
+useReviewGroups: false
+numberOfReviewers: 1
+reviewers:
+  - AjimenezDCL
+  - pravusjif
+  - sandrade-dcl
+  - Kinerius
+  - loruxo
+  - davidejensen

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,12 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.1
+        with:
+          configuration-path: '.github/auto_assign_config.yml'


### PR DESCRIPTION
Add a github acction that set reviewers automatically from a reviewers pool