### PR TITLE
fix: UIText and TextShapes being rendered when not visible 

### DIFF
--- a/unity-renderer/Assets/Scenes/InitialScene.unity
+++ b/unity-renderer/Assets/Scenes/InitialScene.unity
@@ -232,8 +232,10 @@ MonoBehaviour:
   builderInWorld: 0
   soloScene: 0
   debugPanelMode: 0
+  disableAssetBundles: 0
+  disableGLTFDownloadThrottle: 0
   multithreaded: 0
-  runPerformanceMeterToolDuringLoading: 1
+  runPerformanceMeterToolDuringLoading: 0
 --- !u!4 &1444882337
 Transform:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
@@ -100,8 +100,10 @@ namespace DCL.Components
             DCLFont.SetFontFromComponent(scene, model.font, text);
             
             var opacity = model.visible ? model.opacity : 0;
-            var totalSize = model.height + model.width;
-            bool isVisible = opacity > float.Epsilon && totalSize > 4;
+            var totalSize = model.fontSize;
+            var totalScale = text.transform.lossyScale.sqrMagnitude;
+            bool isVisible = opacity > 0 && totalSize > 0 && totalScale > 0;
+            
             text.enabled = isVisible;
             meshRenderer.enabled = isVisible;
             

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
@@ -56,6 +56,7 @@ namespace DCL.Components
             public override BaseModel GetDataFromJSON(string json) { return Utils.SafeFromJson<Model>(json); }
         }
 
+        public MeshRenderer meshRenderer;
         public TextMeshPro text;
         public RectTransform rectTransform;
         private Model cachedModel;
@@ -97,8 +98,15 @@ namespace DCL.Components
             }
 
             DCLFont.SetFontFromComponent(scene, model.font, text);
+            
+            var opacity = model.visible ? model.opacity : 0;
+            var totalSize = model.height + model.width;
+            bool isVisible = opacity > float.Epsilon && totalSize > 4;
+            text.enabled = isVisible;
+            meshRenderer.enabled = isVisible;
+            
             ApplyModelChanges(text, model);
-
+            
             if (entity.meshRootGameObject == null)
                 entity.meshesInfo.meshRootGameObject = gameObject;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.prefab
@@ -44,6 +44,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54708146f182f3e4ab06059d2b471971, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  meshRenderer: {fileID: 7414607916346624055}
   text: {fileID: 1924286501959050350}
   rectTransform: {fileID: 3826371723285139880}
 --- !u!1 &6459203267593316962
@@ -144,7 +145,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Hello
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -187,7 +188,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -196,6 +197,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 0
   m_isCullingEnabled: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIText/Resources/UIText.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIText/Resources/UIText.prefab
@@ -143,7 +143,7 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2091844807093637731}
-  m_CullTransparentMesh: 0
+  m_CullTransparentMesh: 1
 --- !u!114 &2265338682705848464
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -208,7 +208,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -217,6 +217,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0


### PR DESCRIPTION
## What does this PR change?

- Fixed UIText not being culled when its alpha or its alpha group parents had 0 alpha.
- Fixed TextShapes being rendered when their alpha or size was <= 0

Closes #2717 

## Performance Comparison:

PROD ( ICE Poker - The Stronghold ) [ NO AVATARS ]
```
PerformanceMeter - Data report step 2 - Processed values:
 * PERFORMANCE SCORE (0-100) -> 40
 * lowest frame time -> 41.8ms
 * average frame time -> 51.9ms
 * highest frame time -> 100.0ms
 * 1 percentile frame time -> 43.7ms
 * 50 percentile frame time -> 50.2ms
 * 99 percentile frame time -> 100.0ms
 * error percentage -> ±1.4%
 * total hiccups (>0.05ms frames) -> 296 (51.21% of frames were hiccups)
 * total hiccups time (seconds) -> 16.60201
 * total frames -> 578
 * total frames time (seconds) -> 30.00612
```
THIS PR
```
* PERFORMANCE SCORE (0-100) -> 64
 * lowest frame time -> 38.9ms
 * average frame time -> 45.8ms
 * highest frame time -> 100.0ms
 * 1 percentile frame time -> 39.3ms
 * 50 percentile frame time -> 44.2ms
 * 99 percentile frame time -> 100.0ms
 * error percentage -> ±1.5%
 * total hiccups (>0.05ms frames) -> 44 (6.72% of frames were hiccups)
 * total hiccups time (seconds) -> 3.076782
 * total frames -> 655
 * total frames time (seconds) -> 30.00663
```


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
