### PR TITLE
fix: onpointerevent colliders reset on scene bounds check

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/DCL.Plugins.UUIDEventComponents.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/DCL.Plugins.UUIDEventComponents.asmdef
@@ -15,7 +15,8 @@
         "GUID:1dd0780aa6be12b428c8005d0bee46b8",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:a78c5d8dad39efe45ab1b21901f8db0f",
-        "GUID:1c69d8bb67ff1244b8de3b17766ccbef"
+        "GUID:1c69d8bb67ff1244b8de3b17766ccbef",
+        "GUID:5289a39f46259954ca74010d7c9ded16"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/DCL.Components.Events.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/DCL.Components.Events.asmdef
@@ -25,7 +25,8 @@
         "GUID:9857fe4bae4e30441bc3a577c5de790a",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:3047fd2f05bcaae498a99a3f9321f9a8",
-        "GUID:1c69d8bb67ff1244b8de3b17766ccbef"
+        "GUID:1c69d8bb67ff1244b8de3b17766ccbef",
+        "GUID:5289a39f46259954ca74010d7c9ded16"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/OnPointerEvent.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/OnPointerEvent.cs
@@ -27,6 +27,12 @@ namespace DCL.Components
             this.entity = entity;
             eventColliders.Initialize(entity);
         }
+        
+        public void UpdateCollidersEnabledBasedOnRenderers(IDCLEntity entity)
+        {
+            this.entity = entity;
+            eventColliders.UpdateCollidersEnabledBasedOnRenderers(entity);
+        }
 
         public void SetFeedbackState(bool showFeedback, bool hoverState, string button, string hoverText)
         {
@@ -62,7 +68,7 @@ namespace DCL.Components
         }
     }
 
-    public class OnPointerEvent : UUIDComponent, IPointerInputEvent
+    public class OnPointerEvent : UUIDComponent, IPointerInputEvent, IOutOfSceneBoundariesHandler
     {
         public static bool enableInteractionHoverFeedback = true;
 
@@ -109,6 +115,8 @@ namespace DCL.Components
 
             entity.OnShapeUpdated -= SetEventColliders;
             entity.OnShapeUpdated += SetEventColliders;
+            
+            DataStore.i.sceneBoundariesChecker.Add(entity,this);
         }
 
         public WebInterface.ACTION_BUTTON GetActionButton()
@@ -167,6 +175,8 @@ namespace DCL.Components
             if (entity != null)
                 entity.OnShapeUpdated -= SetEventColliders;
 
+            DataStore.i.sceneBoundariesChecker.Remove(entity,this);
+            
             pointerEventHandler.Dispose();
         }
 
@@ -177,6 +187,11 @@ namespace DCL.Components
         public virtual PointerInputEventType GetEventType()
         {
             return PointerInputEventType.NONE;
+        }
+
+        public void UpdateOutOfBoundariesState(bool enable)
+        {
+            pointerEventHandler.UpdateCollidersEnabledBasedOnRenderers(entity);
         }
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/OnPointerEventColliders.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/OnPointerEventColliders.cs
@@ -61,6 +61,27 @@ namespace DCL.Components
             }
         }
 
