### PR TITLE
chore: add Animations Sequencer for DOTween

### DIFF
--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.brunomikoski.animationsequencer": "0.3.8",
     "com.coffee.ui-particle": "https://github.com/mob-sakai/ParticleEffectForUGUI.git#3.3.0",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src",

--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -51,5 +51,15 @@
   },
   "testables": [
     "com.unity.test-framework.performance"
+  ],
+  "scopedRegistries": [
+    {
+      "name": "OpenUPM",
+      "url": "https://package.openupm.com/",
+      "scopes": [
+        "com.brunomikoski",
+        "com.demigiant"
+      ]
+    }
   ]
 }

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.brunomikoski.animationsequencer": {
+      "version": "0.3.8",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
     "com.coffee.ui-particle": {
       "version": "https://github.com/mob-sakai/ParticleEffectForUGUI.git#3.3.0",
       "depth": 0,

--- a/unity-renderer/ProjectSettings/PackageManagerSettings.asset
+++ b/unity-renderer/ProjectSettings/PackageManagerSettings.asset
@@ -24,20 +24,31 @@ MonoBehaviour:
     m_Scopes: []
     m_IsDefault: 1
     m_Capabilities: 7
-  m_UserSelectedRegistryName: 
+  - m_Id: scoped:OpenUPM
+    m_Name: OpenUPM
+    m_Url: https://package.openupm.com
+    m_Scopes:
+    - com.brunomikoski
+    - com.demigiant
+    m_IsDefault: 0
+    m_Capabilities: 0
+  m_UserSelectedRegistryName: OpenUPM
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_ErrorMessage: 
     m_Original:
-      m_Id: 
-      m_Name: 
-      m_Url: 
-      m_Scopes: []
+      m_Id: scoped:OpenUPM
+      m_Name: OpenUPM
+      m_Url: https://package.openupm.com
+      m_Scopes:
+      - com.brunomikoski
+      - com.demigiant
       m_IsDefault: 0
       m_Capabilities: 0
     m_Modified: 0
-    m_Name: 
-    m_Url: 
+    m_Name: OpenUPM
+    m_Url: https://package.openupm.com
     m_Scopes:
-    - 
+    - com.brunomikoski
+    - com.demigiant
     m_SelectedScopeIndex: 0


### PR DESCRIPTION
## What does this PR change?

Adding Animation Sequencer package for DOTween
https://github.com/brunomikoski/Animation-Sequencer

Latest version is `0.3.9`, however, it's not compiling with Unity `2020.3`, and we have to use `0.3.8` for now.
I have created an [issue](https://github.com/brunomikoski/Animation-Sequencer/issues/53), and we can update after the plugin owner makes a change or we upgrade to 2021.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
