### PR TITLE
chore: add memory metrics to ab

### DIFF
--- a/unity-renderer/Assets/ABConverter/AssetBundleMetadata/AssetBundleMetrics.cs
+++ b/unity-renderer/Assets/ABConverter/AssetBundleMetadata/AssetBundleMetrics.cs
@@ -1,6 +1,6 @@
 ﻿[System.Serializable]
 public struct AssetBundleMetrics
 {
-    public long meshes_size;
-    public long animation_size;
+    public long meshesEstimatedSize;
+    public long animationsEstimatedSize;
 }

--- a/unity-renderer/Assets/ABConverter/AssetBundleMetadata/AssetBundleMetrics.cs
+++ b/unity-renderer/Assets/ABConverter/AssetBundleMetadata/AssetBundleMetrics.cs
@@ -1,0 +1,6 @@
+﻿[System.Serializable]
+public struct AssetBundleMetrics
+{
+    public long meshes_size;
+    public long animation_size;
+}

--- a/unity-renderer/Assets/ABConverter/AssetBundleMetadata/AssetBundleMetrics.cs.meta
+++ b/unity-renderer/Assets/ABConverter/AssetBundleMetadata/AssetBundleMetrics.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0fc21896a9544646ab18a1bbfad2343a
+timeCreated: 1659364773

--- a/unity-renderer/Assets/ABConverter/Core.cs
+++ b/unity-renderer/Assets/ABConverter/Core.cs
@@ -15,6 +15,7 @@ using UnityGLTF;
 using UnityGLTF.Cache;
 using GLTF;
 using GLTF.Schema;
+using Newtonsoft.Json;
 using UnityGLTF.Loader;
 
 namespace DCL.ABConverter
