### PR TITLE
fix: duplicated entries in conversation list

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/CollapsableChatSearchListComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/CollapsableChatSearchListComponentView.cs
@@ -78,6 +78,12 @@ public class CollapsableChatSearchListComponentView : CollapsableSortedListCompo
         directChatList.Set(model.userId, model);
         UpdateEmptyState();
     }
+    
+    public void Set(PublicChannelEntry.PublicChannelEntryModel model)
+    {
+        publicChannelList.Set(model.channelId, model);
+        UpdateEmptyState();
+    }
 
     public void Export(CollapsablePublicChannelListComponentView publicChannelList,
         CollapsableDirectChatListComponentView privateChatList)

--- a/unity-renderer/ProjectSettings/PackageManagerSettings.asset
+++ b/unity-renderer/ProjectSettings/PackageManagerSettings.asset
@@ -33,7 +33,7 @@ MonoBehaviour:
     - com.coffee.ui-particle
     m_IsDefault: 0
     m_Capabilities: 0
-  m_UserSelectedRegistryName: OpenUPM
+  m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_ErrorMessage: 


### PR DESCRIPTION
## What does this PR change?

`Fixes #2875 `

The changes ensures the proper usage of entries inside search list, public channel list and direct messages list.

## How to test the changes?

1. Open the conversation list
2. Search for any channel
3. Press enter many times while the search bar is selected
4. Search for `near`
5. #nearby channel should be displayed
6. Press enter many times while the search bar is selected
7. There should not be any duplicated entry in the list

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
