### PR TITLE
docs: update README required Unity version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is the recommended path for artists.
 
 ### Steps
 
-1. Download and install Unity 2020.3.0f1
+1. Download and install Unity 2020.3.34f1
 2. Open the scene named `InitialScene`
 3. Within the scene, select the `DebugConfig` GameObject.
 4. On `DebugConfig` inspector, make sure that `Base url mode` is set to `Custom`


### PR DESCRIPTION
## What does this PR change?

Lately, Decentraland code implemented "SystemInfo.supportsStoreAndResolveAction" and this field does not exist yet in the listed version in the README. This PR only changes the listed version to the current required one.