### PR TITLE
chore: increase step timeout in AB Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
           command: |
             bash ./ci-asset-bundle-test.sh
             exit $?
-          no_output_timeout: 30m
+          no_output_timeout: 45m
       - run:
           name: Cat logs
           when: always


### PR DESCRIPTION
The time that `Run AB Tests` is taking is near the timeout (26-27 minutes), and sometimes it hits it. So this PR increases the timeout.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
