### PR TITLE
fix: ECS7 ensure that avatar modifier area fails gracefully with an unexpected enum

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Handler/AvatarModifierAreaComponentHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Handler/AvatarModifierAreaComponentHandler.cs
@@ -150,6 +150,11 @@ namespace DCL.ECSComponents
                 {
                     var modifier = factory.GetOrCreateAvatarModifier(modifierKey);
                     
+                    // If we don't have a modifier area handler, we fail gracefully
+                    // this can be due to typescript counterpart having an UNRECOGNIZED enum from AvatarModifier of the ECS7 
+                    if(modifier == null)
+                        continue;
+                    
                     OnAvatarEnter += modifier.ApplyModifier;
                     OnAvatarExit += modifier.RemoveModifier;
                 }


### PR DESCRIPTION
## Context

In the current version of ECS7 we have the AvatarModifierArea types in enums so you can choose which modifiers you want to add to the component.

In order to add them, you can use the following enums 

```
AvatarModifier.HIDE_AVATARS
AvatarModifier.DISABLE_PASSPORTS
AvatarModifier.UNRECOGNIZED
```

The `HideAvatar `and the `DisablePassport `have functionality but the `Unrecognized `is one generated by typescript that doesn't have functionality or counterpart in C#


## What does this PR change?

This PR is failing gracefully if the users decided to use the `Unrecognized ` enum.

Without this implementation, the scene will crash and will be shown as an empty scene. 

With this change, it will just ignore that modifier and apply the rest of if are present

## How to test the changes?

In order to test this changes, you will need to run an ECS7 

1.- Download the scene https://github.com/decentraland/ecs7-template (recommended branch: main)
2.- Follow the instructions from the readme of the repo and after that, install a custom SDK version with this command
`npm install "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/readd-avatar-modifier-area/dcl-sdk-7.0.0-2902358903.commit-e58994d.tgz"`
3.- Start the scene with `dcl start`
4.- Use this URL: http://127.0.0.1:8000/?position=0%2C0&ENABLE_ECS7&renderer-branch=fix/avatar-modifier-area&kernel-branch=main&SCENE_DEBUG_PANEL=&realm=v1%7E127.0.0.1%3A8000
5.- Add an AvatarModifierArea and test each combination of enum. They should work even if you add the Unrecognized

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
