### PR TITLE
chore: move texture max size constants to configuration

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -131,8 +131,6 @@ namespace DCL.Configuration
     {
         public const int GLTF_TEX_MAX_SIZE_WEB = 512;
         public const int GENERAL_TEX_MAX_SIZE_WEB = 2048;
-        public const int GLTF_TEX_MAX_SIZE_DESKTOP = 1024;
-        public const int GENERAL_TEX_MAX_SIZE_DESKTOP = 4096;
     }
 
     public static class ApplicationSettings

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -127,6 +127,14 @@ namespace DCL.Configuration
         public const float LAND_CHECK_MESSAGE_TIMER = 5f;
     }
 
+    public static class TextureCompressionSettings
+    {
+        public const int GLTF_TEX_MAX_SIZE_WEB = 512;
+        public const int GENERAL_TEX_MAX_SIZE_WEB = 2048;
+        public const int GLTF_TEX_MAX_SIZE_DESKTOP = 1024;
+        public const int GENERAL_TEXT_MAX_SIZE_DESKTOP = 4096;
+    }
+
     public static class ApplicationSettings
     {
         public static string version = "1.0";

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -132,7 +132,7 @@ namespace DCL.Configuration
         public const int GLTF_TEX_MAX_SIZE_WEB = 512;
         public const int GENERAL_TEX_MAX_SIZE_WEB = 2048;
         public const int GLTF_TEX_MAX_SIZE_DESKTOP = 1024;
-        public const int GENERAL_TEXT_MAX_SIZE_DESKTOP = 4096;
+        public const int GENERAL_TEX_MAX_SIZE_DESKTOP = 4096;
     }
 
     public static class ApplicationSettings

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using DCL.Components;
+using DCL.Configuration;
 using DCL.Controllers;
 using DCL.Helpers;
 using DCL.SettingsCommon;
@@ -60,8 +61,8 @@ namespace DCL
 
         protected virtual void InitializeDataStore()
         {
-            DataStore.i.textureConfig.gltfMaxSize.Set(512);
-            DataStore.i.textureConfig.generalMaxSize.Set(2048);
+            DataStore.i.textureConfig.gltfMaxSize.Set(TextureCompressionSettings.GLTF_TEX_MAX_SIZE_WEB);
+            DataStore.i.textureConfig.generalMaxSize.Set(TextureCompressionSettings.GENERAL_TEX_MAX_SIZE_WEB);
             DataStore.i.avatarConfig.useHologramAvatar.Set(true);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/TextureHelpers/TextureHelpers.cs
@@ -3,7 +3,8 @@ using UnityEngine.Rendering;
 
 public static class TextureHelpers
 {
-    public static Texture2D ClampSize(Texture2D source, int maxTextureSize, bool linear = false, bool useGPUCopy = true)
+    public static Texture2D ClampSize(Texture2D source, int maxTextureSize, 
+        bool linear = false, bool useGPUCopy = true)
     {
         if (source.width <= maxTextureSize && source.height <= maxTextureSize)
             return source;
@@ -13,7 +14,8 @@ public static class TextureHelpers
 
         float factor = GetScalingFactor(width, height, maxTextureSize);
 
-        Texture2D dstTex = Resize(source, (int) (width * factor), (int) (height * factor), linear, useGPUCopy);
+        Texture2D dstTex = Resize(source, (int) (width * factor), 
+            (int) (height * factor), linear, useGPUCopy);
 
         if (Application.isPlaying)
             Object.Destroy(source);


### PR DESCRIPTION
## What does this PR change?

This PR moves two magic numbers used to set texture max size for GLTF and other textures to a new static class in Configuration script file, it also creates two other constants of same type to be used in the desktop repo

...

## How to test the changes?

These changes should be tested in desktop repo together with desktop client changes. In order to test it you would have to make sure your desktop client package manager is using correct branch or local folder of unity-renderer repo.
