### PR TITLE
fix: reduced ReportAvatarPosition overhead

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarReporterController/Implementation/AvatarReporterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarReporterController/Implementation/AvatarReporterController.cs
@@ -6,6 +6,9 @@ using DCL.Controllers;
 using DCL.Helpers;
 using UnityEngine;
 
+/// <summary>
+/// This controller checks if an avatar entered or exited a scene by checking its position every frame
+/// </summary>
 public class AvatarReporterController : IAvatarReporterController
 {
     private string avatarId;
@@ -36,15 +39,8 @@ public class AvatarReporterController : IAvatarReporterController
     
     string GetcurrentSceneIdNonAlloc(Vector2Int coords)
     {
-        foreach (KeyValuePair<string, IParcelScene> parcelScene in worldState.loadedScenes)
-        {
-            var parcels = parcelScene.Value.sceneData.parcels;
-
-            if (parcels != null && parcels.Contains(coords))
-            {
-                return parcelScene.Key;
-            }
-        }
+        if (worldState.loadedScenesByCoordinate.ContainsKey(coords))
+            return worldState.loadedScenesByCoordinate[coords];
         
         return null;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarReporterController/Tests/AvatarReporterControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarReporterController/Tests/AvatarReporterControllerShould.cs
@@ -12,6 +12,7 @@ public class AvatarReporterControllerShould
     private IAvatarReporterController reporterController;
     private IWorldState worldState;
     private Dictionary<string, IParcelScene> scenes;
+    private Dictionary<Vector2Int, string> sceneByCoords;
 
     [SetUp]
     public void SetUp()
@@ -29,8 +30,10 @@ public class AvatarReporterControllerShould
         });
 
         scenes = new Dictionary<string, IParcelScene>() { { "scene0", scene0 } };
+        sceneByCoords = new Dictionary<Vector2Int, string> { { Vector2Int.zero, "scene0" } };
 
         worldState.loadedScenes.Returns(scenes);
+        worldState.loadedScenesByCoordinate.Returns(sceneByCoords);
     }
 
     [Test]
@@ -96,16 +99,21 @@ public class AvatarReporterControllerShould
         reporterController.reporter.Received(1).ReportAvatarSceneChange("1", null);
 
         var loadScene = Substitute.For<IParcelScene>();
+        Vector2Int scenePos = new Vector2Int(1, 0);
+
+        string sceneId = "sceneLoaded";
+
         loadScene.sceneData.Returns(new LoadParcelScenesMessage.UnityParcelScene()
         {
-            id = "sceneLoaded",
-            parcels = new[] { new Vector2Int(1, 0) }
+            id = sceneId,
+            parcels = new[] { scenePos }
         });
 
-        scenes.Add("sceneLoaded", loadScene);
+        scenes.Add(sceneId, loadScene);
+        sceneByCoords.Add(scenePos, sceneId);
 
         reporterController.ReportAvatarPosition(position);
-        reporterController.reporter.Received(1).ReportAvatarSceneChange("1", "sceneLoaded");
+        reporterController.reporter.Received(1).ReportAvatarSceneChange("1", sceneId);
     }
 
     [Test]
@@ -116,13 +124,16 @@ public class AvatarReporterControllerShould
         reporterController.reporter.Received(1).ReportAvatarSceneChange("1", "scene0");
 
         var loadScene = Substitute.For<IParcelScene>();
+        Vector2Int position = new Vector2Int(1, 0);
+
         loadScene.sceneData.Returns(new LoadParcelScenesMessage.UnityParcelScene()
         {
             id = "sceneLoaded",
-            parcels = new[] { new Vector2Int(1, 0) }
+            parcels = new[] { position }
         });
 
         scenes.Add("sceneLoaded", loadScene);
+        sceneByCoords.Add(position, "sceneLoaded");
 
         reporterController.ReportAvatarPosition(new Vector3(ParcelSettings.PARCEL_SIZE, 0, 0));
         reporterController.reporter.Received(1).ReportAvatarSceneChange("1", "sceneLoaded");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -110,6 +110,8 @@ namespace DCL
         {
             playerName = GetComponentInChildren<IPlayerName>();
             playerName?.Hide(true);
+            
+            Environment.i.platform.updateEventHandler.AddListener(IUpdateEventHandler.EventType.Update, OnUpdate);
         }
 
         private void PlayerClicked()
@@ -121,6 +123,8 @@ namespace DCL
 
         public void OnDestroy()
         {
+            Environment.i.platform.updateEventHandler.RemoveListener(IUpdateEventHandler.EventType.Update, OnUpdate);
+
             Cleanup();
 
             if (poolableObject != null && poolableObject.isInsidePool)
@@ -301,7 +305,7 @@ namespace DCL
                 player.playerName.SetName(model.name);
         }
 
