### PR TITLE
fix: Remove "Look rotation" warning

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
@@ -173,7 +173,8 @@ namespace DCL.Camera
         public override void OnSetRotation(CameraController.SetRotationPayload payload)
         {
             var eulerDir = Vector3.zero;
-            var verticalAxisLookAt = Vector3.zero;
+            //Default looking direction is north
+            var verticalAxisLookAt = Vector3.forward;
 
             if (payload.cameraTarget.HasValue)
             {


### PR DESCRIPTION
## What does this PR change?

Changes the default vector for the avatar rotation after teleport. It was set to `Vector3.zero`, which caused Unity to spam a warning into the Console. Now it's set to a default value of `Vector.forward`; so the default-looking direction for every scene will be North.

## How to test the changes?

1. Go to 102,-32. Check that your avatar started looking **North**, and no _Look rotation viewing vector is zero_ warning is logged into the console. 
2.  Go to -74,53. Check that your avatar started looking **West**, and no _Look rotation viewing vector is zero_ warning is logged into the console. Move around a little bit to change the character starting looking direction
1. Go back to 102,-32. Check that your avatar started looking **North**, and no _Look rotation viewing vector is zero_ warning is logged into the console. 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
