### PR TITLE
test: remove optimization in collider scene boundaries check PR

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -347,8 +347,8 @@ namespace DCL.Controllers
 
                 // No need to add the entity to be checked later if we already found it outside its bounds.
                 // When the correct events are triggered again, the entity will be checked again.
-                if (!entity.isInsideSceneOuterBoundaries)
-                    return;
+                // if (!entity.isInsideSceneOuterBoundaries)
+                //     return;
             }
             
             entitiesToCheck.Add(entity);


### PR DESCRIPTION
removed mini optimization to test if it is the culprit of problems found during QA

### TESTING
1. Check that the reported issue got solved:
In [production](https://play.decentraland.org/?position=90%2C-143) there are invisible colliders on the empty parcels at the left of the affected scene (90, -143).
In [this PR's build](https://play.decentraland.zone/?renderer-branch=test/ColliderBoundsSceneChecksUpdate&position=90%2C-143) those colliders are disabled as they are detected as part of the mesh of the entity that contains them and that is detected as outside the scene boundaries.

2. Check that the already-solved https://github.com/decentraland/unity-renderer/issues/2132 issue hasn't reappeared:
    1. Spawn [at -12, -10](https://play.decentraland.zone/?renderer-branch=test/ColliderBoundsSceneChecksUpdate&position=-12%2C-10) and wait until Genesis Plaza finishes loading (make sure the Scene Load Radius value in the settings is 4) 
    2. Open Settings, change the Scene Load Radius to 1 and wait 5~ seconds
    3. Change Scene Load Radius to 4 and close the settings panel, wait for 5~10 seconds after the Genesis Plaza finishes loading and notice that he "black and white" bug doesn't happen anymore
    4. Steps 2 and 3 can be reproduced many times and the black and white bug won't happen again 
[Doing those steps from master's build will trigger the black and white bug]

2. Check that the already-solved https://github.com/decentraland/unity-renderer/issues/844 issue hasn't reappeared:
    1. Spawn [at -12, -10](https://play.decentraland.zone/?renderer-branch=test/ColliderBoundsSceneChecksUpdate&position=-12%2C-10)
    2. Walk towards the tramline at -12, 0
    3. Walk through the tramline to the west, and notice that no mesh is instantiated int the middle of the street

2. Check that the already-solved https://github.com/decentraland/unity-renderer/issues/480 and https://github.com/decentraland/unity-renderer/issues/978 issues haven't reappeared:
    1. Spawn [at -40, 2](https://play.decentraland.zone/?renderer-branch=test/ColliderBoundsSceneChecksUpdate&position=-40%2C2)
    2. Walk to -50, 1 and notice that the paint bucket that attaches to the player in that scene doesn't appear before you enter the scene