### PR TITLE
fix: conversation list empty state when searching

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/CollapsableChatSearchListComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/CollapsableChatSearchListComponentView.cs
@@ -17,6 +17,7 @@ public class CollapsableChatSearchListComponentView : CollapsableSortedListCompo
     {
         directChatList.Filter(search);
         publicChannelList.Filter(search);
+        UpdateEmptyState();
     }
 
     public void Filter(Func<PrivateChatEntry, bool> privateComparision,
@@ -24,12 +25,14 @@ public class CollapsableChatSearchListComponentView : CollapsableSortedListCompo
     {
         directChatList.Filter(privateComparision);
         publicChannelList.Filter(publicComparision);
+        UpdateEmptyState();
     }
 
     public override void Filter(Func<BaseComponentView, bool> comparision)
     {
         directChatList.Filter(comparision);
         publicChannelList.Filter(comparision);
+        UpdateEmptyState();
     }
 
     public override int Count()
@@ -41,12 +44,14 @@ public class CollapsableChatSearchListComponentView : CollapsableSortedListCompo
     {
         directChatList.Clear(releaseEntriesFromPool);
         publicChannelList.Clear(releaseEntriesFromPool);
+        UpdateEmptyState();
     }
 
     public override void Clear()
     {
         directChatList.Clear();
         publicChannelList.Clear();
+        UpdateEmptyState();
     }
 
     public override BaseComponentView Get(string key)
@@ -63,10 +68,16 @@ public class CollapsableChatSearchListComponentView : CollapsableSortedListCompo
 
     public override BaseComponentView Remove(string key)
     {
-        return (BaseComponentView) directChatList.Remove(key) ?? publicChannelList.Remove(key);
+        var view = (BaseComponentView) directChatList.Remove(key) ?? publicChannelList.Remove(key);
+        UpdateEmptyState();
+        return view;
     }
 
-    public void Set(PrivateChatEntry.PrivateChatEntryModel model) => directChatList.Set(model.userId, model);
+    public void Set(PrivateChatEntry.PrivateChatEntryModel model)
+    {
+        directChatList.Set(model.userId, model);
+        UpdateEmptyState();
+    }
 
     public void Export(CollapsablePublicChannelListComponentView publicChannelList,
         CollapsableDirectChatListComponentView privateChatList)
@@ -89,5 +100,7 @@ public class CollapsableChatSearchListComponentView : CollapsableSortedListCompo
         
         privateChatList.Clear(false);
         publicChannelList.Clear(false);
+        
+        UpdateEmptyState();
     }
 }

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/CollapsableSortedList/CollapsableSortedListComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/CollapsableSortedList/CollapsableSortedListComponentView.cs
@@ -173,7 +173,7 @@ namespace UIComponents.CollapsableSortedList
             }
         }
 
-        private void UpdateEmptyState()
+        protected virtual void UpdateEmptyState()
         {
             if (emptyStateContainer == null) return;
             emptyStateContainer.SetActive(Count() == 0);


### PR DESCRIPTION
## What does this PR change?

Correctly updates the empty state container when searching conversations.

## How to test the changes?

1. Open the conversation list (click on chat button, from nearby click back)
2. Search for any text
3. If no results are retrieved then a label should be shown indicating you have no results
4. If results are found, the label should not be shown, only the result entries (direct conversations or nearby channel)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
