### PR TITLE
chore: [UI Components refactor] Make IComponentModelConfig interface generic

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesViewer/Scripts/ExperienceRowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesViewer/Scripts/ExperienceRowComponentView.cs
@@ -66,7 +66,7 @@ namespace DCL.ExperiencesViewer
         void SetAllowStartStop(bool isAllowed);
     }
 
-    public class ExperienceRowComponentView : BaseComponentView, IExperienceRowComponentView, IComponentModelConfig
+    public class ExperienceRowComponentView : BaseComponentView, IExperienceRowComponentView, IComponentModelConfig<ExperienceRowComponentModel>
     {
         [Header("Prefab References")]
         [SerializeField] internal ImageComponentView iconImage;
@@ -104,9 +104,9 @@ namespace DCL.ExperiencesViewer
             SetAsPlaying(model.isPlaying);
         }
 
-        public void Configure(BaseComponentModel newModel)
+        public void Configure(ExperienceRowComponentModel newModel)
         {
-            model = (ExperienceRowComponentModel)newModel;
+            model = newModel;
             RefreshControl();
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/RealmViewer/RealmRowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/RealmViewer/RealmRowComponentView.cs
@@ -43,7 +43,7 @@ public interface IRealmRowComponentView
     void SetOnHoverColor(Color color);
 }
 
