### PR TITLE
fix: show scroll bar on first time opening wearable selection

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/ItemSelector.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/ItemSelector.cs
@@ -129,6 +129,8 @@ public class ItemSelector : MonoBehaviour
         ShowCompatibleWithBodyShape();
     }
 
+    private void OnEnable() { UpdateSelectorLayout(); }
+
     public void UpdateSelectorLayout() { Utils.ForceUpdateLayout(content); }
 
     private void ShowCompatibleWithBodyShape()


### PR DESCRIPTION
## What does this PR change?

Fixes [#2808](https://app.zenhub.com/workspaces/explorer-6047bad476c3c0001942ee91/issues/decentraland/unity-renderer/2808)

The scroll bar was not being displayed the first time correctly because the canvas update with its corresponding ContentSizeFitter was not being done unless the gameobject was active.
This PR fixes that by forcing the content canvas update on enabling the item selector.

## How to test the changes?

0. Open https://play.decentraland.zone/?renderer-branch=fix/scroll-bar-not-displayed-in-backpack
1. Log into the game as a guest or through a wallet.
2. Wait for the game to load.
3. Make the resolution/screen size smaller, so that not all backpack elements can fit on the screen (not required if you have enough items in any section of the Head and Top tabs).
4. Enter the backpack.
5, Choose the Hair section (or any section) in the Head tab.
6. Check that the scroll bar is present the first time a collection was selected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
