### PR TITLE
fix: TextShapes being rendered on the UI

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.prefab
@@ -58,7 +58,7 @@ GameObject:
   - component: {fileID: 3826371723285139880}
   - component: {fileID: 7414607916346624055}
   - component: {fileID: 1924286501959050350}
-  m_Layer: 5
+  m_Layer: 0
   m_Name: TextMeshPro Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}


### PR DESCRIPTION
## What does this PR change?

Changes TextShape layer from UI to Default

## How to test the changes?

Go outside genesis plaza, on the tram, the station has 3 text shapes that are being rendered on the UI, it shouldn't after this pr.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
