### PR TITLE
nft emotes different approach to new structure

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationsTracker.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationsTracker.cs
@@ -100,8 +100,8 @@ namespace DCL.Emotes
 
             try
             {
-                WearableItem emote;
-                emote = await emotesCatalogService.RequestEmoteAsync(emoteId, ct);
+                var emote = await emotesCatalogService.RequestEmoteAsync(emoteId, ct) ?? 
+                                       await wearableItemResolver.Resolve(emoteId, ct);
 
                 IEmoteAnimationLoader animationLoader = emoteAnimationLoaderFactory.Get();
                 loaders.Add((bodyShapeId, emoteId), animationLoader);

--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationsTracker.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationsTracker.cs
@@ -101,10 +101,7 @@ namespace DCL.Emotes
             try
             {
                 WearableItem emote;
-                if (dataStore.newFlowEnabled.Get())
-                    emote = await emotesCatalogService.RequestEmoteAsync(emoteId, ct);
-                else
-                    emote = await wearableItemResolver.Resolve(emoteId, ct);
+                emote = await emotesCatalogService.RequestEmoteAsync(emoteId, ct);
 
                 IEmoteAnimationLoader animationLoader = emoteAnimationLoaderFactory.Get();
                 loaders.Add((bodyShapeId, emoteId), animationLoader);

--- a/unity-renderer/Assets/DCLPlugins/EquippedEmotes/EquippedEmotesPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/EquippedEmotes/EquippedEmotesPlugin.cs
@@ -40,7 +40,7 @@ namespace DCL.EquippedEmotes
 
         private void OnOwnUserProfileUpdated(UserProfile userProfile)
         {
-            if (userProfile == null || userProfile.avatar == null || !DataStore.i.emotes.newFlowEnabled.Get())
+            if (userProfile == null || userProfile.avatar == null)
                 return;
 
             List<string> equippedEmotes = new List<string> (Enumerable.Repeat((string) null, 10));
@@ -91,14 +91,12 @@ namespace DCL.EquippedEmotes
 
         internal void OnEquippedEmotesSet(IEnumerable<EquippedEmoteData> equippedEmotes)
         {
-            if (!DataStore.i.emotes.newFlowEnabled.Get())
-                SaveEquippedEmotesInLocalStorage();
+          
         }
 
         internal void OnEquippedEmoteAddedOrRemoved(EquippedEmoteData equippedEmote)
         {
-            if (!DataStore.i.emotes.newFlowEnabled.Get())
-                SaveEquippedEmotesInLocalStorage();
+          
         }
 
         internal void SaveEquippedEmotesInLocalStorage()

--- a/unity-renderer/Assets/DCLPlugins/EquippedEmotes/EquippedEmotesPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/EquippedEmotes/EquippedEmotesPlugin.cs
@@ -40,7 +40,7 @@ namespace DCL.EquippedEmotes
 
         private void OnOwnUserProfileUpdated(UserProfile userProfile)
         {
-            if (userProfile == null || userProfile.avatar == null)
+            if (userProfile == null || userProfile.avatar == null || userProfile.avatar.emotes.Count == 0)
                 return;
 
             List<string> equippedEmotes = new List<string> (Enumerable.Repeat((string) null, 10));

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService.cs
@@ -172,8 +172,6 @@ public class EmotesCatalogService : IEmotesCatalogService
                 if (promises[id].Count == 0)
                     promises.Remove(id);
             }
-            
-            UnityEngine.Debug.LogError($"RequestEmoteAsync OperationCanceledException: {ex.Message} {ex.StackTrace}");
 
             return null;
         }

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService.cs
@@ -35,6 +35,9 @@ public class EmotesCatalogService : IEmotesCatalogService
                 continue;
 
             emotes[emote.id] = emote;
+            
+            
+            
             if (promises.TryGetValue(emote.id, out var emotePromises))
             {
                 foreach (Promise<WearableItem> promise in emotePromises)

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService.cs
@@ -154,7 +154,7 @@ public class EmotesCatalogService : IEmotesCatalogService
 
     public async UniTask<WearableItem> RequestEmoteAsync(string id, CancellationToken ct = default)
     {
-        const int TIMEOUT = 60;
+        const int TIMEOUT = 45;
         CancellationTokenSource timeoutCTS = new CancellationTokenSource();
         var timeout = timeoutCTS.CancelAfterSlim(TimeSpan.FromSeconds(TIMEOUT));
         ct.ThrowIfCancellationRequested();
@@ -164,7 +164,7 @@ public class EmotesCatalogService : IEmotesCatalogService
             var linkedCt = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCTS.Token);
             await promise.WithCancellation(linkedCt.Token).AttachExternalCancellation(linkedCt.Token);
         }
-        catch (OperationCanceledException e)
+        catch (OperationCanceledException ex)
         {
             if (promises.ContainsKey(id))
             {
@@ -172,6 +172,8 @@ public class EmotesCatalogService : IEmotesCatalogService
                 if (promises[id].Count == 0)
                     promises.Remove(id);
             }
+            
+            UnityEngine.Debug.LogError($"RequestEmoteAsync OperationCanceledException: {ex.Message} {ex.StackTrace}");
 
             return null;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -43,6 +43,7 @@ namespace AvatarSystem
         /// Starts the loading process for the Avatar. 
         /// </summary>
         /// <param name="wearablesIds"></param>
+        /// <param name="emotesIds"></param>
         /// <param name="settings"></param>
         /// <param name="ct"></param>
         public async UniTask Load(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken ct = default)
@@ -93,7 +94,8 @@ namespace AvatarSystem
             catch (Exception e)
             {
                 Dispose();
-                Debug.Log($"Avatar.Load failed with wearables:[{string.Join(",", wearablesIds)}] for bodyshape:{settings.bodyshapeId} and player {settings.playerName}");
+                Debug.Log($"Avatar.Load failed with wearables:[{string.Join(",", wearablesIds)}] " +
+                          $"for bodyshape:{settings.bodyshapeId} and player {settings.playerName}");
                 if (e.InnerException != null)
                     ExceptionDispatchInfo.Capture(e.InnerException).Throw();
                 else

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarCurator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarCurator.cs
@@ -49,7 +49,7 @@ namespace AvatarSystem
                 HashSet<string> hiddenCategories = WearableItem.ComposeHiddenCategories(settings.bodyshapeId, wearableItems);
 
                 //New emotes flow use the emotes catalog
-                if (emoteIds != null && DataStore.i.emotes.newFlowEnabled.Get())
+                if (emoteIds != null)
                 {
                     var moreEmotes = await emotesCatalog.RequestEmotesAsync(emoteIds.ToList(), ct);
                     if (moreEmotes != null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/Loader.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/Loader.cs
@@ -33,7 +33,8 @@ namespace AvatarSystem
             avatarMeshCombiner.uploadMeshToGpu = true;
         }
 
-        public async UniTask Load(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth, List<WearableItem> wearables, AvatarSettings settings, CancellationToken ct = default)
+        public async UniTask Load(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth,
+            List<WearableItem> wearables, AvatarSettings settings, CancellationToken ct = default)
         {
             await Load(bodyshape, eyes, eyebrows, mouth, wearables, settings, null, ct);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/WearableItemResolver.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/WearableItemResolver.cs
@@ -86,10 +86,12 @@ namespace AvatarSystem
                 return promise.value;
 
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException ex)
             {
-                //No disposing required
-                throw;
+                wearablesRetrieved.Remove(wearableId);
+                
+                UnityEngine.Debug.LogError($"Resolve wearable OperationCanceledException: {ex.Message} {ex.StackTrace}");
+                return null;
             }
             finally
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -172,17 +172,7 @@ namespace DCL
             {
                 HashSet<string> emotes = new HashSet<string>(currentAvatar.emotes.Select(x => x.urn));
                 var embeddedEmotesSo = Resources.Load<EmbeddedEmotesSO>("EmbeddedEmotes");
-                if (DataStore.i.emotes.newFlowEnabled.Get())
-                {
-                    emotes.UnionWith(embeddedEmotesSo.emotes.Select(x => x.id));
-                }
-                else
-                {
-                    //temporarily hardcoding the embedded emotes until the user profile provides the equipped ones
-                    //TODO remove this when new flow is the default and we can los retrocompatibility
-                    //temporarily hardcoding the embedded emotes until the user profile provides the equipped ones
-                    wearableItems.AddRange(embeddedEmotesSo.emotes.Select(x => x.id));
-                }
+                emotes.UnionWith(embeddedEmotesSo.emotes.Select(x => x.id));
 
                 //TODO Add Collider to the AvatarSystem
                 //TODO Without this the collider could get triggered disabling the avatar container,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -172,7 +172,14 @@ namespace DCL
             {
                 HashSet<string> emotes = new HashSet<string>(currentAvatar.emotes.Select(x => x.urn));
                 var embeddedEmotesSo = Resources.Load<EmbeddedEmotesSO>("EmbeddedEmotes");
-                emotes.UnionWith(embeddedEmotesSo.emotes.Select(x => x.id));
+                var embeddedEmoteIds = embeddedEmotesSo.emotes.Select(x => x.id);
+                //here we add emote ids to both new and old emote loading flow to merge the results later
+                //because some users might have emotes as wearables and others only as emotes
+                foreach (var emoteId in embeddedEmoteIds)
+                {
+                    emotes.Add(emoteId);
+                    wearableItems.Add(emoteId);
+                }
 
                 //TODO Add Collider to the AvatarSystem
                 //TODO Without this the collider could get triggered disabling the avatar container,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BotsController/BotsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BotsController/BotsController.cs
@@ -81,6 +81,7 @@ namespace DCL.Bots
         /// <param name="newWearables">The list of WearableItem objects to be added to the catalog</param>
         private void PopulateCatalog(List<WearableItem> newWearables)
         {
+            var wearablesToAdd = new List<WearableItem>();
             foreach (var wearableItem in newWearables)
             {
                 switch (wearableItem.data.category)
@@ -113,9 +114,12 @@ namespace DCL.Bots
                         bodyshapeWearableIds.Add(wearableItem.id);
                         break;
                 }
+                
+                if(wearableItem.emoteDataV0 == null)
+                    wearablesToAdd.Add(wearableItem);
             }
 
-            CatalogController.i.AddWearablesToCatalog(newWearables);
+            CatalogController.i.AddWearablesToCatalog(wearablesToAdd);
         }
 
         private Vector3 playerUnityPosition => CommonScriptableObjects.playerUnityPosition.Get();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BotsController/BotsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/BotsController/BotsController.cs
@@ -81,7 +81,6 @@ namespace DCL.Bots
         /// <param name="newWearables">The list of WearableItem objects to be added to the catalog</param>
         private void PopulateCatalog(List<WearableItem> newWearables)
         {
-            var wearablesToAdd = new List<WearableItem>();
             foreach (var wearableItem in newWearables)
             {
                 switch (wearableItem.data.category)
@@ -114,12 +113,9 @@ namespace DCL.Bots
                         bodyshapeWearableIds.Add(wearableItem.id);
                         break;
                 }
-                
-                if(wearableItem.emoteDataV0 == null)
-                    wearablesToAdd.Add(wearableItem);
             }
 
-            CatalogController.i.AddWearablesToCatalog(wearablesToAdd);
+            CatalogController.i.AddWearablesToCatalog(newWearables);
         }
 
         private Vector3 playerUnityPosition => CommonScriptableObjects.playerUnityPosition.Get();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -263,7 +263,7 @@ public class AvatarEditorHUDController : IHUD
                 }
             }
             
-            emotesCustomizationDataStore.FilterOutNotOwnedEquippedEmotes(emotesList);
+            emotesCustomizationDataStore.UnequipMissingEmotes(emotesList);
             emotesCustomizationComponentController.SetEmotes(emotesList.ToArray());
 
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -261,6 +261,8 @@ public class AvatarEditorHUDController : IHUD
 
                     emotesList.Add(emoteAsWearable);
                 }
+
+                emotesLoadedAsWearables = null;
             }
             
             emotesCustomizationDataStore.UnequipMissingEmotes(emotesList);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDModel.cs
@@ -10,7 +10,7 @@ public class AvatarEditorHUDModel
     public Color skinColor;
     public Color eyesColor;
 
-    public AvatarModel ToAvatarModel(int version)
+    public AvatarModel ToAvatarModel()
     {
         return new AvatarModel()
         {
@@ -18,8 +18,7 @@ public class AvatarEditorHUDModel
             wearables = wearables.Select(x => x.id).ToList(),
             hairColor = hairColor,
             skinColor = skinColor,
-            eyeColor = eyesColor,
-            version = version
+            eyeColor = eyesColor
         };
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/EmotesCustomization/EmotesCustomizationComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/EmotesCustomization/EmotesCustomizationComponentControllerTests.cs
@@ -100,39 +100,41 @@ namespace DCL.EmotesCustomization.Tests
             emotesCustomizationComponentController.view.Received().SetActive(isVisible);
         }
 
-        [Test]
-        public void ProcessCatalogCorrectly()
-        {
-            // Arrange
-            emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Set(new List<string>());
-            string testId1 = "TestId1";
-            string testId2 = "TestId2";
-            WearableItem[] emotes = new []
-            {
-                new WearableItem
-                {
-                    id = testId1,
-                    emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
-                    data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
-                    i18n = new i18n[] { new i18n { code = "en", text = testId1 } }
-                },
-                new WearableItem
-                {
-                    id = testId2,
-                    emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
-                    data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
-                    i18n = new i18n[] { new i18n { code = "en", text = testId2 } }
-                }
-            };
-
-            // Act
-            emotesCustomizationComponentController.SetEmotes(emotes);
-
-            // Assert
-            Assert.AreEqual(emotes.Length, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Count());
-            Assert.AreEqual(testId1, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Get().ToList()[0]);
-            Assert.AreEqual(testId2, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Get().ToList()[1]);
-        }
+        
+        //TODO ANTON this test is disabled for now since emotes are not wearables anymore
+        // [Test]
+        // public void ProcessCatalogCorrectly()
+        // {
+        //     // Arrange
+        //     emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Set(new List<string>());
+        //     string testId1 = "TestId1";
+        //     string testId2 = "TestId2";
+        //     WearableItem[] emotes = new []
+        //     {
+        //         new WearableItem
+        //         {
+        //             id = testId1,
+        //             emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
+        //             data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
+        //             i18n = new i18n[] { new i18n { code = "en", text = testId1 } }
+        //         },
+        //         new WearableItem
+        //         {
+        //             id = testId2,
+        //             emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
+        //             data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
+        //             i18n = new i18n[] { new i18n { code = "en", text = testId2 } }
+        //         }
+        //     };
+        //
+        //     // Act
+        //     emotesCustomizationComponentController.SetEmotes(emotes);
+        //
+        //     // Assert
+        //     Assert.AreEqual(emotes.Length, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Count());
+        //     Assert.AreEqual(testId1, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Get().ToList()[0]);
+        //     Assert.AreEqual(testId2, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Get().ToList()[1]);
+        // }
 
         [Test]
         public void RefreshEmoteLoadingStateCorrectly()
@@ -187,47 +189,49 @@ namespace DCL.EmotesCustomization.Tests
             Assert.AreEqual(true, result.isCollectible);
         }
 