-        private void Update()
+        private void OnUpdate()
         {
             if (player != null)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -110,8 +110,6 @@ namespace DCL
         {
             playerName = GetComponentInChildren<IPlayerName>();
             playerName?.Hide(true);
-            
-            Environment.i.platform.updateEventHandler.AddListener(IUpdateEventHandler.EventType.Update, OnUpdate);
         }
 
         private void PlayerClicked()
@@ -123,8 +121,6 @@ namespace DCL
 
         public void OnDestroy()
         {
-            Environment.i.platform.updateEventHandler.RemoveListener(IUpdateEventHandler.EventType.Update, OnUpdate);
-
             Cleanup();
 
             if (poolableObject != null && poolableObject.isInsidePool)
@@ -305,7 +301,7 @@ namespace DCL
                 player.playerName.SetName(model.name);
         }
 
-        private void OnUpdate()
+        private void Update()
         {
             if (player != null)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/DebugBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/DebugBridge.cs
@@ -261,6 +261,16 @@ namespace DCL
                                     "\"areaDepth\":15 " +
                                     "}");
         }
+        
+        [ContextMenu("Instantiate 50 bots at player coordinates")]
+        public void DebugBotsInstantiation2()
+        {
+            InstantiateBotsAtCoords("{ " +
+                                    "\"amount\":50, " +
+                                    "\"areaWidth\":15, " +
+                                    "\"areaDepth\":15 " +
+                                    "}");
+        }
 #endif
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using DCL.Controllers;
 using DCL.Models;
+using UnityEngine;
 
 namespace DCL
 {
@@ -9,6 +10,7 @@ namespace DCL
     {
         HashSet<string> readyScenes { get; set; }
         Dictionary<string, IParcelScene> loadedScenes { get; set; }
+        Dictionary<Vector2Int, string> loadedScenesByCoordinate { get; set; }
         List<IParcelScene> scenesSortedByDistance { get; set; }
         List<string> globalSceneIds { get; set; }
         string currentSceneId { get; set; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -670,6 +670,12 @@ namespace DCL
                 }
 
                 worldState.loadedScenes.Add(sceneToLoad.id, newScene);
+
+                foreach (Vector2Int sceneParcel in newScene.parcels)
+                {
+                    worldState.loadedScenesByCoordinate.Add(sceneParcel, sceneToLoad.id);
+                }
+                
                 worldState.scenesSortedByDistance.Add(newScene);
 
                 sceneSortDirty = true;
@@ -747,6 +753,12 @@ namespace DCL
             
             worldState.loadedScenes.Remove(sceneId);
             worldState.globalSceneIds.Remove(sceneId);
+            
+            foreach (Vector2Int sceneParcel in scene.parcels)
+            {
+                worldState.loadedScenesByCoordinate.Remove(sceneParcel);
+            }
+            
             DataStore.i.world.portableExperienceIds.Remove(sceneId);
             
             // Remove the scene id from the msg. priorities list

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
@@ -11,6 +11,7 @@ namespace DCL
     {
         public HashSet<string> readyScenes { get; set; } = new HashSet<string>();
         public Dictionary<string, IParcelScene> loadedScenes { get; set; } = new Dictionary<string, IParcelScene>();
+        public Dictionary<Vector2Int, string> loadedScenesByCoordinate { get; set; } = new Dictionary<Vector2Int, string>();
         public List<IParcelScene> scenesSortedByDistance { get; set; } = new List<IParcelScene>();
         public List<string> globalSceneIds { get; set; } = new List<string>();
         public string currentSceneId { get; set; } = null;


### PR DESCRIPTION
## What does this PR change?

`AvatarReporterController.ReportAvatarPosition` had a small overhead and allocations, those are gone.

Fixes #2701 

## How to test the changes?

Scenes with `onEnterSceneObservable` and `onLeaveSceneObservable` should work properly. 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Performance Data

# OLD
67 players (-100,126 ) 30 seconds WITHOUT UI (pressing U)
```
 * PERFORMANCE SCORE (0-100) -> 10
 * lowest frame time -> 61.7ms
 * average frame time -> 77.4ms
 * highest frame time -> 100.0ms
 * 1 percentile frame time -> 64.3ms
 * 50 percentile frame time -> 74.4ms
 * 99 percentile frame time -> 100.0ms
 * error percentage -> ±1.3%
 * total hiccups (>0.05ms frames) -> 387 (99.74% of frames were hiccups)
 * total hiccups time (seconds) -> 29.94901
 * total frames -> 388
 * total frames time (seconds) -> 30.0292
```

# NEW
67 players (-100,126 ) 30 seconds WITHOUT UI (pressing U)
```
 * PERFORMANCE SCORE (0-100) -> 11
 * lowest frame time -> 60.8ms
 * average frame time -> 74.5ms
 * highest frame time -> 100.0ms
 * 1 percentile frame time -> 62.2ms
 * 50 percentile frame time -> 70.6ms
 * 99 percentile frame time -> 100.0ms
 * error percentage -> ±1.5%
 * total hiccups (>0.05ms frames) -> 402 (99.75% of frames were hiccups)
 * total hiccups time (seconds) -> 29.94498
 * total frames -> 403
 * total frames time (seconds) -> 30.0436
```

