### PR TITLE
fix: changes noted from review 06082022

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Resources/NotificationBadge_FriendsRequestTab.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Resources/NotificationBadge_FriendsRequestTab.prefab
@@ -184,7 +184,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -193,6 +193,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -219,7 +220,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4429308612254855752}
-  - component: {fileID: 6032877042212716661}
+  - component: {fileID: 4351551900998548871}
   m_Layer: 5
   m_Name: NotificationBadge_FriendsRequestTab
   m_TagString: Untagged
@@ -247,7 +248,7 @@ RectTransform:
   m_AnchoredPosition: {x: 49.8, y: -11.7}
   m_SizeDelta: {x: 15, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &6032877042212716661
+--- !u!114 &4351551900998548871
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -256,10 +257,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 8022463139147755279}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 77d514aaef02f6140b1e793c2d8dcae8, type: 3}
+  m_Script: {fileID: 11500000, guid: 311addb64e4c4a5eb6e6a1383470a438, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  notificationVariables:
-  - {fileID: 11400000, guid: f726059480ddf394bb7a032c8b2a6e2d, type: 2}
   notificationText: {fileID: 5156119195053263761}
   notificationContainer: {fileID: 2091895069224215119}
+  maxNumberToShow: 9

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDController.cs
@@ -21,6 +21,8 @@ public class FriendsHUDController : IHUD
 
     private UserProfile ownUserProfile;
     private bool searchingFriends;
+    private bool isFriendsLoadedForFirstTime;
+    private bool isFriendsRequestsLoadedForFirstTime;
 
     public IFriendsHUDComponentView View { get; private set; }
 
@@ -132,10 +134,10 @@ public class FriendsHUDController : IHUD
         {
             View.Show();
             UpdateNotificationsCounter();
-            
-            if (View.IsFriendListActive)
+
+            if (View.IsFriendListActive && !isFriendsLoadedForFirstTime)
                 DisplayMoreFriends();
-            else if (View.IsRequestListActive)
+            else if (View.IsRequestListActive && !isFriendsRequestsLoadedForFirstTime)
                 DisplayMoreFriendRequests();
             
             OnOpened?.Invoke();
@@ -156,10 +158,10 @@ public class FriendsHUDController : IHUD
 
         if (View.IsActive())
         {
-            if (View.IsFriendListActive)
+            if (View.IsFriendListActive && !isFriendsLoadedForFirstTime)
                 DisplayMoreFriends();
-            else if (View.IsRequestListActive)
-                DisplayMoreFriendRequests();    
+            else if (View.IsRequestListActive && !isFriendsRequestsLoadedForFirstTime)
+                DisplayMoreFriendRequests();
         }
         
         UpdateNotificationsCounter();
@@ -394,6 +396,7 @@ public class FriendsHUDController : IHUD
     private void DisplayFriendsIfAnyIsLoaded()
     {
         if (View.FriendCount > 0) return;
+        if (isFriendsLoadedForFirstTime) return;
         DisplayMoreFriends();
     }
 
@@ -402,6 +405,7 @@ public class FriendsHUDController : IHUD
         if (!friendsController.IsInitialized) return;
         ShowOrHideMoreFriendsToLoadHint();
         friendsController.GetFriends(LOAD_FRIENDS_ON_DEMAND_COUNT, View.FriendCount);
+        isFriendsLoadedForFirstTime = true;
     }
 
     private void DisplayMoreFriendRequests()
@@ -411,11 +415,13 @@ public class FriendsHUDController : IHUD
         friendsController.GetFriendRequests(
             LOAD_FRIENDS_ON_DEMAND_COUNT, View.FriendRequestSentCount,
             LOAD_FRIENDS_ON_DEMAND_COUNT, View.FriendRequestReceivedCount);
+        isFriendsRequestsLoadedForFirstTime = true;
     }
     
     private void DisplayFriendRequestsIfAnyIsLoaded()
     {
         if (View.FriendRequestCount > 0) return;
+        if (isFriendsRequestsLoadedForFirstTime) return;
         DisplayMoreFriendRequests();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendsHUDComponentViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendsHUDComponentViewShould.cs
@@ -10,10 +10,14 @@ using UnityEngine.TestTools;
 public class FriendsHUDComponentViewShould
 {
     private FriendsHUDComponentView view;
-    
+    private GameObject friendsControllerGameObject;
+
     [SetUp]
     public void Setup()
     {
+        // we need to add friends controller because the badge internally uses FriendsController.i
+        friendsControllerGameObject = new GameObject("Main");
+        friendsControllerGameObject.AddComponent<FriendsController>();
         view = FriendsHUDComponentView.Create();
         var friendsController = Substitute.For<IFriendsController>();
         friendsController.GetAllocatedFriends().Returns(new Dictionary<string, UserStatus>());
@@ -24,6 +28,7 @@ public class FriendsHUDComponentViewShould
     [TearDown]
     public void TearDown()
     {
+        Object.Destroy(friendsControllerGameObject);
         view.Dispose();
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendsHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendsHUDControllerShould.cs
@@ -558,4 +558,34 @@ public class FriendsHUDControllerShould
         
         view.Received(1).ClearFriendFilter();
     }
+
+    [Test]
+    public void LoadFriendsOnlyForFirstTime()
+    {
+        friendsController.IsInitialized.Returns(true);
+        view.IsActive().Returns(true);
+        view.IsFriendListActive.Returns(true);
+        controller.SetVisibility(true);
+        controller.SetVisibility(false);
+        controller.SetVisibility(true);
+        view.OnFriendListDisplayed += Raise.Event<Action>();
+        friendsController.OnInitialized += Raise.Event<Action>();
+        
+        friendsController.ReceivedWithAnyArgs(1).GetFriends((int) default, default);
+    }
+    
+    [Test]
+    public void LoadFriendsRequestsOnlyForFirstTime()
+    {
+        friendsController.IsInitialized.Returns(true);
+        view.IsActive().Returns(true);
+        view.IsRequestListActive.Returns(true);
+        controller.SetVisibility(true);
+        controller.SetVisibility(false);
+        controller.SetVisibility(true);
+        view.OnRequestListDisplayed += Raise.Event<Action>();
+        friendsController.OnInitialized += Raise.Event<Action>();
+        
+        friendsController.ReceivedWithAnyArgs(1).GetFriendRequests(default, default, default, default);
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -238,7 +238,7 @@ public class HUDController : IHUDController
                     PublicChatChannelHud.OnClosed += HandlePublicChatChannelClosed;
                     taskbarHud?.AddPublicChatChannel(PublicChatChannelHud);
                     // TODO: this call should be removed when chat notifications are implemented
-                    taskbarHud?.OpenPublicChatChannel("general", false);
+                    taskbarHud?.OpenPublicChatChannel("nearby", false);
                     PublicChatChannelHud.ActivatePreviewModeInstantly();
                 }
                 else

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowComponentViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowComponentViewShould.cs
@@ -161,7 +161,7 @@ public class WorldChatWindowComponentViewShould
     [Test]
     public void CreatePublicChannel()
     {
-        const string channelId = "general";
+        const string channelId = "nearby";
 
         GivenPublicChannel(channelId, "nearby");
 
@@ -189,7 +189,7 @@ public class WorldChatWindowComponentViewShould
     [UnityTest]
     public IEnumerator ReplacePublicChannel()
     {
-        const string channelId = "general";
+        const string channelId = "nearby";
 
         var model = new PublicChatChannelModel(channelId, "nearby", "any description");
         view.SetPublicChannel(model);
@@ -216,7 +216,7 @@ public class WorldChatWindowComponentViewShould
     [Test]
     public void TriggerOpenPublicChannel()
     {
-        const string expectedChannelId = "general";
+        const string expectedChannelId = "nearby";
         var channelId = "";
         view.OnOpenPublicChannel += s => channelId = s;
         GivenPublicChannel(expectedChannelId, "nearby");
@@ -305,7 +305,7 @@ public class WorldChatWindowComponentViewShould
         GivenPrivateChat("pepe");
         GivenPrivateChat("genio");
         GivenPrivateChat("bleh");
-        GivenPublicChannel("general", "general");
+        GivenPublicChannel("nearby", "nearby");
 
         yield return null;
 
@@ -328,7 +328,7 @@ public class WorldChatWindowComponentViewShould
         }, new Dictionary<string, PublicChatChannelModel>
         {
             {
-                "general", new PublicChatChannelModel("general", "general", "")
+                "nearby", new PublicChatChannelModel("nearby", "nearby", "")
             }
         });
 
@@ -341,7 +341,7 @@ public class WorldChatWindowComponentViewShould
         Assert.AreEqual("Results (3)", view.searchResultsHeaderLabel.text);
         Assert.IsNotNull(view.searchResultsList.Get("genio"));
         Assert.IsNotNull(view.searchResultsList.Get("pepe"));
-        Assert.IsNotNull(view.searchResultsList.Get("general"));
+        Assert.IsNotNull(view.searchResultsList.Get("nearby"));
         Assert.IsTrue(view.searchResultsHeader.activeSelf);
         Assert.IsTrue(view.searchResultsList.isVisible);
         Assert.IsFalse(view.directChatsContainer.activeSelf);
@@ -364,7 +364,7 @@ public class WorldChatWindowComponentViewShould
         Assert.IsNotNull(view.directChatList.Get("genio"));
         Assert.IsNotNull(view.directChatList.Get("pepe"));
         Assert.IsNotNull(view.directChatList.Get("bleh"));
-        Assert.IsNotNull(view.publicChannelList.Get("general"));
+        Assert.IsNotNull(view.publicChannelList.Get("nearby"));
         Assert.IsFalse(view.searchResultsHeader.activeSelf);
         Assert.IsFalse(view.searchResultsList.isVisible);
         Assert.IsTrue(view.directChatsContainer.activeSelf);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
@@ -41,7 +41,7 @@ public class WorldChatWindowControllerShould
         controller.Initialize(view);
 
         view.Received(1).SetPublicChannel(Arg.Is<PublicChatChannelModel>(p => p.name == "nearby"
-                                                                              && p.channelId == "general"));
+                                                                              && p.channelId == "nearby"));
     }
 
     [Test]
@@ -273,7 +273,7 @@ public class WorldChatWindowControllerShould
 
         view.Received(1).Filter(
             Arg.Is<Dictionary<string, PrivateChatModel>>(d => d.ContainsKey("nearfr") && d.Count == 1),
-            Arg.Is<Dictionary<string, PublicChatChannelModel>>(d => d.ContainsKey("general") && d.Count == 1));
+            Arg.Is<Dictionary<string, PublicChatChannelModel>>(d => d.ContainsKey("nearby") && d.Count == 1));
     }
 
     [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -7,7 +7,7 @@ using DCL.Friends.WebApi;
 
 public class WorldChatWindowController : IHUD
 {
-    private const string GENERAL_CHANNEL_ID = "general";
+    private const string GENERAL_CHANNEL_ID = "nearby";
     private const int MAX_SEARCHED_CHANNELS = 100;
     private const int USER_DM_ENTRIES_TO_REQUEST_FOR_INITIAL_LOAD = 50;
     private const int USER_DM_ENTRIES_TO_REQUEST_FOR_SHOW_MORE = 20;


### PR DESCRIPTION
## What does this PR change?

- The notification count from friend requests tab is showing the received friend request count.
- GetFriends & GetFriendRequests are only called once
- Replaced general channel id for nearby

## How to test the changes?

1. Set the custom test url: https://play.decentraland.zone/?kernel-branch=feat/add-friends-lazy-load&
2. Open friends and check the number on the requests tab, it should be the same as the taskbar
3. Check that nearby channel keeps working as expected and is listed correctly
4. Check that friends are loaded correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