-public class RealmRowComponentView : BaseComponentView, IRealmRowComponentView, IComponentModelConfig
+public class RealmRowComponentView : BaseComponentView, IRealmRowComponentView, IComponentModelConfig<RealmRowComponentModel>
 {
     [Header("Assets References")]
     [SerializeField] internal FriendHeadForPlaceCardComponentView friendHeadPrefab;
@@ -80,9 +80,9 @@ public class RealmRowComponentView : BaseComponentView, IRealmRowComponentView, 
         onHoverColor = backgroundImage.color;
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(RealmRowComponentModel newModel)
     {
-        model = (RealmRowComponentModel)newModel;
+        model = newModel;
 
         InitializeFriendsTracker();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/RealmViewer/RealmSelectorComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/RealmViewer/RealmSelectorComponentView.cs
@@ -34,7 +34,7 @@ public interface IRealmSelectorComponentView
     void SetAvailableRealms(List<RealmRowComponentModel> realms);
 }
 
-public class RealmSelectorComponentView : BaseComponentView, IRealmSelectorComponentView, IComponentModelConfig
+public class RealmSelectorComponentView : BaseComponentView, IRealmSelectorComponentView, IComponentModelConfig<RealmSelectorComponentModel>
 {
     internal const string REALMS_POOL_NAME = "RealmSelector_RealmRowsPool";
     internal const int REALMS_POOL_PREWARM = 20;
@@ -108,9 +108,9 @@ public class RealmSelectorComponentView : BaseComponentView, IRealmSelectorCompo
         RefreshSortingArrows();
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(RealmSelectorComponentModel newModel)
     {
-        model = (RealmSelectorComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/RealmViewer/RealmViewerComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/RealmViewer/RealmViewerComponentView.cs
@@ -23,7 +23,7 @@ public interface IRealmViewerComponentView
     void SetNumberOfUsers(int newNumberOfUsers);
 }
 
-public class RealmViewerComponentView : BaseComponentView, IRealmViewerComponentView, IComponentModelConfig
+public class RealmViewerComponentView : BaseComponentView, IRealmViewerComponentView, IComponentModelConfig<RealmViewerComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal HorizontalLayoutGroup horizontalLayoutGroup;
@@ -36,9 +36,9 @@ public class RealmViewerComponentView : BaseComponentView, IRealmViewerComponent
 
     public Button.ButtonClickedEvent onLogoClick => logoButton?.onClick;
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(RealmViewerComponentModel newModel)
     {
-        model = (RealmViewerComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventCard/EventCardComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventCard/EventCardComponentView.cs
@@ -117,7 +117,7 @@ public interface IEventCardComponentView
     void SetLoadingIndicatorVisible(bool isVisible);
 }
 
-public class EventCardComponentView : BaseComponentView, IEventCardComponentView, IComponentModelConfig
+public class EventCardComponentView : BaseComponentView, IEventCardComponentView, IComponentModelConfig<EventCardComponentModel>
 {
     internal const string USERS_CONFIRMED_MESSAGE = "{0} confirmed";
     internal const string NOBODY_CONFIRMED_MESSAGE = "Nobody confirmed yet";
@@ -178,9 +178,9 @@ public class EventCardComponentView : BaseComponentView, IEventCardComponentView
             modalBackgroundButton.onClick.AddListener(CloseModal);
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(EventCardComponentModel newModel)
     {
-        model = (EventCardComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlaceCard/FriendHeadForPlaceCardComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlaceCard/FriendHeadForPlaceCardComponentView.cs
@@ -17,7 +17,7 @@ public interface IFriendHeadForPlaceCardComponentView
     void SetUserProfile(UserProfile profile);
 }
 
-public class FriendHeadForPlaceCardComponentView : BaseComponentView, IFriendHeadForPlaceCardComponentView, IComponentModelConfig
+public class FriendHeadForPlaceCardComponentView : BaseComponentView, IFriendHeadForPlaceCardComponentView, IComponentModelConfig<FriendHeadForPlaceCardComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal ImageComponentView friendPortrait;
@@ -30,9 +30,9 @@ public class FriendHeadForPlaceCardComponentView : BaseComponentView, IFriendHea
 
     public override void Start() { friendNameShowHideAnimator.gameObject.SetActive(false); }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(FriendHeadForPlaceCardComponentModel newModel)
     {
-        model = (FriendHeadForPlaceCardComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlaceCard/PlaceCardComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlaceCard/PlaceCardComponentView.cs
@@ -80,7 +80,7 @@ public interface IPlaceCardComponentView
     void SetLoadingIndicatorVisible(bool isVisible);
 }
 
-public class PlaceCardComponentView : BaseComponentView, IPlaceCardComponentView, IComponentModelConfig
+public class PlaceCardComponentView : BaseComponentView, IPlaceCardComponentView, IComponentModelConfig<PlaceCardComponentModel>
 {
     internal const int THMBL_MARKETPLACE_WIDTH = 196;
     internal const int THMBL_MARKETPLACE_HEIGHT = 143;
@@ -149,9 +149,9 @@ public class PlaceCardComponentView : BaseComponentView, IPlaceCardComponentView
         CleanFriendHeadsItems();
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(PlaceCardComponentModel newModel)
     {
-        model = (PlaceCardComponentModel)newModel;
+        model = newModel;
 
         InitializeFriendsTracker();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteCardComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteCardComponentView.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 
 namespace DCL.EmotesCustomization
 {
-    public class EmoteCardComponentView : BaseComponentView, IEmoteCardComponentView, IComponentModelConfig
+    public class EmoteCardComponentView : BaseComponentView, IEmoteCardComponentView, IComponentModelConfig<EmoteCardComponentModel>
     {
         internal static readonly int ON_SELECTED_CARD_COMPONENT_BOOL = Animator.StringToHash("OnSelected");
 
@@ -46,12 +46,12 @@ namespace DCL.EmotesCustomization
                 cardSelectionFrame.SetActive(false);
         }
 
-        public void Configure(BaseComponentModel newModel)
+        public void Configure(EmoteCardComponentModel newModel)
         {
             if (model == newModel)
                 return;
 
-            model = (EmoteCardComponentModel)newModel;
+            model = newModel;
             RefreshControl();
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteSlotCardComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteSlotCardComponentView.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 
 namespace DCL.EmotesCustomization
 {
-    public class EmoteSlotCardComponentView : BaseComponentView, IEmoteSlotCardComponentView, IComponentModelConfig
+    public class EmoteSlotCardComponentView : BaseComponentView, IEmoteSlotCardComponentView, IComponentModelConfig<EmoteSlotCardComponentModel>
     {
         internal const int SLOT_VIEWER_ROTATION_ANGLE = 36;
         internal const string EMPTY_SLOT_TEXT = "None";
@@ -44,12 +44,12 @@ namespace DCL.EmotesCustomization
                 emoteImage.OnLoaded += OnEmoteImageLoaded;
         }
 
-        public void Configure(BaseComponentModel newModel)
+        public void Configure(EmoteSlotCardComponentModel newModel)
         {
             if (model == newModel)
                 return;
 
-            model = (EmoteSlotCardComponentModel)newModel;
+            model = newModel;
             RefreshControl();
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteSlotSelectorComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteSlotSelectorComponentView.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace DCL.EmotesCustomization
 {
-    public class EmoteSlotSelectorComponentView : BaseComponentView, IEmoteSlotSelectorComponentView, IComponentModelConfig
+    public class EmoteSlotSelectorComponentView : BaseComponentView, IEmoteSlotSelectorComponentView, IComponentModelConfig<EmoteSlotSelectorComponentModel>
     {
         [Header("Prefab References")]
         [SerializeField] internal GridContainerComponentView emotesSlots;
@@ -24,12 +24,12 @@ namespace DCL.EmotesCustomization
             ConfigureSlotButtons();
         }
 
-        public void Configure(BaseComponentModel newModel)
+        public void Configure(EmoteSlotSelectorComponentModel newModel)
         {
             if (model == newModel)
                 return;
 
-            model = (EmoteSlotSelectorComponentModel)newModel;
+            model = newModel;
             RefreshControl();
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/NotificationComponent/ChatNotificationMessageComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/NotificationComponent/ChatNotificationMessageComponentView.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-public class ChatNotificationMessageComponentView : BaseComponentView, IChatNotificationMessageComponentView, IComponentModelConfig
+public class ChatNotificationMessageComponentView : BaseComponentView, IChatNotificationMessageComponentView, IComponentModelConfig<ChatNotificationMessageComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal Button button;
@@ -22,9 +22,9 @@ public class ChatNotificationMessageComponentView : BaseComponentView, IChatNoti
     public string notificationTargetId;
     private int maxContentCharacters, maxHeaderCharacters;
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(ChatNotificationMessageComponentModel newModel)
     {
-        model = (ChatNotificationMessageComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatBarComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatBarComponentView.cs
@@ -2,7 +2,7 @@ using System;
 using TMPro;
 using UnityEngine;
 
-public class VoiceChatBarComponentView : BaseComponentView, IVoiceChatBarComponentView, IComponentModelConfig
+public class VoiceChatBarComponentView : BaseComponentView, IVoiceChatBarComponentView, IComponentModelConfig<VoiceChatBarComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal VoiceChatButton voiceChatButton;
@@ -27,9 +27,9 @@ public class VoiceChatBarComponentView : BaseComponentView, IVoiceChatBarCompone
         endCallButton.onClick.AddListener(() => OnLeaveVoiceChat?.Invoke());
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(VoiceChatBarComponentModel newModel)
     {
-        model = (VoiceChatBarComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatPlayerComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatPlayerComponentView.cs
@@ -3,7 +3,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class VoiceChatPlayerComponentView : BaseComponentView, IVoiceChatPlayerComponentView, IComponentModelConfig
+public class VoiceChatPlayerComponentView : BaseComponentView, IVoiceChatPlayerComponentView, IComponentModelConfig<VoiceChatPlayerComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal ImageComponentView avatarPreview;
@@ -46,9 +46,9 @@ public class VoiceChatPlayerComponentView : BaseComponentView, IVoiceChatPlayerC
         menuButton.onClick.AddListener(() => OnContextMenuOpen?.Invoke(model.userId));
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(VoiceChatPlayerComponentModel newModel)
     {
-        model = (VoiceChatPlayerComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatWindowComponentView.cs
@@ -4,7 +4,7 @@ using TMPro;
 using UnityEngine;
 using static DCL.SettingsCommon.GeneralSettings;
 
-public class VoiceChatWindowComponentView : BaseComponentView, IVoiceChatWindowComponentView, IComponentModelConfig
+public class VoiceChatWindowComponentView : BaseComponentView, IVoiceChatWindowComponentView, IComponentModelConfig<VoiceChatWindowComponentModel>
 {
     private const string ALLOW_USERS_TITLE_ALL = "All";
     private const string ALLOW_USERS_TITLE_REGISTERED = "Verified Users";
@@ -63,9 +63,9 @@ public class VoiceChatWindowComponentView : BaseComponentView, IVoiceChatWindowC
         AllowUsersOptionChanged(true, VoiceChatAllow.ALL_USERS.ToString(), ALLOW_USERS_TITLE_ALL);
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(VoiceChatWindowComponentModel newModel)
     {
-        model = (VoiceChatWindowComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PrivateChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PrivateChatEntry.cs
@@ -2,8 +2,9 @@ using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using static PrivateChatEntry;
 
-public class PrivateChatEntry : BaseComponentView, IComponentModelConfig
+public class PrivateChatEntry : BaseComponentView, IComponentModelConfig<PrivateChatEntryModel>
 {
     [SerializeField] internal Button openChatButton;
     [SerializeField] internal PrivateChatEntryModel model;
@@ -52,9 +53,9 @@ public class PrivateChatEntry : BaseComponentView, IComponentModelConfig
         userContextMenu.OnBlock += HandleUserBlocked;
     }
     
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(PrivateChatEntryModel newModel)
     {
-        model = (PrivateChatEntryModel) newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChannelEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChannelEntry.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using static PublicChannelEntry;
 
-public class PublicChannelEntry : BaseComponentView, IComponentModelConfig
+public class PublicChannelEntry : BaseComponentView, IComponentModelConfig<PublicChannelEntryModel>
 {
     [SerializeField] internal Button openChatButton;
     [SerializeField] internal TMP_Text nameLabel;
@@ -35,9 +36,9 @@ public class PublicChannelEntry : BaseComponentView, IComponentModelConfig
         this.lastReadMessagesService = lastReadMessagesService;
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(PublicChannelEntryModel newModel)
     {
-        model = (PublicChannelEntryModel) newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatChannelComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatChannelComponentView.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Collections;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWindowView, IComponentModelConfig, IPointerDownHandler
+public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWindowView, IComponentModelConfig<PublicChatChannelModel>, IPointerDownHandler
 {
     [SerializeField] internal Button closeButton;
     [SerializeField] internal Button backButton;
@@ -111,8 +111,6 @@ public class PublicChatChannelComponentView : BaseComponentView, IChannelChatWin
         alphaRoutine = StartCoroutine(SetAlpha(alphaTarget, 0.5f));
         ((RectTransform) transform).sizeDelta = originalSize;
     }
-
-    public void Configure(BaseComponentModel newModel) => Configure((PublicChatChannelModel) newModel);
     
     public void OnPointerDown(PointerEventData eventData) => OnClickOverWindow?.Invoke();
     

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
@@ -6,7 +6,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowView, IComponentModelConfig
+public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowView, IComponentModelConfig<WorldChatWindowModel>
 {
     private const int CREATION_AMOUNT_PER_FRAME = 5;
     private const int AVATAR_SNAPSHOTS_PER_FRAME = 5;
@@ -127,9 +127,9 @@ public class WorldChatWindowComponentView : BaseComponentView, IWorldChatWindowV
         UpdateLayout();
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(WorldChatWindowModel newModel)
     {
-        model = (WorldChatWindowModel) newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/BaseComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/BaseComponentView.cs
@@ -79,13 +79,13 @@ public interface IBaseComponentView : IPointerEnterHandler, IPointerExitHandler,
     void OnScreenSizeChanged();
 }
 
-public interface IComponentModelConfig
+public interface IComponentModelConfig<T> where T: BaseComponentModel
 {
     /// <summary>
     /// Fill the model and updates the component with this data.
     /// </summary>
     /// <param name="newModel">Data to configure the component.</param>
-    void Configure(BaseComponentModel newModel);
+    void Configure(T newModel);
 }
 
 public abstract class BaseComponentView : MonoBehaviour, IBaseComponentView

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Button/ButtonComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Button/ButtonComponentView.cs
@@ -33,7 +33,7 @@ public interface IButtonComponentView
     bool IsInteractable();
 }
 
-public class ButtonComponentView : BaseComponentView, IButtonComponentView, IComponentModelConfig
+public class ButtonComponentView : BaseComponentView, IButtonComponentView, IComponentModelConfig<ButtonComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal Button button;
@@ -45,9 +45,9 @@ public class ButtonComponentView : BaseComponentView, IButtonComponentView, ICom
 
     public Button.ButtonClickedEvent onClick => button?.onClick;
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(ButtonComponentModel newModel)
     {
-        model = (ButtonComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Carousel/CarouselComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Carousel/CarouselComponentView.cs
@@ -124,7 +124,7 @@ public enum CarouselDirection
     Left
 }
 
-public class CarouselComponentView : BaseComponentView, ICarouselComponentView, IComponentModelConfig
+public class CarouselComponentView : BaseComponentView, ICarouselComponentView, IComponentModelConfig<CarouselComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal RectTransform itemsContainer;
@@ -163,9 +163,9 @@ public class CarouselComponentView : BaseComponentView, ICarouselComponentView, 
             StartCarousel();
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(CarouselComponentModel newModel)
     {
-        model = (CarouselComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/ColorPicker/ColorPickerComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/ColorPicker/ColorPickerComponentView.cs
@@ -24,7 +24,7 @@ public interface IColorPickerComponentView
     void SetIncrementAmount(float amount);
 }
 
-public class ColorPickerComponentView : BaseComponentView, IColorPickerComponentView, IComponentModelConfig
+public class ColorPickerComponentView : BaseComponentView, IColorPickerComponentView, IComponentModelConfig<ColorPickerComponentModel>
 {
 
     [SerializeField] private SliderComponentView sliderHue;
@@ -92,9 +92,9 @@ public class ColorPickerComponentView : BaseComponentView, IColorPickerComponent
         colorSelector.Populate(colorList);
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(ColorPickerComponentModel newModel)
     {
-        model = (ColorPickerComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Dropdown/DropdownComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Dropdown/DropdownComponentView.cs
@@ -102,7 +102,7 @@ public interface IDropdownComponentView
     /// <param name="maxHeight">Max height to apply.</param>
     void SetOptionsPanelHeightAsDynamic(bool isDynamic, float maxHeight);
 }
-public class DropdownComponentView : BaseComponentView, IDropdownComponentView, IComponentModelConfig
+public class DropdownComponentView : BaseComponentView, IDropdownComponentView, IComponentModelConfig<DropdownComponentModel>
 {
     internal const string SELECT_ALL_OPTION_ID = "select_all";
     internal const string SELECT_ALL_OPTION_TEXT = "Select All";
@@ -154,9 +154,9 @@ public class DropdownComponentView : BaseComponentView, IDropdownComponentView, 
         searchBar.OnSearchText += FilterOptions;
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(DropdownComponentModel newModel)
     {
-        model = (DropdownComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/GridContainer/GridContainerComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/GridContainer/GridContainerComponentView.cs
@@ -91,7 +91,7 @@ public interface IGridContainerComponentView
     void RemoveItems();
 }
 
-public class GridContainerComponentView : BaseComponentView, IGridContainerComponentView, IComponentModelConfig
+public class GridContainerComponentView : BaseComponentView, IGridContainerComponentView, IComponentModelConfig<GridContainerComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal GridLayoutGroup gridLayoutGroup;
@@ -111,9 +111,9 @@ public class GridContainerComponentView : BaseComponentView, IGridContainerCompo
         RegisterCurrentInstantiatedItems();
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(GridContainerComponentModel newModel)
     {
-        model = (GridContainerComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Image/ImageComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Image/ImageComponentView.cs
@@ -47,7 +47,7 @@ public interface IImageComponentView
     void SetLoadingIndicatorVisible(bool isVisible);
 }
 
-public class ImageComponentView : BaseComponentView, IImageComponentView, IComponentModelConfig
+public class ImageComponentView : BaseComponentView, IImageComponentView, IComponentModelConfig<ImageComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal Image image;
@@ -72,9 +72,9 @@ public class ImageComponentView : BaseComponentView, IImageComponentView, ICompo
             SetFitParent(model.fitParent);
     }
 
-    public virtual void Configure(BaseComponentModel newModel)
+    public virtual void Configure(ImageComponentModel newModel)
     {
-        model = (ImageComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/ProfileCard/ProfileCardComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/ProfileCard/ProfileCardComponentView.cs
@@ -52,7 +52,7 @@ public interface IProfileCardComponentView
     void SetLoadingIndicatorVisible(bool isVisible);
 }
 
-public class ProfileCardComponentView : BaseComponentView, IProfileCardComponentView, IComponentModelConfig
+public class ProfileCardComponentView : BaseComponentView, IProfileCardComponentView, IComponentModelConfig<ProfileCardComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal Button button;
@@ -71,9 +71,9 @@ public class ProfileCardComponentView : BaseComponentView, IProfileCardComponent
             profileImage.OnLoaded += OnProfileImageLoaded;
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(ProfileCardComponentModel newModel)
     {
-        model = (ProfileCardComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/SearchBar/SearchBarComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/SearchBar/SearchBarComponentView.cs
@@ -35,7 +35,7 @@ public interface ISearchBarComponentView
     void SetIdleSearchTime(float idleSearchTime);
 }
 
-public class SearchBarComponentView : BaseComponentView, ISearchBarComponentView, IComponentModelConfig
+public class SearchBarComponentView : BaseComponentView, ISearchBarComponentView, IComponentModelConfig<SearchBarComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal TMP_InputField inputField;
@@ -65,9 +65,9 @@ public class SearchBarComponentView : BaseComponentView, ISearchBarComponentView
         SetClearMode();
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(SearchBarComponentModel newModel)
     {
-        model = (SearchBarComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/SectionSelector/SectionSelectorComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/SectionSelector/SectionSelectorComponentView.cs
@@ -24,7 +24,7 @@ public interface ISectionSelectorComponentView
     List<ISectionToggle> GetAllSections();
 }
 
-public class SectionSelectorComponentView : BaseComponentView, ISectionSelectorComponentView, IComponentModelConfig
+public class SectionSelectorComponentView : BaseComponentView, ISectionSelectorComponentView, IComponentModelConfig<SectionSelectorComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal SectionToggle sectionToggleTemplate;
@@ -41,9 +41,9 @@ public class SectionSelectorComponentView : BaseComponentView, ISectionSelectorC
         RegisterCurrentInstantiatedSections();
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(SectionSelectorComponentModel newModel)
     {
-        model = (SectionSelectorComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Slider/SliderComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Slider/SliderComponentView.cs
@@ -55,7 +55,7 @@ public interface ISliderComponentView
     bool IsInteractable();
 }
 
-public class SliderComponentView : BaseComponentView, ISliderComponentView, IComponentModelConfig
+public class SliderComponentView : BaseComponentView, ISliderComponentView, IComponentModelConfig<SliderComponentModel>
 {
 
     [Header("Prefab References")]
@@ -77,9 +77,9 @@ public class SliderComponentView : BaseComponentView, ISliderComponentView, ICom
         slider.value += value;
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(SliderComponentModel newModel)
     {
-        model = (SliderComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Tag/TagComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Tag/TagComponentView.cs
@@ -17,7 +17,7 @@ public interface ITagComponentView
     void SetIcon(Sprite newIcon);
 }
 
-public class TagComponentView : BaseComponentView, ITagComponentView, IComponentModelConfig
+public class TagComponentView : BaseComponentView, ITagComponentView, IComponentModelConfig<TagComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal Image icon;
@@ -26,9 +26,9 @@ public class TagComponentView : BaseComponentView, ITagComponentView, IComponent
     [Header("Configuration")]
     [SerializeField] internal TagComponentModel model;
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(TagComponentModel newModel)
     {
-        model = (TagComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Toggle/ToggleComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Toggle/ToggleComponentView.cs
@@ -57,7 +57,7 @@ public interface IToggleComponentView
     void SetChangeTextColorOnSelect(bool changeTextColorOnSelect);
 }
 
-public class ToggleComponentView : BaseComponentView, IToggleComponentView, IComponentModelConfig
+public class ToggleComponentView : BaseComponentView, IToggleComponentView, IComponentModelConfig<ToggleComponentModel>
 {
     [Header("Prefab References")]
     [SerializeField] internal Toggle toggle;
@@ -121,9 +121,9 @@ public class ToggleComponentView : BaseComponentView, IToggleComponentView, ICom
         OnSelectedChanged?.Invoke(isOn, model.id, model.text);
     }
 
-    public void Configure(BaseComponentModel newModel)
+    public void Configure(ToggleComponentModel newModel)
     {
-        model = (ToggleComponentModel)newModel;
+        model = newModel;
         RefreshControl();
     }
 


### PR DESCRIPTION
## What does this PR change?
Make `IComponentModelConfig` interface generic instead of using the specified type `BaseComponentModel`.

The `IComponentModelConfig` should be generic (`IComponentModelConfig<T>`) since we are violating a LiskovSubstitution principle here. The type of the object for `Configure` should be specific, otherwise is open to pass any `BaseComponentModel` which will throw a cast exception.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=chore/make-icomponentmodelconfig-interface-generic
2. Check all UIs continue working correctly.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md