### PR TITLE
fix: scene bounds check persistent scenes

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Tests/BIWEntityHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/BuilderInWorld/Tests/BIWEntityHandlerShould.cs
@@ -34,6 +34,7 @@ public class BIWEntityHandlerShould : IntegrationTestSuite_Legacy
         yield return base.SetUp();
 
         scene = TestUtils.CreateTestScene();
+        scene.isPersistent = false;
         coreComponentsPlugin = new CoreComponentsPlugin();
         BuilderInWorldPlugin.RegisterRuntimeComponents();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -215,6 +215,9 @@ namespace DCL.Controllers
 
         public bool IsInsideSceneBoundaries(Bounds objectBounds)
         {
+            if (isPersistent)
+                return true;
+            
             if (!IsInsideSceneBoundaries(objectBounds.min + CommonScriptableObjects.worldOffset, objectBounds.max.y))
                 return false;
             if (!IsInsideSceneBoundaries(objectBounds.max + CommonScriptableObjects.worldOffset, objectBounds.max.y))
@@ -225,6 +228,9 @@ namespace DCL.Controllers
 
         public virtual bool IsInsideSceneBoundaries(Vector2Int gridPosition, float height = 0f)
         {
+            if (isPersistent)
+                return true;
+            
             if (parcels.Count == 0)
                 return false;
 
@@ -238,6 +244,9 @@ namespace DCL.Controllers
 
         public virtual bool IsInsideSceneBoundaries(Vector3 worldPosition, float height = 0f)
         {
+            if (isPersistent)
+                return true;
+            
             if (parcels.Count == 0)
                 return false;
 
@@ -287,6 +296,9 @@ namespace DCL.Controllers
         
         public bool IsInsideSceneOuterBoundaries(Bounds objectBounds)
         {
+            if (isPersistent)
+                return true;
+            
             Vector3 objectBoundsMin = new Vector3(objectBounds.min.x, 0f, objectBounds.min.z);
             Vector3 objectBoundsMax = new Vector3(objectBounds.max.x, 0f, objectBounds.max.z);
             bool isInsideOuterBoundaries = outerBounds.Contains(objectBoundsMin) && outerBounds.Contains(objectBoundsMax);
@@ -296,6 +308,9 @@ namespace DCL.Controllers
 
         public bool IsInsideSceneOuterBoundaries(Vector3 objectUnityPosition)
         {
+            if (isPersistent)
+                return true;
+            
             objectUnityPosition.y = 0f;
             return outerBounds.Contains(objectUnityPosition);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -140,7 +140,7 @@ namespace DCL.Controllers
 
         public void AddEntityToBeChecked(IDCLEntity entity, bool isPersistent = false, bool runPreliminaryEvaluation = false)
         {
-            if (!enabled)
+            if (!enabled || (entity.scene != null && entity.scene.isPersistent))
                 return;
 
             if (runPreliminaryEvaluation)
@@ -182,7 +182,7 @@ namespace DCL.Controllers
 
         public void RunEntityEvaluation(IDCLEntity entity, bool onlyOuterBoundsCheck)
         {
-            if (entity == null || entity.scene == null || entity.gameObject == null)
+            if (entity == null || entity.gameObject == null || entity.scene == null || entity.scene.isPersistent)
                 return;
 
             // Recursively evaluate entity children as well, we need to check this up front because this entity may not have meshes of its own, but the children may.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -1,15 +1,10 @@
-using System;
-using DCL.Models;
 using NUnit.Framework;
 using System.Collections;
-using System.Linq;
 using DCL;
 using DCL.Components;
 using DCL.Controllers;
 using DCL.Helpers;
-using DCL.Helpers.NFT;
 using DCL.Helpers.NFT.Markets;
-using NFTShape_Internal;
 using NSubstitute;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -29,6 +24,7 @@ namespace SceneBoundariesCheckerTests
 
             coreComponentsPlugin = new CoreComponentsPlugin();
             scene = TestUtils.CreateTestScene() as ParcelScene;
+            scene.isPersistent = false;
             Environment.i.world.sceneBoundsChecker.timeBetweenChecks = 0f;
             TestUtils_NFT.RegisterMockedNFTShape(Environment.i.world.componentFactory);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests_DebugMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests_DebugMode.cs
@@ -19,6 +19,7 @@ namespace SceneBoundariesCheckerTests
         {
             yield return base.SetUp();
             scene = TestUtils.CreateTestScene() as ParcelScene;
+            scene.isPersistent = false;
             coreComponentsPlugin = new CoreComponentsPlugin();
 
             Environment.i.world.sceneBoundsChecker.SetFeedbackStyle(new SceneBoundsFeedbackStyle_RedBox());

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
@@ -27,6 +27,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
     {
         yield return base.SetUp();
         scene = TestUtils.CreateTestScene();
+        scene.isPersistent = false;
         coreComponentsPlugin = new CoreComponentsPlugin();
         uuidComponentsPlugin = new UUIDEventsPlugin();
 

--- a/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
+++ b/unity-renderer/Assets/Tutorial/Tests/TutorialControllerShould.cs
@@ -30,6 +30,7 @@ namespace DCL.Tutorial_Tests
             yield return base.SetUp();
             Environment.i.world.state.loadedScenes = new Dictionary<string, IParcelScene>();
             genesisPlazaSimulator = TestUtils.CreateTestScene();
+            genesisPlazaSimulator.isPersistent = false;
             Environment.i.world.state.currentSceneId = genesisPlazaSimulator.sceneData.id;
             genesisPlazaSimulator.parcels.Add(genesisPlazaLocation);
             CreateAndConfigureTutorial();


### PR DESCRIPTION
Added persistent scenes flag check to avoid running scene boundaries checks for entities that come from a persistent (AKA global) scene, like the global scene for avatar shapes or the scene of every portable experience.

### TESTING - Make sure previously-solved scene boundaries checking issues are still solved:
1. Check that the already-solved https://github.com/decentraland/unity-renderer/pull/2811 issue hasn't reappeared: 
In [production](https://play.decentraland.org/?position=90%2C-143) there are invisible colliders on the empty parcels at the left of the affected scene (90, -143).
In [that PR's build](https://play.decentraland.zone/?renderer-branch=fix/SceneBoundsCheckPersistentScenes&position=90%2C-143) those colliders are disabled as they are detected as part of the mesh of the entity that contains them and that is detected as outside the scene boundaries.

2. Check that the already-solved https://github.com/decentraland/unity-renderer/issues/2132 issue hasn't reappeared:
    1. Spawn [at -12, -10](https://play.decentraland.zone/?renderer-branch=fix/SceneBoundsCheckPersistentScenes&position=-12%2C-10) and wait until Genesis Plaza finishes loading (make sure the Scene Load Radius value in the settings is 4) 
    2. Open Settings, change the Scene Load Radius to 1 and wait 5~ seconds
    3. Change Scene Load Radius to 4 and close the settings panel, wait for 5~10 seconds after the Genesis Plaza finishes loading and notice that he "black and white" bug doesn't happen anymore
    4. Steps 2 and 3 can be reproduced many times and the black and white bug won't happen again 
[Doing those steps from master's build will trigger the black and white bug]

3. Check that the baisc scene bounds checking is working fine in our test scene in GOERLI: https://play.decentraland.zone/?renderer-branch=fix/SceneBoundsCheckPersistentScenes&NETWORK=goerli&position=62%2C-67