### PR TITLE
fix: special characters in chat crash

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -317,6 +317,8 @@ public class ChatHUDView : BaseComponentView, IChatHUDComponentView
         if (inputField.wasCanceled)
             currentMessage.body = string.Empty;
 
+        // we have to wait one frame to disengage the flow triggered by OnSendMessage
+        // otherwise it crashes the application (WebGL only) due a TextMeshPro bug
         StartCoroutine(WaitThenTriggerSendMessage());
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using DCL.Helpers;
@@ -316,6 +317,12 @@ public class ChatHUDView : BaseComponentView, IChatHUDComponentView
         if (inputField.wasCanceled)
             currentMessage.body = string.Empty;
 
+        StartCoroutine(WaitThenTriggerSendMessage());
+    }
+
+    private IEnumerator WaitThenTriggerSendMessage()
+    {
+        yield return null;
         OnSendMessage?.Invoke(currentMessage);
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -183,7 +183,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
     {
         if (pointerEventData.button == PointerEventData.InputButton.Left)
         {
-            int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, null);
+            int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, DataStore.i.camera.hudsCamera.Get());
             if (linkIndex != -1)
             {
                 DataStore.i.HUDs.gotoPanelVisible.Set(true);
@@ -222,7 +222,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
             return;
 
         hoverPanelTimer = 0f;
-        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, null);
+        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, DataStore.i.camera.hudsCamera.Get());
         if (linkIndex == -1)
         {
             isOverCoordinates = false;
@@ -354,7 +354,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
         if (isOverCoordinates)
             return;
 
-        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, Input.mousePosition, null);
+        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, Input.mousePosition, DataStore.i.camera.hudsCamera.Get());
 
         if (linkIndex == -1)
             return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -36,6 +36,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
 
     private Color originalBackgroundColor;
     private Color originalFontColor;
+    private readonly CancellationTokenSource populationTaskCancellationTokenSource = new CancellationTokenSource();
 
     public override ChatEntryModel Model => model;
 
@@ -52,12 +53,22 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
         originalFontColor = body.color;
     }
 
-    public override void Populate(ChatEntryModel chatEntryModel)
+    public override void Populate(ChatEntryModel chatEntryModel) =>
+        PopulateTask(chatEntryModel, populationTaskCancellationTokenSource.Token).Forget();
+
+    private async UniTask PopulateTask(ChatEntryModel chatEntryModel, CancellationToken cancellationToken)
     {
         model = chatEntryModel;
 
         chatEntryModel.bodyText = RemoveTabs(chatEntryModel.bodyText);
         var userString = GetUserString(chatEntryModel);
+
+        // Due to a TMPro bug in Unity 2020 LTS we have to wait several frames before setting the body.text to avoid a
+        // client crash. More info at https://github.com/decentraland/unity-renderer/pull/2345#issuecomment-1155753538
+        // TODO: Remove hack in a newer Unity/TMPro version 
+        await UniTask.NextFrame(cancellationToken);
+        await UniTask.NextFrame(cancellationToken);
+        await UniTask.NextFrame(cancellationToken);
 
         if (!string.IsNullOrEmpty(userString) && showUserName)
             body.text = $"{userString} {chatEntryModel.bodyText}";
@@ -76,11 +87,12 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
     private string GetUserString(ChatEntryModel chatEntryModel)
     {
         var userString = GetDefaultSenderString(chatEntryModel.senderName);
-        switch (chatEntryModel.messageType)
+        switch (chatEntryModel.messageType) 
         {
             case ChatMessage.Type.PUBLIC:
                 userString = chatEntryModel.subType switch
                 {
+            
                     ChatEntryModel.SubType.RECEIVED => userString,
                     ChatEntryModel.SubType.SENT => $"<b>You:</b>",
                     _ => userString
@@ -89,8 +101,8 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
             case ChatMessage.Type.PRIVATE:
                 userString = chatEntryModel.subType switch
                 {
-                    ChatEntryModel.SubType.RECEIVED =>
-                        $"<b><color=#5EBD3D>From {chatEntryModel.senderName}:</color></b>",
+            
+                    ChatEntryModel.SubType.RECEIVED => $"<b><color=#5EBD3D>From {chatEntryModel.senderName}:</color></b>",
                     ChatEntryModel.SubType.SENT => $"<b>To {chatEntryModel.recipientName}:</b>",
                     _ => userString
                 };
@@ -145,11 +157,15 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
                         case ChatEntryModel.SubType.SENT:
                             AudioScriptableObjects.chatSend.Play(true);
                             break;
+                        default:
+                            break;
                     }
 
                     break;
                 case ChatMessage.Type.SYSTEM:
                     AudioScriptableObjects.chatReceiveGlobal.Play(true);
+                    break;
+                default:
                     break;
             }
         }
@@ -167,8 +183,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
     {
         if (pointerEventData.button == PointerEventData.InputButton.Left)
         {
-            int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position,
-                DataStore.i.camera.hudsCamera.Get());
+            int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, null);
             if (linkIndex != -1)
             {
                 DataStore.i.HUDs.gotoPanelVisible.Set(true);
@@ -207,9 +222,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
             return;
 
         hoverPanelTimer = 0f;
-        int linkIndex =
-            TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position,
-                DataStore.i.camera.hudsCamera.Get());
+        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, pointerEventData.position, null);
         if (linkIndex == -1)
         {
             isOverCoordinates = false;
@@ -220,10 +233,9 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
         OnCancelHover?.Invoke();
     }
 
