### PR TITLE
feat: channels search pagination by token

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/Channel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/Channel.cs
@@ -9,9 +9,8 @@
         public bool Muted { get; internal set; }
         public string Name => ChannelId;
         public string Description { get; internal set; }
-        public long LastMessageTimestamp { get; internal set; }
 
-        public Channel(string channelId, int unseenMessages, int memberCount, bool joined, bool muted, string description, long lastMessageTimestamp)
+        public Channel(string channelId, int unseenMessages, int memberCount, bool joined, bool muted, string description)
         {
             ChannelId = channelId;
             UnseenMessages = unseenMessages;
@@ -19,7 +18,6 @@
             Joined = joined;
             Muted = muted;
             Description = description;
-            LastMessageTimestamp = lastMessageTimestamp;
         }
 
         public void CopyFrom(Channel channel)
@@ -29,7 +27,6 @@
             MemberCount = channel.MemberCount;
             Joined = channel.Joined;
             Muted = channel.Muted;
-            LastMessageTimestamp = channel.LastMessageTimestamp;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChannelSearchResultsPayload.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChannelSearchResultsPayload.cs
@@ -1,0 +1,12 @@
+using System;
+using JetBrains.Annotations;
+
+namespace DCL.Chat.Channels
+{
+    [Serializable]
+    public class ChannelSearchResultsPayload
+    {
+        [CanBeNull] public string since;
+        public ChannelInfoPayload[] channels;
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChannelSearchResultsPayload.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChannelSearchResultsPayload.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6610a8989a0e429092be90154cf49dce
+timeCreated: 1663014583

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChatChannelsControllerMock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChatChannelsControllerMock.cs
@@ -88,6 +88,8 @@ namespace DCL.Chat.Channels
             remove => controller.OnUpdateChannelMembers -= value;
         }
 
+        public event Action<string, Channel[]> OnChannelSearchResult;
+
         public int TotalUnseenMessages => controller.TotalUnseenMessages;
 
         public ChatChannelsControllerMock(
@@ -200,11 +202,11 @@ namespace DCL.Chat.Channels
             }
         }
 
-        public void GetChannels(int limit, int skip, string name) =>
-            GetFakeChannels(limit, skip, name).Forget();
+        public void GetChannelsByName(int limit, string name) =>
+            SearchFakeChannels(limit, name).Forget();
 
-        public void GetChannels(int limit, int skip) =>
-            GetFakeChannels(limit, skip, "").Forget();
+        public void GetChannels(int limit, string paginationToken) =>
+            SearchFakeChannels(limit, "").Forget();
 
         public void MuteChannel(string channelId) => MuteFakeChannel(channelId, true).Forget();
         
@@ -555,7 +557,7 @@ Invite others to join by quoting the channel name in other chats or include it a
             controller.UpdateChannelInfo(JsonUtility.ToJson(msg));
         }
         
-        private async UniTask GetFakeChannels(int limit, int skip, string name)
+        private async UniTask SearchFakeChannels(int limit, string name)
         {
             await UniTask.Delay(Random.Range(40, 1000));
 
@@ -576,7 +578,9 @@ Invite others to join by quoting the channel name in other chats or include it a
                 "music-festival"
             };
 
-            for (var i = skip; i < skip + limit && i < ids.Length; i++)
+            var channelPayloads = new List<ChannelInfoPayload>();
+
+            for (var i = 0; i < limit && i < ids.Length; i++)
             {
                 var channelId = ids[i];
                 if (!channelId.StartsWith(name) && !string.IsNullOrEmpty(name)) continue;
@@ -589,8 +593,17 @@ Invite others to join by quoting the channel name in other chats or include it a
                     memberCount = Random.Range(0, 16),
                     unseenMessages = 0
                 };
-                controller.UpdateChannelInfo(JsonUtility.ToJson(msg));
+                
+                channelPayloads.Add(msg);
             }
+
+            var payload = new ChannelSearchResultsPayload
+            {
+                channels = channelPayloads.ToArray(),
+                since = Guid.NewGuid().ToString()
+            };
+            
+            controller.UpdateChannelSearchResults(JsonUtility.ToJson(payload));
         }
         
         private void SendNearbyDescriptionMessage()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChatChannelsControllerMock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChatChannelsControllerMock.cs
@@ -88,7 +88,11 @@ namespace DCL.Chat.Channels
             remove => controller.OnUpdateChannelMembers -= value;
         }
 
-        public event Action<string, Channel[]> OnChannelSearchResult;
+        public event Action<string, Channel[]> OnChannelSearchResult
+        {
+            add => controller.OnChannelSearchResult += value;
+            remove => controller.OnChannelSearchResult -= value;
+        }
 
         public int TotalUnseenMessages => controller.TotalUnseenMessages;
 
@@ -202,7 +206,7 @@ namespace DCL.Chat.Channels
             }
         }
 
-        public void GetChannelsByName(int limit, string name) =>
+        public void GetChannelsByName(int limit, string name, string paginationToken = null) =>
             SearchFakeChannels(limit, name).Forget();
 
         public void GetChannels(int limit, string paginationToken) =>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
@@ -244,7 +244,7 @@ public class ChatController : MonoBehaviour, IChatController
 
     public void GetJoinedChannels(int limit, int skip) => WebInterface.GetJoinedChannels(limit, skip);
 
-    public void GetChannelsByName(int limit, string name) => WebInterface.GetChannels(limit, null, name);
+    public void GetChannelsByName(int limit, string name, string paginationToken = null) => WebInterface.GetChannels(limit, paginationToken, name);
 
     public void GetChannels(int limit, string paginationToken) => WebInterface.GetChannels(limit, paginationToken, string.Empty);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
@@ -1,13 +1,12 @@
-using DCL.Interface;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using DCL.Chat.Channels;
-using DCL.Chat;
 using DCL.Chat.WebApi;
+using DCL.Interface;
 using JetBrains.Annotations;
 using UnityEngine;
