### PR TITLE
fix: support for overlapping avatar modifier areas

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/AvatarModifierAreaFeedbackPlugin/AvatarModifierAreaFeedbackPlugin.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/AvatarModifierAreaFeedbackPlugin/AvatarModifierAreaFeedbackPlugin.asmdef
@@ -7,7 +7,7 @@
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:691ba36162f94224faace1706408a72c",
-        "GUID:c073232dc37f7254ebc6c5dda74c99cb"
+        "GUID:bf7bc5cfaf25db643b5b7e691a83390c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils.meta
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 810c3291fc4cab54ca7c15a21d5d77dd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils/AvatarModifierAreaID.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils/AvatarModifierAreaID.cs
@@ -1,0 +1,1 @@
+public enum AvatarModifierAreaID { HIDE_AVATAR, DISABLE_PASSPORT }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils/AvatarModifierAreaID.cs.meta
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils/AvatarModifierAreaID.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92b32543e2352bf428327131dabe80ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils/AvatarModifierAreaUtils.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils/AvatarModifierAreaUtils.asmdef
@@ -1,9 +1,7 @@
 {
-    "name": "AvatarModifierAreaFeedbackInterfaces",
+    "name": "AvatarModifierAreaUtils",
     "rootNamespace": "",
-    "references": [
-        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils/AvatarModifierAreaUtils.asmdef.meta
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Utils/AvatarModifierAreaUtils.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c073232dc37f7254ebc6c5dda74c99cb
+guid: bf7bc5cfaf25db643b5b7e691a83390c
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
@@ -71,7 +71,8 @@
         "GUID:4016c129fc7e2bd4eba9d6ee09f42a69",
         "GUID:1c69d8bb67ff1244b8de3b17766ccbef",
         "GUID:691ba36162f94224faace1706408a72c",
-        "GUID:c2159e5e82608e6469313e7118f72718"
+        "GUID:c2159e5e82608e6469313e7118f72718",
+        "GUID:bf7bc5cfaf25db643b5b7e691a83390c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -111,7 +111,7 @@ namespace DCL
         {
             playerName = GetComponentInChildren<IPlayerName>();
             playerName?.Hide(true);
-            currentActiveModifiers = new BaseRefCounter<AvatarModifierAreaID>();
+            currentActiveModifiers ??= new BaseRefCounter<AvatarModifierAreaID>();
         }
 
         private void PlayerClicked()
@@ -132,7 +132,8 @@ namespace DCL
         public override IEnumerator ApplyChanges(BaseModel newModel)
         {
             isGlobalSceneAvatar = scene.sceneData.id == EnvironmentSettings.AVATAR_GLOBAL_SCENE_ID;
-
+            currentActiveModifiers ??= new BaseRefCounter<AvatarModifierAreaID>();
+            
             ApplyHidePassportModifier();
 
             var model = (AvatarModel) newModel;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -53,6 +53,7 @@ namespace DCL
         private CancellationTokenSource loadingCts;
         private ILazyTextureObserver currentLazyObserver;
         private bool isGlobalSceneAvatar = true;
+        private BaseRefCounter<AvatarModifierAreaID> currentActiveModifiers;
 
         public override string componentName => "avatarShape";
 
@@ -110,6 +111,7 @@ namespace DCL
         {
             playerName = GetComponentInChildren<IPlayerName>();
             playerName?.Hide(true);
+            currentActiveModifiers = new BaseRefCounter<AvatarModifierAreaID>();
         }
 
         private void PlayerClicked()
@@ -343,33 +345,50 @@ namespace DCL
 
         public void ApplyHideAvatarModifier()
         {
-            avatar.AddVisibilityConstrain(IN_HIDE_AREA);
-            onPointerDown.gameObject.SetActive(false);
-            playerNameContainer.SetActive(false);
-            stickersControllers.ToggleHideArea(true);
+            if (!currentActiveModifiers.ContainsKey(AvatarModifierAreaID.HIDE_AVATAR))
+            {
+                avatar.AddVisibilityConstrain(IN_HIDE_AREA);
+                onPointerDown.gameObject.SetActive(false);
+                playerNameContainer.SetActive(false);
+                stickersControllers.ToggleHideArea(true);
+            }
+            currentActiveModifiers.AddRefCount(AvatarModifierAreaID.HIDE_AVATAR);
         }
 
         public void RemoveHideAvatarModifier()
         {
-            avatar.RemoveVisibilityConstrain(IN_HIDE_AREA);
-            onPointerDown.gameObject.SetActive(true);
-            playerNameContainer.SetActive(true);
-            stickersControllers.ToggleHideArea(false);
+            currentActiveModifiers.RemoveRefCount(AvatarModifierAreaID.HIDE_AVATAR);
+            if (!currentActiveModifiers.ContainsKey(AvatarModifierAreaID.HIDE_AVATAR))
+            {
+                avatar.RemoveVisibilityConstrain(IN_HIDE_AREA);
+                onPointerDown.gameObject.SetActive(true);
+                playerNameContainer.SetActive(true);
+                stickersControllers.ToggleHideArea(false);
+            }
         }
         
         public void ApplyHidePassportModifier()
         {
-            if (onPointerDown.collider == null)
-                return;
+            if (!currentActiveModifiers.ContainsKey(AvatarModifierAreaID.DISABLE_PASSPORT))
+            {
+                if (onPointerDown.collider == null)
+                    return;
 
-            onPointerDown.SetPassportEnabled(false);
+                onPointerDown.SetPassportEnabled(false);
+            }
+            currentActiveModifiers.AddRefCount(AvatarModifierAreaID.DISABLE_PASSPORT);
         }
+        
         public void RemoveHidePassportModifier()
         {
-            if (onPointerDown.collider == null)
-                return;
+            currentActiveModifiers.RemoveRefCount(AvatarModifierAreaID.DISABLE_PASSPORT);
+            if (!currentActiveModifiers.ContainsKey(AvatarModifierAreaID.DISABLE_PASSPORT))
+            {
+                if (onPointerDown.collider == null)
+                    return;
 
-            onPointerDown.SetPassportEnabled(true);
+                onPointerDown.SetPassportEnabled(true);
+            }
         }
 
         public override void Cleanup()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/AvatarModifierAreaFeedbackHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/AvatarModifierAreaFeedbackHUD.asmdef
@@ -8,9 +8,9 @@
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:691ba36162f94224faace1706408a72c",
-        "GUID:c073232dc37f7254ebc6c5dda74c99cb",
         "GUID:bb3eef89092f71f44aa2449a9cf7879c",
-        "GUID:28f74c468a54948bfa9f625c5d428f56"
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:bf7bc5cfaf25db643b5b7e691a83390c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackController.cs
@@ -3,9 +3,9 @@ namespace DCL.AvatarModifierAreaFeedback
     public class AvatarModifierAreaFeedbackController 
     {
         internal IAvatarModifierAreaFeedbackView view;
-        private BaseRefCounter<AvatarAreaWarningID> avatarModifiersWarnings;
+        private BaseRefCounter<AvatarModifierAreaID> avatarModifiersWarnings;
         
-        public AvatarModifierAreaFeedbackController(BaseRefCounter<AvatarAreaWarningID> avatarAreaWarnings, IAvatarModifierAreaFeedbackView view)
+        public AvatarModifierAreaFeedbackController(BaseRefCounter<AvatarModifierAreaID> avatarAreaWarnings, IAvatarModifierAreaFeedbackView view)
         {
             this.view = view;
             view.SetUp(avatarAreaWarnings);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackView.cs
@@ -16,7 +16,7 @@ namespace DCL.AvatarModifierAreaFeedback
 
         private const string PATH = "_AvatarModifierAreaFeedbackHUD";
         private const string PATH_TO_WARNING_MESSAGE = "_WarningMessageAreaFeedbackHUD";
-        private BaseRefCounter<AvatarAreaWarningID> avatarAreaWarningsCounter;
+        private BaseRefCounter<AvatarModifierAreaID> avatarAreaWarningsCounter;
         private HUDCanvasCameraModeController hudCanvasCameraModeController;
 
         
@@ -26,7 +26,7 @@ namespace DCL.AvatarModifierAreaFeedback
        
         internal bool isVisible;
         internal AvatarModifierAreaFeedbackState currentState;
-        internal Dictionary<AvatarAreaWarningID, GameObject> warningMessagesDictionary;
+        internal Dictionary<AvatarModifierAreaID, GameObject> warningMessagesDictionary;
         internal CancellationTokenSource deactivatePreviewCancellationToken = new CancellationTokenSource();
 
         private string msgOutAnimationTrigger = "MsgOut";
@@ -42,15 +42,15 @@ namespace DCL.AvatarModifierAreaFeedback
             hudCanvasCameraModeController = new HUDCanvasCameraModeController(GetComponent<Canvas>(), DataStore.i.camera.hudsCamera);
         }
 
-        public void SetUp(BaseRefCounter<AvatarAreaWarningID> avatarAreaWarnings)
+        public void SetUp(BaseRefCounter<AvatarModifierAreaID> avatarAreaWarnings)
         {
             avatarAreaWarningsCounter = avatarAreaWarnings;
             avatarAreaWarningsCounter.OnAdded += AddedNewWarning;
             avatarAreaWarningsCounter.OnRemoved += RemovedWarning;
 
-            warningMessagesDictionary = new Dictionary<AvatarAreaWarningID, GameObject>();
+            warningMessagesDictionary = new Dictionary<AvatarModifierAreaID, GameObject>();
             
-            foreach (AvatarAreaWarningID warningMessageEnum in Enum.GetValues(typeof(AvatarAreaWarningID)))
+            foreach (AvatarModifierAreaID warningMessageEnum in Enum.GetValues(typeof(AvatarModifierAreaID)))
             {
                 GameObject newWarningMessage = Instantiate(Resources.Load<GameObject>(PATH_TO_WARNING_MESSAGE), warningContainer);
                 newWarningMessage.GetComponent<TMP_Text>().text = GetWarningMessage(warningMessageEnum);
@@ -59,7 +59,7 @@ namespace DCL.AvatarModifierAreaFeedback
             }  
         }
 
-        private void RemovedWarning(AvatarAreaWarningID obj)
+        private void RemovedWarning(AvatarModifierAreaID obj)
         {
             warningMessagesDictionary[obj].gameObject.SetActive(false);
             if (avatarAreaWarningsCounter.Count().Equals(0))
@@ -67,7 +67,7 @@ namespace DCL.AvatarModifierAreaFeedback
                 Hide();
             }
         }
-        private void AddedNewWarning(AvatarAreaWarningID obj)
+        private void AddedNewWarning(AvatarModifierAreaID obj)
         {
             warningMessagesDictionary[obj].gameObject.SetActive(true);
             Show();
@@ -149,13 +149,13 @@ namespace DCL.AvatarModifierAreaFeedback
 			hudCanvasCameraModeController?.Dispose();
         }
         
-        private string GetWarningMessage(AvatarAreaWarningID idToSet)
+        private string GetWarningMessage(AvatarModifierAreaID idToSet)
         {
             switch (idToSet)
             {
-                case AvatarAreaWarningID.HIDE_AVATAR:
+                case AvatarModifierAreaID.HIDE_AVATAR:
                     return "\u2022  The avatars are hidden";
-                case AvatarAreaWarningID.DISABLE_PASSPORT:
+                case AvatarModifierAreaID.DISABLE_PASSPORT:
                     return "\u2022  Your passport is disable for\n    other players";
                 default:
                     throw new NotImplementedException();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/Interfaces/IAvatarModifierAreaFeedbackView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/Interfaces/IAvatarModifierAreaFeedbackView.cs
@@ -2,8 +2,7 @@ using System;
 
 public interface IAvatarModifierAreaFeedbackView : IDisposable
 {
-    void SetUp(BaseRefCounter<AvatarAreaWarningID> avatarAreaWarnings);
+    void SetUp(BaseRefCounter<AvatarModifierAreaID> avatarAreaWarnings);
 
 }
 
-public enum AvatarAreaWarningID { HIDE_AVATAR, DISABLE_PASSPORT }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Test/AvatarModifierAreaFeedbackControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Test/AvatarModifierAreaFeedbackControllerShould.cs
@@ -14,7 +14,7 @@ namespace Tests.AvatarModifierAreaFeedback
    
         private AvatarModifierAreaFeedbackController hudController;
         private IAvatarModifierAreaFeedbackView hudView;
-        private BaseRefCounter<AvatarAreaWarningID> warningMessageList => DataStore.i.HUDs.avatarAreaWarnings;
+        private BaseRefCounter<AvatarModifierAreaID> warningMessageList => DataStore.i.HUDs.avatarAreaWarnings;
 
         [SetUp]
         public void SetUp()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Test/AvatarModifierAreaFeedbackTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Test/AvatarModifierAreaFeedbackTests.asmdef
@@ -9,7 +9,7 @@
         "GUID:81f3218b29e049144b175dad2ebbac1b",
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:691ba36162f94224faace1706408a72c",
-        "GUID:c073232dc37f7254ebc6c5dda74c99cb"
+        "GUID:bf7bc5cfaf25db643b5b7e691a83390c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Test/AvatarModifierAreaFeedbackViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Test/AvatarModifierAreaFeedbackViewShould.cs
@@ -12,7 +12,7 @@ namespace Tests.AvatarModifierAreaFeedback
     {
     
         private AvatarModifierAreaFeedbackView hudView;
-        private BaseRefCounter<AvatarAreaWarningID> warningMessageList => DataStore.i.HUDs.avatarAreaWarnings;
+        private BaseRefCounter<AvatarModifierAreaID> warningMessageList => DataStore.i.HUDs.avatarAreaWarnings;
 
         [SetUp]
         public void SetUp()
@@ -25,7 +25,7 @@ namespace Tests.AvatarModifierAreaFeedback
         public void ShowsProperly()
         {
             warningMessageList.Clear();
-            warningMessageList.AddRefCount(AvatarAreaWarningID.HIDE_AVATAR);
+            warningMessageList.AddRefCount(AvatarModifierAreaID.HIDE_AVATAR);
             Assert.True(hudView.isVisible);
         }
         
@@ -33,14 +33,14 @@ namespace Tests.AvatarModifierAreaFeedback
         public void HidesProperly()
         {
             warningMessageList.Clear();
-            warningMessageList.AddRefCount(AvatarAreaWarningID.HIDE_AVATAR);
-            warningMessageList.AddRefCount(AvatarAreaWarningID.HIDE_AVATAR);
-            warningMessageList.AddRefCount(AvatarAreaWarningID.DISABLE_PASSPORT);
+            warningMessageList.AddRefCount(AvatarModifierAreaID.HIDE_AVATAR);
+            warningMessageList.AddRefCount(AvatarModifierAreaID.HIDE_AVATAR);
+            warningMessageList.AddRefCount(AvatarModifierAreaID.DISABLE_PASSPORT);
             Assert.True(hudView.isVisible);
-            warningMessageList.RemoveRefCount(AvatarAreaWarningID.HIDE_AVATAR);
-            warningMessageList.RemoveRefCount(AvatarAreaWarningID.HIDE_AVATAR);
+            warningMessageList.RemoveRefCount(AvatarModifierAreaID.HIDE_AVATAR);
+            warningMessageList.RemoveRefCount(AvatarModifierAreaID.HIDE_AVATAR);
             Assert.True(hudView.isVisible);
-            warningMessageList.RemoveRefCount(AvatarAreaWarningID.DISABLE_PASSPORT);
+            warningMessageList.RemoveRefCount(AvatarModifierAreaID.DISABLE_PASSPORT);
             Assert.False(hudView.isVisible);
         }
         
@@ -50,7 +50,7 @@ namespace Tests.AvatarModifierAreaFeedback
         {
             warningMessageList.Clear();
             Assert.AreEqual(AvatarModifierAreaFeedbackView.AvatarModifierAreaFeedbackState.NEVER_SHOWN, hudView.currentState);
-            warningMessageList.AddRefCount(AvatarAreaWarningID.HIDE_AVATAR);
+            warningMessageList.AddRefCount(AvatarModifierAreaID.HIDE_AVATAR);
             hudView.OnPointerEnter(null);
             Assert.AreEqual(AvatarModifierAreaFeedbackView.AvatarModifierAreaFeedbackState.WARNING_MESSAGE_VISIBLE,hudView.currentState);
         }
@@ -59,7 +59,7 @@ namespace Tests.AvatarModifierAreaFeedback
         public void CheckPointerExit()
         {
             warningMessageList.Clear();
-            warningMessageList.AddRefCount(AvatarAreaWarningID.HIDE_AVATAR);
+            warningMessageList.AddRefCount(AvatarModifierAreaID.HIDE_AVATAR);
             hudView.OnPointerExit(null);
             Assert.AreEqual(AvatarModifierAreaFeedbackView.AvatarModifierAreaFeedbackState.ICON_VISIBLE, hudView.currentState);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.asmdef
@@ -37,8 +37,8 @@
         "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca",
         "GUID:a1e1473c53889c2489c0822a9dd5fa33",
         "GUID:4016c129fc7e2bd4eba9d6ee09f42a69",
-        "GUID:c073232dc37f7254ebc6c5dda74c99cb",
-        "GUID:c2159e5e82608e6469313e7118f72718"
+        "GUID:c2159e5e82608e6469313e7118f72718",
+        "GUID:bf7bc5cfaf25db643b5b7e691a83390c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
@@ -39,6 +39,7 @@ public class PlayerAvatarController : MonoBehaviour, IHideAvatarAreaHandler, IHi
     private Camera mainCamera;
     private IFatalErrorReporter fatalErrorReporter; // TODO?
     private string VISIBILITY_CONSTRAIN;
+    private BaseRefCounter<AvatarModifierAreaID> currentActiveModifiers;
 
     internal ISocialAnalytics socialAnalytics;
 
@@ -69,6 +70,7 @@ public class PlayerAvatarController : MonoBehaviour, IHideAvatarAreaHandler, IHi
 #endif
 
         mainCamera = Camera.main;
+        currentActiveModifiers = new BaseRefCounter<AvatarModifierAreaID>();
     }
 
     private AvatarSystem.Avatar GetStandardAvatar()
@@ -248,26 +250,36 @@ public class PlayerAvatarController : MonoBehaviour, IHideAvatarAreaHandler, IHi
 
     public void ApplyHideAvatarModifier()
     {
-        avatar.AddVisibilityConstrain(IN_HIDE_AREA);
-        DataStore.i.HUDs.avatarAreaWarnings.AddRefCount(AvatarAreaWarningID.HIDE_AVATAR);
-        stickersControllers.ToggleHideArea(true);
+        if (!currentActiveModifiers.ContainsKey(AvatarModifierAreaID.HIDE_AVATAR))
+        {
+            avatar.AddVisibilityConstrain(IN_HIDE_AREA);
+            stickersControllers.ToggleHideArea(true);
+        }
+        currentActiveModifiers.AddRefCount(AvatarModifierAreaID.HIDE_AVATAR);
+        DataStore.i.HUDs.avatarAreaWarnings.AddRefCount(AvatarModifierAreaID.HIDE_AVATAR);
     }
     
     public void RemoveHideAvatarModifier()
     {
-        avatar.RemoveVisibilityConstrain(IN_HIDE_AREA);
-        DataStore.i.HUDs.avatarAreaWarnings.RemoveRefCount(AvatarAreaWarningID.HIDE_AVATAR);
-        stickersControllers.ToggleHideArea(false);
+        DataStore.i.HUDs.avatarAreaWarnings.RemoveRefCount(AvatarModifierAreaID.HIDE_AVATAR);
+        currentActiveModifiers.RemoveRefCount(AvatarModifierAreaID.HIDE_AVATAR);
+        if (!currentActiveModifiers.ContainsKey(AvatarModifierAreaID.HIDE_AVATAR))
+        {
+            avatar.RemoveVisibilityConstrain(IN_HIDE_AREA);
+            stickersControllers.ToggleHideArea(false);
+        }
     }
 
     public void ApplyHidePassportModifier()
     {
-        DataStore.i.HUDs.avatarAreaWarnings.AddRefCount(AvatarAreaWarningID.DISABLE_PASSPORT);
+        DataStore.i.HUDs.avatarAreaWarnings.AddRefCount(AvatarModifierAreaID.DISABLE_PASSPORT);
+        currentActiveModifiers.AddRefCount(AvatarModifierAreaID.DISABLE_PASSPORT);
     }
     
     public void RemoveHidePassportModifier()
     {
-        DataStore.i.HUDs.avatarAreaWarnings.RemoveRefCount(AvatarAreaWarningID.DISABLE_PASSPORT);
+        DataStore.i.HUDs.avatarAreaWarnings.RemoveRefCount(AvatarModifierAreaID.DISABLE_PASSPORT);
+        currentActiveModifiers.RemoveRefCount(AvatarModifierAreaID.DISABLE_PASSPORT);
     }
 
     private void OnDisable()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore.asmdef
@@ -23,9 +23,9 @@
         "GUID:37d2c04574c1d480d8c817e2a7c578e7",
         "GUID:1c69d8bb67ff1244b8de3b17766ccbef",
         "GUID:fd239a454d9a4039b164f90867ea3216",
-        "GUID:c073232dc37f7254ebc6c5dda74c99cb",
         "GUID:b8b9ca72325745a8a59d88b5f2db198c",
-        "GUID:0b167d3fa6c88454ea3eb69cbabe4eb7"
+        "GUID:0b167d3fa6c88454ea3eb69cbabe4eb7",
+        "GUID:bf7bc5cfaf25db643b5b7e691a83390c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_HUDs.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_HUDs.cs
@@ -22,7 +22,7 @@ namespace DCL
         public readonly BaseVariable<bool> gotoPanelVisible = new BaseVariable<bool>(false);
         public readonly BaseVariable<ParcelCoordinates> gotoPanelCoordinates = new BaseVariable<ParcelCoordinates>(new ParcelCoordinates(0,0));
         public readonly BaseVariable<bool> isSceneUIEnabled = new BaseVariable<bool>(true);
-        public readonly BaseRefCounter<AvatarAreaWarningID> avatarAreaWarnings = new BaseRefCounter<AvatarAreaWarningID>();
+        public readonly BaseRefCounter<AvatarModifierAreaID> avatarAreaWarnings = new BaseRefCounter<AvatarModifierAreaID>();
         public readonly BaseVariable<Dictionary<string, Queue<IUIRefreshable>>> dirtyShapes = new BaseVariable<Dictionary<string, Queue<IUIRefreshable>>>(new Dictionary<string, Queue<IUIRefreshable>>());
         public readonly LoadingHUD loadingHUD = new LoadingHUD();
 


### PR DESCRIPTION
## What does this PR change?

Overlapping modifier areas generates a wrong behavior. Areas turn on and off the modifier even though the user is still inside at least one of the areas. This implementation solves the overlapping issue.

More info here: https://decentralandteam.slack.com/archives/C01QVR7TJK1/p1660333541371069

## How to test the changes?

1. Go to https://play.decentraland.zone/?renderer-branch=fix/overlap-avatar-modifier-areas&NETWORK=mainnet&position=-74,-99. There are some overlapping areas deployed in that scene, same as in this video

https://user-images.githubusercontent.com/1999557/185384451-578b9f31-bb6c-40b5-8c73-165b46fa495c.mp4

2. Check that your character is modified correctly


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
