### PR TITLE
fix: uishape performance regression

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/UIRefresherPlugin/UIRefresherController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UIRefresherPlugin/UIRefresherController.cs
@@ -37,17 +37,19 @@ namespace DCLPlugins.UIRefresherPlugin
                 currentScene = "default";
 
             var dirtyShapesByScene = dirtyShapes.Get();
-            var startTime = Time.time;
+            var startTime = Time.realtimeSinceStartup;
 
             // prioritize current scene
             if (dirtyShapesByScene.ContainsKey(currentScene))
             {
                 var queue = dirtyShapesByScene[sceneID];
             
-                while (queue.Count > 0 && CanRefreshMore(startTime))
+                while (queue.Count > 0)
                 {
                     var uiShape = queue.Dequeue();
                     uiShape.Refresh();
+                    
+                    if (!CanRefreshMore(startTime)) return;
                 }
             }
             
@@ -58,17 +60,19 @@ namespace DCLPlugins.UIRefresherPlugin
 
                 var queue = valuePair.Value;
             
-                while (queue.Count > 0 && CanRefreshMore(startTime))
+                while (queue.Count > 0)
                 {
                     var uiShape = queue.Dequeue();
                     uiShape.Refresh();
+                    
+                    if (!CanRefreshMore(startTime)) return;
                 }
             }
         }
         private static bool CanRefreshMore(float startTime)
         {
             if (Application.isBatchMode) return true;
-            return Time.time - startTime < DIRTY_WATCHER_UPDATE_BUDGET;
+            return Time.realtimeSinceStartup - startTime < DIRTY_WATCHER_UPDATE_BUDGET;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
@@ -259,9 +259,6 @@ namespace DCL.Components
             RefreshDCLLayoutRecursively(refreshSize: true, refreshAlignmentAndPosition: false);
             FixMaxStretchRecursively();
             RefreshDCLLayoutRecursively_Internal(refreshSize: false, refreshAlignmentAndPosition: true);
-
-            OnLayoutRefresh?.Invoke();
-            OnLayoutRefresh = null;
         }
 
         public virtual void MarkLayoutDirty( System.Action OnRefresh = null )
@@ -273,7 +270,7 @@ namespace DCL.Components
             if (rootParent.referencesContainer == null)
                 return;
 
-            RequestRefresh();
+            rootParent.RequestRefresh();
             
             if ( OnRefresh != null )
                 rootParent.OnLayoutRefresh += OnRefresh;
@@ -507,6 +504,9 @@ namespace DCL.Components
         {
             RefreshRecursively(); 
             isLayoutDirty = false;
+            
+            OnLayoutRefresh?.Invoke();
+            OnLayoutRefresh = null;
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fixes hiccups included in #2756 due to an error while refactoring.

## How to test the changes?

Go to [ICE Poker](https://play.decentraland.org/?renderer-branch=fix/uishape-regression&realm=dg&position=-100%2C126)
The scene should load more smoothly than in #2786

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