-using Random = System.Random;
+using Random = UnityEngine.Random;
 
 public class ChatController : MonoBehaviour, IChatController
 {
@@ -21,9 +20,7 @@ public class ChatController : MonoBehaviour, IChatController
 
     private readonly Dictionary<string, Channel> channels = new Dictionary<string, Channel>();
     private readonly List<ChatMessage> messages = new List<ChatMessage>();
-    private readonly Random randomizer = new Random();
     private bool chatAlreadyInitialized;
-    private static Random random = new Random();
 
     public event Action<Channel> OnChannelUpdated;
     public event Action<Channel> OnChannelJoined;
@@ -35,6 +32,7 @@ public class ChatController : MonoBehaviour, IChatController
     public event Action<int> OnTotalUnseenMessagesUpdated;
     public event Action<string, int> OnUserUnseenMessagesUpdated;
     public event Action<string, ChannelMember[]> OnUpdateChannelMembers;
+    public event Action<string, Channel[]> OnChannelSearchResult;
 
     public int TotalUnseenMessages { get; private set; }
     public event Action<string, int> OnChannelUnseenMessagesUpdated;
@@ -44,101 +42,8 @@ public class ChatController : MonoBehaviour, IChatController
         i = this;
         
         channels[NEARBY_CHANNEL_ID] = new Channel(NEARBY_CHANNEL_ID, 0, 0, true, false,
-            NEARBY_CHANNEL_DESCRIPTION,
-            0);
+            NEARBY_CHANNEL_DESCRIPTION);
     }
