### PR TITLE
fix: avatar attach component in portable experience

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarAttach/AnchorPointsGetterHandlers/GetAnchorPointsHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarAttach/AnchorPointsGetterHandlers/GetAnchorPointsHandler.cs
@@ -7,6 +7,7 @@ namespace DCL.Components
         public event Action OnAvatarRemoved;
 
         private Action<IAvatarAnchorPoints> onAvatarFound;
+        private bool cleaned = false;
 
         private UserProfile ownPlayerProfile => UserProfile.GetOwnUserProfile();
 
@@ -22,6 +23,7 @@ namespace DCL.Components
         public void SearchAnchorPoints(string avatarId, Action<IAvatarAnchorPoints> onSuccess)
         {
             CleanUp();
+            cleaned = false;
 
             if (string.IsNullOrEmpty(avatarId))
                 return;
@@ -35,7 +37,7 @@ namespace DCL.Components
                 ownPlayerProfile.OnUpdate -= GetOwnProfileUpdated;
                 ownUserId = profile.userId;
 
-                if (onAvatarFound == null)
+                if (cleaned)
                 {
                     return;
                 }
@@ -74,6 +76,7 @@ namespace DCL.Components
         private void CleanUp()
         {
             onAvatarFound = null;
+            cleaned = true;
 
             if (currentAnchorPointsGetterHandler != null)
             {

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarAttach/AnchorPointsGetterHandlers/GetAnchorPointsHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarAttach/AnchorPointsGetterHandlers/GetAnchorPointsHandler.cs
@@ -8,7 +8,7 @@ namespace DCL.Components
 
         private Action<IAvatarAnchorPoints> onAvatarFound;
 
-        private string ownPlayerId => UserProfile.GetOwnUserProfile().userId;
+        private UserProfile ownPlayerProfile => UserProfile.GetOwnUserProfile();
 
         private IAnchorPointsGetterHandler ownPlayerAnchorPointsGetterHandler => new OwnPlayerGetAnchorPointsHandler();
         private IAnchorPointsGetterHandler otherPlayerAnchorPointsGetterHandler => new OtherPlayerGetAnchorPointsHandler();
@@ -26,12 +26,34 @@ namespace DCL.Components
             if (string.IsNullOrEmpty(avatarId))
                 return;
 
+            string ownUserId = ownPlayerProfile.userId;
+
             onAvatarFound = onSuccess;
 
-            currentAnchorPointsGetterHandler = GetHandler(avatarId);
-            currentAnchorPointsGetterHandler.OnAvatarFound += OnAvatarFoundEvent;
-            currentAnchorPointsGetterHandler.OnAvatarRemoved += OnAvatarRemovedEvent;
-            currentAnchorPointsGetterHandler.GetAnchorPoints(avatarId);
+            void GetOwnProfileUpdated(UserProfile profile)
+            {
+                ownPlayerProfile.OnUpdate -= GetOwnProfileUpdated;
+                ownUserId = profile.userId;
+
+                if (onAvatarFound == null)
+                {
+                    return;
+                }
+
+                currentAnchorPointsGetterHandler = GetHandler(avatarId, ownUserId);
+                currentAnchorPointsGetterHandler.OnAvatarFound += OnAvatarFoundEvent;
+                currentAnchorPointsGetterHandler.OnAvatarRemoved += OnAvatarRemovedEvent;
+                currentAnchorPointsGetterHandler.GetAnchorPoints(avatarId);
+            }
+
+            if (string.IsNullOrEmpty(ownUserId))
+            {
+                ownPlayerProfile.OnUpdate += GetOwnProfileUpdated;
+            }
+            else
+            {
+                GetOwnProfileUpdated(ownPlayerProfile);
+            }
         }
 
         /// <summary>
@@ -61,7 +83,7 @@ namespace DCL.Components
             }
         }
 
-        private IAnchorPointsGetterHandler GetHandler(string id)
+        private IAnchorPointsGetterHandler GetHandler(string id, string ownPlayerId)
         {
             return id == ownPlayerId ? ownPlayerAnchorPointsGetterHandler : otherPlayerAnchorPointsGetterHandler;
         }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarAttach/Tests/AvatarAttachHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarAttach/Tests/AvatarAttachHandlerShould.cs
@@ -7,6 +7,7 @@ using DCL.Models;
 using NSubstitute;
 using NSubstitute.Extensions;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 
 namespace DCL.ECSComponents.Test
@@ -17,6 +18,7 @@ namespace DCL.ECSComponents.Test
         private IParcelScene scene;
         private IDCLEntity entity;
         private GameObject entityGo;
+        private UserProfile userProfile;
 
         [SetUp]
         public void Setup()
@@ -31,11 +33,18 @@ namespace DCL.ECSComponents.Test
 
             entity = Substitute.For<IDCLEntity>();
             entity.Configure().gameObject.Returns(entityGo);
+            
+            userProfile = UserProfile.GetOwnUserProfile();
+            userProfile.UpdateData(new UserProfileModel() { userId = "ownUserId" });
         }
         
         [TearDown]
         public void TearDown()
         {
+            if (userProfile != null && AssetDatabase.Contains(userProfile))
+            {
+                Resources.UnloadAsset(userProfile);
+            }            
             handler.Dispose();
             DataStore.Clear();
             Object.Destroy(entityGo);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/Tests/AvatarAttachHandlerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/Tests/AvatarAttachHandlerShould.cs
@@ -5,16 +5,30 @@ using DCL.Controllers;
 using DCL.Models;
 using NSubstitute;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 
 namespace AvatarAttach_Tests
 {
     public class AvatarAttachHandlerShould
     {
+        private UserProfile userProfile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            userProfile = UserProfile.GetOwnUserProfile();
+            userProfile.UpdateData(new UserProfileModel() { userId = "ownUserId" });
+        }
+
         [TearDown]
         public void TearDown()
         {
             DataStore.Clear();
+            if (userProfile != null && AssetDatabase.Contains(userProfile))
+            {
+                Resources.UnloadAsset(userProfile);
+            }
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/Tests/AvatarAttachPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/AvatarAttach/Tests/AvatarAttachPlayerHandlerShould.cs
@@ -10,6 +10,13 @@ namespace AvatarAttach_Tests
     {
         private UserProfile userProfile;
 
+        [SetUp]
+        public void SetUp()
+        {
+            userProfile = UserProfile.GetOwnUserProfile();
+            userProfile.UpdateData(new UserProfileModel() { userId = "ownUserId" });
+        }
+
         [TearDown]
         public void TearDown()
         {
@@ -44,7 +51,6 @@ namespace AvatarAttach_Tests
         {
             const string playerId = "Temptation";
 
-            userProfile = UserProfile.GetOwnUserProfile();
             userProfile.UpdateData(new UserProfileModel() { userId = playerId });
 
             BaseVariable<Player> ownPlayer = DataStore.i.player.ownPlayer;


### PR DESCRIPTION
player profile is resolved after the component is updated.
adding this component at the beginning of a portable experience won't attach the entity to the player since userId is empty.
we are hooking to the profile update to wait until is resolved before trying make the attachment

test link: https://play.decentraland.zone/?GLOBAL_PX=urn%3Adecentraland%3Aentity%3Abafkreidfs3xlfb6kkemmjn23qpg64qhghbghwafoa2uoi57izof5kf2nti%3FbaseUrl%3Dhttps%3A%2F%2Fsdk-content-server.decentraland.org%2Fipfs%2F&position=52,52&DEBUG_SCENE_LOG&renderer-branch=fix/avatar-attach-px
if you see a cube over your avatar head, then it's working :)