@@ -156,6 +157,14 @@ namespace DCL.ABConverter
                             
                             if (value.IsCompleted)
                             {
+                                FileInfo gltfFilePath = new FileInfo(key);
+                                var metrics = new Dictionary<string, object>()
+                                {
+                                    { "meshes_size", value.meshesEstimatedSize },
+                                    { "animation_size", value.animationsEstimatedSize }
+                                };
+                                File.WriteAllText($"{gltfFilePath.Directory.FullName}/metrics.json", JsonConvert.SerializeObject(metrics, Formatting.Indented));
+
                                 GLTFImporter.PreloadedGLTFObjects.Add(GetRelativePath(key), value.lastLoadedScene);
                                 
                                 env.assetDatabase.ImportAsset(key, ImportAssetOptions.ImportRecursive | ImportAssetOptions.ForceUpdate);

--- a/unity-renderer/Assets/ABConverter/Core.cs
+++ b/unity-renderer/Assets/ABConverter/Core.cs
@@ -158,12 +158,12 @@ namespace DCL.ABConverter
                             if (value.IsCompleted)
                             {
                                 FileInfo gltfFilePath = new FileInfo(key);
-                                var metrics = new Dictionary<string, object>()
+                                AssetBundleMetrics metrics = new AssetBundleMetrics()
                                 {
-                                    { "meshes_size", value.meshesEstimatedSize },
-                                    { "animation_size", value.animationsEstimatedSize }
+                                    meshesEstimatedSize = value.meshesEstimatedSize,
+                                    animationsEstimatedSize = value.animationsEstimatedSize
                                 };
-                                File.WriteAllText($"{gltfFilePath.Directory.FullName}/metrics.json", JsonConvert.SerializeObject(metrics, Formatting.Indented));
+                                File.WriteAllText($"{gltfFilePath.Directory.FullName}/metrics.json", JsonUtility.ToJson(metrics, true));
 
                                 GLTFImporter.PreloadedGLTFObjects.Add(GetRelativePath(key), value.lastLoadedScene);
                                 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
@@ -186,6 +186,7 @@ namespace DCL
             }
 
             asset.SetAssetBundle(assetBundle);
+            asset.LoadMetrics();
 
             return true;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/Asset_AB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/Asset_AB.cs
@@ -7,19 +7,12 @@ namespace DCL
 {
     public class Asset_AB : Asset
     {
-        [Serializable]
-        public struct MetricsPayload
-        {
-            public long meshes_size;
-            public long animation_size;
-        }
-
         const string METADATA_FILENAME = "metadata.json";
         const string METRICS_FILENAME = "metrics.json";
 
         private AssetBundle assetBundle;
         private Dictionary<string, List<Object>> assetsByExtension;
-        public MetricsPayload metrics { get; private set; } = new MetricsPayload { meshes_size = 0, animation_size = 0 };
+        public AssetBundleMetrics metrics { get; private set; } = new AssetBundleMetrics { meshes_size = 0, animation_size = 0 };
 
         public Asset_AB()
         {
@@ -95,7 +88,7 @@ namespace DCL
         {
             var metricsFile = assetBundle.LoadAsset<TextAsset>(METRICS_FILENAME);
             if (metricsFile != null)
-                metrics = JsonUtility.FromJson<MetricsPayload>(metricsFile.text);
+                metrics = JsonUtility.FromJson<AssetBundleMetrics>(metricsFile.text);
         }
 
         public TextAsset GetMetadata()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/Asset_AB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/Asset_AB.cs
@@ -12,7 +12,7 @@ namespace DCL
 
         private AssetBundle assetBundle;
         private Dictionary<string, List<Object>> assetsByExtension;
-        public AssetBundleMetrics metrics { get; private set; } = new AssetBundleMetrics { meshes_size = 0, animation_size = 0 };
+        public AssetBundleMetrics metrics { get; private set; } = new AssetBundleMetrics { meshesEstimatedSize = 0, animationsEstimatedSize = 0 };
 
         public Asset_AB()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/Asset_AB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/Asset_AB.cs
@@ -1,14 +1,25 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace DCL
 {
     public class Asset_AB : Asset
     {
+        [Serializable]
+        public struct MetricsPayload
+        {
+            public long meshes_size;
+            public long animation_size;
+        }
+
         const string METADATA_FILENAME = "metadata.json";
+        const string METRICS_FILENAME = "metrics.json";
 
         private AssetBundle assetBundle;
         private Dictionary<string, List<Object>> assetsByExtension;
+        public MetricsPayload metrics { get; private set; } = new MetricsPayload { meshes_size = 0, animation_size = 0 };
 
         public Asset_AB()
         {
@@ -78,6 +89,13 @@ namespace DCL
         public void SetAssetBundle(AssetBundle ab)
         {
             assetBundle = ab;
+        }
+
+        public void LoadMetrics()
+        {
+            var metricsFile = assetBundle.LoadAsset<TextAsset>(METRICS_FILENAME);
+            if (metricsFile != null)
+                metrics = JsonUtility.FromJson<MetricsPayload>(metricsFile.text);
         }
 
         public TextAsset GetMetadata()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -183,8 +183,8 @@ namespace DCL
                 yield return MaterialCachingHelper.Process(asset.renderers.ToList(), enableRenderers: false, settings.cachingFlags);
 
                 var animators = MeshesInfoUtils.ExtractUniqueAnimations(assetBundleModelGO);
-                asset.animationClipSize = 0; // TODO(Brian): Extract animation clip size from metadata
-                asset.meshDataSize = 0; // TODO(Brian): Extract mesh clip size from metadata
+                asset.animationClipSize = subPromise.asset.metrics.animation_size;
+                asset.meshDataSize = subPromise.asset.metrics.meshes_size;
 
                 foreach (var animator in animators)
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -183,8 +183,8 @@ namespace DCL
                 yield return MaterialCachingHelper.Process(asset.renderers.ToList(), enableRenderers: false, settings.cachingFlags);
 
                 var animators = MeshesInfoUtils.ExtractUniqueAnimations(assetBundleModelGO);
-                asset.animationClipSize = subPromise.asset.metrics.animation_size;
-                asset.meshDataSize = subPromise.asset.metrics.meshes_size;
+                asset.animationClipSize = subPromise.asset.metrics.animationsEstimatedSize;
+                asset.meshDataSize = subPromise.asset.metrics.meshesEstimatedSize;
 
                 foreach (var animator in animators)
                 {


### PR DESCRIPTION
Fixes #2124 

Added metrics generation file for ABs to have memory scoring for GLTFs and Animation Clips.

# Test
Cannot really be tested, just do a smoke run with and without Asset Bundles, everything should be fine.