### PR TITLE
chore: add QA to reviewers and exclussion label

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -4,10 +4,19 @@ numberOfAssignees: 1
 addReviewers: true
 useReviewGroups: false
 numberOfReviewers: 1
-reviewers:
-  - AjimenezDCL
-  - pravusjif
-  - sandrade-dcl
-  - Kinerius
-  - lorux0
-  - davidejensen
+useReviewGroups: true
+reviewGroups:
+  devs:
+    - AjimenezDCL
+    - pravusjif
+    - sandrade-dcl
+    - Kinerius
+    - lorux0
+    - davidejensen
+  qa:
+    - kwssbocian
+    - kwspgoliasz
+
+filterLabels:
+  exclude:
+    - no_reviewers

--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -2,7 +2,6 @@ addAssignees: author
 numberOfAssignees: 1
 
 addReviewers: true
-useReviewGroups: false
 numberOfReviewers: 1
 useReviewGroups: true
 reviewGroups:


### PR DESCRIPTION
QA team has been added as reviewers for the auto-assign tool.

Also added a new label to exclude the auto-assign tool