-    private void OnDisable()
-    {
-        OnPointerExit(null);
-    }
+    private void OnDisable() { OnPointerExit(null); }
+
+    private void OnDestroy() { populationTaskCancellationTokenSource.Cancel(); }
 
     public override void SetFadeout(bool enabled)
     {
@@ -256,7 +268,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
         previewInterpolationRoutine =
             StartCoroutine(InterpolatePreviewColor(originalBackgroundColor, originalFontColor, 0.5f));
     }
-
+    
     public override void FadeOut()
     {
         if (!gameObject.activeInHierarchy)
@@ -264,7 +276,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
             group.alpha = 0;
             return;
         }
-
+        
         if (previewInterpolationAlphaRoutine != null)
             StopCoroutine(previewInterpolationAlphaRoutine);
 
@@ -295,7 +307,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
     {
         if (!gameObject.activeInHierarchy)
             return;
-
+        
         if (previewInterpolationRoutine != null)
             StopCoroutine(previewInterpolationRoutine);
 
@@ -342,8 +354,7 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
         if (isOverCoordinates)
             return;
 
-        int linkIndex =
-            TMP_TextUtilities.FindIntersectingLink(body, Input.mousePosition, DataStore.i.camera.hudsCamera.Get());
+        int linkIndex = TMP_TextUtilities.FindIntersectingLink(body, Input.mousePosition, null);
 
         if (linkIndex == -1)
             return;
@@ -423,4 +434,5 @@ public class DefaultChatEntry : ChatEntry, IPointerClickHandler, IPointerEnterHa
         previewBackgroundImage.color = backgroundColor;
         body.color = fontColor;
     }
+
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
@@ -41,6 +41,8 @@ public class DefaultChatEntryShould
 
         entry.Populate(message);
 
+        await UniTask.DelayFrame(4);
+
         Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
     });
 
@@ -59,6 +61,8 @@ public class DefaultChatEntryShould
         };
         
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
     });
@@ -78,6 +82,8 @@ public class DefaultChatEntryShould
         };
         
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("<b>You:</b> test message", entry.body.text);
     });
@@ -97,6 +103,8 @@ public class DefaultChatEntryShould
         };
         
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("<b><color=#5EBD3D>From user-test:</color></b> test message", entry.body.text);
     });
@@ -116,6 +124,8 @@ public class DefaultChatEntryShould
         };
         
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
     });
@@ -135,6 +145,8 @@ public class DefaultChatEntryShould
         };
         
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("test message", entry.body.text);
     });
@@ -154,6 +166,8 @@ public class DefaultChatEntryShould
         };
         
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("test message", entry.body.text);
     });
@@ -175,6 +189,8 @@ public class DefaultChatEntryShould
         };
         
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual($"<b>To receiver-test:</b> {bodyWithoutCoordinates}</noparse><link={coordinates}><color=#4886E3><u>{coordinates}</u></color></link><noparse>", entry.body.text);
     });
@@ -194,6 +210,8 @@ public class DefaultChatEntryShould
         };
         
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("<b>To receiver-test:</b> perhaps </noparse><link=73,94><color=#4886E3><u>73,94</u></color></link><noparse> then </noparse><link=-5,42><color=#4886E3><u>-5,42</u></color></link><noparse> and after </noparse><link=-36,72><color=#4886E3><u>-36,72</u></color></link><noparse>", entry.body.text);
     });
@@ -214,6 +232,8 @@ public class DefaultChatEntryShould
         };
 
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("test message", entry.body.text);
     });
@@ -234,6 +254,8 @@ public class DefaultChatEntryShould
         };
 
         entry.Populate(message);
+        
+        await UniTask.DelayFrame(4);
 
         Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
     });

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
@@ -39,7 +39,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.RECEIVED
         };
 
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
     });
@@ -58,7 +58,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.RECEIVED
         };
         
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
     });
@@ -77,7 +77,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.SENT
         };
         
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("<b>You:</b> test message", entry.body.text);
     });
@@ -96,7 +96,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.RECEIVED
         };
         
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("<b><color=#5EBD3D>From user-test:</color></b> test message", entry.body.text);
     });
@@ -115,7 +115,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.SENT
         };
         
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
     });
@@ -134,7 +134,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.SENT
         };
         
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("test message", entry.body.text);
     });
@@ -153,7 +153,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.RECEIVED
         };
         
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("test message", entry.body.text);
     });
@@ -174,7 +174,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.SENT
         };
         
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual($"<b>To receiver-test:</b> {bodyWithoutCoordinates}</noparse><link={coordinates}><color=#4886E3><u>{coordinates}</u></color></link><noparse>", entry.body.text);
     });
@@ -193,7 +193,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.SENT
         };
         
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("<b>To receiver-test:</b> perhaps </noparse><link=73,94><color=#4886E3><u>73,94</u></color></link><noparse> then </noparse><link=-5,42><color=#4886E3><u>-5,42</u></color></link><noparse> and after </noparse><link=-36,72><color=#4886E3><u>-36,72</u></color></link><noparse>", entry.body.text);
     });
@@ -213,7 +213,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.RECEIVED
         };
 
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("test message", entry.body.text);
     });
@@ -233,7 +233,7 @@ public class DefaultChatEntryShould
             subType = ChatEntryModel.SubType.SENT
         };
 
-        await entry.PopulateTask(message, entry.populationTaskCancellationTokenSource.Token);
+        entry.Populate(message);
 
         Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
     });


### PR DESCRIPTION
## What does this PR change?

Fixes a crash when you write special messages, for example: `-100,-100` or `-ewoifjweo -ewfew-ff fweowfj`.

## How to test the changes?

1. Open the nearby channel window and write anything that starts with `-` character, for example `-30,-30`
2. Open the start menu, go to places and then jumpin to Wondermine
3. The application should not freeze

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