+        public void UpdateCollidersEnabledBasedOnRenderers(IDCLEntity entity)
+        {
+            if (colliders == null || colliders.Length == 0)
+                return;
+            
+            Renderer[] rendererList = entity?.meshesInfo?.renderers;
+            
+            if (rendererList == null || rendererList.Length == 0)
+            {
+                DestroyColliders();
+                return;
+            }
+            
+            for (int i = 0; i < colliders.Length; i++)
+            {
+                if (rendererList[i] == null)
+                    continue;
+                colliders[i].enabled = rendererList[i].enabled;
+            }
+        }
+
         void UpdateCollidersWithRenderersMesh(Renderer[] rendererList)
         {
             for (int i = 0; i < colliders.Length; i++)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/Tests/AudioTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/Tests/AudioTests.cs
@@ -195,9 +195,6 @@ namespace Tests
             // We disable SceneController monobehaviour to avoid its current scene id update
             sceneController.enabled = false;
 
-            // Set current scene with this scene's id
-            CommonScriptableObjects.sceneID.Set(scene.sceneData.id);
-
             var entity = TestUtils.CreateSceneEntity(scene);
             yield return null;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/Tests/AudioTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/Tests/AudioTests.cs
@@ -195,6 +195,9 @@ namespace Tests
             // We disable SceneController monobehaviour to avoid its current scene id update
             sceneController.enabled = false;
 
+            // Set current scene with this scene's id
+            CommonScriptableObjects.sceneID.Set(scene.sceneData.id);
+
             var entity = TestUtils.CreateSceneEntity(scene);
             yield return null;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Tests/VideoTextureShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Tests/VideoTextureShould.cs
@@ -3,7 +3,6 @@ using DCL;
 using DCL.Helpers;
 using DCL.Components;
 using DCL.Models;
-using NUnit.Framework;
 using System.Collections;
 using DCL.Components.Video.Plugin;
 using UnityEngine;
@@ -11,8 +10,6 @@ using UnityEngine.TestTools;
 using DCL.Controllers;
 using DCL.Interface;
 using DCL.SettingsCommon;
-using NSubstitute;
-using UnityEngine.Assertions;
 using Assert = UnityEngine.Assertions.Assert;
 using AudioSettings = DCL.SettingsCommon.AudioSettings;
 
@@ -31,6 +28,8 @@ namespace Tests
 
             coreComponentsPlugin = new CoreComponentsPlugin();
             scene = TestUtils.CreateTestScene() as ParcelScene;
+            CommonScriptableObjects.sceneID.Set(scene.sceneData.id);
+            
             IVideoPluginWrapper pluginWrapper = new VideoPluginWrapper_Mock();
             originalVideoPluginBuilder = DCLVideoTexture.videoPluginWrapperBuilder;
             DCLVideoTexture.videoPluginWrapperBuilder = () => pluginWrapper;
@@ -332,7 +331,7 @@ namespace Tests
             var component = CreateDCLVideoTextureWithCustomTextureModel(scene, model);
 
             yield return component.routine;
-
+            
             Assert.AreApproximatelyEqual(1f, component.texturePlayer.volume, 0.01f);
 
             AudioSettings settings = Settings.i.audioSettings.Data;
@@ -349,7 +348,6 @@ namespace Tests
 
             DCLVideoTexture.videoPluginWrapperBuilder = originalVideoPluginBuilder;
         }
-
 
         [UnityTest]
         public IEnumerator UnmuteWhenVideoIsCreatedWithUserInScene()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_SceneBoundariesChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_SceneBoundariesChecker.cs