-
-    [UsedImplicitly]
-    public void UpdateChannelInfo(string payload)
-    {
-        var msg = JsonUtility.FromJson<ChannelInfoPayload>(payload);
-        var channelId = msg.channelId;
-        var channel = new Channel(channelId, msg.unseenMessages, msg.memberCount, msg.joined, msg.muted, msg.description,
-            (long) (randomizer.NextDouble() * DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
-        var justLeft = false;
-
-        if (channels.ContainsKey(channelId))
-        {
-            justLeft = channels[channelId].Joined && !channel.Joined;
-            channels[channelId].CopyFrom(channel);
-        }
-        else
-            channels[channelId] = channel;
-
-        if (justLeft)
-        {
-            OnChannelLeft?.Invoke(channelId);
-
-            // TODO (responsibility issues): extract to another class
-            AudioScriptableObjects.leaveChannel.Play(true);
-        }
-
-        OnChannelUpdated?.Invoke(channel);
-    }
-
-    // called by kernel
-    [UsedImplicitly]
-    public void JoinChannelConfirmation(string payload)
-    {
-        var msg = JsonUtility.FromJson<ChannelInfoPayload>(payload);
-        var channel = new Channel(msg.channelId, msg.unseenMessages, msg.memberCount, msg.joined, msg.muted, msg.description,
-            (long) (randomizer.NextDouble() * DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
-        var channelId = channel.ChannelId;
-        
-        if (channels.ContainsKey(channelId))
-            channels[channelId].CopyFrom(channel);
-        else
-            channels[channelId] = channel;
-        
-        OnChannelJoined?.Invoke(channel);
-        OnChannelUpdated?.Invoke(channel);
-
-        // TODO (responsibility issues): extract to another class
-        AudioScriptableObjects.joinChannel.Play(true);
-    }
-
-    // called by kernel
-    [UsedImplicitly]
-    public void JoinChannelError(string payload)
-    {
-        var msg = JsonUtility.FromJson<JoinChannelErrorPayload>(payload);
-        OnJoinChannelError?.Invoke(msg.channelId, msg.message);
-    }
-
-    // called by kernel
-    [UsedImplicitly]
-    public void LeaveChannelError(string payload)
-    {
-        var msg = JsonUtility.FromJson<JoinChannelErrorPayload>(payload);
-        OnChannelLeaveError?.Invoke(msg.channelId, msg.message);
-    }
-
-    // called by kernel
-    [UsedImplicitly]
-    public void MuteChannelError(string payload)
-    {
-        var msg = JsonUtility.FromJson<MuteChannelErrorPayload>(payload);
-        OnMuteChannelError?.Invoke(msg.channelId, msg.message);
-    }
-
-    public void JoinOrCreateChannel(string channelId) => WebInterface.JoinOrCreateChannel(channelId);
-
-    public void LeaveChannel(string channelId) => WebInterface.LeaveChannel(channelId);
-
-    public void GetChannelMessages(string channelId, int limit, string fromMessageId) => WebInterface.GetChannelMessages(channelId, limit, fromMessageId);
-
-    public void GetJoinedChannels(int limit, int skip) => WebInterface.GetJoinedChannels(limit, skip);
-
-    public void GetChannels(int limit, int skip, string name) => WebInterface.GetChannels(limit, skip, name);
-
-    public void GetChannels(int limit, int skip) => WebInterface.GetChannels(limit, skip, string.Empty);
-
-    public void MuteChannel(string channelId) => WebInterface.MuteChannel(channelId, true);
-
-    public void UnmuteChannel(string channelId) => WebInterface.MuteChannel(channelId, false);
-
-    public Channel GetAllocatedChannel(string channelId) =>
-        channels.ContainsKey(channelId) ? channels[channelId] : null;
 
     // called by kernel
     [UsedImplicitly]
@@ -234,14 +139,122 @@ public class ChatController : MonoBehaviour, IChatController
         var msg = JsonUtility.FromJson<UpdateChannelMembersPayload>(payload);
         OnUpdateChannelMembers?.Invoke(msg.channelId, msg.members);
     }
-
-    public void Send(ChatMessage message) => WebInterface.SendChatMessage(message);
-
-    public void MarkMessagesAsSeen(string userId)
+    
+    [UsedImplicitly]
+    public void UpdateChannelInfo(string payload)
     {
-        WebInterface.MarkMessagesAsSeen(userId);
+        var msg = JsonUtility.FromJson<ChannelInfoPayload>(payload);
+        var channelId = msg.channelId;
+        var channel = new Channel(channelId, msg.unseenMessages, msg.memberCount, msg.joined, msg.muted, msg.description);
+        var justLeft = false;
+
+        if (channels.ContainsKey(channelId))
+        {
+            justLeft = channels[channelId].Joined && !channel.Joined;
+            channels[channelId].CopyFrom(channel);
+        }
+        else
+            channels[channelId] = channel;
+
+        if (justLeft)
+        {
+            OnChannelLeft?.Invoke(channelId);
+
+            // TODO (responsibility issues): extract to another class
+            AudioScriptableObjects.leaveChannel.Play(true);
+        }
+
+        OnChannelUpdated?.Invoke(channel);
     }
 
+    // called by kernel
+    [UsedImplicitly]
+    public void JoinChannelConfirmation(string payload)
+    {
+        var msg = JsonUtility.FromJson<ChannelInfoPayload>(payload);
+        var channel = new Channel(msg.channelId, msg.unseenMessages, msg.memberCount, msg.joined, msg.muted, msg.description);
+        var channelId = channel.ChannelId;
+        
+        if (channels.ContainsKey(channelId))
+            channels[channelId].CopyFrom(channel);
+        else
+            channels[channelId] = channel;
+        
+        OnChannelJoined?.Invoke(channel);
+        OnChannelUpdated?.Invoke(channel);
+
+        // TODO (responsibility issues): extract to another class
+        AudioScriptableObjects.joinChannel.Play(true);
+    }
+
+    // called by kernel
+    [UsedImplicitly]
+    public void JoinChannelError(string payload)
+    {
+        var msg = JsonUtility.FromJson<JoinChannelErrorPayload>(payload);
+        OnJoinChannelError?.Invoke(msg.channelId, msg.message);
+    }
+
+    // called by kernel
+    [UsedImplicitly]
+    public void LeaveChannelError(string payload)
+    {
+        var msg = JsonUtility.FromJson<JoinChannelErrorPayload>(payload);
+        OnChannelLeaveError?.Invoke(msg.channelId, msg.message);
+    }
+
+    // called by kernel
+    [UsedImplicitly]
+    public void MuteChannelError(string payload)
+    {
+        var msg = JsonUtility.FromJson<MuteChannelErrorPayload>(payload);
+        OnMuteChannelError?.Invoke(msg.channelId, msg.message);
+    }
+
+    // called by kernel
+    [UsedImplicitly]
+    public void UpdateChannelSearchResults(string payload)
+    {
+        var msg = JsonUtility.FromJson<ChannelSearchResultsPayload>(payload);
+        var channelsResult = new Channel[msg.channels.Length];
+
+        for (var i = 0; i < msg.channels.Length; i++)
+        {
+            var channelPayload = msg.channels[i];
+            var channelId = channelPayload.channelId;
+            var channel = new Channel(channelId, channelPayload.unseenMessages, channelPayload.memberCount,
+                channelPayload.joined, channelPayload.muted, channelPayload.description);
+
+            if (channels.ContainsKey(channelId))
+                channels[channelId].CopyFrom(channel);
+            else
+                channels[channelId] = channel;
+
+            channelsResult[i] = channel;
+        }
+
+        OnChannelSearchResult?.Invoke(msg.since, channelsResult);
+    }
+    
+    public void JoinOrCreateChannel(string channelId) => WebInterface.JoinOrCreateChannel(channelId);
+
+    public void LeaveChannel(string channelId) => WebInterface.LeaveChannel(channelId);
+
+    public void GetChannelMessages(string channelId, int limit, string fromMessageId) => WebInterface.GetChannelMessages(channelId, limit, fromMessageId);
+
+    public void GetJoinedChannels(int limit, int skip) => WebInterface.GetJoinedChannels(limit, skip);
+
+    public void GetChannelsByName(int limit, string name) => WebInterface.GetChannels(limit, null, name);
+
+    public void GetChannels(int limit, string paginationToken) => WebInterface.GetChannels(limit, paginationToken, string.Empty);
+
+    public void MuteChannel(string channelId) => WebInterface.MuteChannel(channelId, true);
+
+    public void UnmuteChannel(string channelId) => WebInterface.MuteChannel(channelId, false);
+
+    public Channel GetAllocatedChannel(string channelId) =>
+        channels.ContainsKey(channelId) ? channels[channelId] : null;
+    
     public void GetPrivateMessages(string userId, int limit, string fromMessageId) =>
         WebInterface.GetPrivateMessages(userId, limit, fromMessageId);
     
@@ -269,21 +282,28 @@ public class ChatController : MonoBehaviour, IChatController
             .Where(x => (x.sender == userId || x.recipient == userId) && x.messageType == ChatMessage.Type.PRIVATE)
             .ToList();
     }
-
+    
     public void GetChannelInfo(string[] channelIds) => WebInterface.GetChannelInfo(channelIds);
 
     public void GetChannelMembers(string channelId, int limit, int skip, string name) => WebInterface.GetChannelMembers(channelId, limit, skip, name);
 
     public void GetChannelMembers(string channelId, int limit, int skip) => WebInterface.GetChannelMembers(channelId, limit, skip, string.Empty);
+    
+    public void Send(ChatMessage message) => WebInterface.SendChatMessage(message);
+
+    public void MarkMessagesAsSeen(string userId) => WebInterface.MarkMessagesAsSeen(userId);
 
     [ContextMenu("Fake Public Message")]
     public void FakePublicMessage()
     {
         UserProfile ownProfile = UserProfile.GetOwnUserProfile();
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        string bodyText = new string(Enumerable.Repeat(chars, UnityEngine.Random.Range(5, 30))
-         .Select(s => s[random.Next(s.Length)]).ToArray());
-        var model = new UserProfileModel()
+        var bodyLength = Random.Range(5, 30);
+        var bodyText = "";
+        for (var i = 0; i < bodyLength; i++)
+            bodyText += chars[Random.Range(0, chars.Length)];
+        
+        var model = new UserProfileModel
         {
             userId = "test user 1",
             name = "test user 1",
@@ -311,14 +331,14 @@ public class ChatController : MonoBehaviour, IChatController
         {
             body = bodyText,
             sender = ownProfile.userId,
-            messageType = ChatMessage.Type.PRIVATE,
+            messageType = ChatMessage.Type.PUBLIC,
             timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
         };
 
         AddMessageToChatWindow(JsonUtility.ToJson(msg));
         AddMessageToChatWindow(JsonUtility.ToJson(msg2));
     }
-
+    
     [ContextMenu("Fake Private Message")]
     public void FakePrivateMessage()
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChatController.cs
@@ -30,7 +30,7 @@ public interface IChatController
     void LeaveChannel(string channelId);
     void GetChannelMessages(string channelId, int limit, string fromMessageId);
     void GetJoinedChannels(int limit, int skip);
-    void GetChannelsByName(int limit, string name);
+    void GetChannelsByName(int limit, string name, string paginationToken = null);
     void GetChannels(int limit, string paginationToken = null);
     void MuteChannel(string channelId);
     void UnmuteChannel(string channelId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChatController.cs
@@ -16,6 +16,7 @@ public interface IChatController
     event Action<string, int> OnUserUnseenMessagesUpdated;
     event Action<string, int> OnChannelUnseenMessagesUpdated;
     event Action<string, ChannelMember[]> OnUpdateChannelMembers;
+    event Action<string, Channel[]> OnChannelSearchResult;
 
     int TotalUnseenMessages { get; }
 
@@ -29,8 +30,8 @@ public interface IChatController
     void LeaveChannel(string channelId);
     void GetChannelMessages(string channelId, int limit, string fromMessageId);
     void GetJoinedChannels(int limit, int skip);
-    void GetChannels(int limit, int skip, string name);
-    void GetChannels(int limit, int skip);
+    void GetChannelsByName(int limit, string name);
+    void GetChannels(int limit, string paginationToken = null);
     void MuteChannel(string channelId);
     void UnmuteChannel(string channelId);
     Channel GetAllocatedChannel(string channelId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/Helpers/ChatController_Mock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/Helpers/ChatController_Mock.cs
@@ -18,6 +18,7 @@ public class ChatController_Mock : IChatController
     public event Action<string, int> OnUserUnseenMessagesUpdated;
     public event Action<string, int> OnChannelUnseenMessagesUpdated;
     public event Action<string, ChannelMember[]> OnUpdateChannelMembers;
+    public event Action<string, Channel[]> OnChannelSearchResult;
 
     public int TotalUnseenMessages { get; }
 
@@ -53,10 +54,6 @@ public class ChatController_Mock : IChatController
     {
     }
 
-    public void GetPrivateMessages(string userId, int limit, long fromTimestamp)
-    {
-    }
-
     public void JoinOrCreateChannel(string channelId)
     {
     }
@@ -73,11 +70,11 @@ public class ChatController_Mock : IChatController
     {
     }
 
-    public void GetChannels(int limit, int skip, string name)
+    public void GetChannelsByName(int limit, string name)
     {
     }
 
-    public void GetChannels(int limit, int skip)
+    public void GetChannels(int limit, string paginationToken)
     {
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/Helpers/ChatController_Mock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/Helpers/ChatController_Mock.cs
@@ -70,7 +70,7 @@ public class ChatController_Mock : IChatController
     {
     }
 
-    public void GetChannelsByName(int limit, string name)
+    public void GetChannelsByName(int limit, string name, string paginationToken = null)
     {
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/Tests/ChatNotificationControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/Tests/ChatNotificationControllerShould.cs
@@ -47,7 +47,7 @@ namespace DCL.Chat.HUD.NotificationMessages
         public void FilterNotificationWhenChannelIsMuted()
         {
             chatController.GetAllocatedChannel("mutedChannel").Returns(new Channel("mutedChannel", 0, 3, true,
-                true, "", 0));
+                true, ""));
 
             chatController.OnAddMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage("mid",
                 ChatMessage.Type.PUBLIC, "sender", "hey") {recipient = "mutedChannel"});

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/TaskbarHUDShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/TaskbarHUDShould.cs
@@ -65,7 +65,7 @@ public class TaskbarHUDShould : IntegrationTestSuite_Legacy
     public void AddWorldChatWindowProperly()
     {
         var chatController = Substitute.For<IChatController>();
-        chatController.GetAllocatedChannel("nearby").Returns(new Channel("nearby", 0, 0, true, false, "", 0));
+        chatController.GetAllocatedChannel("nearby").Returns(new Channel("nearby", 0, 0, true, false, ""));
         chatController.GetAllocatedEntries().Returns(new List<ChatMessage>());
         worldChatWindowController = new WorldChatWindowController(
             Substitute.For<IUserProfileBridge>(),
@@ -111,7 +111,7 @@ public class TaskbarHUDShould : IntegrationTestSuite_Legacy
         controller.AddPrivateChatWindow(privateChatController);
 
         var chatController = Substitute.For<IChatController>();
-        chatController.GetAllocatedChannel("nearby").Returns(new Channel("nearby", 0, 0, true, false, "", 0));
+        chatController.GetAllocatedChannel("nearby").Returns(new Channel("nearby", 0, 0, true, false, ""));
         chatController.GetAllocatedEntries().Returns(new List<ChatMessage>());
         worldChatWindowController = new WorldChatWindowController(
             userProfileBridge,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -425,7 +425,7 @@ namespace DCL.Chat.HUD
 
         private PublicChatModel ToPublicChatModel(Channel channel)
         {
-            return new PublicChatModel(channelId, channel.Name, channel.Description, channel.LastMessageTimestamp,
+            return new PublicChatModel(channelId, channel.Name, channel.Description,
                 channel.Joined, channel.MemberCount, channel.Muted);
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatEntryModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatEntryModel.cs
@@ -7,16 +7,14 @@ namespace DCL.Chat.HUD
     {
         public string channelId;
         public string name;
-        public long lastMessageTimestamp;
         public bool isJoined;
         public int memberCount;
         public bool muted;
 
-        public PublicChatEntryModel(string channelId, string name, long lastMessageTimestamp, bool isJoined, int memberCount, bool muted)
+        public PublicChatEntryModel(string channelId, string name, bool isJoined, int memberCount, bool muted)
         {
             this.channelId = channelId;
             this.name = name;
-            this.lastMessageTimestamp = lastMessageTimestamp;
             this.isJoined = isJoined;
             this.memberCount = memberCount;
             this.muted = muted;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatModel.cs
@@ -6,18 +6,16 @@ public class PublicChatModel : BaseComponentModel
     public string channelId;
     public string name;
     public string description;
-    public long lastMessageTimestamp;
     public bool joined;
     public int memberCount;
     public bool muted;
 
-    public PublicChatModel(string channelId, string name, string description, long lastMessageTimestamp, bool joined,
+    public PublicChatModel(string channelId, string name, string description, bool joined,
         int memberCount, bool muted)
     {
         this.channelId = channelId;
         this.name = name;
         this.description = description;
-        this.lastMessageTimestamp = lastMessageTimestamp;
         this.joined = joined;
         this.memberCount = memberCount;
         this.muted = muted;
@@ -28,7 +26,6 @@ public class PublicChatModel : BaseComponentModel
         channelId = model.channelId;
         name = model.name;
         description = model.description;
-        lastMessageTimestamp = model.lastMessageTimestamp;
         joined = model.joined;
         memberCount = model.memberCount;
         muted = model.muted;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
@@ -97,7 +97,6 @@ public class PublicChatWindowController : IHUD
         View.Configure(new PublicChatModel(this.channelId,
             channel.Name,
             channel.Description,
-            channel.LastMessageTimestamp,
             channel.Joined,
             channel.MemberCount,
             false));

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowComponentView.cs
@@ -93,7 +93,7 @@ namespace DCL.Chat.HUD
         public void Set(Channel channel)
         {
             channelList.Set(channel.ChannelId,
-                new PublicChatEntryModel(channel.ChannelId, channel.Name, channel.LastMessageTimestamp, channel.Joined, channel.MemberCount, channel.Muted));
+                new PublicChatEntryModel(channel.ChannelId, channel.Name, channel.Joined, channel.MemberCount, channel.Muted));
 
             var entry = channelList.Get(channel.ChannelId);
             entry.OnOpenChat -= HandleJoinRequest;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
@@ -20,6 +20,7 @@ namespace DCL.Chat.HUD
         private DateTime loadStartedTimestamp = DateTime.MinValue;
         private CancellationTokenSource loadingCancellationToken = new CancellationTokenSource();
         private string paginationToken;
+        private string searchText;
         private BaseVariable<HashSet<string>> visibleTaskbarPanels => dataStore.HUDs.visibleTaskbarPanels;
 
         public ISearchChannelsWindowView View => view;
@@ -119,6 +120,7 @@ namespace DCL.Chat.HUD
             view.ClearAllEntries();
             view.HideLoadingMore();
             view.ShowLoading();
+            this.searchText = searchText;
             
             if (string.IsNullOrEmpty(searchText))
                 chatController.GetChannels(LOAD_PAGE_SIZE);
@@ -147,9 +149,15 @@ namespace DCL.Chat.HUD
         private void LoadMoreChannels()
         {
             if (IsLoading()) return;
+            if (string.IsNullOrEmpty(paginationToken)) return;
+            
             loadStartedTimestamp = DateTime.Now;
             view.HideLoadingMore();
-            chatController.GetChannels(LOAD_PAGE_SIZE, paginationToken);
+            
+            if (string.IsNullOrEmpty(searchText))
+                chatController.GetChannels(LOAD_PAGE_SIZE, paginationToken);
+            else
+                chatController.GetChannelsByName(LOAD_PAGE_SIZE, searchText, paginationToken);
         }
 
         private bool IsLoading() => (DateTime.Now - loadStartedTimestamp).TotalSeconds < LOAD_TIMEOUT;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
@@ -140,9 +140,6 @@ namespace DCL.Chat.HUD
         
         private void ShowRequestedChannels(string paginationToken, Channel[] channels)
         {
-            view.HideLoading();
-            view.ShowLoadingMore();
-            
             this.paginationToken = paginationToken;
 
             foreach (var channel in channels)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
@@ -22,7 +22,7 @@ namespace DCL.Chat.HUD
         private string paginationToken;
         private string searchText;
         private BaseVariable<HashSet<string>> visibleTaskbarPanels => dataStore.HUDs.visibleTaskbarPanels;
-        private bool isSearching;
+        private bool isSearchingByName;
 
         public ISearchChannelsWindowView View => view;
 
@@ -123,9 +123,9 @@ namespace DCL.Chat.HUD
             view.ShowLoading();
             view.HideResultsHeader();
             this.searchText = searchText;
-            isSearching = !string.IsNullOrEmpty(searchText);
+            isSearchingByName = !string.IsNullOrEmpty(searchText);
             
-            if (!isSearching)
+            if (!isSearchingByName)
                 chatController.GetChannels(LOAD_PAGE_SIZE);
             else
             {
@@ -148,7 +148,7 @@ namespace DCL.Chat.HUD
             foreach (var channel in channels)
                 view.Set(channel);
             
-            if (isSearching)
+            if (isSearchingByName)
             {
                 view.HideLoadingMore();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelComponentViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelComponentViewShould.cs
@@ -10,7 +10,7 @@ namespace DCL.Chat.HUD
         public void SetUp()
         {
             view = ChatChannelComponentView.Create();
-            view.Setup(new PublicChatModel("channelId", "name", "desc", 0, true, 5, false));
+            view.Setup(new PublicChatModel("channelId", "name", "desc", true, 5, false));
         }
 
         [TearDown]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelHUDControllerShould.cs
@@ -34,7 +34,7 @@ namespace DCL.Chat.HUD
             
             chatController = Substitute.For<IChatController>();
             chatController.GetAllocatedChannel(CHANNEL_ID)
-                .Returns(new Channel(CHANNEL_ID, 4, 12, true, false, "desc", 0));
+                .Returns(new Channel(CHANNEL_ID, 4, 12, true, false, "desc"));
             chatController.GetAllocatedEntries().Returns(new List<ChatMessage>());
 
             dataStore = new DataStore();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/CollapsableChatSearchListComponentViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/CollapsableChatSearchListComponentViewShould.cs
@@ -82,7 +82,7 @@ namespace DCL.Chat.HUD
 
         private void GivenPublicChatEntry()
         {
-            view.Set(new PublicChatEntryModel("chan", "chan", 0, true, 2, false));
+            view.Set(new PublicChatEntryModel("chan", "chan", true, 2, false));
         }
 
         private void GivenPrivateChatEntry()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/CreateChannelWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/CreateChannelWindowControllerShould.cs
@@ -62,7 +62,7 @@ namespace DCL.Chat.HUD
         public void ShowChannelExistsErrorWithJoinOptionDisabled()
         {
             chatController.GetAllocatedChannel("foo").Returns(
-                new Channel("foo", 0, 2, true, false, "", 0));
+                new Channel("foo", 0, 2, true, false, ""));
             controller.SetVisibility(true);
             view.ClearReceivedCalls();
 
@@ -76,7 +76,7 @@ namespace DCL.Chat.HUD
         public void ShowChannelExistsErrorWithJoinOptionEnabled()
         {
             chatController.GetAllocatedChannel("foo").Returns(
-                new Channel("foo", 0, 2, false, false, "", 0));
+                new Channel("foo", 0, 2, false, false, ""));
             controller.SetVisibility(true);
             view.ClearReceivedCalls();
 
@@ -149,7 +149,7 @@ namespace DCL.Chat.HUD
             view.ClearReceivedCalls();
             
             chatController.OnChannelJoined += Raise.Event<Action<Channel>>(
-                new Channel("foo", 0, 2, false, false, "", 0));
+                new Channel("foo", 0, 2, false, false, ""));
             
             Assert.AreEqual("foo", navigatedChannel);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChannelEntryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChannelEntryShould.cs
@@ -22,7 +22,7 @@ public class PublicChannelEntryShould
     [Test]
     public void Configure()
     {
-        view.Configure(new PublicChatEntryModel("nearby", "nearby", 0, true, 4, false));
+        view.Configure(new PublicChatEntryModel("nearby", "nearby", true, 4, false));
         view.nameLabel.text = "#nearby";
         Assert.IsFalse(view.muteNotificationsToggle.isOn);
         Assert.AreEqual("4 members", view.memberCountLabel.text);
@@ -42,7 +42,7 @@ public class PublicChannelEntryShould
     [Test]
     public void ConfigureAsMuted()
     {
-        view.Configure(new PublicChatEntryModel("nearby", "nearby", 0, true, 0, true));
+        view.Configure(new PublicChatEntryModel("nearby", "nearby", true, 0, true));
         Assert.IsTrue(view.muteNotificationsToggle.isOn);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChatChannelComponentViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChatChannelComponentViewShould.cs
@@ -38,7 +38,7 @@ public class PublicChatChannelComponentViewShould
     [Test]
     public void Configure()
     {
-        view.Configure(new PublicChatModel("nearby", "nearby", "any description", 0, true, 0, false));
+        view.Configure(new PublicChatModel("nearby", "nearby", "any description", true, 0, false));
         
         Assert.AreEqual("~nearby", view.nameLabel.text);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChatEntryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChatEntryShould.cs
@@ -24,7 +24,7 @@ namespace DCL.Chat.HUD
         [TestCase(8)]
         public void SetMemberCount(int members)
         {
-            view.Configure(new PublicChatEntryModel("channelId", "bleh", 0, true, members, false));
+            view.Configure(new PublicChatEntryModel("channelId", "bleh", true, members, false));
 
             Assert.AreEqual($"{members} members", view.memberCountLabel.text);
         }
@@ -33,7 +33,7 @@ namespace DCL.Chat.HUD
         [TestCase("woo")]
         public void SetName(string name)
         {
-            view.Configure(new PublicChatEntryModel("channelId", name, 0, true, 0, false));
+            view.Configure(new PublicChatEntryModel("channelId", name, true, 0, false));
             
             Assert.AreEqual($"#{name}", view.nameLabel.text);
         }
@@ -41,7 +41,7 @@ namespace DCL.Chat.HUD
         [Test]
         public void EnableJoinedContainerWhenIsJoined()
         {
-            view.Configure(new PublicChatEntryModel("channelId", "bleh", 0, true, 0, false));
+            view.Configure(new PublicChatEntryModel("channelId", "bleh", true, 0, false));
             
             Assert.IsTrue(view.joinedContainer.activeSelf);
         }
@@ -49,7 +49,7 @@ namespace DCL.Chat.HUD
         [Test]
         public void DisableJoinedContainerWhenIsNotJoined()
         {
-            view.Configure(new PublicChatEntryModel("channelId", "bleh", 0, false, 0, false));
+            view.Configure(new PublicChatEntryModel("channelId", "bleh", false, 0, false));
             
             Assert.IsFalse(view.joinedContainer.activeSelf);
         }
@@ -61,7 +61,7 @@ namespace DCL.Chat.HUD
             var chatController = Substitute.For<IChatController>();
             chatController.GetAllocatedUnseenChannelMessages("channelId").Returns(5);
             view.Initialize(chatController);
-            view.Configure(new PublicChatEntryModel("channelId", "bleh", 0, true, 0, false));
+            view.Configure(new PublicChatEntryModel("channelId", "bleh", true, 0, false));
             
             Assert.AreEqual("5", view.unreadNotifications.notificationText.text);
         }
@@ -92,7 +92,7 @@ namespace DCL.Chat.HUD
         [Test]
         public void EnableLeaveOptionWhenIsJoined()
         {
-            view.Configure(new PublicChatEntryModel("channelId", "bleh", 0, true, 0, false));
+            view.Configure(new PublicChatEntryModel("channelId", "bleh", true, 0, false));
             
             Assert.IsTrue(view.joinedContainer.activeSelf);
         }
@@ -100,7 +100,7 @@ namespace DCL.Chat.HUD
         [Test]
         public void DisableLeaveOptionWhenIsNotJoined()
         {
-            view.Configure(new PublicChatEntryModel("channelId", "bleh", 0, false, 0, false));
+            view.Configure(new PublicChatEntryModel("channelId", "bleh", false, 0, false));
             
             Assert.IsFalse(view.joinedContainer.activeSelf);
         }
@@ -110,7 +110,7 @@ namespace DCL.Chat.HUD
         {
             var called = false;
             view.OnLeave += entry => called = entry == view; 
-            view.Configure(new PublicChatEntryModel("channelId", "bleh", 0, true, 0, false));
+            view.Configure(new PublicChatEntryModel("channelId", "bleh", true, 0, false));
             
             view.leaveButton.onClick.Invoke();
             

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/SearchChannelsWindowComponentViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/SearchChannelsWindowComponentViewShould.cs
@@ -42,7 +42,7 @@ namespace DCL.Chat.HUD
         public void ShowChannel()
         {
             view.Show();
-            view.Set(new Channel("bleh", 7, 4, false, false, "desc", 0));
+            view.Set(new Channel("bleh", 7, 4, false, false, "desc"));
             
             Assert.AreEqual(1, view.channelList.Count());
             Assert.AreEqual("Results (1)", view.resultsHeaderLabel.text);
@@ -56,7 +56,7 @@ namespace DCL.Chat.HUD
         public void ShowJoinedChannel()
         {
             view.Show();
-            view.Set(new Channel("bleh", 7, 4, true, false, "desc", 0));
+            view.Set(new Channel("bleh", 7, 4, true, false, "desc"));
             
             Assert.AreEqual(1, view.channelList.Count());
             Assert.AreEqual("Results (1)", view.resultsHeaderLabel.text);
@@ -77,9 +77,9 @@ namespace DCL.Chat.HUD
         public void ShowManyChannels()
         {
             view.Show();
-            view.Set(new Channel("bleh", 7, 4, false, false, "desc", 0));
-            view.Set(new Channel("foo", 2, 9, false, false, "desc", 0));
-            view.Set(new Channel("bar", 0, 5, false, false, "desc", 0));
+            view.Set(new Channel("bleh", 7, 4, false, false, "desc"));
+            view.Set(new Channel("foo", 2, 9, false, false, "desc"));
+            view.Set(new Channel("bar", 0, 5, false, false, "desc"));
             
             Assert.AreEqual(3, view.channelList.Count());
             Assert.AreEqual("Results (3)", view.resultsHeaderLabel.text);
@@ -121,7 +121,7 @@ namespace DCL.Chat.HUD
             var triggeredSearch = "";
             view.OnSearchUpdated += s => triggeredSearch = s;
             view.searchBar.SubmitSearch(text);
-            view.Set(new Channel(text, 1, 42, false, false, "desc", 0));
+            view.Set(new Channel(text, 1, 42, false, false, "desc"));
             
             Assert.AreEqual(text, triggeredSearch);
             Assert.AreEqual(text, view.searchBar.Text);
@@ -137,7 +137,7 @@ namespace DCL.Chat.HUD
             view.OnSearchUpdated += s => triggeredSearch = s;
             
             view.ClearSearchInput();
-            view.Set(new Channel("bleh", 1, 42, false, false, "desc", 0));
+            view.Set(new Channel("bleh", 1, 42, false, false, "desc"));
             
             Assert.AreEqual("", triggeredSearch);
             Assert.AreEqual("", view.searchBar.Text);
@@ -178,7 +178,7 @@ namespace DCL.Chat.HUD
         {
             var leaveChannelId = "";
             view.OnLeaveChannel += s => leaveChannelId = s; 
-            view.Set(new Channel("bleh", 7, 4, true, false, "desc", 0));
+            view.Set(new Channel("bleh", 7, 4, true, false, "desc"));
             
             view.channelList.Get("bleh").leaveButton.onClick.Invoke();
             

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/SearchChannelsWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/SearchChannelsWindowControllerShould.cs
@@ -59,7 +59,7 @@ namespace DCL.Chat.HUD
             view.Received(1).ClearAllEntries();
             view.Received(1).ShowLoading();
 
-            chatController.Received(1).GetChannels(SearchChannelsWindowController.LOAD_PAGE_SIZE, 0);
+            chatController.Received(1).GetChannels(SearchChannelsWindowController.LOAD_PAGE_SIZE);
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace DCL.Chat.HUD
             view.IsActive.Returns(true);
             controller.SetVisibility(true);
 
-            var channel = new Channel("channel", 15, 11, false, false, "desc", 0);
+            var channel = new Channel("channel", 15, 11, false, false, "desc");
             chatController.OnChannelUpdated += Raise.Event<Action<Channel>>(channel);
 
             view.Received(1).HideLoading();
@@ -82,7 +82,7 @@ namespace DCL.Chat.HUD
             controller.SetVisibility(false);
 
             chatController.OnChannelUpdated += Raise.Event<Action<Channel>>(
-                new Channel("channel", 15, 11, false, false, "desc", 0));
+                new Channel("channel", 15, 11, false, false, "desc"));
 
             view.DidNotReceiveWithAnyArgs().Set(default);
         }
@@ -93,6 +93,7 @@ namespace DCL.Chat.HUD
             view.EntryCount.Returns(16);
             view.IsActive.Returns(true);
             controller.SetVisibility(true);
+            chatController.OnChannelSearchResult += Raise.Event<Action<string, Channel[]>>("page1", Array.Empty<Channel>());
 
             // must wait at least 2 seconds to keep loading channels since the last time requested
             yield return new WaitForSeconds(3);
@@ -102,7 +103,7 @@ namespace DCL.Chat.HUD
             view.OnRequestMoreChannels += Raise.Event<Action>();
 
             view.Received(1).HideLoadingMore();
-            chatController.Received(1).GetChannels(SearchChannelsWindowController.LOAD_PAGE_SIZE, 16);
+            chatController.Received(1).GetChannels(SearchChannelsWindowController.LOAD_PAGE_SIZE, "page1");
         }
 
         [UnityTest]
@@ -123,7 +124,7 @@ namespace DCL.Chat.HUD
             view.Received(1).ClearAllEntries();
             view.Received(1).ShowLoading();
             socialAnalytics.Received(1).SendChannelSearch(searchText);
-            chatController.Received(1).GetChannels(SearchChannelsWindowController.LOAD_PAGE_SIZE, 0, searchText);
+            chatController.Received(1).GetChannelsByName(SearchChannelsWindowController.LOAD_PAGE_SIZE, searchText);
         }
         
         [UnityTest]
@@ -141,7 +142,7 @@ namespace DCL.Chat.HUD
 
             view.Received(1).ClearAllEntries();
             view.Received(1).ShowLoading();
-            chatController.Received(1).GetChannels(SearchChannelsWindowController.LOAD_PAGE_SIZE, 0);
+            chatController.Received(1).GetChannels(SearchChannelsWindowController.LOAD_PAGE_SIZE);
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/SearchChannelsWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/SearchChannelsWindowControllerShould.cs
@@ -67,11 +67,11 @@ namespace DCL.Chat.HUD
         {
             view.IsActive.Returns(true);
             controller.SetVisibility(true);
+            view.ClearReceivedCalls();
 
             var channel = new Channel("channel", 15, 11, false, false, "desc");
             chatController.OnChannelSearchResult += Raise.Event<Action<string, Channel[]>>("page1", new[] {channel});
 
-            view.Received(1).HideLoading();
             view.Received(1).ShowLoadingMore();
             view.Received(1).Set(Arg.Is<Channel>(c => c.Equals(channel)));
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowComponentViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowComponentViewShould.cs
@@ -217,7 +217,7 @@ public class WorldChatWindowComponentViewShould
     {
         const string channelId = "nearby";
 
-        var model = new PublicChatModel(channelId, "nearby", "any description", 0, true, 0, false);
+        var model = new PublicChatModel(channelId, "nearby", "any description", true, 0, false);
         view.SetPublicChat(model);
 
         yield return null;
@@ -359,7 +359,7 @@ public class WorldChatWindowComponentViewShould
         }, new Dictionary<string, PublicChatModel>
         {
             {
-                "nearby", new PublicChatModel("nearby", "nearby", "", 0, true, 0, false)
+                "nearby", new PublicChatModel("nearby", "nearby", "", true, 0, false)
             }
         });
 
@@ -488,7 +488,7 @@ public class WorldChatWindowComponentViewShould
 
     private void GivenPublicChannel(string channelId, string name)
     {
-        view.SetPublicChat(new PublicChatModel(channelId, name, "any description", 0, true, 0, false));
+        view.SetPublicChat(new PublicChatModel(channelId, name, "any description", true, 0, false));
     }
 
     private UserProfile GivenProfile(string userId)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
@@ -34,7 +34,7 @@ public class WorldChatWindowControllerShould
         chatController = Substitute.For<IChatController>();
         mouseCatcher = Substitute.For<IMouseCatcher>();
         chatController.GetAllocatedEntries().Returns(new List<ChatMessage>());
-        chatController.GetAllocatedChannel("nearby").Returns(new Channel("nearby", 0, 0, true, false, "", 0));
+        chatController.GetAllocatedChannel("nearby").Returns(new Channel("nearby", 0, 0, true, false, ""));
         friendsController = Substitute.For<IFriendsController>();
         friendsController.IsInitialized.Returns(true);
         socialAnalytics = Substitute.For<ISocialAnalytics>();
@@ -451,7 +451,7 @@ public class WorldChatWindowControllerShould
 
         dataStore.channels.channelJoinedSource.Set(ChannelJoinedSource.Search);
         chatController.OnChannelJoined +=
-            Raise.Event<Action<Channel>>(new Channel("channelId", 0, 1, true, false, "", 0));
+            Raise.Event<Action<Channel>>(new Channel("channelId", 0, 1, true, false, ""));
         
         socialAnalytics.Received(1).SendEmptyChannelCreated("channelId", ChannelJoinedSource.Search);
     }
@@ -463,7 +463,7 @@ public class WorldChatWindowControllerShould
 
         dataStore.channels.channelJoinedSource.Set(ChannelJoinedSource.Link);
         chatController.OnChannelJoined +=
-            Raise.Event<Action<Channel>>(new Channel("channelId", 0, 2, true, false, "", 0));
+            Raise.Event<Action<Channel>>(new Channel("channelId", 0, 2, true, false, ""));
         
         socialAnalytics.Received(1).SendPopulatedChannelJoined("channelId", ChannelJoinedSource.Link);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
@@ -319,7 +319,7 @@ namespace DCL.Chat.HUD
         private void Set(PublicChatModel model)
         {
             var channelId = model.channelId;
-            var entryModel = new PublicChatEntryModel(channelId, model.name, model.lastMessageTimestamp, model.joined, model.memberCount, model.muted);
+            var entryModel = new PublicChatEntryModel(channelId, model.name, model.joined, model.memberCount, model.muted);
             PublicChatEntry entry;
 
             if (isSearchMode)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -92,7 +92,6 @@ public class WorldChatWindowController : IHUD
         var channel = chatController.GetAllocatedChannel(ChatUtils.NEARBY_CHANNEL_ID);
         publicChannels[ChatUtils.NEARBY_CHANNEL_ID] = new PublicChatModel(ChatUtils.NEARBY_CHANNEL_ID, channel.Name,
             channel.Description,
-            channel.LastMessageTimestamp,
             channel.Joined,
             channel.MemberCount,
             false);
@@ -475,7 +474,7 @@ public class WorldChatWindowController : IHUD
         }
         
         var channelId = channel.ChannelId;
-        var model = new PublicChatModel(channelId, channel.Name, channel.Description, channel.LastMessageTimestamp, channel.Joined, channel.MemberCount, channel.Muted);
+        var model = new PublicChatModel(channelId, channel.Name, channel.Description, channel.Joined, channel.MemberCount, channel.Muted);
         
         if (publicChannels.ContainsKey(channelId))
             publicChannels[channelId].CopyFrom(model);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -832,7 +832,7 @@ namespace DCL.Interface
         private class GetChannelsPayload
         {
             public int limit;
-            public int skip;
+            public string since;
             public string name;
         }
 
@@ -1887,12 +1887,12 @@ namespace DCL.Interface
             });
         }
 
-        public static void GetChannels(int limit, int skip, string name)
+        public static void GetChannels(int limit, string since, string name)
         {
             SendMessage("GetChannels", new GetChannelsPayload
             {
                 limit = limit,
-                skip = skip,
+                since = since,
                 name = name
             });
         }


### PR DESCRIPTION
## What does this PR change?

Changes the way pagination works when searching channels. It is required a `string paginationToken` instead of a `skip` parameter.

## How to test the changes?

1. Open the channel browser
2. All channels should be loaded
3. Scroll down to load more
4. Use the searchbar and type a name

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