-        [Test]
-        public void UpdateEmoteSlotsCorrectly()
-        {
-            // Arrange
-            string testId1 = "TestId1";
-            string testId2 = "TestId2";
-
-            WearableItem[] emotes = new []
-            {
-            
-                new WearableItem
-                {
-                    id = testId1,
-                    emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
-                    data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
-                    i18n = new i18n[] { new i18n { code = "en", text = testId1 } }
-                },
-                new WearableItem
-                {
-                    id = testId2,
-                    emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
-                    data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
-                    i18n = new i18n[] { new i18n { code = "en", text = testId2 } }
-                }
-            };
-
-            emotesCustomizationComponentController.ownedEmotes = emotes.ToDictionary(x => x.id, x => x);
-            emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Set(new List<string> { testId1, testId2 });
-
-            emotesCustomizationDataStore.unsavedEquippedEmotes.Set(new List<EquippedEmoteData>
-            {
-                new EquippedEmoteData { id = testId1, cachedThumbnail = null },
-                new EquippedEmoteData { id = testId2, cachedThumbnail = null }
-            });
-
-            // Act
-            emotesCustomizationComponentController.UpdateEmoteSlots();
-
-            // Assert
-            emotesCustomizationComponentController.view.Received(2).EquipEmote(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), false, false);
-        }
+        
+        //TODO ANTON: this test is disabled for now since emotes are not wearables anymore
+        // [Test]
+        // public void UpdateEmoteSlotsCorrectly()
+        // {
+        //     // Arrange
+        //     string testId1 = "TestId1";
+        //     string testId2 = "TestId2";
+        //
+        //     WearableItem[] emotes = new []
+        //     {
+        //     
+        //         new WearableItem
+        //         {
+        //             id = testId1,
+        //             emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
+        //             data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
+        //             i18n = new i18n[] { new i18n { code = "en", text = testId1 } }
+        //         },
+        //         new WearableItem
+        //         {
+        //             id = testId2,
+        //             emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
+        //             data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
+        //             i18n = new i18n[] { new i18n { code = "en", text = testId2 } }
+        //         }
+        //     };
+        //
+        //     emotesCustomizationComponentController.ownedEmotes = emotes.ToDictionary(x => x.id, x => x);
+        //     emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Set(new List<string> { testId1, testId2 });
+        //
+        //     emotesCustomizationDataStore.unsavedEquippedEmotes.Set(new List<EquippedEmoteData>
+        //     {
+        //         new EquippedEmoteData { id = testId1, cachedThumbnail = null },
+        //         new EquippedEmoteData { id = testId2, cachedThumbnail = null }
+        //     });
+        //
+        //     // Act
+        //     emotesCustomizationComponentController.UpdateEmoteSlots();
+        //
+        //     // Assert
+        //     emotesCustomizationComponentController.view.Received(2).EquipEmote(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), false, false);
+        // }
 
         [Test]
         public void RaiseOnEmoteEquippedCorrectly()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/EmotesCustomization/EmotesCustomizationComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/EmotesCustomization/EmotesCustomizationComponentControllerTests.cs
