### PR TITLE
fix: direct message listing fixes

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
@@ -107,8 +107,10 @@ public class WorldChatWindowControllerShould
         });
     }
 
-    [Test]
-    public void RemovePrivateChatWhenFriendIsRemoved()
+    [TestCase(FriendshipStatus.REQUESTED_TO)]
+    [TestCase(FriendshipStatus.REQUESTED_FROM)]
+    [TestCase(FriendshipStatus.NOT_FRIEND)]
+    public void RemovePrivateChatWhenUserIsUpdatedAsNonFriend(FriendshipStatus status)
     {
         GivenFriend(FRIEND_ID, PresenceStatus.OFFLINE);
         chatController.GetAllocatedEntries().Returns(new List<ChatMessage>
@@ -123,9 +125,26 @@ public class WorldChatWindowControllerShould
             {
                 userId = FRIEND_ID,
                 presence = PresenceStatus.ONLINE,
-                friendshipStatus = FriendshipStatus.NOT_FRIEND
+                friendshipStatus = status
             });
 
+        view.Received(1).RemovePrivateChat(FRIEND_ID);
+    }
+
+    [TestCase(FriendshipAction.NONE)]
+    [TestCase(FriendshipAction.DELETED)]
+    [TestCase(FriendshipAction.REJECTED)]
+    [TestCase(FriendshipAction.CANCELLED)]
+    [TestCase(FriendshipAction.REQUESTED_TO)]
+    [TestCase(FriendshipAction.REQUESTED_FROM)]
+    public void RemovePrivateChatWhenFriendshipUpdatesAsNonFriend(FriendshipAction action)
+    {
+        GivenFriend(FRIEND_ID, PresenceStatus.OFFLINE);
+        
+        controller.Initialize(view);
+
+        friendsController.OnUpdateFriendship += Raise.Event<Action<string, FriendshipAction>>(FRIEND_ID, action);
+        
         view.Received(1).RemovePrivateChat(FRIEND_ID);
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -16,7 +16,10 @@ public class WorldChatWindowController : IHUD
     private readonly IUserProfileBridge userProfileBridge;
     private readonly IFriendsController friendsController;
     private readonly IChatController chatController;
-    private readonly Dictionary<string, PublicChatChannelModel> publicChannels = new Dictionary<string, PublicChatChannelModel>();
+
+    private readonly Dictionary<string, PublicChatChannelModel> publicChannels =
+        new Dictionary<string, PublicChatChannelModel>();
+
     private readonly Dictionary<string, UserProfile> recipientsFromPrivateChats = new Dictionary<string, UserProfile>();
     private readonly Dictionary<string, ChatMessage> lastPrivateMessages = new Dictionary<string, ChatMessage>();
     private int hiddenDMs;
@@ -52,26 +55,27 @@ public class WorldChatWindowController : IHUD
         view.OnOpenPublicChannel += OpenPublicChannel;
         view.OnSearchChannelRequested += SearchChannels;
         view.OnRequireMorePrivateChats += ShowMorePrivateChats;
-        
+
         ownUserProfile = userProfileBridge.GetOwn();
         if (ownUserProfile != null)
             ownUserProfile.OnUpdate += OnUserProfileUpdate;
-        
+
         // TODO: this data should come from the chat service when channels are implemented
         publicChannels[GENERAL_CHANNEL_ID] = new PublicChatChannelModel(GENERAL_CHANNEL_ID, "nearby",
             "Talk to the people around you. If you move far away from someone you will lose contact. All whispers will be displayed.");
         view.SetPublicChannel(publicChannels[GENERAL_CHANNEL_ID]);
-        
+
         foreach (var value in chatController.GetAllocatedEntries())
             HandleMessageAdded(value);
-        
+
         if (!friendsController.IsInitialized)
             if (ownUserProfile?.hasConnectedWeb3 ?? false)
                 view.ShowPrivateChatsLoading();
-        
+
         chatController.OnAddMessage += HandleMessageAdded;
         friendsController.OnAddFriendsWithDirectMessages += HandleFriendsWithDirectMessagesAdded;
         friendsController.OnUpdateUserStatus += HandleUserStatusChanged;
+        friendsController.OnUpdateFriendship += HandleFriendshipUpdated;
         friendsController.OnInitialized += HandleFriendsControllerInitialization;
     }
 
@@ -86,6 +90,7 @@ public class WorldChatWindowController : IHUD
         chatController.OnAddMessage -= HandleMessageAdded;
         friendsController.OnAddFriendsWithDirectMessages -= HandleFriendsWithDirectMessagesAdded;
         friendsController.OnUpdateUserStatus -= HandleUserStatusChanged;
