### PR TITLE
fix: Change message of the Voice Chat bar when no one else is in your area

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatWindowController.cs
@@ -12,7 +12,7 @@ public class VoiceChatWindowController : IHUD
     internal const string VOICE_CHAT_FEATURE_FLAG = "voice_chat";
     internal const float MUTE_STATUS_UPDATE_INTERVAL = 0.3f;
     internal const string TALKING_MESSAGE_YOU = "You";
-    internal const string TALKING_MESSAGE_JUST_YOU_IN_THE_VOICE_CHAT = "Just you in the voice chat";
+    internal const string TALKING_MESSAGE_JUST_YOU_IN_THE_VOICE_CHAT = "No one else is here";
     internal const string TALKING_MESSAGE_NOBODY_TALKING = "Nobody is talking";
     internal const string TALKING_MESSAGE_SEVERAL_PEOPLE_TALKING = "Several people talking";
 


### PR DESCRIPTION
## What does this PR change?
Change this text by `No one else is here`:

![image](https://user-images.githubusercontent.com/64659061/182849264-644b1c73-a938-4044-99ec-0aaaf88218ac.png)

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/change-info-message-in-the-voice-chat-bar-
2. Go to any place woth nobody around.
3. Notice that the message in the Voice Chat bar is `No one else is here`.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md