@@ -99,42 +99,40 @@ namespace DCL.EmotesCustomization.Tests
             // Assert
             emotesCustomizationComponentController.view.Received().SetActive(isVisible);
         }
-
         
-        //TODO ANTON this test is disabled for now since emotes are not wearables anymore
-        // [Test]
-        // public void ProcessCatalogCorrectly()
-        // {
-        //     // Arrange
-        //     emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Set(new List<string>());
-        //     string testId1 = "TestId1";
-        //     string testId2 = "TestId2";
-        //     WearableItem[] emotes = new []
-        //     {
-        //         new WearableItem
-        //         {
-        //             id = testId1,
-        //             emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
-        //             data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
-        //             i18n = new i18n[] { new i18n { code = "en", text = testId1 } }
-        //         },
-        //         new WearableItem
-        //         {
-        //             id = testId2,
-        //             emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
-        //             data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
-        //             i18n = new i18n[] { new i18n { code = "en", text = testId2 } }
-        //         }
-        //     };
-        //
-        //     // Act
-        //     emotesCustomizationComponentController.SetEmotes(emotes);
-        //
-        //     // Assert
-        //     Assert.AreEqual(emotes.Length, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Count());
-        //     Assert.AreEqual(testId1, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Get().ToList()[0]);
-        //     Assert.AreEqual(testId2, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Get().ToList()[1]);
-        // }
+        [Test]
+        public void ProcessCatalogCorrectly()
+        {
+            // Arrange
+            emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Set(new List<string>());
+            string testId1 = "TestId1";
+            string testId2 = "TestId2";
+            WearableItem[] emotes = new []
+            {
+                new WearableItem
+                {
+                    id = testId1,
+                    emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
+                    data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
+                    i18n = new i18n[] { new i18n { code = "en", text = testId1 } }
+                },
+                new WearableItem
+                {
+                    id = testId2,
+                    emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
+                    data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
+                    i18n = new i18n[] { new i18n { code = "en", text = testId2 } }
+                }
+            };
+        
+            // Act
+            emotesCustomizationComponentController.SetEmotes(emotes);
+        
+            // Assert
+            Assert.AreEqual(emotes.Length, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Count());
+            Assert.AreEqual(testId1, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Get().ToList()[0]);
+            Assert.AreEqual(testId2, emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Get().ToList()[1]);
+        }
 
         [Test]
         public void RefreshEmoteLoadingStateCorrectly()
