### PR TITLE
chore: WorldState refactor

### DIFF
--- a/unity-renderer/Assets/Builder/Scripts/DCLBuilderBridge.cs
+++ b/unity-renderer/Assets/Builder/Scripts/DCLBuilderBridge.cs
@@ -335,19 +335,8 @@ namespace Builder
 
         private static ParcelScene GetLoadedScene()
         {
-            ParcelScene loadedScene = null;
             IWorldState worldState = Environment.i.world.state;
-
-            if (worldState != null && worldState.loadedScenes.Count > 0)
-            {
-                using (var iterator = worldState.loadedScenes.GetEnumerator())
-                {
-                    iterator.MoveNext();
-                    loadedScene = iterator.Current.Value as ParcelScene;
-                }
-            }
-
-            return loadedScene;
+            return worldState.GetScene(worldState.GetCurrentSceneId()) as ParcelScene;
         }
 
         private void Awake()

--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/SceneManager/SceneManager.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Scripts/SceneManager/SceneManager.cs
@@ -282,9 +282,7 @@ namespace DCL.Builder
 
         private void OnPlayerTeleportedToEditScene(Vector2Int coords)
         {
-            var targetScene = Environment.i.world.state.scenesSortedByDistance
-                                         .FirstOrDefault(scene => scene.sceneData.parcels.Contains(coords));
-            StartFlowFromLandWithPermission(targetScene, SOURCE_BUILDER_PANEl);
+            StartFlowFromLandWithPermission(Environment.i.world.state.GetScene(coords), SOURCE_BUILDER_PANEl);
         }
 
         public void StartFlowFromProject(Manifest.Manifest manifest)
@@ -352,7 +350,7 @@ namespace DCL.Builder
 
         public IParcelScene FindSceneToEdit()
         {
-            foreach (IParcelScene scene in Environment.i.world.state.scenesSortedByDistance)
+            foreach (IParcelScene scene in Environment.i.world.state.GetScenesSortedByDistance())
             {
                 if (WorldStateUtils.IsCharacterInsideScene(scene))
                     return scene;

--- a/unity-renderer/Assets/DCLPlugins/CoreComponentsPlugin/CoreComponentsPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/CoreComponentsPlugin/CoreComponentsPlugin.cs
@@ -80,7 +80,7 @@ public class CoreComponentsPlugin : IPlugin
     {
         // NOTE: TRANSFORM and AVATAR_ATTACH can't be used in the same Entity at the same time.
         // so we remove AVATAR_ATTACH (if exists) when a TRANSFORM is created.
-        IParcelScene scene = Environment.i.world.state.loadedScenes[sceneid];
+        IParcelScene scene = Environment.i.world.state.GetScene(sceneid);
         IDCLEntity entity = scene.entities[entityid];
 
         if (scene.componentsManagerLegacy.TryGetBaseComponent(entity, CLASS_ID_COMPONENT.AVATAR_ATTACH, out IEntityComponent component))

--- a/unity-renderer/Assets/DCLPlugins/DebugPlugins/PreviewMenu/Tests/PreviewMenuViewShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/DebugPlugins/PreviewMenu/Tests/PreviewMenuViewShould.cs
@@ -53,8 +53,8 @@ namespace Tests
             });
 
             var worldState = Substitute.For<IWorldState>();
-            worldState.currentSceneId.Returns("temptation");
-            worldState.loadedScenes.Returns(new Dictionary<string, IParcelScene>() { { "temptation", scene } });
+            worldState.GetCurrentSceneId().Returns("temptation");
+            worldState.GetLoadedScenes().Returns(new Dictionary<string, IParcelScene>() { { "temptation", scene } });
 
             var serviceLocator = new ServiceLocator();
             serviceLocator.Register<IWorldState>(() => worldState);

--- a/unity-renderer/Assets/DCLPlugins/DebugPlugins/ShapesBoundingBoxDisplayer/DebugShapesBoundingBoxDisplayer.cs
+++ b/unity-renderer/Assets/DCLPlugins/DebugPlugins/ShapesBoundingBoxDisplayer/DebugShapesBoundingBoxDisplayer.cs
@@ -69,7 +69,7 @@ public class DebugShapesBoundingBoxDisplayer : IPlugin
     private void WatchScene(string sceneId)
     {
         // NOTE: in case scene is not loaded yet, we add it to the "pending" list
-        if (!worldState.loadedScenes.TryGetValue(sceneId, out IParcelScene scene))
+        if (!worldState.TryGetScene(sceneId, out IParcelScene scene))
         {
             if (!pendingScenesId.Contains(sceneId))
             {

--- a/unity-renderer/Assets/DCLPlugins/DebugPlugins/ShapesBoundingBoxDisplayer/Tests/DebugPlugins.ShapesBoundingBoxDisplayer.Tests.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/DebugPlugins/ShapesBoundingBoxDisplayer/Tests/DebugPlugins.ShapesBoundingBoxDisplayer.Tests.asmdef
@@ -20,7 +20,9 @@
         "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
         "GUID:9857fe4bae4e30441bc3a577c5de790a"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,

--- a/unity-renderer/Assets/DCLPlugins/DebugPlugins/ShapesBoundingBoxDisplayer/Tests/DebugShapesBoundingBoxDisplayerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/DebugPlugins/ShapesBoundingBoxDisplayer/Tests/DebugShapesBoundingBoxDisplayerShould.cs
@@ -30,7 +30,6 @@ namespace Tests
         public void SetUp()
         {
             worldState = Substitute.For<IWorldState>();
-            worldState.loadedScenes.Returns(loadedScenes);
 
             sceneController = Substitute.For<ISceneController>();
             updateEventHandler = Substitute.For<IUpdateEventHandler>();
@@ -331,6 +330,9 @@ namespace Tests
             scene.entities.Returns(entities[id]);
 
             sceneController.OnNewSceneAdded += Raise.Event<Action<IParcelScene>>(scene);
+            
+            worldState.GetLoadedScenes().Returns(loadedScenes);
+            worldState.TryGetScene(id, out Arg.Any<IParcelScene>()).Returns(param => param[1] = scene);
 
             return scene;
         }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/CanvasPainter/CanvasPainter.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/CanvasPainter/CanvasPainter.cs
@@ -115,7 +115,7 @@ namespace DCL.ECS7
             bool sceneFound = false;
             for (int i = 0; i < loadedScenes.Count; i++)
             {
-                if(loadedScenes[i].sceneData.id != worldState.currentSceneId)
+                if(loadedScenes[i].sceneData.id != worldState.GetCurrentSceneId())
                     continue;
                 sceneFound = true;
                 DrawUI(loadedScenes[i]);

--- a/unity-renderer/Assets/DCLPlugins/ECS7/CanvasPainter/Tests/CanvasPainterShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/CanvasPainter/Tests/CanvasPainterShould.cs
@@ -97,8 +97,8 @@ namespace DCL.ECS7.Tests
             canvasPainter.SetScene(initialParcelScene);
             canvasPainter.framesCounter = 9999;
 
-            worldState.Configure().loadedScenes.Returns(loadedScenes);
-            worldState.Configure().currentSceneId.Returns("Newscene");
+            worldState.Configure().GetLoadedScenes().Returns(loadedScenes);
+            worldState.Configure().GetCurrentSceneId().Returns("Newscene");
             
             // Act
             canvasPainter.Update();

--- a/unity-renderer/Assets/DCLPlugins/ECS7/CanvasPainter/Tests/CanvasPainterUITransformIntegrationTest.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/CanvasPainter/Tests/CanvasPainterUITransformIntegrationTest.cs
@@ -304,7 +304,7 @@ namespace DCL.ECS7.Tests
         private ECS7TestScene CreateUITestScene()
         {
             string testSceneId = "testId";
-            worldState.Configure().currentSceneId.Returns(testSceneId);
+            worldState.Configure().GetCurrentSceneId().Returns(testSceneId);
             var testScene = testUtils.CreateScene(testSceneId);
             testScene.CreateEntity(512);
             testScene.CreateEntity(513);

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ComponentCrdtWriteSystem/Tests/ComponentCrdtWriteSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ComponentCrdtWriteSystem/Tests/ComponentCrdtWriteSystemShould.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using DCL;
 using DCL.Controllers;
 using DCL.CRDT;
 using DCL.ECSRuntime;
 using NSubstitute;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Tests
 {
@@ -24,7 +26,8 @@ namespace Tests
             crdtExecutor.crdtProtocol.Returns(new CRDTProtocol());
 
             scene.crdtExecutor.Returns(crdtExecutor);
-            worldState.loadedScenes.Add(SCENE_ID, scene);
+            scene.parcels.Returns(new HashSet<Vector2Int>());
+            worldState.AddScene(SCENE_ID, scene);
 
             crdtWriteSystem = new ComponentCrdtWriteSystem(worldState,
                 Substitute.For<ISceneController>(), DataStore.i.rpcContext.context);

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ComponentCrdtWriteSystem/Tests/ComponentCrdtWriteSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ComponentCrdtWriteSystem/Tests/ComponentCrdtWriteSystemShould.cs
@@ -26,7 +26,7 @@ namespace Tests
             crdtExecutor.crdtProtocol.Returns(new CRDTProtocol());
 
             scene.crdtExecutor.Returns(crdtExecutor);
-            scene.parcels.Returns(new HashSet<Vector2Int>());
+            scene.GetParcels().Returns(new HashSet<Vector2Int>());
             worldState.AddScene(SCENE_ID, scene);
 
             crdtWriteSystem = new ComponentCrdtWriteSystem(worldState,

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -112,7 +112,7 @@ namespace DCL.ECSComponents
         {
             // If player is not at the scene that triggered this event
             // we'll ignore it
-            if (scene.sceneData.id != worldState.currentSceneId)
+            if (scene.sceneData.id != worldState.GetCurrentSceneId())
             {
                 return false;
             }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformHandlerShould.cs
@@ -122,7 +122,7 @@ namespace Tests
         public void MoveCharacterWhenSameSceneAndValidPosition()
         {
             string sceneId = scene.sceneData.id;
-            worldState.currentSceneId.Returns(sceneId);
+            worldState.GetCurrentSceneId().Returns(sceneId);
             var playerEntity = scene.CreateEntity(SpecialEntityId.PLAYER_ENTITY);
 
             Vector3 position = new Vector3(8, 0, 0);
@@ -134,7 +134,7 @@ namespace Tests
         public void NotMoveCharacterWhenSameSceneButInvalidPosition()
         {
             string sceneId = scene.sceneData.id;
-            worldState.currentSceneId.Returns(sceneId);
+            worldState.GetCurrentSceneId().Returns(sceneId);
             var playerEntity = scene.CreateEntity(SpecialEntityId.PLAYER_ENTITY);
 
             Vector3 position = new Vector3(1000, 0, 0);
@@ -145,7 +145,7 @@ namespace Tests
         [Test]
         public void NotMoveCharacterWhenPlayerIsNotInScene()
         {
-            worldState.currentSceneId.Returns("NOTtemptation");
+            worldState.GetCurrentSceneId().Returns("NOTtemptation");
             var playerEntity = scene.CreateEntity(SpecialEntityId.PLAYER_ENTITY);
 
             Vector3 position = new Vector3(1000, 0, 0);

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Editor/TestScene/ECSTestScene.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Editor/TestScene/ECSTestScene.cs
@@ -35,8 +35,8 @@ public class ECSTestScene : MonoBehaviour
     
     private static void AddGLTFShapeComponent(string sceneId, IECSComponentWriter componentWriter)
     {
-        Environment.i.world.state.scenesSortedByDistance[0].contentProvider.baseUrl = "https://peer.decentraland.org/content/contents/";
-        Environment.i.world.state.scenesSortedByDistance[0].contentProvider.fileToHash.Add("models/SCENE.glb".ToLower(), "QmQgQtuAg9qsdrmLwnFiLRAYZ6Du4Dp7Yh7bw7ELn7AqkD");
+        Environment.i.world.state.GetScenesSortedByDistance()[0].contentProvider.baseUrl = "https://peer.decentraland.org/content/contents/";
+        Environment.i.world.state.GetScenesSortedByDistance()[0].contentProvider.fileToHash.Add("models/SCENE.glb".ToLower(), "QmQgQtuAg9qsdrmLwnFiLRAYZ6Du4Dp7Yh7bw7ELn7AqkD");
             
         componentWriter.PutComponent(sceneId, 2, ComponentID.GLTF_SHAPE,
             new PBGLTFShape() { Src = "models/SCENE.glb", Visible = true});

--- a/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestScene.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestScene.cs
@@ -47,6 +47,7 @@ public class ECS7TestScene : IParcelScene
         throw new NotImplementedException();
     }
     ISceneMetricsCounter IParcelScene.metricsCounter => throw new NotImplementedException();
+    public HashSet<Vector2Int> GetParcels() { throw new NotImplementedException(); }
     bool IParcelScene.IsInsideSceneBoundaries(Bounds objectBounds)
     {
         throw new NotImplementedException();

--- a/unity-renderer/Assets/DCLPlugins/UIComponentsPlugin/UIComponentsPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/UIComponentsPlugin/UIComponentsPlugin.cs
@@ -28,7 +28,7 @@ public class UIComponentsPlugin : IPlugin
 
     bool CanCreateScreenShape(string sceneId, int classId)
     {
-        IParcelScene scene = Environment.i.world.state.loadedScenes[sceneId];
+        IParcelScene scene = Environment.i.world.state.GetScene(sceneId);
 
         if (scene.componentsManagerLegacy.GetSceneSharedComponent<UIScreenSpace>() != null)
             return false;

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
@@ -86,10 +86,10 @@ namespace DCL
                 PhysicsLayers.physicsCastLayerMaskWithoutCharacter);
 
             bool uiIsBlocking = false;
-            string currentSceneId = worldState.currentSceneId;
+            string currentSceneId = worldState.GetCurrentSceneId();
 
             bool validCurrentSceneId = !string.IsNullOrEmpty(currentSceneId);
-            bool validCurrentScene = validCurrentSceneId && worldState.loadedScenes.ContainsKey(currentSceneId);
+            bool validCurrentScene = validCurrentSceneId && worldState.ContainsScene(currentSceneId);
 
             // NOTE: in case of a single scene loaded (preview or builder) sceneId is set to null when stepping outside
             if (didHit && validCurrentSceneId && validCurrentScene)
@@ -110,14 +110,17 @@ namespace DCL
             {
                 clickHandler = null;
                 UnhoverLastHoveredObject();
+
                 return;
             }
 
             var raycastHandlerTarget = hitInfo.collider.GetComponent<IRaycastPointerHandler>();
+
             if (raycastHandlerTarget != null)
             {
                 ResolveGenericRaycastHandlers(raycastHandlerTarget);
                 UnhoverLastHoveredObject();
+
                 return;
             }
 
@@ -131,6 +134,7 @@ namespace DCL
             if (!EventObjectCanBeHovered(info, hitInfo.distance))
             {
                 UnhoverLastHoveredObject();
+
                 return;
             }
 
@@ -193,7 +197,7 @@ namespace DCL
             newHoveredGO = null;
             newHoveredInputEvent = null;
         }
-        
+
         private IList<IPointerEvent> GetPointerEventList(IDCLEntity entity)
         {
             // If an event exist in the new ECS, we got that value, if not it is ECS 6, so we continue as before
@@ -267,6 +271,7 @@ namespace DCL
                 {
                     if (clickHandler == click)
                         click.OnPointerClick();
+
                     clickHandler = null;
                 }
             }
@@ -288,6 +293,7 @@ namespace DCL
             {
                 if (lastHoveredEventList[i] == null)
                     continue;
+
                 lastHoveredEventList[i].SetHoverState(false);
             }
 
@@ -327,10 +333,7 @@ namespace DCL
             }
         }
 
-        public Ray GetRayFromCamera()
-        {
-            return charCamera.ScreenPointToRay(new Vector3(Screen.width / 2, Screen.height / 2, 0));
-        }
+        public Ray GetRayFromCamera() { return charCamera.ScreenPointToRay(new Vector3(Screen.width / 2, Screen.height / 2, 0)); }
 
         void OnButtonEvent(WebInterface.ACTION_BUTTON buttonId, InputController_Legacy.EVENT evt, bool useRaycast,
             bool enablePointerEvent)
@@ -355,6 +358,7 @@ namespace DCL
 
             var pointerEventLayer =
                 PhysicsLayers.physicsCastLayerMaskWithoutCharacter; //Ensure characterController is being filtered
+
             var globalLayer = pointerEventLayer & ~PhysicsLayers.physicsCastLayerMask;
 
             if (evt == InputController_Legacy.EVENT.BUTTON_DOWN)
@@ -372,25 +376,30 @@ namespace DCL
         {
             IWorldState worldState = Environment.i.world.state;
 
-            if (string.IsNullOrEmpty(worldState.currentSceneId))
+            string currentSceneId = worldState.GetCurrentSceneId();
+            if (string.IsNullOrEmpty(currentSceneId))
                 return;
 
             RaycastHitInfo raycastGlobalLayerHitInfo;
             Ray ray = GetRayFromCamera();
 
             // Raycast for global pointer events
+            worldState.TryGetScene(currentSceneId, out var loadedScene);
+
             RaycastResultInfo raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer,
-                worldState.loadedScenes[worldState.currentSceneId]);
+                loadedScene);
+
             raycastGlobalLayerHitInfo = raycastInfoGlobalLayer.hitInfo;
 
             if (pointerInputUpEvent != null)
             {
                 // Raycast for pointer event components
                 RaycastResultInfo raycastInfoPointerEventLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane,
-                    pointerEventLayer, worldState.loadedScenes[worldState.currentSceneId]);
+                    pointerEventLayer, loadedScene);
 
                 bool isOnClickComponentBlocked =
                     IsBlockingOnClick(raycastInfoPointerEventLayer.hitInfo, raycastGlobalLayerHitInfo);
+
                 bool isSameEntityThatWasPressed = AreCollidersFromSameEntity(raycastInfoPointerEventLayer.hitInfo,
                     lastPointerDownEventHitInfo);
 
@@ -403,20 +412,23 @@ namespace DCL
             }
 
             ReportGlobalPointerUpEvent(buttonId, useRaycast, raycastGlobalLayerHitInfo, raycastInfoGlobalLayer,
-                worldState.currentSceneId);
+                currentSceneId);
 
             // Raycast for global pointer events (for each PE scene)
-            List<string> currentPortableExperienceIds =
-                DataStore.i.Get<DataStore_World>().portableExperienceIds.Get().ToList();
+            List<string> currentPortableExperienceIds = DataStore.i.Get<DataStore_World>().portableExperienceIds.Get().ToList();
 
             for (int i = 0; i < currentPortableExperienceIds.Count; i++)
             {
-                raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer,
-                    worldState.loadedScenes[currentPortableExperienceIds[i]]);
-                raycastGlobalLayerHitInfo = raycastInfoGlobalLayer.hitInfo;
+                if (worldState.TryGetScene(currentPortableExperienceIds[i], out var portableScene))
+                {
+                    raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer,
+                        portableScene);
 
-                ReportGlobalPointerUpEvent(buttonId, useRaycast, raycastGlobalLayerHitInfo, raycastInfoGlobalLayer,
-                    currentPortableExperienceIds[i]);
+                    raycastGlobalLayerHitInfo = raycastInfoGlobalLayer.hitInfo;
+
+                    ReportGlobalPointerUpEvent(buttonId, useRaycast, raycastGlobalLayerHitInfo, raycastInfoGlobalLayer,
+                        currentPortableExperienceIds[i]);
+                }
             }
         }
 
@@ -425,19 +437,20 @@ namespace DCL
         {
             IWorldState worldState = Environment.i.world.state;
 
-            if (string.IsNullOrEmpty(worldState.currentSceneId))
+            string currentSceneId = worldState.GetCurrentSceneId();
+            if (string.IsNullOrEmpty(currentSceneId))
                 return;
 
             RaycastHitInfo raycastGlobalLayerHitInfo;
             Ray ray = GetRayFromCamera();
+            worldState.TryGetScene(currentSceneId, out var loadedScene);
 
             // Raycast for pointer event components
-            RaycastResultInfo raycastInfoPointerEventLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane,
-                pointerEventLayer, worldState.loadedScenes[worldState.currentSceneId]);
+            RaycastResultInfo raycastInfoPointerEventLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, pointerEventLayer, loadedScene);
 
             // Raycast for global pointer events
-            RaycastResultInfo raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer,
-                worldState.loadedScenes[worldState.currentSceneId]);
+            RaycastResultInfo raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer, loadedScene);
+
             raycastGlobalLayerHitInfo = raycastInfoGlobalLayer.hitInfo;
 
             bool isOnClickComponentBlocked =