@@ -8,6 +8,6 @@ namespace DCL
 {
     public class DataStore_SceneBoundariesChecker
     {
-        public BaseDictionary<long, List<IOutOfSceneBoundariesHandler>> componentsCheckSceneBoundaries = new BaseDictionary<long, List<IOutOfSceneBoundariesHandler>>();
+        public BaseDictionary<long, HashSet<IOutOfSceneBoundariesHandler>> componentsCheckSceneBoundaries = new BaseDictionary<long, HashSet<IOutOfSceneBoundariesHandler>>();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_SceneBoundariesChecker_Extensions.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_SceneBoundariesChecker_Extensions.cs
@@ -9,15 +9,15 @@ public static class DataStore_SceneBoundariesChecker_Extensions
 {
     public static void Add(this DataStore_SceneBoundariesChecker self,IDCLEntity entity, IOutOfSceneBoundariesHandler handler)
     {
-        if (!self.componentsCheckSceneBoundaries.TryGetValue(entity.entityId, out List<IOutOfSceneBoundariesHandler> handlersList))
-            self.componentsCheckSceneBoundaries.Add(entity.entityId,new List<IOutOfSceneBoundariesHandler>() { handler });
+        if (!self.componentsCheckSceneBoundaries.TryGetValue(entity.entityId, out HashSet<IOutOfSceneBoundariesHandler> handlersList))
+            self.componentsCheckSceneBoundaries.Add(entity.entityId,new HashSet<IOutOfSceneBoundariesHandler>() { handler });
         else
             handlersList.Add(handler);
     }
     
     public static void Remove(this DataStore_SceneBoundariesChecker self,IDCLEntity entity, IOutOfSceneBoundariesHandler handler)
     {
-        if (!self.componentsCheckSceneBoundaries.TryGetValue(entity.entityId, out List<IOutOfSceneBoundariesHandler> handlersList))
+        if (!self.componentsCheckSceneBoundaries.TryGetValue(entity.entityId, out HashSet<IOutOfSceneBoundariesHandler> handlersList))
             return;
 
         if (handlersList.Count <= 1)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
@@ -11,6 +11,13 @@ public static class NotificationScriptableObjects
 
     private static FloatVariable pendingFriendRequestsValue;
     public static FloatVariable pendingFriendRequests => CommonScriptableObjects.GetOrLoad(ref pendingFriendRequestsValue, "ScriptableObjects/NotificationBadge_PendingFriendRequests");
+    
+    public static void UnloadAll()
+    {
+        Resources.UnloadAsset(newApprovedFriendsValue);
+        Resources.UnloadAsset(pendingChatMessagesValue);
+        Resources.UnloadAsset(pendingFriendRequestsValue);
+    }
 }
 
 public static class AudioScriptableObjects
@@ -99,6 +106,37 @@ public static class AudioScriptableObjects
 
     private static AudioEvent tooltipPopupEvent;
     public static AudioEvent tooltipPopup => CommonScriptableObjects.GetOrLoad(ref tooltipPopupEvent, "ScriptableObjects/AudioEvents/HUDCommon/TooltipPopup");
+    
+    public static void UnloadAll()
+    {
+        Resources.UnloadAsset(builderEnterEvent);
+        Resources.UnloadAsset(builderReadyEvent);
+        Resources.UnloadAsset(cameraFadeInEvent);
+        Resources.UnloadAsset(cameraFadeOutEvent);
+        Resources.UnloadAsset(buttonHoverEvent);
+        Resources.UnloadAsset(buttonClickEvent);
+        Resources.UnloadAsset(buttonReleaseEvent);
+        Resources.UnloadAsset(cancelEvent);
+        Resources.UnloadAsset(confirmEvent);
+        Resources.UnloadAsset(dialogOpenEvent);
+        Resources.UnloadAsset(dialogCloseEvent);
+        Resources.UnloadAsset(enableEvent);
+        Resources.UnloadAsset(errorEvent);
+        Resources.UnloadAsset(disableEvent);
+        Resources.UnloadAsset(fadeInEvent);
+        Resources.UnloadAsset(fadeOutEvent);
+        Resources.UnloadAsset(listItemAppearEvent);
+        Resources.UnloadAsset(chatReceiveGlobalEvent);
+        Resources.UnloadAsset(chatReceivePrivateEvent);
+        Resources.UnloadAsset(chatSendEvent);
+        Resources.UnloadAsset(notificationEvent);
+        Resources.UnloadAsset(sliderValueChangeEvent);
+        Resources.UnloadAsset(inputFieldFocusEvent);
+        Resources.UnloadAsset(inputFieldUnfocusEvent);
+        Resources.UnloadAsset(UIHideEvent);
+        Resources.UnloadAsset(UIShowEvent);
+        Resources.UnloadAsset(tooltipPopupEvent);
+    }
 }
 
 public static class CommonScriptableObjects
@@ -207,5 +245,41 @@ public static class CommonScriptableObjects
         }
 
         return variable;
+    }
+
+    public static void UnloadAll()
+    {
+        Resources.UnloadAsset(playerUnityPositionValue);
+        Resources.UnloadAsset(playerUnityEulerAnglesValue);
+        Resources.UnloadAsset(worldOffsetValue);
+        Resources.UnloadAsset(playerCoordsValue);
+        Resources.UnloadAsset(playerIsOnMovingPlatformValue);
+        Resources.UnloadAsset(movingPlatformRotationDeltaValue);
+        Resources.UnloadAsset(sceneIDValue);
+        Resources.UnloadAsset(minimapZoomValue);
+        Resources.UnloadAsset(characterForwardValue);
+        Resources.UnloadAsset(cameraForwardValue);
+        Resources.UnloadAsset(cameraPositionValue);
+        Resources.UnloadAsset(cameraRightValue);
+        Resources.UnloadAsset(cameraIsBlendingValue);
+        Resources.UnloadAsset(cameraBlockedValue);
+        Resources.UnloadAsset(playerInfoCardVisibleStateValue);
+        Resources.UnloadAsset(forcePerformanceMeterValue);
+        Resources.UnloadAsset(rendererStateValue);
+        Resources.UnloadAsset(focusStateValue);
+        Resources.UnloadAsset(lastReadChatMessagesDictionary);
+        Resources.UnloadAsset(lastReadChatMessagesValue);
+        Resources.UnloadAsset(allUIHiddenValue);
+        Resources.UnloadAsset(builderInWorldNotNecessaryUIVisibilityStatusValue);
+        Resources.UnloadAsset(latestOpenChatsValue);
+        Resources.UnloadAsset(cameraModeValue);
+        Resources.UnloadAsset(cameraModeInputLockedValue);
+        Resources.UnloadAsset(isProfileHUDOpenValue);
+        Resources.UnloadAsset(isFullscreenHUDOpenValue);
+        Resources.UnloadAsset(isTaskbarHUDInitializedValue);
+        Resources.UnloadAsset(tutorialActiveValue);
+        Resources.UnloadAsset(featureKeyTriggersBlockedValue);
+        Resources.UnloadAsset(emailPromptActiveValue);
+        Resources.UnloadAsset(voiceChatDisabledValue);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -231,15 +231,15 @@ namespace DCL.Controllers
             
             if (!entity.isInsideSceneOuterBoundaries)
             {
-                SetEntityInsideBoundariesState(entity, false);
                 SetComponentsInsideBoundariesValidState(entity, false);
+                SetEntityInsideBoundariesState(entity, false);
             }
             
             if (!onlyOuterBoundsCheck)
             {
                 bool isInsideBoundaries = entity.scene.IsInsideSceneBoundaries(entityGOPosition + CommonScriptableObjects.worldOffset.Get());
-                SetEntityInsideBoundariesState(entity, isInsideBoundaries);
                 SetComponentsInsideBoundariesValidState(entity, isInsideBoundaries);
+                SetEntityInsideBoundariesState(entity, isInsideBoundaries);
             }
         }
 