+        friendsController.OnUpdateFriendship -= HandleFriendshipUpdated;
         friendsController.OnInitialized -= HandleFriendsControllerInitialization;
 
         if (ownUserProfile != null)
@@ -122,40 +127,57 @@ public class WorldChatWindowController : IHUD
         }
         else
             view.HidePrivateChatsLoading();
-
-        // show only private chats from friends. Change it whenever the catalyst supports to send pms to any user
-        foreach (var userId in recipientsFromPrivateChats.Keys)
-            if (!friendsController.IsFriend(userId))
-                view.RemovePrivateChat(userId);
     }
 
-    private void OpenPrivateChat(string userId) { OnOpenPrivateChat?.Invoke(userId); }
+    private void OpenPrivateChat(string userId)
+    {
+        OnOpenPrivateChat?.Invoke(userId);
+    }
 
     private void OpenPublicChannel(string channelId) => OnOpenPublicChannel?.Invoke(channelId);
 
     private void HandleViewCloseRequest() => SetVisibility(false);
-    
+
+    private void HandleFriendshipUpdated(string userId, FriendshipAction friendship)
+    {
+        if (friendship == FriendshipAction.APPROVED)
+        {
+            var profile = userProfileBridge.Get(userId);
+            if (profile == null) return;
+
+            view.SetPrivateChat(new PrivateChatModel
+            {
+                user = profile,
+                isBlocked = ownUserProfile.IsBlocked(userId),
+                isOnline = friendsController.GetUserStatus(userId) is {presence: PresenceStatus.ONLINE},
+                recentMessage = lastPrivateMessages.ContainsKey(userId) ? lastPrivateMessages[userId] : null
+            });
+        }
+        else
+        {
+            // show only private chats from friends. Change it whenever the catalyst supports to send pms to any user
+            view.RemovePrivateChat(userId);
+        }
+    }
+
     private void HandleUserStatusChanged(string userId, UserStatus status)
     {
         if (!recipientsFromPrivateChats.ContainsKey(userId)) return;
         if (!lastPrivateMessages.ContainsKey(userId)) return;
-        
+
         if (status.friendshipStatus == FriendshipStatus.FRIEND)
         {
             var profile = recipientsFromPrivateChats[userId];
-            
-            if (ShouldDisplayPrivateChat(profile.userId))
+
+            view.SetPrivateChat(new PrivateChatModel
             {
-                view.SetPrivateChat(new PrivateChatModel
-                {
-                    user = profile,
-                    recentMessage = lastPrivateMessages[userId],
-                    isBlocked = ownUserProfile.IsBlocked(userId),
-                    isOnline = status.presence == PresenceStatus.ONLINE
-                });
-            }
+                user = profile,
+                recentMessage = lastPrivateMessages[userId],
+                isBlocked = ownUserProfile.IsBlocked(userId),
+                isOnline = status.presence == PresenceStatus.ONLINE
+            });
         }
