### PR TITLE
docs: add missing frontmatter to ecs7-component-creation.md

### DIFF
--- a/docs/ecs7-component-creation.md
+++ b/docs/ecs7-component-creation.md
@@ -1,3 +1,8 @@
+---
+title: "How to create new components for ECS7"
+slug: "/contributor/unity-renderer/components/how-to-create-components"
+---
+
 # How to create new components for ECS7
 
 In order to create new components, we need to do a couple of things before start coding them in the renderer


### PR DESCRIPTION
## Context

We are creating a new site for docs in Decentraland. This site will includes all documentation for players, content creator and for contributors to the project.

The unity renderer repo is the biggest repo of Decentraland and needs to be documented in the contributor part. This is the first iteration of adding documentation from the repo. After that, we are going to add the rest of the documentation

## What does this PR change?

This PR adds the correct frontmatter metadata on top otherwise it won't appear on the docs site.

This metadata allows the docs site to recognize this document as a part of the documentation site

## How to test the changes?

It can't be tested per see. You can see the changes in the file. After this PR and [this](https://github.com/decentraland/technical-documentation/pull/55) PR are merged. We will be able to see them in the contributor part of the Docs

We cannot preview it since it will need to point to this specific branch and then make a change again to the main branch

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
