### PR TITLE
fix: animator bug sometimes not playing ECS 7

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Animator/Handler/AnimatorComponentHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Animator/Handler/AnimatorComponentHandler.cs
@@ -70,7 +70,7 @@ namespace DCL.ECSComponents
                 return;
 
             //NOTE(Brian): fetch all the AnimationClips in Animation component.
-            animComponent = entity.gameObject.transform.parent.GetComponentInChildren<Animation>(true);
+            animComponent = entity.gameObject.GetComponentInChildren<Animation>(true);
 
             if (animComponent == null)
                 return;


### PR DESCRIPTION
## What does this PR change?

This PR fixes a situation where if you have more than 1 animator and changes the animation of 1 of them, it is not working

## How to test the changes?

1.- Download the scene https://github.com/decentraland/ecs7-template (recommended branch: feat/cube-spawner)
2.- Follow the instructions and start the scene with npm start
3.- Use this URL: http://127.0.0.1:8000/?position=0%2C0&ENABLE_ECS7=&renderer-branch=fix/animator-component&kernel-branch=main&SCENE_DEBUG_PANEL=&realm=v1%7E127.0.0.1%3A8000
4.- Change the code to see if everything works as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