@@ -466,16 +479,19 @@ namespace DCL
                         case PointerInputEventType.CLICK:
                             if (areSameEntity && enablePointerEvent)
                                 e.Report(buttonId, ray, raycastInfoPointerEventLayer.hitInfo.hit);
+
                             break;
                         case PointerInputEventType.DOWN:
                             if (areSameEntity && enablePointerEvent)
                                 e.Report(buttonId, ray, raycastInfoPointerEventLayer.hitInfo.hit);
+
                             break;
                         case PointerInputEventType.UP:
                             if (areSameEntity && enablePointerEvent)
                                 pointerInputUpEvent = e;
                             else
                                 pointerInputUpEvent = null;
+
                             break;
                     }
                 }
@@ -483,20 +499,23 @@ namespace DCL
                 lastPointerDownEventHitInfo = raycastInfoPointerEventLayer.hitInfo;
             }
 
-            ReportGlobalPointerDownEvent(buttonId, useRaycast, raycastGlobalLayerHitInfo, raycastInfoGlobalLayer,
-                worldState.currentSceneId);
+            ReportGlobalPointerDownEvent(buttonId, useRaycast, raycastGlobalLayerHitInfo, raycastInfoGlobalLayer, currentSceneId);
 
             // Raycast for global pointer events (for each PE scene)
             IEnumerable<string> currentPortableExperienceIds = DataStore.i.world.portableExperienceIds.Get();
 
             foreach (var pexId in currentPortableExperienceIds)
             {
-                raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer,
-                    worldState.loadedScenes[pexId]);
-                raycastGlobalLayerHitInfo = raycastInfoGlobalLayer.hitInfo;
+                if (worldState.TryGetScene(pexId, out var portableScene))
+                {
+                    raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer, portableScene);
 
-                ReportGlobalPointerDownEvent(buttonId, useRaycast, raycastGlobalLayerHitInfo, raycastInfoGlobalLayer,
-                    pexId);
+                    raycastGlobalLayerHitInfo = raycastInfoGlobalLayer.hitInfo;
+
+                    ReportGlobalPointerDownEvent(buttonId, useRaycast, raycastGlobalLayerHitInfo, raycastInfoGlobalLayer,
+                        pexId);
+                }
+                
             }
         }
 
@@ -592,6 +611,7 @@ namespace DCL
         bool EntityHasPointerEvent(IDCLEntity entity)
         {
             var componentsManager = entity.scene.componentsManagerLegacy;
+
             return componentsManager.HasComponent(entity, Models.CLASS_ID_COMPONENT.UUID_CALLBACK) ||
                    componentsManager.HasComponent(entity, Models.CLASS_ID_COMPONENT.UUID_ON_UP) ||
                    componentsManager.HasComponent(entity, Models.CLASS_ID_COMPONENT.UUID_ON_DOWN) ||
@@ -634,19 +654,10 @@ namespace DCL
                 UnhoverLastHoveredObject();
         }
 
-        private void HideOrShowCursor(bool isCursorLocked)
-        {
-            DataStore.i.Get<DataStore_Cursor>().cursorVisible.Set(isCursorLocked);
-        }
+        private void HideOrShowCursor(bool isCursorLocked) { DataStore.i.Get<DataStore_Cursor>().cursorVisible.Set(isCursorLocked); }
 
-        private void SetHoverCursor()
-        {
-            DataStore.i.Get<DataStore_Cursor>().cursorType.Set(DataStore_Cursor.CursorType.HOVER);
-        }
+        private void SetHoverCursor() { DataStore.i.Get<DataStore_Cursor>().cursorType.Set(DataStore_Cursor.CursorType.HOVER); }
 
-        private void SetNormalCursor()
-        {
-            DataStore.i.Get<DataStore_Cursor>().cursorType.Set(DataStore_Cursor.CursorType.NORMAL);
-        }
+        private void SetNormalCursor() { DataStore.i.Get<DataStore_Cursor>().cursorType.Set(DataStore_Cursor.CursorType.NORMAL); }
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Tests/UUIDComponentTests.cs
@@ -56,7 +56,6 @@ namespace Tests
             mainCamera.transform.forward = Vector3.forward;
 
             EntityIdHelper idHelper = new EntityIdHelper();
-            DCL.Environment.i.world.state.currentSceneId = scene.sceneData.id;
             DCL.Environment.i.world.sceneController.Configure().entityIdHelper.Returns(idHelper);
 
             uuidEventsPlugin = new UUIDEventsPlugin();
@@ -1768,7 +1767,6 @@ namespace Tests
         public IEnumerator PointerEventNotTriggeredByParent()
         {
             EntityIdHelper idHelper = new EntityIdHelper();
-            DCL.Environment.i.world.state.currentSceneId = scene.sceneData.id;
             DCL.Environment.i.world.sceneController.Configure().entityIdHelper.Returns(idHelper);
             
             // Create parent entity

--- a/unity-renderer/Assets/Rendering/UI/ChargeWheel/M_ChargeBarV2.mat
+++ b/unity-renderer/Assets/Rendering/UI/ChargeWheel/M_ChargeBarV2.mat
@@ -48,7 +48,7 @@ Material:
     - _StencilOp: 0
     - _StencilReadMask: 255
     - _StencilWriteMask: 255
-    - _fillHead: 0.8321704
+    - _fillHead: 0.00016866415
     - _fillTail: 0
     - _fillTails: 0.5
     m_Colors:

--- a/unity-renderer/Assets/Rendering/UI/ChargeWheel/M_ChargeBarV2SingleColor.mat
+++ b/unity-renderer/Assets/Rendering/UI/ChargeWheel/M_ChargeBarV2SingleColor.mat
@@ -48,7 +48,7 @@ Material:
     - _StencilOp: 0
     - _StencilReadMask: 255
     - _StencilWriteMask: 255
-    - _fillHead: 0.08148244
+    - _fillHead: 0.00016866415
     - _fillTail: 0
     - _fillTails: 0.5
     m_Colors:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarReporterController/Implementation/AvatarReporterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarReporterController/Implementation/AvatarReporterController.cs
@@ -39,10 +39,7 @@ public class AvatarReporterController : IAvatarReporterController
     
     string GetcurrentSceneIdNonAlloc(Vector2Int coords)
     {
-        if (worldState.loadedScenesByCoordinate.ContainsKey(coords))
-            return worldState.loadedScenesByCoordinate[coords];
-        
-        return null;
+        return worldState.GetSceneIdByCoords(coords);
     }
 
     void IAvatarReporterController.ReportAvatarPosition(Vector3 position)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarReporterController/Tests/AvatarReporterControllerTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarReporterController/Tests/AvatarReporterControllerTests.asmdef
@@ -7,9 +7,13 @@
         "GUID:97d8897529779cb49bebd400c7f402a6",
         "GUID:a881b57670b1d2747a6d7f9e32b63230",
         "GUID:cc6bfabbfe87b7949aa248893f89ce37",
-        "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
@@ -107,7 +107,7 @@ namespace DCL.Components
             }
             
             bool shouldBeVisible = model.visible && isInsideSceneBounds && !CommonScriptableObjects.allUIHidden.Get() && isUIEnabled.Get();
-
+            
             canvasGroup.alpha = shouldBeVisible ? 1f : 0f;
             canvasGroup.blocksRaycasts = shouldBeVisible;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BotsController/BotsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BotsController/BotsController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using DCL.Controllers;
 using DCL.Interface;
 using DCL.Models;
@@ -41,7 +42,7 @@ namespace DCL.Bots
             if (globalScene != null)
                 yield break;
 
-            globalScene = Environment.i.world.state.loadedScenes[Environment.i.world.state.globalSceneIds[0]];
+            globalScene = Environment.i.world.state.GetGlobalScenes().First();
 
             CatalogController.wearableCatalog.Clear();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/LoadingHUD/Textures/Assets/LoadingAtlas.spriteatlas
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/LoadingHUD/Textures/Assets/LoadingAtlas.spriteatlas
@@ -56,7 +56,6 @@ SpriteAtlas:
     variantMultiplier: 1
     packables:
     - {fileID: 102900000, guid: cd392c048cef94fdb84e162fc608cdae, type: 3}
-    totalSpriteSurfaceArea: 1168160
     bindAsDefault: 1
     isAtlasV2: 0
     cachedData: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/LoadingHUD/Textures/Teleport/TeleportLoadingAtlas.spriteatlas
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/LoadingHUD/Textures/Teleport/TeleportLoadingAtlas.spriteatlas
@@ -51,7 +51,6 @@ SpriteAtlas:
     - {fileID: 2800000, guid: e1a280e254e7409429de218f8922c52a, type: 3}
     - {fileID: 2800000, guid: 1d3b42f3b5fa46446abb348ca49e0ab6, type: 3}
     - {fileID: 2800000, guid: 674eb2ea60e168a469c9a4a80983c0c9, type: 3}
-    totalSpriteSurfaceArea: 206584
     bindAsDefault: 1
     isAtlasV2: 0
     cachedData: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/Tests/TransactionHUDTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/Tests/TransactionHUDTests.asmdef
@@ -10,7 +10,12 @@
         "GUID:e6f5b34eba99b4ed9836f899578ee258",
         "GUID:029e05fd02d6c49d5ac9dd7e3725a35b",
         "GUID:d854a4b265f0e4ab6b27af4b554b3d0a",
-        "GUID:bd51ff2b035ce4ab4be7c38c43c88889"
+        "GUID:bd51ff2b035ce4ab4be7c38c43c88889",
+        "GUID:3a20a11f4753f4b1d8138f27e5d5f870",
+        "GUID:c9fbb75c15a4cd042b731877ede4a5c1",
+        "GUID:80f579cff5cf4136aa8969bf6fa1098c",
+        "GUID:a881b57670b1d2747a6d7f9e32b63230",
+        "GUID:44a9db8f655ab05409802e5476cf9dd3"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/Tests/TransactionHUDTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/Tests/TransactionHUDTests.cs
@@ -1,28 +1,37 @@
 using NUnit.Framework;
 using System.Collections;
 using DCL;