@@ -310,19 +310,23 @@ namespace DCL.Controllers
 
         private void SetMeshesAndComponentsInsideBoundariesState(IDCLEntity entity, bool isInsideBoundaries)
         {
-            SetEntityInsideBoundariesState(entity, isInsideBoundaries);
-
-            SetEntityMeshesValidState(entity.meshesInfo, isInsideBoundaries);
-            SetEntityCollidersValidState(entity.meshesInfo, isInsideBoundaries);
+            if (entity.isInsideSceneBoundaries == isInsideBoundaries)
+                return;
+            
+            SetEntityMeshesInsideBoundariesState(entity.meshesInfo, isInsideBoundaries);
+            SetEntityCollidersInsideBoundariesState(entity.meshesInfo, isInsideBoundaries);
             SetComponentsInsideBoundariesValidState(entity, isInsideBoundaries);
+            
+            // Should always be set last as entity.isInsideSceneBoundaries is checked to avoid re-running code unnecessarily
+            SetEntityInsideBoundariesState(entity, isInsideBoundaries);
         }
 
-        private void SetEntityMeshesValidState(MeshesInfo meshesInfo, bool isInsideBoundaries)
+        private void SetEntityMeshesInsideBoundariesState(MeshesInfo meshesInfo, bool isInsideBoundaries)
         {
             feedbackStyle.ApplyFeedback(meshesInfo, isInsideBoundaries);
         }
 
