### PR TITLE
chore: implement use-gpu-only-meshes flag

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -189,6 +189,8 @@ namespace DCL
 
         private void UploadMeshesToGPU(HashSet<Mesh> meshesList)
         {
+            var uploadToGPU = DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(FeatureFlag.GPU_ONLY_MESHES);
+            
             foreach ( Mesh mesh in meshesList )
             {
                 if ( !mesh.isReadable )
@@ -196,6 +198,12 @@ namespace DCL
 
                 asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
                 asset.meshes.Add(mesh);
+                
+                if (uploadToGPU)
+                {
+                    Physics.BakeMesh(mesh.GetInstanceID(), false);
+                    mesh.UploadMeshData(true);
+                }
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -17,6 +17,7 @@ namespace DCL
 
         private BaseVariable<FeatureFlag> featureFlags => DataStore.i.featureFlags.flags;
         private const string AB_LOAD_ANIMATION = "ab_load_animation";
+        private const string GPU_ONLY_MESHES = "use_gpu_only_meshes";
         private bool doTransitionAnimation;
 
         public AssetPromise_AB_GameObject(string contentUrl, string hash) : base(contentUrl, hash)
@@ -189,7 +190,7 @@ namespace DCL
 
         private void UploadMeshesToGPU(HashSet<Mesh> meshesList)
         {
-            var uploadToGPU = DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(FeatureFlag.GPU_ONLY_MESHES);
+            var uploadToGPU = featureFlags.Get().IsFeatureEnabled(GPU_ONLY_MESHES);
             
             foreach ( Mesh mesh in meshesList )
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/FeatureFlags/Data/FeatureFlag.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/FeatureFlags/Data/FeatureFlag.cs
@@ -7,6 +7,8 @@ public class FeatureFlag
 {
     public readonly Dictionary<string, bool> flags  = new Dictionary<string, bool>();
     public readonly Dictionary<string, FeatureFlagVariant> variants  = new Dictionary<string, FeatureFlagVariant>();
+    
+    public const string GPU_ONLY_MESHES = "ab-use-gpu-only-meshes";
 
     public bool IsFeatureEnabled(string featureName)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/FeatureFlags/Data/FeatureFlag.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/FeatureFlags/Data/FeatureFlag.cs
@@ -8,7 +8,6 @@ public class FeatureFlag
     public readonly Dictionary<string, bool> flags  = new Dictionary<string, bool>();
     public readonly Dictionary<string, FeatureFlagVariant> variants  = new Dictionary<string, FeatureFlagVariant>();
     
-    public const string GPU_ONLY_MESHES = "ab-use-gpu-only-meshes";
 
     public bool IsFeatureEnabled(string featureName)
     {

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -100,6 +100,9 @@ namespace UnityGLTF
         private Settings settings;
 
         private  CancellationTokenSource ctokenSource;
+        
+        private const string GPU_ONLY_MESHES = "use_gpu_only_meshes";
+
 
         public Action OnSuccess { get { return OnFinishedLoadingAsset; } set { OnFinishedLoadingAsset = value; } }
 
@@ -348,8 +351,7 @@ namespace UnityGLTF
             sceneImporter.initialVisibility = initialVisibility;
             sceneImporter.addMaterialsToPersistentCaching = addMaterialsToPersistentCaching;
 
-            sceneImporter.forceGPUOnlyMesh = settings.forceGPUOnlyMesh
-                                             && DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(FeatureFlag.GPU_ONLY_MESHES);
+            sceneImporter.forceGPUOnlyMesh = settings.forceGPUOnlyMesh && DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(GPU_ONLY_MESHES);
 
             sceneImporter.OnMeshCreated += meshCreatedCallback;
             sceneImporter.OnRendererCreated += rendererCreatedCallback;

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -348,7 +348,8 @@ namespace UnityGLTF
             sceneImporter.initialVisibility = initialVisibility;
             sceneImporter.addMaterialsToPersistentCaching = addMaterialsToPersistentCaching;
 
-            sceneImporter.forceGPUOnlyMesh = false;
+            sceneImporter.forceGPUOnlyMesh = settings.forceGPUOnlyMesh
+                                             && DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(FeatureFlag.GPU_ONLY_MESHES);
 
             sceneImporter.OnMeshCreated += meshCreatedCallback;
             sceneImporter.OnRendererCreated += rendererCreatedCallback;


### PR DESCRIPTION
## What does this PR change?

Brought back flag and functionality deleted on commit #2876. The flag is Unleash is called [explorer-use_gpu_only_meshes](https://features.decentraland.systems/#/features/strategies/explorer-ab_use_gpu_only_meshes)

## How to test the changes?

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
