### PR TITLE
fix: emotes play analytics fixed for new emotes

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
@@ -163,7 +163,12 @@ public class PlayerAvatarController : MonoBehaviour, IHideAvatarAreaHandler, IHi
     {
         avatar.PlayEmote(id, timestamp);
 
-        DataStore.i.common.wearables.TryGetValue(id, out WearableItem emoteItem);
+        bool found = DataStore.i.common.wearables.TryGetValue(id, out WearableItem emoteItem);
+        if (!found)
+        {
+            var emotesCatalog = Environment.i.serviceLocator.Get<IEmotesCatalogService>();
+            emotesCatalog.TryGetLoadedEmote(id, out emoteItem);
+        }
 
         if (emoteItem != null)
         {


### PR DESCRIPTION
## What does this PR change?

This PR fixes analytics of playing an emote for new emotes. If the emote is not found in the collection of wearables in that case it will be found in the new emotes catalog.

Closes #2963 

## How to test the changes?

Check if analytics event actually coming to our analytics when you play a new custom NFT emote.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