-        private void SetEntityCollidersValidState(MeshesInfo meshesInfo, bool isInsideBoundaries)
+        private void SetEntityCollidersInsideBoundariesState(MeshesInfo meshesInfo, bool isInsideBoundaries)
         {
             if (meshesInfo == null || meshesInfo.colliders.Count == 0 || !meshesInfo.currentShape.HasCollisions())
                 return;
@@ -338,7 +342,7 @@ namespace DCL.Controllers
 
         private void SetComponentsInsideBoundariesValidState(IDCLEntity entity, bool isInsideBoundaries)
         {
-            if(!DataStore.i.sceneBoundariesChecker.componentsCheckSceneBoundaries.ContainsKey(entity.entityId))
+            if(entity.isInsideSceneBoundaries == isInsideBoundaries || !DataStore.i.sceneBoundariesChecker.componentsCheckSceneBoundaries.ContainsKey(entity.entityId))
                 return;
             
             List<IOutOfSceneBoundariesHandler> components = DataStore.i.sceneBoundariesChecker.componentsCheckSceneBoundaries[entity.entityId];

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -310,9 +310,6 @@ namespace DCL.Controllers
 
         private void SetMeshesAndComponentsInsideBoundariesState(IDCLEntity entity, bool isInsideBoundaries)
         {
-            if (entity.isInsideSceneBoundaries == isInsideBoundaries)
-                return;
-            
             SetEntityMeshesInsideBoundariesState(entity.meshesInfo, isInsideBoundaries);
             SetEntityCollidersInsideBoundariesState(entity.meshesInfo, isInsideBoundaries);
             SetComponentsInsideBoundariesValidState(entity, isInsideBoundaries);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -345,11 +345,9 @@ namespace DCL.Controllers
             if(entity.isInsideSceneBoundaries == isInsideBoundaries || !DataStore.i.sceneBoundariesChecker.componentsCheckSceneBoundaries.ContainsKey(entity.entityId))
                 return;
             
-            List<IOutOfSceneBoundariesHandler> components = DataStore.i.sceneBoundariesChecker.componentsCheckSceneBoundaries[entity.entityId];
-
-            for (int i = 0; i < components.Count; i++)
+            foreach (IOutOfSceneBoundariesHandler component in DataStore.i.sceneBoundariesChecker.componentsCheckSceneBoundaries[entity.entityId])
             {
-                components[i].UpdateOutOfBoundariesState(isInsideBoundaries);
+                component.UpdateOutOfBoundariesState(isInsideBoundaries);   
             }
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
@@ -386,6 +386,46 @@ namespace SceneBoundariesCheckerTests
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
+        
+        public static IEnumerator OnPointerEventCollidersAreResetWhenReenteringBounds(ParcelScene scene)
+        {
+            var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(18, 1, 18));
+            yield return boxShape.routine;
+            
+            var entity = boxShape.attachedEntities.First();
+            // yield return null;
+            
+            // Attach onpointer event component
+            string onPointerId = "pointerevent-1";
+            var OnPointerDownModel = new OnPointerDown.Model()
+            {
+                type = "pointerUp",
+                uuid = onPointerId
+            };
+            
+            // Grab onpointer event collider
+            var component = TestUtils.EntityComponentCreate<OnPointerDown, OnPointerDown.Model>(scene, entity,
+                OnPointerDownModel, CLASS_ID_COMPONENT.UUID_CALLBACK);
+
+            var meshFilter = entity.gameObject.GetComponentInChildren<MeshFilter>();
+            var onPointerEventCollider = meshFilter.transform.Find(OnPointerEventColliders.COLLIDER_NAME).GetComponent<MeshCollider>();
+
+            Assert.IsTrue(onPointerEventCollider != null, "OnPointerEventCollider should exist");
+
+            // Check onpointer evwent collider is disabled with the entity outside scene boundaries
+            AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
+            Assert.IsFalse(onPointerEventCollider.enabled);
+
+            // Move object to re-enter the scene boundaries
+            var transformModel = new DCLTransform.Model { position = new Vector3(8, 1, 8) };
+            TestUtils.SetEntityTransform(scene, entity, transformModel);
+
+            yield return null;
+            yield return null;
+
+            AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
+            Assert.IsTrue(onPointerEventCollider.enabled);
+        }
 
         public static IEnumerator GLTFShapeIsResetWhenReenteringBounds(ParcelScene scene)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
@@ -393,7 +393,6 @@ namespace SceneBoundariesCheckerTests
             yield return boxShape.routine;
             
             var entity = boxShape.attachedEntities.First();
-            // yield return null;
             
             // Attach onpointer event component
             string onPointerId = "pointerevent-1";
@@ -412,7 +411,7 @@ namespace SceneBoundariesCheckerTests
 
             Assert.IsTrue(onPointerEventCollider != null, "OnPointerEventCollider should exist");
 
-            // Check onpointer evwent collider is disabled with the entity outside scene boundaries
+            // Check onpointer event collider is disabled with the entity outside scene boundaries
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
             Assert.IsFalse(onPointerEventCollider.enabled);
 
@@ -423,6 +422,7 @@ namespace SceneBoundariesCheckerTests
             yield return null;
             yield return null;
 
+            // Check onpointer event collider got enabled
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
             Assert.IsTrue(onPointerEventCollider.enabled);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.asmdef
@@ -51,7 +51,9 @@
         "GUID:ba1fa35f5f69c024fabff38cdd17f569",
         "GUID:ab04b35c8c4a57847889009b508e53ae",
         "GUID:44a9db8f655ab05409802e5476cf9dd3",
-        "GUID:9a16a75a9de4ba2458b50ed374f1b28f"
+        "GUID:9a16a75a9de4ba2458b50ed374f1b28f",
+        "GUID:be0e3042b7c1c6e41ae8221ae6470d80",
+        "GUID:44002c75b9995c34d97b8afc551d32eb"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -16,29 +16,32 @@ namespace SceneBoundariesCheckerTests
     {
         private ParcelScene scene;
         private CoreComponentsPlugin coreComponentsPlugin;
+        private UUIDEventsPlugin uuidEventsPlugin;
 
         [UnitySetUp]
         protected override IEnumerator SetUp()
         {
             yield return base.SetUp();
 
+            uuidEventsPlugin = new UUIDEventsPlugin();
             coreComponentsPlugin = new CoreComponentsPlugin();
             scene = TestUtils.CreateTestScene() as ParcelScene;
             scene.isPersistent = false;
             Environment.i.world.sceneBoundsChecker.timeBetweenChecks = 0f;
             TestUtils_NFT.RegisterMockedNFTShape(Environment.i.world.componentFactory);
+            
         }
 
         protected override IEnumerator TearDown()
         {
+            uuidEventsPlugin.Dispose();
             coreComponentsPlugin.Dispose();
             yield return base.TearDown();
         }
-
+        
         protected override ServiceLocator InitializeServiceLocator()
         {
             ServiceLocator result = base.InitializeServiceLocator();
-
             result.Register<IServiceProviders>(
                 () =>
                 {
@@ -90,6 +93,9 @@ namespace SceneBoundariesCheckerTests
 
         [UnityTest]
         public IEnumerator PShapeIsResetWhenReenteringBounds() { yield return SBC_Asserts.PShapeIsResetWhenReenteringBounds(scene); }
+        
+        [UnityTest]
+        public IEnumerator OnPointerEventCollidersAreResetWhenReenteringBounds() { yield return SBC_Asserts.OnPointerEventCollidersAreResetWhenReenteringBounds(scene); }
 
         [UnityTest]
         public IEnumerator NFTShapeIsInvalidatedWhenStartingOutOfBounds() { yield return SBC_Asserts.NFTShapeIsInvalidatedWhenStartingOutOfBounds(scene); }

--- a/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
+++ b/unity-renderer/Assets/Scripts/Tests/IntegrationTestSuite_Legacy.cs
@@ -114,6 +114,12 @@ public class IntegrationTestSuite_Legacy
         Environment.Dispose();
 
         yield return null;
+        
+        NotificationScriptableObjects.UnloadAll();
+        AudioScriptableObjects.UnloadAll();
+        CommonScriptableObjects.UnloadAll();
+        
+        yield return null;
 
         GameObject[] gos = Object.FindObjectsOfType<GameObject>(true);
 


### PR DESCRIPTION
### WHY
When an entity with a shape is outside the scene boundaries, its renderers are disabled. If at that moment an OnPointerEvent component is attached to the entity, it will have its onpointer event colliders disabled and they'll never be enabled when the entity re-enters the scene boundaries and gets re-evaluated.

That happens because during onpointer vent colliders initialization, the colliders are initialized as enabled/disabled based on the entity renderers enabled value.

### WHAT
- Implemented 'IOutOfSceneBoundariesHandler' interface in OnPointerEvent to be called when the pertinent scene changes its 'inside scene boundaries' state.
- Added pointer event colliders update based on renderers state after scene boundaries state change event
- Implemented `UnloadAll()` method in old `CommonScriptableObjects` classes
- Added `UnloadAll()` call in `IntegrationTestSuite_Legacy.TearDown()` to clean `CommonScriptableObjects` classes after every test to avoid many tests failing only when run all together (but passing when run as isolated).

### TESTING
1. Enter the Ice Poker Stronghold scene (`.org` url has to be used otherwise the scene doesn't load the poker tables)
2. Approach a poker table and confirm that every floating card has the onpointer event hover feedback and is clickable

#### Confirm **problem** using `dev` build
https://play.decentraland.org/?renderer-branch=dev&position=-100,129&LOS=0

https://user-images.githubusercontent.com/1031741/187985556-41c70df6-5833-460b-9233-ef564bce4292.mp4

#### Confirm **fix** using `fix/onPointerEventCollidersResetOnSceneBoundsCheck` build
https://play.decentraland.org/?renderer-branch=fix/onPointerEventCollidersResetOnSceneBoundsCheck&position=-100,129&LOS=0

https://user-images.githubusercontent.com/1031741/187985650-185884e2-aea2-4aa8-a54a-ec340cfc064f.mp4