@@ -190,48 +188,47 @@ namespace DCL.EmotesCustomization.Tests
         }
 
         
-        //TODO ANTON: this test is disabled for now since emotes are not wearables anymore
-        // [Test]
-        // public void UpdateEmoteSlotsCorrectly()
-        // {
-        //     // Arrange
-        //     string testId1 = "TestId1";
-        //     string testId2 = "TestId2";
-        //
-        //     WearableItem[] emotes = new []
-        //     {
-        //     
-        //         new WearableItem
-        //         {
-        //             id = testId1,
-        //             emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
-        //             data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
-        //             i18n = new i18n[] { new i18n { code = "en", text = testId1 } }
-        //         },
-        //         new WearableItem
-        //         {
-        //             id = testId2,
-        //             emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
-        //             data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
-        //             i18n = new i18n[] { new i18n { code = "en", text = testId2 } }
-        //         }
-        //     };
-        //
-        //     emotesCustomizationComponentController.ownedEmotes = emotes.ToDictionary(x => x.id, x => x);
-        //     emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Set(new List<string> { testId1, testId2 });
-        //
-        //     emotesCustomizationDataStore.unsavedEquippedEmotes.Set(new List<EquippedEmoteData>
-        //     {
-        //         new EquippedEmoteData { id = testId1, cachedThumbnail = null },
-        //         new EquippedEmoteData { id = testId2, cachedThumbnail = null }
-        //     });
-        //
-        //     // Act
-        //     emotesCustomizationComponentController.UpdateEmoteSlots();
-        //
-        //     // Assert
-        //     emotesCustomizationComponentController.view.Received(2).EquipEmote(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), false, false);
-        // }
+        [Test]
+        public void UpdateEmoteSlotsCorrectly()
+        {
+            // Arrange
+            string testId1 = "TestId1";
+            string testId2 = "TestId2";
+        
+            WearableItem[] emotes = new []
+            {
+            
+                new WearableItem
+                {
+                    id = testId1,
+                    emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
+                    data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
+                    i18n = new i18n[] { new i18n { code = "en", text = testId1 } }
+                },
+                new WearableItem
+                {
+                    id = testId2,
+                    emoteDataV0 = new Emotes.EmoteDataV0 { loop = false },
+                    data = new WearableItem.Data { tags = new string[] { WearableLiterals.Tags.BASE_WEARABLE } },
+                    i18n = new i18n[] { new i18n { code = "en", text = testId2 } }
+                }
+            };
+        
+            emotesCustomizationComponentController.ownedEmotes = emotes.ToDictionary(x => x.id, x => x);
+            emotesCustomizationComponentController.emotesCustomizationDataStore.currentLoadedEmotes.Set(new List<string> { testId1, testId2 });
+        
+            emotesCustomizationDataStore.unsavedEquippedEmotes.Set(new List<EquippedEmoteData>
+            {
+                new EquippedEmoteData { id = testId1, cachedThumbnail = null },
+                new EquippedEmoteData { id = testId2, cachedThumbnail = null }
+            });
+        
+            // Act
+            emotesCustomizationComponentController.UpdateEmoteSlots();
+        
+            // Assert
+            emotesCustomizationComponentController.view.Received(2).EquipEmote(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), false, false);
+        }
 
         [Test]
         public void RaiseOnEmoteEquippedCorrectly()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesWheelHUD/EmotesWheelController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesWheelHUD/EmotesWheelController.cs
