### PR TITLE
fix: added payloads for reporting scenes and players

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDController.cs
@@ -9,6 +9,7 @@ public class MinimapHUDController : IHUD
     public MinimapHUDView view;
     private FloatVariable minimapZoom => CommonScriptableObjects.minimapZoom;
     private StringVariable currentSceneId => CommonScriptableObjects.sceneID;
+    private Vector2IntVariable playerCoords => CommonScriptableObjects.playerCoords;
 
     public MinimapHUDModel model { get; private set; } = new MinimapHUDModel();
 
@@ -97,8 +98,8 @@ public class MinimapHUDController : IHUD
 
     public void ReportScene()
     {
-        if (!string.IsNullOrEmpty(currentSceneId))
-            WebInterface.SendReportScene(currentSceneId);
+        var coords = playerCoords.Get();
+        WebInterface.SendReportScene($"{coords.x},{coords.y}");
     }
 
     public void ChangeVisibilityForBuilderInWorld(bool current, bool previus) { view.gameObject.SetActive(current); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDController.cs
@@ -234,7 +234,7 @@ public class PlayerInfoCardHUDController : IHUD
 
     private void ReportPlayer()
     {
-        WebInterface.SendReportPlayer(currentPlayerId);
+        WebInterface.SendReportPlayer(currentPlayerId, currentUserProfile?.name);
         socialAnalytics.SendPlayerReport(PlayerReportIssueType.None, 0, PlayerActionSource.Passport);
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
@@ -158,7 +158,7 @@ public class UserContextMenu : MonoBehaviour
     private void OnReportUserButtonPressed()
     {
         OnReport?.Invoke(userId);
-        WebInterface.SendReportPlayer(userId);
+        WebInterface.SendReportPlayer(userId, UserProfileController.userProfilesCatalog.Get(userId)?.userName);
         GetSocialAnalytics().SendPlayerReport(PlayerReportIssueType.None, 0, PlayerActionSource.ProfileContextMenu);
         Hide();
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -410,6 +410,18 @@ namespace DCL.Interface
         {
             public string userId;
         }
+        
+        [Serializable]
+        private class SendReportPlayerPayload
+        {
+            public string userId;
+        }
+        
+        [Serializable]
+        private class SendReportScenePayload
+        {
+            public string sceneId;
+        }
 
         [System.Serializable]
         public class SendUnblockPlayerPayload
@@ -1269,9 +1281,21 @@ namespace DCL.Interface
 
         public static void StopIsolatedMode(IsolatedConfig config) { MessageFromEngine("StopIsolatedMode", JsonConvert.SerializeObject(config)); }
 
-        public static void SendReportScene(string sceneID) { SendMessage("ReportScene", sceneID); }
+        public static void SendReportScene(string sceneID)
+        {
+            SendMessage("ReportScene", new SendReportScenePayload
+            {
+                sceneId = sceneID
+            });
+        }
 
-        public static void SendReportPlayer(string playerName) { SendMessage("ReportPlayer", playerName); }
+        public static void SendReportPlayer(string playerName)
+        {
+            SendMessage("ReportPlayer", new SendReportPlayerPayload
+            {
+                userId = playerName
+            });
+        }
 
         public static void SendBlockPlayer(string userId)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -415,6 +415,7 @@ namespace DCL.Interface
         private class SendReportPlayerPayload
         {
             public string userId;
+            public string name;
         }
         
         [Serializable]
@@ -1289,11 +1290,12 @@ namespace DCL.Interface
             });
         }
 
-        public static void SendReportPlayer(string playerName)
+        public static void SendReportPlayer(string playerId, string playerName)
         {
             SendMessage("ReportPlayer", new SendReportPlayerPayload
             {
-                userId = playerName
+                userId = playerId,
+                name = playerName
             });
         }
 


### PR DESCRIPTION
## What does this PR change?

Adds a data structure for the payloads when reporting players and scenes.
The reported scene id has been replaced for coordinates: `x,y`

## How to test the changes?

1. You cannot report a scene with the current ui
2. Click over other player, then open the passport and click the report button

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