-        else if (status.friendshipStatus == FriendshipStatus.NOT_FRIEND)
+        else
         {
             // show only private chats from friends. Change it whenever the catalyst supports to send pms to any user
             view.RemovePrivateChat(userId);
@@ -165,21 +187,20 @@ public class WorldChatWindowController : IHUD
     private void HandleMessageAdded(ChatMessage message)
     {
         if (message.messageType != ChatMessage.Type.PRIVATE) return;
-        var profile = ExtractRecipient(message);
-        if (profile == null) return;
         
-        if (friendsController.IsInitialized)
-            if (!friendsController.IsFriend(profile.userId))
-                return;
-
-        if (lastPrivateMessages.ContainsKey(profile.userId))
+        var userId = ExtractRecipientId(message);
+        
+        if (lastPrivateMessages.ContainsKey(userId))
         {
-            if (message.timestamp > lastPrivateMessages[profile.userId].timestamp)
-                lastPrivateMessages[profile.userId] = message;
+            if (message.timestamp > lastPrivateMessages[userId].timestamp)
+                lastPrivateMessages[userId] = message;
         }
         else
-            lastPrivateMessages[profile.userId] = message;
-        
+            lastPrivateMessages[userId] = message;
+
+        var profile = userProfileBridge.Get(userId);
+        if (profile == null) return;
+
         recipientsFromPrivateChats[profile.userId] = profile;
 
         view.SetPrivateChat(CreatePrivateChatModel(message, profile));
@@ -187,18 +208,19 @@ public class WorldChatWindowController : IHUD
 
     private void HandleFriendsWithDirectMessagesAdded(List<FriendWithDirectMessages> usersWithDM)
     {
-        for (int i = 0; i < usersWithDM.Count; i++)
+        for (var i = 0; i < usersWithDM.Count; i++)
         {
-            if (recipientsFromPrivateChats.ContainsKey(usersWithDM[i].userId))
-                continue;
+            if (recipientsFromPrivateChats.ContainsKey(usersWithDM[i].userId)) continue;
 
             var profile = userProfileBridge.Get(usersWithDM[i].userId);
             if (profile == null) continue;
 
-            ChatMessage lastMessage = new ChatMessage();
-            lastMessage.messageType = ChatMessage.Type.PRIVATE;
-            lastMessage.body = usersWithDM[i].lastMessageBody;
-            lastMessage.timestamp = (ulong)usersWithDM[i].lastMessageTimestamp;
+            var lastMessage = new ChatMessage
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                body = usersWithDM[i].lastMessageBody,
+                timestamp = (ulong) usersWithDM[i].lastMessageTimestamp
+            };
 
             if (lastPrivateMessages.ContainsKey(profile.userId))
             {
@@ -224,14 +246,6 @@ public class WorldChatWindowController : IHUD
         isRequestingFriendsWithDMs = false;
     }
 
-    private bool ShouldDisplayPrivateChat(string userId)
-    {
-        if (!friendsController.IsInitialized) return false;
-        if (view.PrivateChannelsCount < USER_DM_ENTRIES_TO_REQUEST_FOR_INITIAL_LOAD) return true;
-        if (view.ContainsPrivateChannel(userId)) return true;
-        return false;
-    }
-
     private PrivateChatModel CreatePrivateChatModel(ChatMessage recentMessage, UserProfile profile)
     {
         return new PrivateChatModel
@@ -243,17 +257,19 @@ public class WorldChatWindowController : IHUD
         };
     }
 
-    private UserProfile ExtractRecipient(ChatMessage message) =>
-        userProfileBridge.Get(message.sender != ownUserProfile.userId ? message.sender : message.recipient);
+    private string ExtractRecipientId(ChatMessage message)
+    {
+        return message.sender != ownUserProfile.userId ? message.sender : message.recipient;
+    }
 
     private void OnUserProfileUpdate(UserProfile profile)
     {
         view.RefreshBlockedDirectMessages(profile.blocked);
-        
+
         if (!profile.hasConnectedWeb3)
             view.HidePrivateChatsLoading();
     }
-    
+
     private void SearchChannels(string search)
     {
         currentSearch = search;
@@ -277,9 +293,10 @@ public class WorldChatWindowController : IHUD
             var regex = new Regex(search, RegexOptions.IgnoreCase);
 
             return recipientsFromPrivateChats.Values.Where(profile =>
-                !string.IsNullOrEmpty(profile.userName) && regex.IsMatch(profile.userName))
+                    !string.IsNullOrEmpty(profile.userName) && regex.IsMatch(profile.userName))
                 .Take(MAX_SEARCHED_CHANNELS)
-                .ToDictionary(model => model.userId, profile => CreatePrivateChatModel(lastPrivateMessages[profile.userId], profile));
+                .ToDictionary(model => model.userId,
+                    profile => CreatePrivateChatModel(lastPrivateMessages[profile.userId], profile));
         }
 
         Dictionary<string, PublicChatChannelModel> FilterPublicChannelsByName(string search)
@@ -297,8 +314,8 @@ public class WorldChatWindowController : IHUD
 
     private void ShowMorePrivateChats()
     {
-        if (isRequestingFriendsWithDMs || 
-            hiddenDMs == 0 || 
+        if (isRequestingFriendsWithDMs ||
+            hiddenDMs == 0 ||
             !string.IsNullOrEmpty(currentSearch))
             return;
 
@@ -338,6 +355,6 @@ public class WorldChatWindowController : IHUD
         view.ShowSearchLoading();
         friendsController.GetFriendsWithDirectMessages(userNameOrId, limit);
     }
-    
+
     private void RequestUnreadMessages() => chatController.GetUnseenMessagesByUser();
 }


### PR DESCRIPTION
## What does this PR change?

- removes direct messages entries when the friendship updates
- always allocates the last message received no matter if the profile exists or not
- removed deprecated filters for showing direct messages
- added test coverage

## How to test the changes?

1. Go to the conversation list and check everything is listed correctly
2. Remove any friend that has a direct message with you
3. The friend should be removed from the list
4. Check that the last message is correctly display in the entry, when you receive one

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