@@ -98,11 +98,7 @@ namespace DCL.EmotesWheel
             {
                 if (equippedEmoteData != null)
                 {
-                    WearableItem emoteItem;
-                    if (DataStore.i.emotes.newFlowEnabled.Get())
-                        emoteCatalog.TryGetLoadedEmote(equippedEmoteData.id, out emoteItem);
-                    else
-                        catalog.TryGetValue(equippedEmoteData.id, out emoteItem);
+                    emoteCatalog.TryGetLoadedEmote(equippedEmoteData.id, out var emoteItem);
 
                     if (emoteItem != null)
                     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
@@ -205,16 +205,7 @@ public class PlayerAvatarController : MonoBehaviour, IHideAvatarAreaHandler, IHi
 
                 HashSet<string> emotes = new HashSet<string>(currentAvatar.emotes.Select(x => x.urn));
                 var embeddedEmotesSo = Resources.Load<EmbeddedEmotesSO>("EmbeddedEmotes");
-                if (DataStore.i.emotes.newFlowEnabled.Get())
-                {
-                    emotes.UnionWith(embeddedEmotesSo.emotes.Select(x => x.id));
-                }
-                else
-                {
-                    //TODO remove this when new flow is the default and we can los retrocompatibility
-                    //temporarily hardcoding the embedded emotes until the user profile provides the equipped ones
-                    wearableItems.AddRange(embeddedEmotesSo.emotes.Select(x => x.id));
-                }
+                emotes.UnionWith(embeddedEmotesSo.emotes.Select(x => x.id));
 
                 await avatar.Load(wearableItems, emotes.ToList(), new AvatarSettings
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
@@ -206,6 +206,7 @@ public class PlayerAvatarController : MonoBehaviour, IHideAvatarAreaHandler, IHi
                 HashSet<string> emotes = new HashSet<string>(currentAvatar.emotes.Select(x => x.urn));
                 var embeddedEmotesSo = Resources.Load<EmbeddedEmotesSO>("EmbeddedEmotes");
                 emotes.UnionWith(embeddedEmotesSo.emotes.Select(x => x.id));
+                wearableItems.AddRange(embeddedEmotesSo.emotes.Select(x => x.id));
 
                 await avatar.Load(wearableItems, emotes.ToList(), new AvatarSettings
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Emotes.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Emotes.cs
@@ -8,6 +8,6 @@ namespace DCL
     {
         public readonly BaseRefCountedCollection<(string bodyshapeId, string emoteId)> emotesOnUse = new BaseRefCountedCollection<(string bodyshapeId, string emoteId)>();
         public readonly BaseDictionary<(string bodyshapeId, string emoteId), AnimationClip> animations = new BaseDictionary<(string bodyshapeId, string emoteId), AnimationClip>();
-        public BaseVariable<bool> newFlowEnabled = new BaseVariable<bool>(false);
+
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_EmotesCustomization.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_EmotesCustomization.cs
@@ -18,10 +18,17 @@ namespace DCL
         public readonly BaseVariable<bool> isEmotesCustomizationSelected = new BaseVariable<bool>(false);
         public readonly BaseCollection<string> currentLoadedEmotes = new BaseCollection<string>();
 
-        public void FilterOutNotOwnedEquippedEmotes(IEnumerable<WearableItem> emotes)
+        public void UnequipMissingEmotes(IEnumerable<WearableItem> emotes)
         {
-            var filtered = equippedEmotes.Get().Where(x => emotes.Any(y => x.id == y.id) ).ToArray();
-            equippedEmotes.Set(filtered);
+            var setOfIds = new HashSet<string>();
+            foreach (var emote in emotes)
+                setOfIds.Add(emote.id);
+            
+            for (int i = 0; i < equippedEmotes.Count(); i++)
+            {
+                if (equippedEmotes[i] != null && !setOfIds.Contains(equippedEmotes[i].id))
+                    equippedEmotes[i] = null;
+            }
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
@@ -22,8 +22,6 @@ public class AvatarModel : BaseModel
     public Color eyeColor;
     public List<string> wearables = new List<string>();
 
-    // if version < 1 Emotes are contained in wearables instead of the emotes propery.  
-    public int version = 0;
     public List<AvatarEmoteEntry> emotes = new List<AvatarEmoteEntry>();
 
     public string expressionTriggerId = null;
@@ -38,7 +36,9 @@ public class AvatarModel : BaseModel
             return false;
 
         //wearables are the same
-        if (!(wearables.Count == other.wearables.Count && wearables.All(other.wearables.Contains)))
+        if (!(wearables.Count == other.wearables.Count 
+              && wearables.All(other.wearables.Contains) 
+              && other.wearables.All(wearables.Contains)))
             return false;
 
         //emotes are the same
@@ -74,7 +74,9 @@ public class AvatarModel : BaseModel
 
     public bool Equals(AvatarModel other)
     {
-        bool wearablesAreEqual = wearables.All(other.wearables.Contains) && wearables.Count == other.wearables.Count;
+        bool wearablesAreEqual = wearables.All(other.wearables.Contains) 
+                                 && other.wearables.All(wearables.Contains) 
+                                 && wearables.Count == other.wearables.Count;
 
         return id == other.id &&
                name == other.name &&
@@ -105,7 +107,8 @@ public class AvatarModel : BaseModel
         stickerTriggerTimestamp = other.stickerTriggerTimestamp;
         wearables = new List<string>(other.wearables);
         emotes = other.emotes.Select(x => new AvatarEmoteEntry() { slot = x.slot, urn = x.urn }).ToList();
-        version = other.version;
+        
+        
     }
 
     public override BaseModel GetDataFromJSON(string json) { return Utils.SafeFromJson<AvatarModel>(json); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
@@ -49,7 +49,6 @@ public class UserProfileController : MonoBehaviour
             return;
 
         var model = JsonUtility.FromJson<UserProfileModel>(payload);
-        DataStore.i.emotes.newFlowEnabled.Set(model.avatar.version >= 1);
         ownUserProfile.UpdateData(model);
         userProfilesCatalog.Add(model.userId, ownUserProfile);
     }


### PR DESCRIPTION
## WHAT AND WHY

There were issues in changing nft emotes structure so after discussion with Mendez we decided to use different approach: make only one version for the Renderer emote structure but convert structures for old users in runtime.

## HOW TO TEST

To test this change it is very important to test in both old users and new users. For old users we need to check if their old NFT emotes will be present. Old user is considered anyone who created his profile and added some NFT emotes and/or other wearables before this change was in the Renderer.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