+using DCL.Helpers;
 using UnityEngine.TestTools;
 using DCL.TransactionHUDModel;
 
 namespace Tests
 {
-    public class TransactionHUDTests
+    public class TransactionHUDTests : IntegrationTestSuite
     {
         private TransactionHUDController controller;
 
         [SetUp]
-        protected void SetUp()
+
+        protected override IEnumerator SetUp()
         {
             MainSceneFactory.CreateBridges();
+
+            TestUtils.CreateTestScene();
             
             controller = new TransactionHUDController();
             controller.Initialize();
+            
+            return base.SetUp();
         }
 
+
         [TearDown]
-        protected void TearDown()
+        protected override IEnumerator TearDown()
         {
             controller.Dispose();
+
+            return base.TearDown();
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/Tests/TransactionHUDTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/Tests/TransactionHUDTests.cs
@@ -11,27 +11,22 @@ namespace Tests
     {
         private TransactionHUDController controller;
 
-        [SetUp]
-
         protected override IEnumerator SetUp()
         {
+            yield return base.SetUp();
             MainSceneFactory.CreateBridges();
 
             TestUtils.CreateTestScene();
             
             controller = new TransactionHUDController();
             controller.Initialize();
-            
-            return base.SetUp();
         }
-
-
-        [TearDown]
+        
         protected override IEnumerator TearDown()
         {
-            controller.Dispose();
+            yield return base.TearDown();
 
-            return base.TearDown();
+            controller.Dispose();
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/TransactionHUD.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TransactionHUD/TransactionHUD.cs
@@ -32,16 +32,8 @@ public class TransactionHUD : MonoBehaviour, ITransactionHUD
     
     public IParcelScene FindScene(string sceneId)
     {
-        if (DCL.Environment.i.world?.state?.scenesSortedByDistance != null)
-        {
-            foreach (IParcelScene scene in DCL.Environment.i.world.state.scenesSortedByDistance)
-            {
-                if (scene.sceneData.id == sceneId)
-                    return scene;
-            }
-        }
-
-        return null;
+        DCL.Environment.i.world.state.TryGetScene(sceneId, out var scene);
+        return scene;
     }
 
     private void OnDisable()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/AnalyticsHelper/AnalyticsHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/AnalyticsHelper/AnalyticsHelper.cs
@@ -5,10 +5,15 @@ public static class AnalyticsHelper
 {
     public static void AddSceneNameAndBasePositionToDictionary(Dictionary<string, string> analyticDict)
     {
-        string sceneId = Environment.i.world.state.currentSceneId;
+        IWorldState worldState = Environment.i.world.state;
+        string sceneId = worldState.GetCurrentSceneId();
+
+        if (!worldState.TryGetScene(sceneId, out var scene))
+            return;
+        
         if (!string.IsNullOrEmpty(sceneId))
         {
-            analyticDict.Add("base_parcel_position", Environment.i.world.state.loadedScenes[sceneId].sceneData.basePosition.x + "," + Environment.i.world.state.loadedScenes[sceneId].sceneData.basePosition.y );
+            analyticDict.Add("base_parcel_position", scene.sceneData.basePosition.x + "," + scene.sceneData.basePosition.y );
             analyticDict.Add("scene", sceneId);
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/PositionUtils/WorldStateUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/PositionUtils/WorldStateUtils.cs
@@ -86,12 +86,12 @@ namespace DCL
         public static IParcelScene GetCurrentScene()
         {
             var worldState = Environment.i.world.state;
-            string currentSceneId = worldState.currentSceneId;
+            string currentSceneId = worldState.GetCurrentSceneId();
 
             if (string.IsNullOrEmpty(currentSceneId))
                 return null;
 
-            bool foundCurrentScene = worldState.loadedScenes.TryGetValue(currentSceneId, out IParcelScene scene);
+            bool foundCurrentScene = worldState.TryGetScene(currentSceneId, out IParcelScene scene);
 
             if (!foundCurrentScene)
                 return null;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/CrashPayloadUtils/CrashPayloadUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/CrashPayloadUtils/CrashPayloadUtils.cs
@@ -12,7 +12,7 @@ namespace DCL.Helpers
 {
     public static class CrashPayloadUtils
     {
-        public static CrashPayload ComputePayload(Dictionary<string, IParcelScene> allScenes,
+        public static CrashPayload ComputePayload(IEnumerable<KeyValuePair<string, IParcelScene>> allScenes,
             List<Vector3> trackedMovements,
             List<Vector3> trackedTeleports)
         {
@@ -187,7 +187,7 @@ namespace DCL.Helpers
             public int quantity;
         }
 
-        public static void Dump(Dictionary<string, IParcelScene> allScenes, AssetLibrary_Texture library,
+        public static void Dump(IEnumerable<KeyValuePair<string, IParcelScene>> allScenes, AssetLibrary_Texture library,
             Dictionary<string, RefCountedTextureData> textureData, CrashPayload payload)
         {
             var componentsDump = new List<ComponentsDump>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/DebugBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/DebugBridge.cs
@@ -59,7 +59,7 @@ namespace DCL
         {
             bool originalLoggingValue = Debug.unityLogger.logEnabled;
             Debug.unityLogger.logEnabled = true;
-            foreach (var kvp in DCL.Environment.i.world.state.loadedScenes)
+            foreach (var kvp in DCL.Environment.i.world.state.GetLoadedScenes())
             {
                 IParcelScene scene = kvp.Value;
                 debugLogger.Log("Dumping state for scene: " + kvp.Value.sceneData.id);
@@ -123,7 +123,7 @@ namespace DCL
 
             var crashPayload = CrashPayloadUtils.ComputePayload
             (
-                DCL.Environment.i.world.state.loadedScenes,
+                DCL.Environment.i.world.state.GetLoadedScenes(),
                 debugController.GetTrackedMovements(),
                 debugController.GetTrackedTeleportPositions()
             );
@@ -150,7 +150,7 @@ namespace DCL
 
             var payload = CrashPayloadUtils.ComputePayload
             (
-                DCL.Environment.i.world.state.loadedScenes,
+                DCL.Environment.i.world.state.GetLoadedScenes(),
                 debugController.GetTrackedMovements(),
                 debugController.GetTrackedTeleportPositions()
             );

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/MiscBenchmarkController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/MiscBenchmarkController.cs
@@ -144,7 +144,7 @@ namespace DCL
                 int materialCount = 0;
                 int meshesCount = 0;
 
-                var loadedScenes = Environment.i.world.state.loadedScenes;
+                var loadedScenes = Environment.i.world.state.GetLoadedScenes();
 
                 foreach (var v in loadedScenes)
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/PreviewSceneLimitsWarning/PreviewSceneLimitsWarning.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/PreviewSceneLimitsWarning/PreviewSceneLimitsWarning.cs
@@ -90,7 +90,7 @@ namespace DCL
 
             if (!string.IsNullOrEmpty(sceneId))
             {
-                worldState.loadedScenes.TryGetValue(sceneId, out IParcelScene scene);
+                worldState.TryGetScene(sceneId, out IParcelScene scene);
                 ISceneMetricsCounter metricsController = scene?.metricsCounter;
                 SceneMetricsModel currentMetrics = metricsController?.currentCount;
                 SceneMetricsModel limit = metricsController?.maxCount;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/PreviewSceneLimitsWarning/Tests/PreviewSceneLimitsWarningShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/PreviewSceneLimitsWarning/Tests/PreviewSceneLimitsWarningShould.cs
@@ -31,8 +31,9 @@ public class PreviewSceneLimitsWarningShould
         sceneMetrics.maxCount.Returns(limit);
 
         scene.metricsCounter.Returns(sceneMetrics);
-        worldState.loadedScenes.Returns(scenes);
-
+        worldState.GetLoadedScenes().Returns(scenes);
+        worldState.TryGetScene(SCENE_ID, out Arg.Any<IParcelScene>()).Returns(param => param[1] = scene);
+        
         kernelConfigModel.debugConfig.sceneLimitsWarningSceneId = SCENE_ID;
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/PreviewSceneLimitsWarning/Tests/PreviewSceneLimitsWarningTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/PreviewSceneLimitsWarning/Tests/PreviewSceneLimitsWarningTests.asmdef
@@ -1,25 +1,29 @@
 {
-  "name": "PreviewSceneLimitsWarningTests",
-  "rootNamespace": "",
-  "references": [
-    "GUID:babeb23c08de24656a3ee7e29a141fef",
-    "GUID:97d8897529779cb49bebd400c7f402a6",
-    "GUID:c44f6fd10d3d94432a107d581e0096b5",
-    "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": true,
-  "precompiledReferences": [
-    "NSubstitute.dll",
-    "System.Threading.Tasks.Extensions.dll",
-    "nunit.framework.dll"
-  ],
-  "autoReferenced": false,
-  "defineConstraints": [
-    "UNITY_INCLUDE_TESTS"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "PreviewSceneLimitsWarningTests",
+    "rootNamespace": "",
+    "references": [
+        "GUID:babeb23c08de24656a3ee7e29a141fef",
+        "GUID:97d8897529779cb49bebd400c7f402a6",
+        "GUID:c44f6fd10d3d94432a107d581e0096b5",
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "NSubstitute.dll",
+        "System.Threading.Tasks.Extensions.dll",
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/UserBenchmarkController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Panels/UserBenchmarkController.cs
@@ -180,14 +180,14 @@ namespace DCL
 
             if (!string.IsNullOrEmpty(debugSceneId))
             {
-                if (worldState.loadedScenes.TryGetValue(debugSceneId, out IParcelScene scene))
+                if (worldState.TryGetScene(debugSceneId, out IParcelScene scene))
                     return scene;
             }
 
             var currentPos = DataStore.i.player.playerGridPosition.Get();
-            return worldState.loadedScenes.Values.FirstOrDefault(
-                x => x.sceneData.parcels != null
-                     && x.sceneData.parcels.Any(y => y == currentPos));
+            worldState.TryGetScene(worldState.GetSceneIdByCoords(currentPos), out IParcelScene resultScene);
+
+            return resultScene;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMetricsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/Performance/PerformanceMetricsController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using DCL.Controllers;
 using DCL.Interface;
 using DCL.FPSDisplay;
@@ -90,15 +91,17 @@ namespace DCL
         private void Report(string encodedSamples)
         {
 
-            Dictionary<string, IParcelScene>.ValueCollection loadedScenesValues = worldState.loadedScenes.Values;
+            var loadedScenesValues = worldState.GetLoadedScenes();
             scenesMemoryScore.Clear();
-            foreach (IParcelScene parcelScene in loadedScenesValues)
+            foreach (var parcelScene in loadedScenesValues)
             {
                 // we ignore global scene
-                if (parcelScene.isPersistent)
+                IParcelScene parcelSceneValue = parcelScene.Value;
+
+                if (parcelSceneValue.isPersistent)
                     continue; 
 
-                scenesMemoryScore.Add(parcelScene.sceneData.id, parcelScene.metricsCounter.currentCount.totalMemoryScore);
+                scenesMemoryScore.Add(parcelSceneValue.sceneData.id, parcelSceneValue.metricsCounter.currentCount.totalMemoryScore);
             }
 
             object drawCalls = null;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IParcelScene.cs
@@ -26,6 +26,7 @@ namespace DCL.Controllers
         string GetSceneName();
         ISceneMetricsCounter metricsCounter { get; }
         ICRDTExecutor crdtExecutor { get; set; }
+        HashSet<Vector2Int> parcels { get ; set; }
         bool IsInsideSceneBoundaries(Bounds objectBounds);
         bool IsInsideSceneBoundaries(Vector2Int gridPosition, float height = 0f);
         bool IsInsideSceneBoundaries(Vector3 worldPosition, float height = 0f);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IParcelScene.cs
@@ -26,7 +26,7 @@ namespace DCL.Controllers
         string GetSceneName();
         ISceneMetricsCounter metricsCounter { get; }
         ICRDTExecutor crdtExecutor { get; set; }
-        HashSet<Vector2Int> parcels { get ; set; }
+        HashSet<Vector2Int> GetParcels();
         bool IsInsideSceneBoundaries(Bounds objectBounds);
         bool IsInsideSceneBoundaries(Vector2Int gridPosition, float height = 0f);
         bool IsInsideSceneBoundaries(Vector3 worldPosition, float height = 0f);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
@@ -25,5 +25,6 @@ namespace DCL
         void AddScene(string id, IParcelScene newScene);
         void RemoveScene(string id);
         void AddGlobalScene(string sceneId, IParcelScene newScene);
+        void ForceCurrentScene(string sceneDataID);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
@@ -8,18 +8,22 @@ namespace DCL
 {
     public interface IWorldState : ISceneHandler, IService
     {
-        HashSet<string> readyScenes { get; set; }
-        Dictionary<string, IParcelScene> loadedScenes { get; set; }
-        Dictionary<Vector2Int, string> loadedScenesByCoordinate { get; set; }
-        List<IParcelScene> scenesSortedByDistance { get; set; }
-        List<string> globalSceneIds { get; set; }
-        string currentSceneId { get; set; }
+        string GetCurrentSceneId();
+        IEnumerable<KeyValuePair<string, IParcelScene>> GetLoadedScenes();
+        List<IParcelScene> GetGlobalScenes();
         bool TryGetScene(string id, out IParcelScene scene);
         bool TryGetScene<T>(string id, out T scene) where T : class, IParcelScene;
+        IParcelScene GetScene(Vector2Int coords);
         IParcelScene GetScene(string id);
-        bool Contains(string id);
+        bool ContainsScene(string id);
         LoadWrapper GetLoaderForEntity(IDCLEntity entity);
         T GetOrAddLoaderForEntity<T>(IDCLEntity entity) where T : LoadWrapper, new();
         void RemoveLoaderForEntity(IDCLEntity entity);
+        string GetSceneIdByCoords(Vector2Int coords);
+        List<IParcelScene> GetScenesSortedByDistance();
+        void SortScenesByDistance(Vector2Int position);
+        void AddScene(string id, IParcelScene newScene);
+        void RemoveScene(string id);
+        void AddGlobalScene(string sceneId, IParcelScene newScene);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/Tests/WSSTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/Tests/WSSTests.cs
@@ -91,9 +91,9 @@ namespace Tests
 
                 yield return null;
 
-                Assert.IsTrue(DCL.Environment.i.world.state.loadedScenes.ContainsKey(loadedSceneID),
+                Assert.IsTrue(DCL.Environment.i.world.state.ContainsScene(loadedSceneID),
                     "Expected loadedScene not found!");
-                Assert.IsTrue(DCL.Environment.i.world.state.loadedScenes[loadedSceneID] != null,
+                Assert.IsTrue(DCL.Environment.i.world.state.GetScene(loadedSceneID) != null,
                     "Expected loadedScene found but was null!!!");
             }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Messaging/MessagingControllersManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Messaging/MessagingControllersManager.cs
@@ -85,8 +85,8 @@ namespace DCL
             lock (busesToProcess)
             {
                 IWorldState worldState = Environment.i.world.state;
-                string currentSceneId = worldState.currentSceneId;
-                List<IParcelScene> scenesSortedByDistance = worldState.scenesSortedByDistance;
+                string currentSceneId = worldState.GetCurrentSceneId();
+                var scenesSortedByDistance = worldState.GetScenesSortedByDistance();
 
                 int count = scenesSortedByDistance.Count; // we need to retrieve list count everytime because it
                 // may change after a yield return

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -20,7 +20,7 @@ namespace DCL.Controllers
         public IECSComponentsManagerLegacy componentsManagerLegacy { get; private set; }
         public LoadParcelScenesMessage.UnityParcelScene sceneData { get; protected set; }
 
-        public HashSet<Vector2Int> parcels = new HashSet<Vector2Int>();
+        public HashSet<Vector2Int> parcels { get; set; } = new HashSet<Vector2Int>();
         public ISceneMetricsCounter metricsCounter { get; set; }
         public event System.Action<IDCLEntity> OnEntityAdded;
         public event System.Action<IDCLEntity> OnEntityRemoved;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -20,7 +20,7 @@ namespace DCL.Controllers
         public IECSComponentsManagerLegacy componentsManagerLegacy { get; private set; }
         public LoadParcelScenesMessage.UnityParcelScene sceneData { get; protected set; }
 
-        public HashSet<Vector2Int> parcels { get; set; } = new HashSet<Vector2Int>();
+        public HashSet<Vector2Int> parcels = new HashSet<Vector2Int>();
         public ISceneMetricsCounter metricsCounter { get; set; }
         public event System.Action<IDCLEntity> OnEntityAdded;
         public event System.Action<IDCLEntity> OnEntityRemoved;
@@ -213,6 +213,7 @@ namespace DCL.Controllers
             return string.IsNullOrEmpty(sceneName) ? "Unnamed" : sceneName;
         }
 
+        public HashSet<Vector2Int> GetParcels() => parcels;
         public bool IsInsideSceneBoundaries(Bounds objectBounds)
         {
             if (isPersistent)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScenesCleaner.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScenesCleaner.cs
@@ -135,7 +135,7 @@ namespace DCL
 
             foreach (var scene in scenesToRemove)
             {
-                if (scene != null && !Environment.i.world.state.loadedScenes.ContainsKey(scene.sceneData.id))
+                if (scene != null && !Environment.i.world.state.ContainsScene(scene.sceneData.id))
                     Object.Destroy(scene.gameObject);
 
                 if (!immediate && DCLTime.realtimeSinceStartup - lastTime >= MAX_TIME_BUDGET)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -176,7 +176,7 @@ namespace DCL
             IWorldState worldState = Environment.i.world.state;
             DebugConfig debugConfig = DataStore.i.debugConfig;
 
-            if (worldState.loadedScenes.TryGetValue(sceneId, out scene))
+            if (worldState.TryGetScene(sceneId, out scene))
             {
 #if UNITY_EDITOR
                 if (debugConfig.soloScene && scene is GlobalScene && debugConfig.ignoreGlobalScenes)
@@ -365,7 +365,7 @@ namespace DCL
 
         public void ParseQuery(object payload, string sceneId)
         {
-            IParcelScene scene = Environment.i.world.state.loadedScenes[sceneId];
+            if (!Environment.i.world.state.TryGetScene(sceneId, out var scene)) return;
 
             if (!(payload is RaycastQuery raycastQuery))
                 return;
@@ -522,8 +522,6 @@ namespace DCL
         
         public void SendSceneReady(string sceneId)
         {
-            Environment.i.world.state.readyScenes.Add(sceneId);
-
             messagingControllersManager.SetSceneReady(sceneId);
 
             WebInterface.ReportControlEvent(new WebInterface.SceneReady(sceneId));
@@ -564,34 +562,11 @@ namespace DCL
 
             IWorldState worldState = Environment.i.world.state;
 
-            worldState.currentSceneId = null;
-            worldState.scenesSortedByDistance.Sort(SortScenesByDistanceMethod);
+            worldState.SortScenesByDistance(currentGridSceneCoordinate);
 
-            using (var iterator = Environment.i.world.state.scenesSortedByDistance.GetEnumerator())
-            {
-                IParcelScene scene;
-                bool characterIsInsideScene;
+            string currentSceneId = worldState.GetCurrentSceneId();
 
-                while (iterator.MoveNext())
-                {
-                    scene = iterator.Current;
-
-                    if (scene == null)
-                        continue;
-
-                    characterIsInsideScene = WorldStateUtils.IsCharacterInsideScene(scene);
-                    bool isGlobalScene = worldState.globalSceneIds.Contains(scene.sceneData.id);
-
-                    if (!isGlobalScene && characterIsInsideScene)
-                    {
-                        worldState.currentSceneId = scene.sceneData.id;
-
-                        break;
-                    }
-                }
-            }
-
-            if (!DataStore.i.debugConfig.isDebugMode.Get() && string.IsNullOrEmpty(worldState.currentSceneId))
+            if (!DataStore.i.debugConfig.isDebugMode.Get() && string.IsNullOrEmpty(currentSceneId))
             {
                 // When we don't know the current scene yet, we must lock the rendering from enabling until it is set
                 CommonScriptableObjects.rendererState.AddLock(this);
@@ -599,7 +574,7 @@ namespace DCL
             else
             {
                 // 1. Set current scene id
-                CommonScriptableObjects.sceneID.Set(worldState.currentSceneId);
+                CommonScriptableObjects.sceneID.Set(currentSceneId);
 
                 // 2. Attempt to remove SceneController's lock on rendering
                 CommonScriptableObjects.rendererState.RemoveLock(this);
@@ -607,18 +582,7 @@ namespace DCL
 
             OnSortScenes?.Invoke();
         }
-
-        private int SortScenesByDistanceMethod(IParcelScene sceneA, IParcelScene sceneB)
-        {
-            sortAuxiliaryVector = sceneA.sceneData.basePosition - currentGridSceneCoordinate;
-            int dist1 = sortAuxiliaryVector.sqrMagnitude;
-
-            sortAuxiliaryVector = sceneB.sceneData.basePosition - currentGridSceneCoordinate;
-            int dist2 = sortAuxiliaryVector.sqrMagnitude;
-
-            return dist1 - dist2;
-        }
-
+        
         private void OnCurrentSceneIdChange(string newSceneId, string prevSceneId)
         {
             if (Environment.i.world.state.TryGetScene(newSceneId, out IParcelScene newCurrentScene)
@@ -657,7 +621,7 @@ namespace DCL
 
             IWorldState worldState = Environment.i.world.state;
 
-            if (!worldState.loadedScenes.ContainsKey(sceneToLoad.id))
+            if (!worldState.ContainsScene(sceneToLoad.id))
             {
                 var newGameObject = new GameObject("New Scene");
 
@@ -669,14 +633,7 @@ namespace DCL
                     newScene.InitializeDebugPlane();
                 }
 
-                worldState.loadedScenes.Add(sceneToLoad.id, newScene);
-
-                foreach (Vector2Int sceneParcel in newScene.parcels)
-                {
-                    worldState.loadedScenesByCoordinate.Add(sceneParcel, sceneToLoad.id);
-                }
-                
-                worldState.scenesSortedByDistance.Add(newScene);
+                worldState.AddScene(sceneToLoad.id, newScene);
 
                 sceneSortDirty = true;
 
@@ -746,26 +703,15 @@ namespace DCL
 
             IWorldState worldState = Environment.i.world.state;
 
-            if (!worldState.Contains(sceneId))
+            if (!worldState.TryGetScene(sceneId, out ParcelScene scene))
                 return;
 
-            ParcelScene scene = (ParcelScene) worldState.loadedScenes[sceneId];
-            
-            worldState.loadedScenes.Remove(sceneId);
-            worldState.globalSceneIds.Remove(sceneId);
-            
-            foreach (Vector2Int sceneParcel in scene.parcels)
-            {
-                worldState.loadedScenesByCoordinate.Remove(sceneParcel);
-            }
+            worldState.RemoveScene(sceneId);
             
             DataStore.i.world.portableExperienceIds.Remove(sceneId);
             
-            // Remove the scene id from the msg. priorities list
-            worldState.scenesSortedByDistance.Remove(scene);
-
             // Remove messaging controller for unloaded scene
-            messagingControllersManager.RemoveController(scene.sceneData.id);
+            messagingControllersManager.RemoveController(sceneId);
 
             scene.Cleanup(!CommonScriptableObjects.rendererState.Get());
 
@@ -783,15 +729,16 @@ namespace DCL
         public void UnloadAllScenes(bool includePersistent = false)
         {
             var worldState = Environment.i.world.state;
+            
+            // since the list was changing by this foreach, we make a copy
+            var list = worldState.GetLoadedScenes().ToArray();
 
-            var list = worldState.loadedScenes.ToArray();
-
-            for (int i = 0; i < list.Length; i++)
+            foreach (var kvp in list)
             {
-                if (list[i].Value.isPersistent && !includePersistent)
+                if (kvp.Value.isPersistent && !includePersistent)
                     continue;
-                
-                UnloadParcelSceneExecute(list[i].Key);
+
+                UnloadParcelSceneExecute(kvp.Key);
             }
         }
 
@@ -854,7 +801,7 @@ namespace DCL
 
             IWorldState worldState = Environment.i.world.state;
 
-            if (worldState.loadedScenes.ContainsKey(newGlobalSceneId))
+            if (worldState.ContainsScene(newGlobalSceneId))
                 return;
 
             var newGameObject = new GameObject("Global Scene - " + newGlobalSceneId);
@@ -880,15 +827,13 @@ namespace DCL
                 newScene.iconUrl = newScene.contentProvider.GetContentsUrl(globalScene.icon);
             }
 
-            worldState.loadedScenes.Add(newGlobalSceneId, newScene);
+            worldState.AddGlobalScene(newGlobalSceneId, newScene);
             OnNewSceneAdded?.Invoke(newScene);
 
             if (newScene.isPortableExperience)
             {
                 DataStore.i.world.portableExperienceIds.Add(newGlobalSceneId);
             }
-
-            worldState.globalSceneIds.Add(newGlobalSceneId);
 
             messagingControllersManager.AddControllerIfNotExists(this, newGlobalSceneId, isGlobal: true);
 
@@ -898,7 +843,7 @@ namespace DCL
 
         public void IsolateScene(IParcelScene sceneToActive)
         {
-            foreach (IParcelScene scene in Environment.i.world.state.scenesSortedByDistance)
+            foreach (IParcelScene scene in Environment.i.world.state.GetScenesSortedByDistance())
             {
                 if (scene != sceneToActive)
                     scene.GetSceneTransform().gameObject.SetActive(false);
@@ -907,7 +852,7 @@ namespace DCL
 
         public void ReIntegrateIsolatedScene()
         {
-            foreach (IParcelScene scene in Environment.i.world.state.scenesSortedByDistance)
+            foreach (IParcelScene scene in Environment.i.world.state.GetScenesSortedByDistance())
             {
                 scene.GetSceneTransform().gameObject.SetActive(true);
             }
@@ -934,6 +879,5 @@ namespace DCL
         public event Action<IParcelScene> OnSceneRemoved;
         
         private Vector2Int currentGridSceneCoordinate = new Vector2Int(EnvironmentSettings.MORDOR_SCALAR, EnvironmentSettings.MORDOR_SCALAR);
-        private Vector2Int sortAuxiliaryVector = new Vector2Int(EnvironmentSettings.MORDOR_SCALAR, EnvironmentSettings.MORDOR_SCALAR);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
@@ -222,7 +222,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
 
         Assert.AreEqual(12, Environment.i.world.state.GetLoadedScenes().Count());
 
-        var loadedScenes = Environment.i.world.state.GetLoadedScenes();
+        var loadedScenes = Environment.i.world.state.GetLoadedScenes().Select(kvp => kvp.Value);
         foreach (var reference in referenceCheck)
         {
             CollectionAssert.Contains(loadedScenes, reference, "References must be the same");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
@@ -60,11 +60,11 @@ public class SceneTests : IntegrationTestSuite_Legacy
 
         GameObject sceneGo = GameObject.Find(sceneGameObjectNamePrefix + sceneId);
 
-        GlobalScene globalScene = Environment.i.world.state.loadedScenes[sceneId] as GlobalScene;
+        GlobalScene globalScene = Environment.i.world.state.GetScene(sceneId) as GlobalScene;
 
         Assert.IsTrue(globalScene != null, "Scene isn't a GlobalScene?");
         Assert.IsTrue(sceneGo != null, "scene game object not found!");
-        Assert.IsTrue(Environment.i.world.state.loadedScenes[sceneId] != null, "Scene not in loaded dictionary!");
+        Assert.IsTrue(Environment.i.world.state.GetScene(sceneId) != null, "Scene not in loaded dictionary!");
         Assert.IsTrue(globalScene.unloadWithDistance == false,
             "Scene will unload when far!");
 
@@ -83,7 +83,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
         sceneGo = GameObject.Find(sceneGameObjectNamePrefix + sceneId);
 
         Assert.IsTrue(sceneGo != null, "scene game object not found! GlobalScenes must not be unloaded by distance!");
-        Assert.IsTrue(Environment.i.world.state.loadedScenes[sceneId] != null,
+        Assert.IsTrue(Environment.i.world.state.GetScene(sceneId) != null,
             "Scene not in loaded dictionary when far! GlobalScenes must not be unloaded by distance!");
     }
 
@@ -94,11 +94,11 @@ public class SceneTests : IntegrationTestSuite_Legacy
 
         sceneController.CreateGlobalScene(JsonUtility.ToJson(new CreateGlobalSceneMessage() {id = sceneId}));
 
-        Assert.IsTrue(Environment.i.world.state.Contains(sceneId), "Scene not in loaded dictionary!");
+        Assert.IsTrue(Environment.i.world.state.ContainsScene(sceneId), "Scene not in loaded dictionary!");
 
         sceneController.UnloadParcelSceneExecute(sceneId);
 
-        Assert.IsFalse(Environment.i.world.state.Contains(sceneId), "Scene not unloaded correctly!");
+        Assert.IsFalse(Environment.i.world.state.ContainsScene(sceneId), "Scene not unloaded correctly!");
 
         yield break;
     }
@@ -147,8 +147,8 @@ public class SceneTests : IntegrationTestSuite_Legacy
 
         string loadedSceneID = "0,0";
 
-        Assert.IsTrue(Environment.i.world.state.loadedScenes.ContainsKey(loadedSceneID));
-        Assert.IsTrue(Environment.i.world.state.loadedScenes[loadedSceneID] != null);
+        Assert.IsTrue(Environment.i.world.state.ContainsScene(loadedSceneID));
+        Assert.IsTrue(Environment.i.world.state.GetScene(loadedSceneID) != null);
     }
 
     [UnityTest]
@@ -160,9 +160,9 @@ public class SceneTests : IntegrationTestSuite_Legacy
 
         string loadedSceneID = "0,0";
 
-        Assert.IsTrue(Environment.i.world.state.loadedScenes.ContainsKey(loadedSceneID));
+        Assert.IsTrue(Environment.i.world.state.ContainsScene(loadedSceneID));
 
-        var loadedScene = Environment.i.world.state.loadedScenes[loadedSceneID] as ParcelScene;
+        var loadedScene = Environment.i.world.state.GetScene(loadedSceneID) as ParcelScene;
         // Add 1 entity to the loaded scene
         TestUtils.CreateSceneEntity(loadedScene, 6);
 
@@ -173,7 +173,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
         yield return new WaitForAllMessagesProcessed();
         yield return new WaitForSeconds(0.5f);
 
-        Assert.IsTrue(Environment.i.world.state.loadedScenes.ContainsKey(loadedSceneID) == false);
+        Assert.IsTrue(Environment.i.world.state.ContainsScene(loadedSceneID) == false);
 
         Assert.IsTrue(loadedScene == null, "Scene root gameobject reference is not getting destroyed.");
 
@@ -197,7 +197,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
             .DeserializeObject<LoadParcelScenesMessage.UnityParcelScene[]>(severalParcelsJson)
             .Select(x => JsonUtility.ToJson(x));
 
-        Assert.AreEqual(Environment.i.world.state.loadedScenes.Count, 1);
+        Assert.AreEqual(Environment.i.world.state.GetLoadedScenes().Count(), 1);
 
         foreach (string jsonScene in jsonScenes)
         {
@@ -208,23 +208,24 @@ public class SceneTests : IntegrationTestSuite_Legacy
 
         var referenceCheck = new List<DCL.Controllers.ParcelScene>();
 
-        foreach (var kvp in Environment.i.world.state.loadedScenes)
+        foreach (var kvp in Environment.i.world.state.GetLoadedScenes())
         {
             referenceCheck.Add(kvp.Value as ParcelScene);
         }
 
-        Assert.AreEqual(12, Environment.i.world.state.loadedScenes.Count);
+        Assert.AreEqual(12, Environment.i.world.state.GetLoadedScenes().Count());
 
         foreach (var jsonScene in jsonScenes)
         {
             sceneController.LoadParcelScenes(jsonScene);
         }
 
-        Assert.AreEqual(12, Environment.i.world.state.loadedScenes.Count);
+        Assert.AreEqual(12, Environment.i.world.state.GetLoadedScenes().Count());
 
+        var loadedScenes = Environment.i.world.state.GetLoadedScenes();
         foreach (var reference in referenceCheck)
         {
-            Assert.IsTrue(Environment.i.world.state.loadedScenes.ContainsValue(reference), "References must be the same");
+            CollectionAssert.Contains(loadedScenes, reference, "References must be the same");
         }
 
         sceneController.UnloadAllScenes(includePersistent: true);
@@ -252,16 +253,16 @@ public class SceneTests : IntegrationTestSuite_Legacy
     [UnityTest]
     public IEnumerator PositionParcels()
     {
-        Assert.AreEqual(1, Environment.i.world.state.loadedScenes.Count);
+        Assert.AreEqual(1, Environment.i.world.state.GetLoadedScenes().Count());
 
         var jsonMessageToLoad = "{\"id\":\"xxx\",\"basePosition\":{\"x\":0,\"y\":0},\"parcels\":[{\"x\":-1,\"y\":0}, {\"x\":0,\"y\":0}, {\"x\":-1,\"y\":1}],\"baseUrl\":\"http://localhost:9991/local-ipfs/contents/\",\"contents\":[],\"owner\":\"0x0f5d2fb29fb7d3cfee444a200298f468908cc942\"}";
         sceneController.LoadParcelScenes(jsonMessageToLoad);
 
         yield return new WaitForAllMessagesProcessed();
 
-        Assert.AreEqual(2, Environment.i.world.state.loadedScenes.Count);
+        Assert.AreEqual(2, Environment.i.world.state.GetLoadedScenes().Count());
 
-        var theScene = Environment.i.world.state.loadedScenes["xxx"];
+        var theScene = Environment.i.world.state.GetScene("xxx");
         yield return null;
 
         Assert.AreEqual(3, theScene.sceneData.parcels.Length);
@@ -279,16 +280,16 @@ public class SceneTests : IntegrationTestSuite_Legacy
     [UnityTest]
     public IEnumerator PositionParcels2()
     {
-        Assert.AreEqual(1, Environment.i.world.state.loadedScenes.Count);
+        Assert.AreEqual(1, Environment.i.world.state.GetLoadedScenes().Count());
 
         var jsonMessageToLoad = "{\"id\":\"xxx\",\"basePosition\":{\"x\":90,\"y\":90},\"parcels\":[{\"x\":89,\"y\":90}, {\"x\":90,\"y\":90}, {\"x\":89,\"y\":91}],\"baseUrl\":\"http://localhost:9991/local-ipfs/contents/\",\"contents\":[],\"owner\":\"0x0f5d2fb29fb7d3cfee444a200298f468908cc942\"}";
         sceneController.LoadParcelScenes(jsonMessageToLoad);
 
         yield return new WaitForAllMessagesProcessed();
 
-        Assert.AreEqual(2, Environment.i.world.state.loadedScenes.Count);
+        Assert.AreEqual(2, Environment.i.world.state.GetLoadedScenes().Count());
 
-        var theScene = Environment.i.world.state.loadedScenes["xxx"] as ParcelScene;
+        var theScene = Environment.i.world.state.GetScene("xxx") as ParcelScene;
         yield return null;
 
         Assert.AreEqual(3, theScene.sceneData.parcels.Length);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Utils/PortableExperienceUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Utils/PortableExperienceUtils.cs
@@ -10,14 +10,15 @@ namespace DCL
             List<GlobalScene> activePortableExperienceScenes = new List<GlobalScene>();
             IWorldState worldState = Environment.i.world.state;
 
-            foreach (var globalSceneId in worldState.globalSceneIds)
+            List<IParcelScene> parcelScenes = worldState.GetGlobalScenes();
+
+            foreach (var parcelScene in parcelScenes)
             {
-                if (worldState.TryGetScene(globalSceneId, out GlobalScene scene))
+                var globalScene = (GlobalScene)parcelScene;
+
+                if (globalScene.isPortableExperience)
                 {
-                    if (scene.isPortableExperience)
-                    {
-                        activePortableExperienceScenes.Add(scene);
-                    }
+                    activePortableExperienceScenes.Add(globalScene);
                 }
             }
 
@@ -29,14 +30,15 @@ namespace DCL
             List<string> currentSceneAndPortableExperiencesIds = new List<string>();
             IWorldState worldState = Environment.i.world.state;
 
-            foreach (var globalSceneId in worldState.globalSceneIds)
+            List<IParcelScene> parcelScenes = worldState.GetGlobalScenes();
+
+            foreach (var parcelScene in parcelScenes)
             {
-                if (worldState.TryGetScene(globalSceneId, out GlobalScene scene))
+                var globalScene = (GlobalScene)parcelScene;
+
+                if (globalScene.isPortableExperience)
                 {
-                    if (scene.isPortableExperience)
-                    {
-                        currentSceneAndPortableExperiencesIds.Add(globalSceneId);
-                    }
+                    currentSceneAndPortableExperiencesIds.Add(globalScene.sceneName);
                 }
             }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
@@ -172,6 +172,10 @@ namespace DCL
             }
 
         }
+        public void ForceCurrentScene(string id)
+        {
+            currentSceneId = id;
+        }
         
         public void AddScene(string id, IParcelScene newScene)
         {
@@ -183,12 +187,8 @@ namespace DCL
             
             loadedScenes.Add(id, newScene);
             
-            foreach (Vector2Int parcelPosition in newScene.parcels)
+            foreach (Vector2Int parcelPosition in newScene.GetParcels())
             {
-                if (loadedScenesByCoordinate.ContainsKey(parcelPosition) && loadedScenesByCoordinate[parcelPosition] != id)
-                {
-                    Debug.LogWarning($"[{parcelPosition}] different id? original: {loadedScenesByCoordinate[parcelPosition]} new: {id}");
-                }
                 loadedScenesByCoordinate[parcelPosition] = id;
             }
                 
@@ -204,7 +204,7 @@ namespace DCL
         {
             IParcelScene loadedScene = loadedScenes[id];
 
-            foreach (Vector2Int sceneParcel in loadedScene.parcels)
+            foreach (Vector2Int sceneParcel in loadedScene.GetParcels())
             {
                 loadedScenesByCoordinate.Remove(sceneParcel);
             }
@@ -236,6 +236,12 @@ namespace DCL
 
         public void Dispose()
         {
+            loadedScenes.Clear();
+            loadedScenesByCoordinate.Clear();
+            scenesSortedByDistance.Clear();
+            globalScenes.Clear();
+            globalScenes.Clear();
+            currentSceneId = null;
         }
 
         public void Initialize()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
@@ -230,6 +230,8 @@ namespace DCL
             
             globalSceneIds.Add(sceneId);
             globalScenes.Add(newScene);
+
+            AddScene(sceneId, newScene);
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/Tests/CursorControllerTests/CursorControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/Tests/CursorControllerTests/CursorControllerTests.cs
@@ -70,10 +70,6 @@ namespace Tests
             mainCamera.tag = "MainCamera";
             mainCamera.transform.position = Vector3.zero;
             mainCamera.transform.forward = Vector3.forward;
-
-            DCL.Environment.i.world.state.currentSceneId = scene.sceneData.id;
-
-
         }
 
         protected override IEnumerator TearDown()

--- a/unity-renderer/Assets/Scripts/Tests/EntityMaterialUpdateTestController.cs
+++ b/unity-renderer/Assets/Scripts/Tests/EntityMaterialUpdateTestController.cs
@@ -15,7 +15,7 @@ public class EntityMaterialUpdateTestController : MonoBehaviour
         sceneController.UnloadAllScenes();
         sceneController.LoadParcelScenes(scenesToLoad);
 
-        var scene = Environment.i.world.state.loadedScenes["0,0"] as ParcelScene;
+        var scene = Environment.i.world.state.GetScene("0,0") as ParcelScene;
 
         DCLTexture dclAtlasTexture = TestUtils.CreateDCLTexture(
             scene,

--- a/unity-renderer/Assets/Scripts/Tests/GLTFLoadingTestController.cs
+++ b/unity-renderer/Assets/Scripts/Tests/GLTFLoadingTestController.cs
@@ -23,7 +23,7 @@ public class GLTFLoadingTestController : MonoBehaviour
         sceneController.UnloadAllScenes();
         sceneController.LoadParcelScenes(scenesToLoad);
 
-        var scene = Environment.i.world.state.loadedScenes["0,0"] as ParcelScene;
+        var scene = Environment.i.world.state.GetScene("0,0") as ParcelScene;
 
         // FULL GLB
         TestUtils.InstantiateEntityWithShape(scene, 1, DCL.Models.CLASS_ID.GLTF_SHAPE, new Vector3(-2.5f, 1, 0),

--- a/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
+++ b/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
@@ -33,6 +33,7 @@ public class IntegrationTestSuite_Legacy
 
         // TODO(Brian): Move these variants to a DataStore object to avoid having to reset them
         //              like this.
+        CommonScriptableObjects.allUIHidden.Set(false);
         CommonScriptableObjects.isFullscreenHUDOpen.Set(false);
         CommonScriptableObjects.rendererState.Set(true);
 

--- a/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
+++ b/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
@@ -31,9 +31,7 @@ namespace DCL.Helpers
 
     // NOTE(Brian): Attribute used to determine if tests are visual. Those tests will be run to generate the baseline images.
     [AttributeUsage(AttributeTargets.Method)]
-    public class VisualTestAttribute : Attribute
-    {
-    }
+    public class VisualTestAttribute : Attribute { }
 
     public static class TestUtils
     {
@@ -45,10 +43,7 @@ namespace DCL.Helpers
         static int entityCounter = 513;
         static int disposableIdCounter = 123;
 
-        public static string GetB64Transform(Vector3 position, Quaternion rotation, Vector3 scale)
-        {
-            return DCLTransformUtils.EncodeTransform(position, rotation, scale);
-        }
+        public static string GetB64Transform(Vector3 position, Quaternion rotation, Vector3 scale) { return DCLTransformUtils.EncodeTransform(position, rotation, scale); }
 
         /// <summary>
         /// This will mock the request to invoke the success param when called,
@@ -65,25 +60,25 @@ namespace DCL.Helpers
             operation.Configure().GetResultData().Returns(Encoding.ASCII.GetBytes(jsonData));
 
             mockedRequestController.Configure()
-                .Get(Arg.Any<string>(),
-                    Arg.Any<DownloadHandler>(),
-                    Arg.Any<System.Action<IWebRequestAsyncOperation>>(),
-                    Arg.Any<Action<IWebRequestAsyncOperation>>(),
-                    Arg.Any<int>(),
-                    Arg.Any<int>(),
-                    Arg.Any<bool>(),
-                    Arg.Any<Dictionary<string, string>>())
-                .Returns(operation);
+                                   .Get(Arg.Any<string>(),
+                                       Arg.Any<DownloadHandler>(),
+                                       Arg.Any<System.Action<IWebRequestAsyncOperation>>(),
+                                       Arg.Any<Action<IWebRequestAsyncOperation>>(),
+                                       Arg.Any<int>(),
+                                       Arg.Any<int>(),
+                                       Arg.Any<bool>(),
+                                       Arg.Any<Dictionary<string, string>>())
+                                   .Returns(operation);
 
             mockedRequestController.When(x => x.Get(Arg.Any<string>(),
-                Arg.Any<DownloadHandler>(),
-                Arg.Any<System.Action<IWebRequestAsyncOperation>>(),
-                Arg.Any<Action<IWebRequestAsyncOperation>>(),
-                Arg.Any<int>(),
-                Arg.Any<int>(),
-                Arg.Any<bool>(),
-                Arg.Any<Dictionary<string, string>>())).Do(x => x.ArgAt<Action<IWebRequestAsyncOperation>>(successParamIndex).Invoke(operation));
-
+                                       Arg.Any<DownloadHandler>(),
+                                       Arg.Any<System.Action<IWebRequestAsyncOperation>>(),
+                                       Arg.Any<Action<IWebRequestAsyncOperation>>(),
+                                       Arg.Any<int>(),
+                                       Arg.Any<int>(),
+                                       Arg.Any<bool>(),
+                                       Arg.Any<Dictionary<string, string>>()))
+                                   .Do(x => x.ArgAt<Action<IWebRequestAsyncOperation>>(successParamIndex).Invoke(operation));
 
             return operation;
         }
@@ -91,6 +86,7 @@ namespace DCL.Helpers
         public static FeatureFlag CreateFeatureFlag(List<string> enabledFlags = null)
         {
             FeatureFlag featureFlag = new FeatureFlag();
+
             if (enabledFlags == null)
                 return featureFlag;
 
@@ -105,6 +101,7 @@ namespace DCL.Helpers
         public static string GetB64TransformFromModelJson(string json)
         {
             DCLTransform.Model transfModel = JsonUtility.FromJson<DCLTransform.Model>(json);
+
             return GetB64Transform(transfModel.position, transfModel.rotation, transfModel.scale);
         }
 
@@ -114,6 +111,7 @@ namespace DCL.Helpers
 
             entityCounter++;
             long id = entityCounter;
+
             return scene.CreateEntity(id);
         }
 
@@ -130,6 +128,7 @@ namespace DCL.Helpers
         {
             IPoolableComponentFactory poolableFactory =
                 Resources.Load<PoolableComponentFactory>("PoolableCoreComponentsFactory");
+
             ;
             int inferredId = (int) poolableFactory.GetIdForType<T>();
 
@@ -165,6 +164,7 @@ namespace DCL.Helpers
 
             IPoolableComponentFactory poolableFactory =
                 Resources.Load<PoolableComponentFactory>("PoolableCoreComponentsFactory");
+
             ;
             int inferredId = (int) poolableFactory.GetIdForType<T>();
 
@@ -256,6 +256,7 @@ namespace DCL.Helpers
         public static void SharedComponentAttach(BaseDisposable component, IDCLEntity entity)
         {
             ParcelScene scene = entity.scene as ParcelScene;
+
             scene.componentsManagerLegacy.SceneSharedComponentAttach(
                 entity.entityId,
                 component.id
@@ -278,6 +279,7 @@ namespace DCL.Helpers
         public static TextShape InstantiateEntityWithTextShape(ParcelScene scene, Vector3 position, TextShape.Model model)
         {
             IDCLEntity entity = CreateSceneEntity(scene);
+
             string componentId =
                 GetComponentUniqueId(scene, "textShape", (int) CLASS_ID_COMPONENT.TEXT_SHAPE, entity.entityId);
 
@@ -295,12 +297,14 @@ namespace DCL.Helpers
 
             SetEntityTransform(scene, entity, position, Quaternion.identity, Vector3.one);
             SharedComponentAttach(gltfShape, entity);
+
             return gltfShape;
         }
 
         public static GLTFShape CreateEntityWithGLTFShape(ParcelScene scene, Vector3 position, string url)
         {
             IDCLEntity entity = null;
+
             return CreateEntityWithGLTFShape(scene, position, new GLTFShape.Model() { src = url }, out entity);
         }
 
@@ -313,6 +317,7 @@ namespace DCL.Helpers
         public static GLTFShape CreateEntityWithGLTFShape(ParcelScene scene, Vector3 position, GLTFShape.Model model)
         {
             IDCLEntity entity = null;
+
             return CreateEntityWithGLTFShape(scene, position, model, out entity);
         }
 
@@ -321,6 +326,7 @@ namespace DCL.Helpers
         {
             entity = CreateSceneEntity(scene);
             GLTFShape gltfShape = AttachGLTFShape(entity, scene, position, model);
+
             return gltfShape;
         }
 
@@ -333,6 +339,7 @@ namespace DCL.Helpers
                 }));
 
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(scene.entities[entity.entityId]);
+
             yield return new DCL.WaitUntil(() => gltfShape.alreadyLoaded);
         }
 
@@ -393,6 +400,7 @@ namespace DCL.Helpers
             T shape = SharedComponentCreate<T, K>(scene, classId, model);
             SharedComponentAttach(shape, entity);
             SetEntityTransform(scene, entity, position, Quaternion.identity, Vector3.one);
+
             return shape;
         }
 
@@ -415,6 +423,7 @@ namespace DCL.Helpers
         {
             BasicMaterial material = SharedComponentCreate<BasicMaterial, BasicMaterial.Model>(scene, CLASS_ID.BASIC_MATERIAL, model);
             SharedComponentAttach(material, entity);
+
             return material;
         }
 
@@ -422,6 +431,7 @@ namespace DCL.Helpers
         {
             PBRMaterial material = SharedComponentCreate<PBRMaterial, PBRMaterial.Model>(scene, CLASS_ID.PBR_MATERIAL, model);
             SharedComponentAttach(material, entity);
+
             return material;
         }
 
@@ -436,9 +446,12 @@ namespace DCL.Helpers
         {
             InstantiateEntityWithShape<BoxShape, BoxShape.Model>(scene, CLASS_ID.BOX_SHAPE, position,
                 out entity);
+
             PBRMaterial material =
                 SharedComponentCreate<PBRMaterial, PBRMaterial.Model>(scene, CLASS_ID.PBR_MATERIAL, model);
+
             SharedComponentAttach(material, entity);
+
             return material;
         }
 
@@ -635,10 +648,7 @@ namespace DCL.Helpers
             return componentId;
         }
 
-        public static void UpdateShape(ParcelScene scene, string componentId, string model)
-        {
-            scene.componentsManagerLegacy.SceneSharedComponentUpdate(componentId, model);
-        }
+        public static void UpdateShape(ParcelScene scene, string componentId, string model) { scene.componentsManagerLegacy.SceneSharedComponentUpdate(componentId, model); }
 
         static object GetRandomValueForType(System.Type t)
         {
@@ -746,6 +756,7 @@ namespace DCL.Helpers
 
             IPoolableComponentFactory poolableFactory =
                 Resources.Load<PoolableComponentFactory>("PoolableCoreComponentsFactory");
+
             ;
             int id = (int) poolableFactory.GetIdForType<TComponent>();
 
@@ -842,6 +853,7 @@ namespace DCL.Helpers
             // make sure the shape is collidable first
             shapeModel.withCollisions = true;
             SharedComponentUpdate(shapeComponent, shapeModel);
+
             yield return shapeComponent.routine;
 
             // check every collider is enabled
@@ -855,6 +867,7 @@ namespace DCL.Helpers
             // update collision property with 'false'
             shapeModel.withCollisions = false;
             SharedComponentUpdate(shapeComponent, shapeModel);
+
             yield return shapeComponent.routine;
 
             // check colliders correct behaviour
@@ -866,6 +879,7 @@ namespace DCL.Helpers
             // update collision property with 'true' again
             shapeModel.withCollisions = true;
             SharedComponentUpdate(shapeComponent, shapeModel);
+
             yield return shapeComponent.routine;
 
             // check colliders correct behaviour
@@ -881,6 +895,7 @@ namespace DCL.Helpers
         {
             // make sure the shape is visible first
             shapeModel.visible = true;
+
             yield return SharedComponentUpdate(shapeComponent, shapeModel);
 
             // check every mesh is shown by default
@@ -895,6 +910,7 @@ namespace DCL.Helpers
 
             // update visibility with 'false'
             shapeModel.visible = false;
+
             yield return SharedComponentUpdate(shapeComponent, shapeModel);
 
             // check renderers correct behaviour
@@ -905,6 +921,7 @@ namespace DCL.Helpers
 
             // update visibility with 'true'
             shapeModel.visible = true;
+
             yield return SharedComponentUpdate(shapeComponent, shapeModel);
 
             // check renderers correct behaviour
@@ -919,16 +936,19 @@ namespace DCL.Helpers
         {
             // make sure the shape is visible first
             shapeModel.visible = true;
+
             yield return SharedComponentUpdate(shapeComponent, shapeModel);
             yield return TestShapeOnPointerEventCollider(entity);
 
             // update visibility with 'false'
             shapeModel.visible = false;
+
             yield return SharedComponentUpdate(shapeComponent, shapeModel);
             yield return TestShapeOnPointerEventCollider(entity);
 
             // update visibility with 'true'
             shapeModel.visible = true;
+
             yield return SharedComponentUpdate(shapeComponent, shapeModel);
             yield return TestShapeOnPointerEventCollider(entity);
         }
@@ -948,9 +968,11 @@ namespace DCL.Helpers
             ParcelScene scene = entity.scene as ParcelScene;
 
             var onClickComponent = TestUtils.EntityComponentCreate<OnClick, OnClick.Model>(scene, entity, onClickComponentModel, CLASS_ID_COMPONENT.UUID_CALLBACK);
+
             yield return onClickComponent.routine;
 
             Collider onPointerEventCollider;
+
             for (int i = 0; i < renderers.Length; i++)
             {
                 Assert.IsTrue(renderers[i].transform.childCount > 0, "OnClick collider should exist as this mesh's child");
@@ -967,6 +989,7 @@ namespace DCL.Helpers
                 entity.entityId,
                 onClickComponent.name
             );
+
             yield return null;
         }
 
@@ -975,6 +998,7 @@ namespace DCL.Helpers
             where TComponentModel : UIShape.Model, new()
         {
             UIScreenSpace parentElement = TestUtils.SharedComponentCreate<UIScreenSpace, UIScreenSpace.Model>(scene, CLASS_ID.UI_SCREEN_SPACE_SHAPE);
+
             yield return parentElement.routine;
 
             // make canvas invisible
@@ -989,6 +1013,7 @@ namespace DCL.Helpers
                         width = new UIValue(100f),
                         height = new UIValue(100f)
                     });
+
             yield return targetUIElement.routine;
 
             RectTransform uiCanvasRectTransform = parentElement.childHookRectTransform.GetComponentInParent<RectTransform>();
@@ -1160,6 +1185,7 @@ namespace DCL.Helpers
             for (int i = SceneManager.sceneCount - 1; i >= 0; i--)
             {
                 var scene = SceneManager.GetSceneAt(i);
+
                 yield return SceneManager.UnloadSceneAsync(scene);
             }
         }
@@ -1191,6 +1217,7 @@ namespace DCL.Helpers
             yield return new DCL.WaitUntil(() =>
             {
                 OnIterationStart?.Invoke();
+
                 return awaitedConditionMet;
             }, 2f);
 
@@ -1241,6 +1268,7 @@ namespace DCL.Helpers
                 if (OnMessageReceived == null)
                 {
                     messageWasReceived = true;
+
                     return;
                 }
 
@@ -1253,6 +1281,7 @@ namespace DCL.Helpers
             yield return new DCL.WaitUntil(() =>
             {
                 OnIterationStart?.Invoke();
+
                 return messageWasReceived;
             }, 2f);
 
@@ -1263,12 +1292,16 @@ namespace DCL.Helpers
         {
             Assert.AreEqual(Vector2.zero, rt.anchorMin,
                 $"Rect transform {rt.name} isn't stretched out!. unexpected anchorMin value.");
+
             Assert.AreEqual(Vector2.zero, rt.offsetMin,
                 $"Rect transform {rt.name} isn't stretched out!. unexpected offsetMin value.");
+
             Assert.AreEqual(Vector2.one, rt.anchorMax,
                 $"Rect transform {rt.name} isn't stretched out!. unexpected anchorMax value.");
+
             Assert.AreEqual(Vector2.one, rt.offsetMax,
                 $"Rect transform {rt.name} isn't stretched out!. unexpected offsetMax value.");
+
             Assert.AreEqual(Vector2.zero, rt.sizeDelta,
                 $"Rect transform {rt.name} isn't stretched out!. unexpected sizeDelta value.");
         }
@@ -1278,6 +1311,7 @@ namespace DCL.Helpers
         public static IEnumerator WaitForGLTFLoad(IDCLEntity entity)
         {
             LoadWrapper_GLTF wrapper = Environment.i.world.state.GetLoaderForEntity(entity) as LoadWrapper_GLTF;
+
             return new WaitUntil(() => wrapper.alreadyLoaded);
         }
 
@@ -1290,12 +1324,17 @@ namespace DCL.Helpers
 
             if (data.parcels == null)
             {
-                data.parcels = new Vector2Int[] {data.basePosition};
+                data.parcels = new Vector2Int[] { data.basePosition };
             }
 
             if (string.IsNullOrEmpty(data.id))
             {
                 data.id = $"(test):{data.basePosition.x},{data.basePosition.y}";
+            }
+
+            if (Environment.i.world.state.ContainsScene(data.id))
+            {
+                Environment.i.world.state.GetScene(data.id);
             }
 
             var go = new GameObject();
@@ -1306,14 +1345,14 @@ namespace DCL.Helpers
 
             if (DCLCharacterController.i != null)
                 newScene.InitializeDebugPlane();
-            
+
+            Environment.i.world.state.AddScene(data.id, newScene);
+            Environment.i.world.state.SortScenesByDistance(Vector2Int.zero);
+
             return newScene;
         }
 
-        public static T CreateComponentWithGameObject<T>(string gameObjectName) where T : Component
-        {
-            return new GameObject(gameObjectName).AddComponent<T>();
-        }
+        public static T CreateComponentWithGameObject<T>(string gameObjectName) where T : Component { return new GameObject(gameObjectName).AddComponent<T>(); }
 
         // NUnit version of Unity is not up to day and doesnt have ThrowsAsync assertions, this mimics it:
         // https://forum.unity.com/threads/can-i-replace-upgrade-unitys-nunit.488580/#post-6543523
@@ -1340,8 +1379,10 @@ namespace DCL.Helpers
                 {
                     Assert.That(e, Is.TypeOf<T>(), e.ToString());
                 }
+
                 throw; //probably unreachable
             }
+
             Assert.Fail("Expected an exception of type " + typeof(T).FullName + " but no exception was thrown."  );
         }
     }

--- a/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
+++ b/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
@@ -1298,15 +1298,6 @@ namespace DCL.Helpers
                 data.id = $"(test):{data.basePosition.x},{data.basePosition.y}";
             }
 
-            if (Environment.i.world.state.loadedScenes != null)
-            {
-                if (Environment.i.world.state.loadedScenes.ContainsKey(data.id))
-                {
-                    Debug.LogWarning($"Scene {data.id} is already loaded.");
-                    return Environment.i.world.state.loadedScenes[data.id] as ParcelScene;
-                }
-            }
-
             var go = new GameObject();
             var newScene = go.AddComponent<ParcelScene>();
             newScene.isTestScene = true;
@@ -1315,10 +1306,7 @@ namespace DCL.Helpers
 
             if (DCLCharacterController.i != null)
                 newScene.InitializeDebugPlane();
-
-            Environment.i.world.state.scenesSortedByDistance?.Add(newScene);
-            Environment.i.world.state.loadedScenes?.Add(data.id, newScene);
-
+            
             return newScene;
         }
 

--- a/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
+++ b/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
@@ -1314,7 +1314,7 @@ namespace DCL.Helpers
 
             return new WaitUntil(() => wrapper.alreadyLoaded);
         }
-
+        
         public static ParcelScene CreateTestScene(LoadParcelScenesMessage.UnityParcelScene data = null)
         {
             if (data == null)
@@ -1347,7 +1347,7 @@ namespace DCL.Helpers
                 newScene.InitializeDebugPlane();
 
             Environment.i.world.state.AddScene(data.id, newScene);
-            Environment.i.world.state.SortScenesByDistance(Vector2Int.zero);
+            Environment.i.world.state.ForceCurrentScene(data.id);
 
             return newScene;
         }

--- a/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
+++ b/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
@@ -48,8 +48,6 @@ public class VisualTestsBase : IntegrationTestSuite_Legacy
         uiComponentsPlugin = new UIComponentsPlugin();
         uiRefresherPlugin = new UIRefresherPlugin();
 
-        DCL.Environment.i.world.state.currentSceneId = scene.sceneData.id;
-
         VisualTestUtils.snapshotIndex = 0;
 
         VisualTestUtils.SetTestingRenderSettings();

--- a/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
+++ b/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
@@ -65,6 +65,8 @@ public class VisualTestsBase : IntegrationTestSuite_Legacy
         UnityEngine.RenderSettings.fogStartDistance = 100;
         UnityEngine.RenderSettings.fogEndDistance = 110;
 
+        DCL.Environment.i.world.state.ForceCurrentScene( scene.sceneData.id);
+        
         VisualTestUtils.RepositionVisualTestsCamera(camera, new Vector3(0, 2, 0));
     }
 

--- a/unity-renderer/Assets/TextMesh Pro/Resources/Fonts & Materials/Inter-Regular SDF.asset
+++ b/unity-renderer/Assets/TextMesh Pro/Resources/Fonts & Materials/Inter-Regular SDF.asset
@@ -49,6 +49,7 @@ Material:
     - _BumpFace: 0
     - _BumpOutline: 0
     - _ColorMask: 15
+    - _CullMode: 0
     - _Diffuse: 0.5
     - _FaceDilate: 0
     - _FaceUVSpeedX: 0
@@ -73,6 +74,7 @@ Material:
     - _ScaleX: 1
     - _ScaleY: 1
     - _ShaderFlags: 0
+    - _Sharpness: 0
     - _SpecularPower: 2
     - _Stencil: 0
     - _StencilComp: 8
@@ -113,15 +115,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Inter-Regular SDF
   m_EditorClassIdentifier: 
-  hashCode: 1383506018
-  material: {fileID: -6676260188536263158}
-  materialHashCode: 2012274050
   m_Version: 1.1.0
-  m_SourceFontFileGUID: dc6cf9e57ef7e42e8a8968ea4a8b2cfa
-  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: dc6cf9e57ef7e42e8a8968ea4a8b2cfa,
-    type: 3}
-  m_SourceFontFile: {fileID: 0}
-  m_AtlasPopulationMode: 0
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: Inter UI
@@ -143,6 +137,12 @@ MonoBehaviour:
     m_StrikethroughOffset: 7.6
     m_StrikethroughThickness: 2.0525568
     m_TabWidth: 10
+  m_Material: {fileID: -6676260188536263158}
+  m_SourceFontFileGUID: dc6cf9e57ef7e42e8a8968ea4a8b2cfa
+  m_SourceFontFile: {fileID: 0}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 0
+  InternalDynamicOS: 0
   m_GlyphTable:
   - m_Index: 2
     m_Metrics:
@@ -5226,6 +5226,10 @@ MonoBehaviour:
   m_AtlasTextureIndex: 0
   m_IsMultiAtlasTexturesEnabled: 0
   m_ClearDynamicDataOnBuild: 0
+  m_AtlasWidth: 512
+  m_AtlasHeight: 512
+  m_AtlasPadding: 5
+  m_AtlasRenderMode: 4165
   m_UsedGlyphRects:
   - m_X: 0
     m_Y: 0
@@ -6900,39 +6904,13 @@ MonoBehaviour:
     m_Y: 302
     m_Width: 13
     m_Height: 108
-  m_fontInfo:
-    Name: 
-    PointSize: 0
-    Scale: 0
-    CharacterCount: 0
-    LineHeight: 0
-    Baseline: 0
-    Ascender: 0
-    CapHeight: 0
-    Descender: 0
-    CenterLine: 0
-    SuperscriptOffset: 0
-    SubscriptOffset: 0
-    SubSize: 0
-    Underline: 0
-    UnderlineThickness: 0
-    strikethrough: 0
-    strikethroughThickness: 0
-    TabWidth: 0
-    Padding: 0
-    AtlasWidth: 0
-    AtlasHeight: 0
-  atlas: {fileID: 0}
-  m_AtlasWidth: 512
-  m_AtlasHeight: 512
-  m_AtlasPadding: 5
-  m_AtlasRenderMode: 4165
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
   m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
     m_GlyphPairAdjustmentRecords: []
-  fallbackFontAssets: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable:
   - {fileID: 11400000, guid: 82f86e6c95d775f4e8488447b6885323, type: 2}
   - {fileID: 11400000, guid: 4cc5b9c92b8be214dbbd4f1f502110de, type: 2}
@@ -6940,9 +6918,11 @@ MonoBehaviour:
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 09b97968322d548d48263701ed418976
+    faceIndex: 0
     pointSizeSamplingMode: 0
     pointSize: 34
     padding: 5
+    paddingMode: 0
     packingMode: 0
     atlasWidth: 512
     atlasHeight: 512
@@ -6982,6 +6962,33 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}
 --- !u!28 &1385607251689435446
 Texture2D:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/TextMesh Pro/Resources/Fonts & Materials/Inter-SemiBold SDF.asset
+++ b/unity-renderer/Assets/TextMesh Pro/Resources/Fonts & Materials/Inter-SemiBold SDF.asset
@@ -59,15 +59,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Inter-SemiBold SDF
   m_EditorClassIdentifier: 
-  hashCode: -76807953
-  material: {fileID: 1196159134475820439}
-  materialHashCode: 1292101103
   m_Version: 1.1.0
-  m_SourceFontFileGUID: b35565151a8cb443e8e3f0ba313dc5c5
-  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: b35565151a8cb443e8e3f0ba313dc5c5,
-    type: 3}
-  m_SourceFontFile: {fileID: 0}
-  m_AtlasPopulationMode: 0
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: Inter UI
@@ -89,6 +81,12 @@ MonoBehaviour:
     m_StrikethroughOffset: 7.2
     m_StrikethroughThickness: 2.390625
     m_TabWidth: 8
+  m_Material: {fileID: 1196159134475820439}
+  m_SourceFontFileGUID: b35565151a8cb443e8e3f0ba313dc5c5
+  m_SourceFontFile: {fileID: 0}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 0
+  InternalDynamicOS: 0
   m_GlyphTable:
   - m_Index: 2
     m_Metrics:
@@ -5172,6 +5170,10 @@ MonoBehaviour:
   m_AtlasTextureIndex: 0
   m_IsMultiAtlasTexturesEnabled: 0
   m_ClearDynamicDataOnBuild: 0
+  m_AtlasWidth: 512
+  m_AtlasHeight: 512
+  m_AtlasPadding: 5
+  m_AtlasRenderMode: 4165
   m_UsedGlyphRects:
   - m_X: 0
     m_Y: 0
@@ -6826,39 +6828,13 @@ MonoBehaviour:
     m_Y: 346
     m_Width: 35
     m_Height: 130
-  m_fontInfo:
-    Name: 
-    PointSize: 0
-    Scale: 0
-    CharacterCount: 0
-    LineHeight: 0
-    Baseline: 0
-    Ascender: 0
-    CapHeight: 0
-    Descender: 0
-    CenterLine: 0
-    SuperscriptOffset: 0
-    SubscriptOffset: 0
-    SubSize: 0
-    Underline: 0
-    UnderlineThickness: 0
-    strikethrough: 0
-    strikethroughThickness: 0
-    TabWidth: 0
-    Padding: 0
-    AtlasWidth: 0
-    AtlasHeight: 0
-  atlas: {fileID: 0}
-  m_AtlasWidth: 512
-  m_AtlasHeight: 512
-  m_AtlasPadding: 5
-  m_AtlasRenderMode: 4165
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
   m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
     m_GlyphPairAdjustmentRecords: []
-  fallbackFontAssets: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable:
   - {fileID: 11400000, guid: 82f86e6c95d775f4e8488447b6885323, type: 2}
   - {fileID: 11400000, guid: 4cc5b9c92b8be214dbbd4f1f502110de, type: 2}
@@ -6866,9 +6842,11 @@ MonoBehaviour:
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 3942118ae9f584456a7a70d2ad9a8d31
+    faceIndex: 0
     pointSizeSamplingMode: 0
     pointSize: 33
     padding: 5
+    paddingMode: 0
     packingMode: 0
     atlasWidth: 512
     atlasHeight: 512
@@ -6908,6 +6886,33 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}
 --- !u!21 &1196159134475820439
 Material:
   serializedVersion: 6
@@ -6917,7 +6922,7 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Inter-SemiBold SDF Material
   m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
-  m_ShaderKeywords: 
+  m_ShaderKeywords: OUTLINE_ON
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -6957,6 +6962,7 @@ Material:
     - _BumpFace: 0
     - _BumpOutline: 0
     - _ColorMask: 15
+    - _CullMode: 0
     - _Diffuse: 0.5
     - _FaceDilate: 0
     - _FaceUVSpeedX: 0
@@ -6981,6 +6987,7 @@ Material:
     - _ScaleX: 1
     - _ScaleY: 1
     - _ShaderFlags: 0
+    - _Sharpness: 0
     - _SpecularPower: 2
     - _Stencil: 0
     - _StencilComp: 8

--- a/unity-renderer/Assets/Textures/UI/Emotes/EmotesAtlas.spriteatlas
+++ b/unity-renderer/Assets/Textures/UI/Emotes/EmotesAtlas.spriteatlas
@@ -31,7 +31,6 @@ SpriteAtlas:
     secondaryTextureSettings: {}
     variantMultiplier: 1
     packables: []
-    totalSpriteSurfaceArea: 0
     bindAsDefault: 1
     isAtlasV2: 0
     cachedData: {fileID: 0}

--- a/unity-renderer/Assets/Textures/UI/TexturesUI.spriteatlas
+++ b/unity-renderer/Assets/Textures/UI/TexturesUI.spriteatlas
@@ -56,7 +56,6 @@ SpriteAtlas:
     variantMultiplier: 1
     packables:
     - {fileID: 102900000, guid: 1eee3b038d846456b84c415627892c52, type: 3}
-    totalSpriteSurfaceArea: 5488409
     bindAsDefault: 1
     isAtlasV2: 0
     cachedData: {fileID: 0}
@@ -74,6 +73,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 88dde3500b2da42c89518050e5250b21, type: 3}
   - {fileID: 21300000, guid: 8e5a1950f42154e5dac07dae292d5c6a, type: 3}
   - {fileID: 21300000, guid: 90d19c500d961c44f8941c69dcdae46a, type: 3}
+  - {fileID: 21300000, guid: 91681e50568d84e93b76b1767abc283f, type: 3}
   - {fileID: 21300000, guid: 9ee0d9605c0e04a57946e54a0b997c90, type: 3}
   - {fileID: 21300000, guid: 8be7de606f9c7ca4cbc9d31a3a82dfd5, type: 3}
   - {fileID: 21300000, guid: b6b6bf6065bcc4d26939c4f9986de3da, type: 3}
@@ -91,6 +91,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 3354932168610498ebc347e78ae840d7, type: 3}
   - {fileID: 21300000, guid: 38dc6a210cae34a439bd286f6c382165, type: 3}
   - {fileID: 21300000, guid: e8a30441514b5499ea02a9e5a4617028, type: 3}
+  - {fileID: 21300000, guid: 5fc25d41256974b138a7c25b1c0b30de, type: 3}
   - {fileID: 21300000, guid: 4b1c9751d9ed642a190d2431fa02b5f8, type: 3}
   - {fileID: 21300000, guid: 35d9dd519b2dd8a47a6f251b25fded0f, type: 3}
   - {fileID: 21300000, guid: 24bad1613b3e14b969cf6086aa095ffc, type: 3}
@@ -125,7 +126,6 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 03b222c2450ce4c57ba7e9d6268b0c92, type: 3}
   - {fileID: 21300000, guid: 147d94c24838a2647bbaf2fb16ac913c, type: 3}
   - {fileID: 21300000, guid: 166eccd2b230b3a45b65e30f02348cd6, type: 3}
-  - {fileID: 21300000, guid: 01b18fd2b4265411bbd6afcd11e373cc, type: 3}
   - {fileID: 21300000, guid: a628efe28360b426c8ca23b43ad06c2b, type: 3}
   - {fileID: 21300000, guid: 04c3edf2ef4a747ffbe6f20a72aac0d9, type: 3}
   - {fileID: 21300000, guid: 3e119603a7cc61744b63c95d90495efc, type: 3}
@@ -158,6 +158,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 0822ae34e463d49f49b978299714fd21, type: 3}
   - {fileID: 21300000, guid: 65d50244ec48c4d31b169fe48412f711, type: 3}
   - {fileID: 21300000, guid: b85ea444031cf415f95fa3022c2305dc, type: 3}
+  - {fileID: 21300000, guid: 06ec3644c3f104203b897e53615acd2c, type: 3}
   - {fileID: 21300000, guid: 2cc1bc54dd98f77459c059ab58670f74, type: 3}
   - {fileID: 21300000, guid: 14d01e642387749e482a6f14133c57b8, type: 3}
   - {fileID: 21300000, guid: 51517794ebfef5b49b08d321c661cee2, type: 3}
@@ -188,6 +189,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 1a32f285ef84d8e44856f0e495cffd4d, type: 3}
   - {fileID: 21300000, guid: 5c569e851fe024c7e8e4b57c07575226, type: 3}
   - {fileID: 21300000, guid: 4308be85a340e4a2b9b19adedb9593f8, type: 3}
+  - {fileID: 21300000, guid: 5e9852a564f64410f8029a89c63e85c1, type: 3}
   - {fileID: 21300000, guid: 54679ca5073f143a6b562c4f5c5f81ef, type: 3}
   - {fileID: 21300000, guid: 520d44b5687394783ae96976dbb73c7c, type: 3}
   - {fileID: 21300000, guid: 643485b56259a47ff8f14e9b10fd47bb, type: 3}
@@ -196,6 +198,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: e2754ed5e27ef44bfaacd0c451d88263, type: 3}
   - {fileID: 21300000, guid: 8ee9aed5af74d4e399555cda5681978e, type: 3}
   - {fileID: 21300000, guid: 5082f4f53f951407fadf55de7e770f50, type: 3}
+  - {fileID: 21300000, guid: f8e385f5fbb5940f09971392899eb6ff, type: 3}
   - {fileID: 21300000, guid: b16568f5e2de64c8dbc491d9ac2830e9, type: 3}
   - {fileID: 21300000, guid: 91e559f524592ad4a94afd8829f86e75, type: 3}
   - {fileID: 21300000, guid: b7f3fdf5bf2a24afdaeef1c2d7edb8ea, type: 3}
@@ -214,7 +217,9 @@ SpriteAtlas:
   - {fileID: 21300000, guid: e42d263701088429292b3462f9d1d21c, type: 3}
   - {fileID: 21300000, guid: 0771864752bc141ab96ff9dcc751419d, type: 3}
   - {fileID: 21300000, guid: 6b35c647bc47eb94486089adcb53c8b9, type: 3}
+  - {fileID: 21300000, guid: a6be5747f33e34c91922c7512b0f445a, type: 3}
   - {fileID: 21300000, guid: f00094572a9874a0e92b4d347ce91bba, type: 3}
+  - {fileID: 21300000, guid: afd325574219143ac872ad347827c300, type: 3}
   - {fileID: 21300000, guid: 243dd557f2b614bc5ba2599f40d20448, type: 3}
   - {fileID: 21300000, guid: 7b4468575e3ab49e1aec3edd88298137, type: 3}
   - {fileID: 21300000, guid: 5f5d6367f6d5ebc4ab5480df6fb70c5f, type: 3}
@@ -224,6 +229,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 058e0097872914023991446b014562ef, type: 3}
   - {fileID: 21300000, guid: c319fd971d09e1745b925fff3aa3012a, type: 3}
   - {fileID: 21300000, guid: b2755fa77563aad42bfdaa03c0e54746, type: 3}
+  - {fileID: 21300000, guid: 451b9fa7c6c084bb2967830f3d587b3a, type: 3}
   - {fileID: 21300000, guid: 7404b1b7d6b0f40929ae536f5b39be50, type: 3}
   - {fileID: 21300000, guid: 9af081c7b27544b809eda744a31a2889, type: 3}
   - {fileID: 21300000, guid: b0b580e7bcb4e4d1fb4fc635fd057a89, type: 3}
@@ -231,6 +237,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 9ef211f7dbe2c4e13911b4054a18334b, type: 3}
   - {fileID: 21300000, guid: e0fcedf7c3fa64d24b85a27aa8bb93a9, type: 3}
   - {fileID: 21300000, guid: ec2731182caf94ac1a2c3e37bed6c769, type: 3}
+  - {fileID: 21300000, guid: dcbf4a1870c524ae5a2d1bad9d1bf3ea, type: 3}
   - {fileID: 21300000, guid: 2b2f4028cd39d984e80dabe0732fdd87, type: 3}
   - {fileID: 21300000, guid: 7fa4c0281629e43abbcb190d00fe187a, type: 3}
   - {fileID: 21300000, guid: 08d52e28c31ca4d049008be051e8b8a1, type: 3}
@@ -254,6 +261,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 874182f8d364145bd9836b8e817019eb, type: 3}
   - {fileID: 21300000, guid: 9ed344f88537e43a6b35556d00b77b39, type: 3}
   - {fileID: 21300000, guid: bc1386f864ce3b64baafbb1e74763408, type: 3}
+  - {fileID: 21300000, guid: b44b6109984974ac6bb84146469cbc7a, type: 3}
   - {fileID: 21300000, guid: 87bf14092660947eb9909d5772886279, type: 3}
   - {fileID: 21300000, guid: 5dc96a095ce3483459044bf3e74ccb59, type: 3}
   - {fileID: 21300000, guid: 314ecf09e6e7447d9aa0421d996754cc, type: 3}
@@ -261,6 +269,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 1c63e329c16184c1bb493ada5f85c91b, type: 3}
   - {fileID: 21300000, guid: f9934449af9e15443befe12f639d5979, type: 3}
   - {fileID: 21300000, guid: e36f3569fbdef4c609c33f7a1cebace5, type: 3}
+  - {fileID: 21300000, guid: ad6a5c692d0a34fbe8f1e4dd9bee0c2b, type: 3}
   - {fileID: 21300000, guid: 46524689a799e4be9941af9ef6f45a89, type: 3}
   - {fileID: 21300000, guid: 247c07994d33848d5be25ccac8f0538d, type: 3}
   - {fileID: 21300000, guid: 604176a988cdc416ca612d5e95156254, type: 3}
@@ -273,7 +282,6 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 8631f81a1b5cb4bfea4f8cd0fcfd6d76, type: 3}
   - {fileID: 21300000, guid: a1317b1aff4d943b9b7361cc061816bf, type: 3}
   - {fileID: 21300000, guid: 7b9d8b2a13149489fac02d8d802c41b6, type: 3}
-  - {fileID: 21300000, guid: c911da3afe9724d9e9b54f5a13c970d7, type: 3}
   - {fileID: 21300000, guid: 4716bd3a235374a27bd75705f5b7a1af, type: 3}
   - {fileID: 21300000, guid: 0b63c85aaf7c44493a7613587a1a8a4f, type: 3}
   - {fileID: 21300000, guid: df21406aac3b94b18b9edcf3e6ae36c4, type: 3}
@@ -317,6 +325,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 7bfca4cb270a343c682028817c0d5bf4, type: 3}
   - {fileID: 21300000, guid: fe4a00db663ed4d3abe06167ea5b3317, type: 3}
   - {fileID: 21300000, guid: c7f8f6db5623d8f4c935edeff9912df8, type: 3}
+  - {fileID: 21300000, guid: c7140bdb251224b66aba206fd5ff73ee, type: 3}
   - {fileID: 21300000, guid: 07a400eb205264a4f9e2aad5d599b4a3, type: 3}
   - {fileID: 21300000, guid: 42eb1ceb0cb414d60b49ce912a143517, type: 3}
   - {fileID: 21300000, guid: 64b96cebc797f4e75ad10e05ff68466f, type: 3}
@@ -336,10 +345,12 @@ SpriteAtlas:
   - {fileID: 21300000, guid: b3dde05c995029e4c8e4a4acd0f99337, type: 3}
   - {fileID: 21300000, guid: 2dcab87c551ac42a3b30debae889baad, type: 3}
   - {fileID: 21300000, guid: f0bcc87cbbf78438ebfb049f6c1aa203, type: 3}
+  - {fileID: 21300000, guid: 6017049c5a0dc43f6a4a68f1b4e28664, type: 3}
   - {fileID: 21300000, guid: 31a98abcdcc4e4022b74038cdc7154be, type: 3}
   - {fileID: 21300000, guid: 21fb0bbc6fe494c8789ea7221ac96c59, type: 3}
   - {fileID: 21300000, guid: ce0e66cca3918473693726f3bf7da082, type: 3}
   - {fileID: 21300000, guid: a6f0d6dcdab344ad88af35e7ed9071b5, type: 3}
+  - {fileID: 21300000, guid: cfa089dc4012b4f59964c220fbf31fba, type: 3}
   - {fileID: 21300000, guid: 6d5f6edc2bfb441e1969ee1e10c3c572, type: 3}
   - {fileID: 21300000, guid: 2f88b1fc7390f42f881f72ccfcde00db, type: 3}
   - {fileID: 21300000, guid: 654b9c0dd7f12442687bd4d4b034ece7, type: 3}
@@ -352,6 +363,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: a0422c4d3e4fd483f98f3bbd16e5ae2e, type: 3}
   - {fileID: 21300000, guid: 59758d5dbedcd0746be3439895558d6a, type: 3}
   - {fileID: 21300000, guid: 4ee2739d276aba843bd732c5a4a40dad, type: 3}
+  - {fileID: 21300000, guid: c6cb56bd6fdab4d49879218fffcfc7f7, type: 3}
   - {fileID: 21300000, guid: afc72abd3262c43798a1167db98081d9, type: 3}
   - {fileID: 21300000, guid: 463541cd13ac34ce992618e04bc5dc9f, type: 3}
   - {fileID: 21300000, guid: ffdb9ddd1a2d940e5a6daf599ae1c755, type: 3}
@@ -409,6 +421,7 @@ SpriteAtlas:
   - CellBright
   - RarityCornerWheel
   - mc_hammer_256
+  - Mic off
   - Spinner
   - DclLogoBg
   - RectRadius8
@@ -426,6 +439,7 @@ SpriteAtlas:
   - DownloadIconOutline
   - ContainerShadowRadiusFour
   - NFTStarContainer
+  - SpeakerOn
   - ContainerRadius6
   - VoiceChatCross
   - DecentralandIsologotipo68
@@ -460,7 +474,6 @@ SpriteAtlas:
   - WifiIcon
   - PolygonManaIcon
   - MicrophoneVoiceChatOn
-  - VoiceChatOn
   - DisclaimerBackground
   - NFTContainer
   - ExperienceIconOff
@@ -493,6 +506,7 @@ SpriteAtlas:
   - DialogCornerRight
   - ConnectionStatus
   - Container12Shadow20
+  - SpeakerOff
   - HideIcon
   - Container12Shadow4
   - DclLogoCircle
@@ -523,6 +537,7 @@ SpriteAtlas:
   - RectRadius12Shadow
   - RectRadius12Bottom
   - Label26
+  - VoiceChatOff
   - BugIcon
   - GraphicsIcon
   - ArrowLeft
@@ -531,6 +546,7 @@ SpriteAtlas:
   - CodeIcon
   - BackgroundValue
   - SearchBarBuilder
+  - VoiceChatOn
   - PoiIcon
   - ImageIcon
   - ExploreOff
@@ -549,7 +565,9 @@ SpriteAtlas:
   - PlacesIcon
   - ProfileHudTopContainer
   - no-image-icon-32
+  - ChatOn
   - QuestIcon
+  - FriendsOn
   - Switch32
   - ContainerRadius11Shadow
   - WalletConnectLogo
@@ -559,6 +577,7 @@ SpriteAtlas:
   - VoiceChatDisable
   - ShowIcon
   - RoundedContainer23
+  - FriendsIconHD
   - MouseLocked
   - FriendsListImage
   - DayModeIcon
@@ -566,6 +585,7 @@ SpriteAtlas:
   - AudioIcon
   - MapIcon
   - WheelSlot
+  - JoinVoiceChat
   - fist_pump_256
   - GeneralIcon
   - NFTFrame
@@ -589,6 +609,7 @@ SpriteAtlas:
   - BackButton
   - ContainerShadow
   - QuitIcon
+  - Mic on
   - DecentralandLogo
   - disco_dance_256
   - RejectButtonHover
@@ -596,6 +617,7 @@ SpriteAtlas:
   - Frame12
   - ContainerRadius24Shadow
   - Ellipse128
+  - FriendsOff
   - FloorLight
   - MessageIcon
   - FriendsIcon
@@ -608,7 +630,6 @@ SpriteAtlas:
   - Shadow
   - OngoingEventIcon
   - Handle
-  - EmotesOff
   - MicrophoneIcon
   - ContainerRadius16
   - CardCollectiblesIcon
@@ -652,6 +673,7 @@ SpriteAtlas:
   - SettingsVolumetricIcon
   - Compass
   - rectangle_gray_corner_radius_8
+  - EmotesOn
   - BackpackIconNew
   - Ellipse32
   - ChatIcon
@@ -671,10 +693,12 @@ SpriteAtlas:
   - InputRed
   - CrowdIcon
   - OutlineGradient
+  - EndVoiceChat
   - HelpIcon
   - SettingsOff
   - VoiceChatPlayer
   - HideNameIcon
+  - ChatOff
   - ArrowGradient
   - ContainerOutline100
   - MarketplaceOn
@@ -687,6 +711,7 @@ SpriteAtlas:
   - Div
   - rectangle_100
   - talk_to_hand_256
+  - EmotesOff
   - OutlineRightRect12
   - Cursor
   - Container24Shadow4

--- a/unity-renderer/Assets/Tutorial/Atlas/TutorialStepsAtlas.spriteatlas
+++ b/unity-renderer/Assets/Tutorial/Atlas/TutorialStepsAtlas.spriteatlas
@@ -56,7 +56,6 @@ SpriteAtlas:
     variantMultiplier: 1
     packables:
     - {fileID: 102900000, guid: 3acab99763c85c14a98d022b27506bbf, type: 3}
-    totalSpriteSurfaceArea: 110393
     bindAsDefault: 1
     isAtlasV2: 0
     cachedData: {fileID: 0}

--- a/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
@@ -45,7 +45,7 @@ namespace DCL.Tutorial
 
                 if (Environment.i != null && Environment.i.world != null)
                 {
-                    WebInterface.SendSceneExternalActionEvent(Environment.i.world.state.currentSceneId, "tutorial", "begin");
+                    WebInterface.SendSceneExternalActionEvent(Environment.i.world.state.GetCurrentSceneId(), "tutorial", "begin");
                 }
             }
         }

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
@@ -218,7 +218,7 @@ namespace DCL.Tutorial
 
             if (Environment.i != null && Environment.i.world != null)
             {
-                WebInterface.SendSceneExternalActionEvent(Environment.i.world.state.currentSceneId, "tutorial", "end");
+                WebInterface.SendSceneExternalActionEvent(Environment.i.world.state.GetCurrentSceneId(), "tutorial", "end");
             }
 
             NotificationsController.disableWelcomeNotification = false;
@@ -601,7 +601,7 @@ namespace DCL.Tutorial
         {
             IWorldState worldState = Environment.i.world.state;
 
-            if (worldState == null || worldState.currentSceneId == null)
+            if (worldState == null || worldState.GetCurrentSceneId() == null)
                 return false;
 
             return true;
@@ -614,14 +614,12 @@ namespace DCL.Tutorial
 
             IWorldState worldState = Environment.i.world.state;
 
-            if (worldState == null || worldState.currentSceneId == null)
+            if (worldState == null || worldState.GetCurrentSceneId() == null)
                 return false;
 
             Vector2Int genesisPlazaBaseCoords = new Vector2Int(-9, -9);
 
-            IParcelScene currentScene = null;
-            if (worldState.loadedScenes != null)
-                currentScene = worldState.loadedScenes[worldState.currentSceneId];
+            var currentScene = worldState.GetScene(worldState.GetCurrentSceneId());
 
             if (currentScene != null && currentScene.IsInsideSceneBoundaries(genesisPlazaBaseCoords))
                 return true;

--- a/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
+++ b/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
@@ -7,6 +7,7 @@ using DCL.CameraTool;
 using DCL.Controllers;
 using DCL.Helpers;
 using DCL.Models;
+using NSubstitute;
 using Tests;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -28,11 +29,11 @@ namespace DCL.Tutorial_Tests
         protected override IEnumerator SetUp()
         {
             yield return base.SetUp();
-            Environment.i.world.state.loadedScenes = new Dictionary<string, IParcelScene>();
-            genesisPlazaSimulator = TestUtils.CreateTestScene();
+            genesisPlazaSimulator = TestUtils.CreateTestScene(new LoadParcelScenesMessage.UnityParcelScene() {basePosition = genesisPlazaLocation});
             genesisPlazaSimulator.isPersistent = false;
-            Environment.i.world.state.currentSceneId = genesisPlazaSimulator.sceneData.id;
-            genesisPlazaSimulator.parcels.Add(genesisPlazaLocation);
+            IWorldState worldState = Environment.i.world.state;
+            worldState.TryGetScene(Arg.Any<string>(), out Arg.Any<IParcelScene>()).Returns(param => param[1] = genesisPlazaSimulator);
+            
             CreateAndConfigureTutorial();
         }
 

--- a/unity-renderer/Assets/Tutorial/Tests/TutorialControllerTests.asmdef
+++ b/unity-renderer/Assets/Tutorial/Tests/TutorialControllerTests.asmdef
@@ -24,12 +24,16 @@
         "GUID:44a9db8f655ab05409802e5476cf9dd3",
         "GUID:a881b57670b1d2747a6d7f9e32b63230"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "NSubstitute.dll",
+        "System.Threading.Tasks.Extensions.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/unity-renderer/ProjectSettings/ProjectSettings.asset
+++ b/unity-renderer/ProjectSettings/ProjectSettings.asset
@@ -68,6 +68,12 @@ PlayerSettings:
   androidRenderOutsideSafeArea: 0
   androidUseSwappy: 0
   androidBlitType: 1
+  androidResizableWindow: 0
+  androidDefaultWindowWidth: 1920
+  androidDefaultWindowHeight: 1080
+  androidMinimumWindowWidth: 400
+  androidMinimumWindowHeight: 300
+  androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 1
@@ -121,6 +127,7 @@ PlayerSettings:
   vulkanEnableSetSRGBWrite: 0
   vulkanEnablePreTransform: 0
   vulkanEnableLateAcquireNextImage: 0
+  vulkanEnableCommandBufferRecycling: 1
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 1
@@ -237,6 +244,7 @@ PlayerSettings:
   useCustomGradlePropertiesTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 5
+  AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: '{inproject}: '
@@ -253,6 +261,7 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
+  chromeosInputEmulation: 1
   AndroidMinifyWithR8: 0
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
@@ -350,6 +359,7 @@ PlayerSettings:
   cameraUsageDescription: 
   locationUsageDescription: 
   microphoneUsageDescription: 
+  bluetoothUsageDescription: 
   switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144
@@ -487,6 +497,10 @@ PlayerSettings:
   switchNetworkInterfaceManagerInitializeEnabled: 1
   switchPlayerConnectionEnabled: 1
   switchUseNewStyleFilepaths: 0
+  switchUseMicroSleepForYield: 1
+  switchEnableRamDiskSupport: 0
+  switchMicroSleepForYieldTime: 25
+  switchRamDiskSpaceSize: 12
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -557,6 +571,7 @@ PlayerSettings:
   ps4videoRecordingFeaturesUsed: 0
   ps4contentSearchFeaturesUsed: 0
   ps4CompatibilityPS5: 0
+  ps4AllowPS5Detection: 0
   ps4GPU800MHz: 1
   ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []
@@ -646,6 +661,7 @@ PlayerSettings:
   metroFTAName: 
   metroFTAFileTypes: []
   metroProtocolName: 
+  vcxProjDefaultLanguage: 
   XboxOneProductId: 
   XboxOneUpdateKey: 
   XboxOneSandboxId: 


### PR DESCRIPTION
## What does this PR change?

It contains a refactor of the `WorldState` class for it to be a Data Object with completely encapsulated fields, also additional logic of SceneController was moved into `WorldState` because it makes more sense.

It closes #2861

## How to test the changes?

This change can mess everything up that requires scene data, so we have to do a bit of a smoke test on scenes with interactables, teleporting, transaction windows, smart wearables and maybe more. 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
