### PR TITLE
chore: add "Not QA Needed" exclusion label to auto-assign action

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -19,3 +19,4 @@ reviewGroups:
 filterLabels:
   exclude:
     - no_reviewers
+    - "Not QA Needed"


### PR DESCRIPTION
Added Not QA Needed label for auto assign github action to follow the agreed process.
