### PR TITLE
Fix: gray screen flash on nav map

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
@@ -3727,6 +3727,7 @@ GameObject:
   - component: {fileID: 4407499575277028384}
   - component: {fileID: 1615518836687384758}
   - component: {fileID: 1257995942692528190}
+  - component: {fileID: 1671988932632039188}
   m_Layer: 5
   m_Name: SectionsContent
   m_TagString: Untagged
@@ -3811,6 +3812,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 1
+--- !u!114 &1671988932632039188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7023077538247408467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8628ccfd6bcc47d6aaa3d926a0727a12, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sectionsContent: {fileID: 1615518836687384758}
+  radialGradient: {fileID: 5211940635867006629}
+  navMapSection: {fileID: 6541208048180886267}
 --- !u!1 &7387171519451911844
 GameObject:
   m_ObjectHideFlags: 0
@@ -7277,18 +7293,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 47888b63c7dcb7f4a9fbda4bd22c7894, type: 3}
---- !u!114 &8087733458050873985 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8731583579770001316, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
+--- !u!224 &5737986593011763845 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5093812924977342368, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
     type: 3}
   m_PrefabInstance: {fileID: 653505431577750821}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dda0ecb03cbed18448861c3f10dfbfdd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &4593437355348245885 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3940259666297114712, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
@@ -7301,12 +7311,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2fafe2cfe61f6974895a912c3755e8f1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &5737986593011763845 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5093812924977342368, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
+--- !u!114 &8087733458050873985 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8731583579770001316, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
     type: 3}
   m_PrefabInstance: {fileID: 653505431577750821}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dda0ecb03cbed18448861c3f10dfbfdd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3608467515198330940
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10803,6 +10819,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 01095a78852393446834e68bf8628274, type: 3}
+--- !u!224 &6897819228172551501 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2595460879837104802, guid: 01095a78852393446834e68bf8628274,
+    type: 3}
+  m_PrefabInstance: {fileID: 8916309094798233583}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &9218004316370049640 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 311304691206690183, guid: 01095a78852393446834e68bf8628274,
@@ -10815,9 +10837,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 509258bf67fe12f4c90a44fb48fcc558, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &6897819228172551501 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2595460879837104802, guid: 01095a78852393446834e68bf8628274,
-    type: 3}
-  m_PrefabInstance: {fileID: 8916309094798233583}
-  m_PrefabAsset: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -259,8 +259,6 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
         if (!SectionsVariables[section].initVar.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
-        Debug.Log($"{Time.frameCount} [Controller] SetMenuTargetVisibility with GoTo visible {section} is {toVisible}");
-
         if (toVisible)
         {
             if (DataStore.i.exploreV2.currentSectionIndex.Get() != (int)section)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -11,6 +11,8 @@ using Variables.RealmsInfo;
 /// </summary>
 public class ExploreV2MenuComponentController : IExploreV2MenuComponentController
 {
+    internal const ExploreSection DEFAULT_SECTION = ExploreSection.Explore;
+
     internal const float MIN_TIME_AFTER_CLOSE_OTHER_UI_TO_OPEN_START_MENU = 0.1f;
     internal readonly List<RealmRowComponentModel> currentAvailableRealms = new List<RealmRowComponentModel>();
     internal float chatInputHUDCloseTime = 0f;
@@ -123,6 +125,8 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
         isInitialized.Set(true);
 
+        DataStore.i.exploreV2.currentSectionIndex.Set((int)DEFAULT_SECTION, false);
+
         //view.ConfigureEncapsulatedSection(ExploreSection.Backpack, DataStore.i.exploreV2.configureBackpackInFullscreenMenu);
         view.ConfigureEncapsulatedSection(ExploreSection.Map, DataStore.i.exploreV2.configureMapInFullscreenMenu);
         view.ConfigureEncapsulatedSection(ExploreSection.Builder, DataStore.i.exploreV2.configureBuilderInFullscreenMenu);
@@ -233,7 +237,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
             mouseCatcher?.UnlockCursor();
 
             if (DataStore.i.common.isTutorialRunning.Get())
-                view.GoToSection(ExploreV2MenuComponentView.DEFAULT_SECTION);
+                view.GoToSection(DEFAULT_SECTION);
         }
         else
         {
@@ -255,11 +259,21 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
         if (!SectionsVariables[section].initVar.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
-        if (toVisible || currentOpenSection == section)
-            SetSectionTargetVisibility(section, toVisible);
+        Debug.Log($"{Time.frameCount} [Controller] SetMenuTargetVisibility with GoTo visible {section} is {toVisible}");
 
         if (toVisible)
+        {
+            if (DataStore.i.exploreV2.currentSectionIndex.Get() != (int)section)
+                DataStore.i.exploreV2.currentSectionIndex.Set((int)section);
+
+            SetSectionTargetVisibility(section, toVisible: true);
+
             view.GoToSection(section);
+        }
+        else if (currentOpenSection == section)
+        {
+            SetSectionTargetVisibility(section, toVisible: false);
+        }
     }
 
     private void SetSectionTargetVisibility(ExploreSection section, bool toVisible)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -256,7 +256,9 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal void SetMenuTargetVisibility(ExploreSection section, bool toVisible, bool _ = false)
     {
-        if (!SectionsVariables[section].initVar.Get() || DataStore.i.common.isSignUpFlow.Get())
+        var initVar = section == ExploreSection.Explore ? isInitialized : SectionsVariables[section].initVar;
+
+        if (!initVar.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
         if (toVisible)
@@ -265,7 +267,6 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
                 DataStore.i.exploreV2.currentSectionIndex.Set((int)section);
 
             SetSectionTargetVisibility(section, toVisible: true);
-
             view.GoToSection(section);
         }
         else if (currentOpenSection == section)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -181,8 +181,16 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
             InitializePlacesAndEventsSection();
     }
 
-    private void OnSectionVisiblityChanged(BaseVariable<bool> visibilityVar, bool visible, bool previous = false) =>
+    private void OnSectionVisiblityChanged(BaseVariable<bool> visibilityVar, bool visible, bool previous = false)
+    {
+        ExploreSection section = SectionsByVisiblityVar[visibilityVar];
+        BaseVariable<bool> initVar = section == ExploreSection.Explore ? isInitialized : SectionsVariables[section].initVar;
+
+        if (!initVar.Get() || DataStore.i.common.isSignUpFlow.Get())
+            return;
+
         SetMenuTargetVisibility(SectionsByVisiblityVar[visibilityVar], visible);
+    }
 
     internal void InitializePlacesAndEventsSection()
     {
@@ -256,11 +264,6 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal void SetMenuTargetVisibility(ExploreSection section, bool toVisible, bool _ = false)
     {
-        var initVar = section == ExploreSection.Explore ? isInitialized : SectionsVariables[section].initVar;
-
-        if (!initVar.Get() || DataStore.i.common.isSignUpFlow.Get())
-            return;
-
         if (toVisible)
         {
             if (DataStore.i.exploreV2.currentSectionIndex.Get() != (int)section)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -23,9 +23,10 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
     internal MouseCatcher mouseCatcher;
     internal IPlacesAndEventsSectionComponentController placesAndEventsSectionController;
     internal float playerInfoCardHUDCloseTime = 0f;
-
     private Dictionary<BaseVariable<bool>, ExploreSection> sectionsByInitVar;
-    private Dictionary<BaseVariable<bool>, ExploreSection> sectionsByVisiblityVar;
+    internal Dictionary<BaseVariable<bool>, ExploreSection> sectionsByVisiblityVar;
+
+    private Dictionary<ExploreSection, (BaseVariable<bool> initVar, BaseVariable<bool> visibilityVar)> sectionsVariables;
 
     internal IExploreV2MenuComponentView view;
 
@@ -61,8 +62,9 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
     internal BaseVariable<bool> chatInputVisible => DataStore.i.HUDs.chatInputVisible;
     internal BooleanVariable playerInfoCardVisible => CommonScriptableObjects.playerInfoCardVisibleState;
 
-    private Dictionary<ExploreSection, (BaseVariable<bool> initVar, BaseVariable<bool> visibilityVar)> sectionsVariables =>
-        new Dictionary<ExploreSection, (BaseVariable<bool>, BaseVariable<bool>)>
+    public void Initialize()
+    {
+        sectionsVariables = new Dictionary<ExploreSection, (BaseVariable<bool>, BaseVariable<bool>)>
         {
             { ExploreSection.Explore, (isPlacesAndEventsSectionInitialized,  placesAndEventsVisible) },
             { ExploreSection.Backpack, (isAvatarEditorInitialized,  avatarEditorVisible) },
@@ -71,9 +73,6 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
             { ExploreSection.Quest, (isQuestInitialized,  questVisible) },
             { ExploreSection.Settings, (isSettingsPanelInitialized,  settingsVisible) },
         };
-
-    public void Initialize()
-    {
         sectionsByInitVar = sectionsVariables.ToDictionary(pair => pair.Value.initVar, pair => pair.Key);
         sectionsByVisiblityVar = sectionsVariables.ToDictionary(pair => pair.Value.visibilityVar, pair => pair.Key);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -295,11 +295,9 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
     public override void RefreshControl()
     {
         placesAndEventsSection.RefreshControl();
-        backpackSection.RefreshControl();
-        mapSection.RefreshControl();
-        builderSection.RefreshControl();
-        questSection.RefreshControl();
-        settingsSection.RefreshControl();
+
+        foreach (var section in exploreSectionsById.Keys)
+            exploreSectionsById[section]?.RefreshControl();
     }
 
     internal void RemoveSectionSelectorMappings()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -130,8 +130,6 @@ public interface IExploreV2MenuComponentView : IDisposable
 
 public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuComponentView
 {
-
-    internal const ExploreSection DEFAULT_SECTION = ExploreSection.Explore;
     internal const string REALM_SELECTOR_MODAL_ID = "RealmSelector_Modal";
 
     [Header("Assets References")]
@@ -184,8 +182,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
     public override void Start()
     {
-        DataStore.i.exploreV2.currentSectionIndex.Set((int)DEFAULT_SECTION, false);
-
         DataStore.i.exploreV2.isInitialized.OnChange += IsInitialized_OnChange;
         IsInitialized_OnChange(DataStore.i.exploreV2.isInitialized.Get(), false);
 
@@ -239,7 +235,10 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
             ISectionToggle sectionToGo = sectionSelector.GetSection(DataStore.i.exploreV2.currentSectionIndex.Get());
 
             if (sectionToGo != null && sectionToGo.IsActive())
+            {
+                Debug.Log($"{Time.frameCount} [View.SetVisible({isActive})] GoToSection({(ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get()} where SectionToGo={sectionToGo})");
                 GoToSection((ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get());
+            }
             else
             {
                 List<ISectionToggle> allSections = sectionSelector.GetAllSections();
@@ -262,9 +261,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
     public void GoToSection(ExploreSection section)
     {
-        if (DataStore.i.exploreV2.currentSectionIndex.Get() != (int)section)
-            DataStore.i.exploreV2.currentSectionIndex.Set((int)section);
-
         sectionSelector.GetSection((int)section)?.SelectToggleWithReset();
 
         AudioScriptableObjects.dialogOpen.Play(true);
@@ -381,7 +377,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
                 if (sectionView != null)
                     sectionView.Show();
 
-                DataStore.i.exploreV2.currentSectionIndex.Set((int)sectionId, false);
                 OnSectionOpen?.Invoke(sectionId);
             }
             else if (sectionView != null) // If not an explorer Section, because we do not Show/Hide it

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -260,9 +260,7 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
     public void GoToSection(ExploreSection section)
     {
-        sectionSelector.GetSection((int)section)
-                       ?
-                       .SelectToggle(reselectIfAlreadyOn: true);
+        sectionSelector.GetSection((int)section)?.SelectToggle(reselectIfAlreadyOn: true);
 
         AudioScriptableObjects.dialogOpen.Play(true);
         AudioScriptableObjects.listItemAppear.ResetPitch();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -246,7 +246,7 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
                 {
                     if (section != null && section.IsActive())
                     {
-                        section.SelectToggleWithReset();
+                        section.SelectToggle(reselectIfAlreadyOn: true);
                         break;
                     }
                 }
@@ -261,7 +261,9 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
     public void GoToSection(ExploreSection section)
     {
-        sectionSelector.GetSection((int)section)?.SelectToggleWithReset();
+        sectionSelector.GetSection((int)section)
+                       ?
+                       .SelectToggle(reselectIfAlreadyOn: true);
 
         AudioScriptableObjects.dialogOpen.Play(true);
         AudioScriptableObjects.listItemAppear.ResetPitch();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -236,7 +236,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
             if (sectionToGo != null && sectionToGo.IsActive())
             {
-                Debug.Log($"{Time.frameCount} [View.SetVisible({isActive})] GoToSection({(ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get()} where SectionToGo={sectionToGo})");
                 GoToSection((ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get());
             }
             else
@@ -373,8 +372,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
             if (isOn)
             {
-                Debug.Log($"{Time.frameCount} [ExploreV2MenuComponentView.CreateSectionSelectorMappings] - {sectionId}Section.Show()");
-
                 // If not an explorer Section, because we do not Show/Hide it
                 if (sectionView != null)
                     sectionView.Show();
@@ -383,7 +380,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
             }
             else if (sectionView != null) // If not an explorer Section, because we do not Show/Hide it
             {
-                Debug.Log($"{Time.frameCount} [ExploreV2MenuComponentView.CreateSectionSelectorMappings] - {sectionId}Section.Hide()");
                 sectionView.Hide();
             }
         };

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -237,6 +237,7 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
             Show();
 
             ISectionToggle sectionToGo = sectionSelector.GetSection(DataStore.i.exploreV2.currentSectionIndex.Get());
+
             if (sectionToGo != null && sectionToGo.IsActive())
                 GoToSection((ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get());
             else
@@ -304,9 +305,7 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
     internal void RemoveSectionSelectorMappings()
     {
         foreach (int sectionId in Enum.GetValues(typeof(ExploreSection)))
-        {
             sectionSelector.GetSection(sectionId)?.onSelect.RemoveAllListeners();
-        }
     }
 
     internal void ConfigureCloseButton()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentView.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 
 public interface IPlacesAndEventsSectionComponentView
@@ -47,11 +46,17 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
 
     internal bool isDefaultSubSectionLoadedByFirstTime = false;
 
+    public override void Start() { CreateSubSectionSelectorMappings(); }
+
     public IHighlightsSubSectionComponentView currentHighlightsSubSectionComponentView => highlightsSubSection;
     public IPlacesSubSectionComponentView currentPlacesSubSectionComponentView => placesSubSection;
     public IEventsSubSectionComponentView currentEventsSubSectionComponentView => eventsSubSection;
 
-    public override void Start() { CreateSubSectionSelectorMappings(); }
+    public void GoToSubsection(int subSectionIndex) =>
+        subSectionSelector.GetSection(subSectionIndex)?.SelectToggleWithReset();
+
+    public void SetActive(bool isActive) =>
+        gameObject.SetActive(isActive);
 
     public override void RefreshControl()
     {
@@ -92,7 +97,7 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
                               eventsSubSection.gameObject.SetActive(isOn);
                           });
 
-        subSectionSelector.GetSection(HIGHLIGHTS_SUB_SECTION_INDEX)?.SelectToggle(true);
+        subSectionSelector.GetSection(HIGHLIGHTS_SUB_SECTION_INDEX)?.SelectToggleWithReset();
     }
 
     internal void RemoveSectionSelectorMappings()
@@ -101,8 +106,4 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
         subSectionSelector.GetSection(PLACES_SUB_SECTION_INDEX)?.onSelect.RemoveAllListeners();
         subSectionSelector.GetSection(EVENTS_SUB_SECTION_INDEX)?.onSelect.RemoveAllListeners();
     }
-
-    public void GoToSubsection(int subSectionIndex) { subSectionSelector.GetSection(subSectionIndex)?.SelectToggle(true); }
-
-    public void SetActive(bool isActive) { gameObject.SetActive(isActive); }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentView.cs
@@ -53,7 +53,7 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
     public IEventsSubSectionComponentView currentEventsSubSectionComponentView => eventsSubSection;
 
     public void GoToSubsection(int subSectionIndex) =>
-        subSectionSelector.GetSection(subSectionIndex)?.SelectToggleWithReset();
+        subSectionSelector.GetSection(subSectionIndex)?.SelectToggle(reselectIfAlreadyOn: true);
 
     public void SetActive(bool isActive) =>
         gameObject.SetActive(isActive);
@@ -97,7 +97,7 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
                               eventsSubSection.gameObject.SetActive(isOn);
                           });
 
-        subSectionSelector.GetSection(HIGHLIGHTS_SUB_SECTION_INDEX)?.SelectToggleWithReset();
+        subSectionSelector.GetSection(HIGHLIGHTS_SUB_SECTION_INDEX)?.SelectToggle(reselectIfAlreadyOn: true);
     }
 
     internal void RemoveSectionSelectorMappings()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentView.cs
@@ -46,7 +46,8 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
 
     internal bool isDefaultSubSectionLoadedByFirstTime = false;
 
-    public override void Start() { CreateSubSectionSelectorMappings(); }
+    public override void Start() =>
+        CreateSubSectionSelectorMappings();
 
     public IHighlightsSubSectionComponentView currentHighlightsSubSectionComponentView => highlightsSubSection;
     public IPlacesSubSectionComponentView currentPlacesSubSectionComponentView => placesSubSection;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -112,7 +112,7 @@ public class ExploreV2MenuComponentControllerTests
         DataStore.i.common.isTutorialRunning.Set(true);
 
         // Act
-        exploreV2MenuController.IsOpenChanged(isVisible, !isVisible);
+        exploreV2MenuController.SetVisibilityOnOpenChanged(isVisible, !isVisible);
 
         // Assert
         if (isVisible)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -140,7 +140,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Explore;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Explore, isVisible);
+        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Explore, isVisible);
 
         // Assert
         if (isVisible)
@@ -171,7 +171,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Backpack;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Backpack, isVisible);
+        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Backpack, isVisible);
         ;
 
         // Assert
@@ -202,7 +202,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Map;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Map, isVisible);
+        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Map, isVisible);
 
         // Assert
         if (isVisible)
@@ -232,7 +232,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Builder;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Builder, isVisible);
+        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Builder, isVisible);
 
         // Assert
         if (isVisible)
@@ -262,7 +262,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Quest;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Quest, isVisible);
+        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Quest, isVisible);
 
         // Assert
         if (isVisible)
@@ -292,7 +292,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Settings;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Settings, isVisible);
+        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Settings, isVisible);
 
         // Assert
         if (isVisible)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -116,7 +116,7 @@ public class ExploreV2MenuComponentControllerTests
 
         // Assert
         if (isVisible)
-            exploreV2MenuView.Received().GoToSection(ExploreV2MenuComponentView.DEFAULT_SECTION);
+            exploreV2MenuView.Received().GoToSection(ExploreV2MenuComponentController.DEFAULT_SECTION);
         else
         {
             Assert.IsFalse(exploreV2MenuController.placesAndEventsVisible.Get());

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using DCL;
 using ExploreV2Analytics;
@@ -341,6 +342,30 @@ public class ExploreV2MenuComponentControllerTests
 
         // Assert
         Assert.AreEqual((int)section, DataStore.i.exploreV2.currentSectionIndex.Get());
+    }
+
+    [TestCase(ExploreSection.Explore)]
+    [TestCase(ExploreSection.Backpack)]
+    [TestCase(ExploreSection.Map)]
+    [TestCase(ExploreSection.Builder)]
+    [TestCase(ExploreSection.Quest)]
+    [TestCase(ExploreSection.Settings)]
+    public void ShouldChangeVisibilityVarsOnViewSectionOpen(ExploreSection sectionId)
+    {
+        // Arrange
+        if (sectionId == ExploreSection.Explore)
+            exploreV2MenuController.currentOpenSection = ExploreSection.Backpack ;
+
+        // Act
+        exploreV2MenuView.OnSectionOpen += Raise.Event<Action<ExploreSection>>(sectionId);
+
+        // Assert
+        Assert.AreEqual(sectionId, exploreV2MenuController.currentOpenSection);
+
+        foreach (KeyValuePair<BaseVariable<bool>, ExploreSection> sectionVisiblityVar in exploreV2MenuController.sectionsByVisiblityVar)
+            Assert.IsTrue(sectionVisiblityVar.Key.Get() == (sectionId == sectionVisiblityVar.Value));
+
+        // would be nice to implement: exploreV2MenuView.ReceivedWithAnyArgs(1).GoToSection(default); exploreV2MenuView.Received(1).GoToSection(sectionId);
     }
 
     [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -140,7 +140,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Explore;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Explore);
+        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Explore, isVisible);
 
         // Assert
         if (isVisible)
@@ -155,7 +155,7 @@ public class ExploreV2MenuComponentControllerTests
     public void RaiseIsAvatarEditorInitializedChangedCorrectly(bool isVisible)
     {
         // Act
-        exploreV2MenuController.IsAvatarEditorInitializedChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Backpack, isVisible);
 
         // Assert
         exploreV2MenuView.Received().SetSectionActive(ExploreSection.Backpack, isVisible);
@@ -171,7 +171,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Backpack;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Backpack);
+        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Backpack, isVisible);
         ;
 
         // Assert
@@ -187,7 +187,7 @@ public class ExploreV2MenuComponentControllerTests
     public void RaiseIsNavMapInitializedChangedCorrectly(bool isVisible)
     {
         // Act
-        exploreV2MenuController.IsNavMapInitializedChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Map, isVisible);
 
         // Assert
         exploreV2MenuView.Received().SetSectionActive(ExploreSection.Map, isVisible);
@@ -202,7 +202,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Map;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Map);
+        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Map, isVisible);
 
         // Assert
         if (isVisible)
@@ -217,7 +217,7 @@ public class ExploreV2MenuComponentControllerTests
     public void RaiseIsBuilderInitializedChangedCorrectly(bool isVisible)
     {
         // Act
-        exploreV2MenuController.IsBuilderInitializedChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Builder, isVisible);
 
         // Assert
         exploreV2MenuView.Received().SetSectionActive(ExploreSection.Builder, isVisible);
@@ -232,7 +232,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Builder;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Builder);
+        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Builder, isVisible);
 
         // Assert
         if (isVisible)
@@ -247,7 +247,7 @@ public class ExploreV2MenuComponentControllerTests
     public void RaiseIsQuestInitializedChangedCorrectly(bool isVisible)
     {
         // Act
-        exploreV2MenuController.IsQuestInitializedChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Quest, isVisible);
 
         // Assert
         exploreV2MenuView.Received().SetSectionActive(ExploreSection.Quest, isVisible);
@@ -262,7 +262,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Quest;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Quest);
+        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Quest, isVisible);
 
         // Assert
         if (isVisible)
@@ -277,7 +277,7 @@ public class ExploreV2MenuComponentControllerTests
     public void RaiseIsSettingsPanelInitializedChangedCorrectly(bool isVisible)
     {
         // Act
-        exploreV2MenuController.IsSettingsPanelInitializedChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Settings, isVisible);
 
         // Assert
         exploreV2MenuView.Received().SetSectionActive(ExploreSection.Settings, isVisible);
@@ -292,7 +292,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Settings;
 
         // Act
-        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Settings);
+        exploreV2MenuController.SectionVisibilityChanged(ExploreSection.Settings, isVisible);
 
         // Assert
         if (isVisible)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -1,17 +1,16 @@
+using System.Collections.Generic;
 using DCL;
 using ExploreV2Analytics;
 using NSubstitute;
 using NSubstitute.Extensions;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using Variables.RealmsInfo;
 
 public class ExploreV2MenuComponentControllerTests
 {
+    private IExploreV2Analytics exploreV2Analytics;
     private ExploreV2MenuComponentController exploreV2MenuController;
     private IExploreV2MenuComponentView exploreV2MenuView;
-    private IExploreV2Analytics exploreV2Analytics;
 
     [SetUp]
     public void SetUp()
@@ -141,7 +140,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Explore;
 
         // Act
-        exploreV2MenuController.PlacesAndEventsVisibleChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Explore);
 
         // Assert
         if (isVisible)
@@ -172,7 +171,8 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Backpack;
 
         // Act
-        exploreV2MenuController.AvatarEditorVisibleChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Backpack);
+        ;
 
         // Assert
         if (isVisible)
@@ -202,7 +202,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Map;
 
         // Act
-        exploreV2MenuController.NavmapVisibleChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Map);
 
         // Assert
         if (isVisible)
@@ -232,7 +232,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Builder;
 
         // Act
-        exploreV2MenuController.BuilderVisibleChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Builder);
 
         // Assert
         if (isVisible)
@@ -262,7 +262,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Quest;
 
         // Act
-        exploreV2MenuController.QuestVisibleChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Quest);
 
         // Assert
         if (isVisible)
@@ -292,7 +292,7 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuController.currentOpenSection = ExploreSection.Settings;
 
         // Act
-        exploreV2MenuController.SettingsVisibleChanged(isVisible, !isVisible);
+        exploreV2MenuController.SectionVisibilityChanged(isVisible, ExploreSection.Settings);
 
         // Assert
         if (isVisible)
@@ -356,8 +356,8 @@ public class ExploreV2MenuComponentControllerTests
     public void UpdateAvailableRealmsInfoCorrectly()
     {
         // Arrange
-        RealmModel[] testRealms = 
-        { 
+        RealmModel[] testRealms =
+        {
             new RealmModel
             {
                 serverName = "TestRealm1",

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -322,6 +322,27 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuView.Received().GoToSection(Arg.Any<ExploreSection>());
     }
 
+    [TestCase(ExploreSection.Backpack)]
+    [TestCase(ExploreSection.Builder)]
+    [TestCase(ExploreSection.Explore)]
+    [TestCase(ExploreSection.Map)]
+    [TestCase(ExploreSection.Quest)]
+    [TestCase(ExploreSection.Settings)]
+    public void GoToSectionCorrectly(ExploreSection section)
+    {
+        // Arrange
+        if (section == ExploreSection.Backpack)
+            DataStore.i.exploreV2.currentSectionIndex.Set((int)ExploreSection.Builder);
+        else
+            DataStore.i.exploreV2.currentSectionIndex.Set((int)ExploreSection.Backpack);
+
+        // Act
+        exploreV2MenuController.SetMenuTargetVisibility(section, true);
+
+        // Assert
+        Assert.AreEqual((int)section, DataStore.i.exploreV2.currentSectionIndex.Get());
+    }
+
     [Test]
     public void UpdateRealmInfoCorrectly()
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentViewTests.cs
@@ -36,28 +36,6 @@ public class ExploreV2MenuComponentViewTests
     }
 
     [Test]
-    [TestCase(ExploreSection.Backpack)]
-    [TestCase(ExploreSection.Builder)]
-    [TestCase(ExploreSection.Explore)]
-    [TestCase(ExploreSection.Map)]
-    [TestCase(ExploreSection.Quest)]
-    [TestCase(ExploreSection.Settings)]
-    public void GoToSectionCorrectly(ExploreSection section)
-    {
-        // Arrange
-        if (section == ExploreSection.Backpack)
-            DataStore.i.exploreV2.currentSectionIndex.Set((int)ExploreSection.Builder);
-        else
-            DataStore.i.exploreV2.currentSectionIndex.Set((int)ExploreSection.Backpack);
-
-        // Act
-        exploreV2MenuComponent.GoToSection(section);
-
-        // Assert
-        Assert.AreEqual((int)section, DataStore.i.exploreV2.currentSectionIndex.Get());
-    }
-
-    [Test]
     [TestCase(ExploreSection.Backpack, true)]
     [TestCase(ExploreSection.Builder, true)]
     [TestCase(ExploreSection.Explore, true)]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentViewTests.cs
@@ -76,7 +76,6 @@ public class ExploreV2MenuComponentViewTests
         Assert.IsTrue(featureConfiguratorFlag.Get());
     }
 
-    [Test]
     [TestCase(0)]
     [TestCase(1)]
     [TestCase(2)]
@@ -95,7 +94,6 @@ public class ExploreV2MenuComponentViewTests
         exploreV2MenuComponent.sectionSelector.GetSection(sectionIndex).onSelect.Invoke(true);
 
         // Assert
-        Assert.AreEqual(sectionIndex, (int)DataStore.i.exploreV2.currentSectionIndex.Get());
         Assert.AreEqual(sectionIndex, (int)sectionSelected);
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideAnimator/ShowHideAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideAnimator/ShowHideAnimator.cs
@@ -15,18 +15,7 @@ public class ShowHideAnimator : MonoBehaviour
 
     public bool isVisible => animator.GetBool(visibleParamHash);
 
-    private Animator animator
-    {
-        get
-        {
-            if (animatorValue == null)
-            {
-                animatorValue = GetComponent<Animator>();
-            }
-
-            return animatorValue;
-        }
-    }
+    private Animator animator => animatorValue ??= GetComponent<Animator>();
 
     private int visibleParamHash
     {
@@ -77,12 +66,13 @@ public class ShowHideAnimator : MonoBehaviour
     {
         OnWillFinishHide?.Invoke(this);
 
-        if (disableAfterFadeOut)
+        if (disableAfterFadeOut && gameObject != null)
         {
-            gameObject?.SetActive(false);
+            gameObject.SetActive(false);
         }
     }
 
     [UsedImplicitly]
-    public void AnimEvent_ShowFinished() { OnWillFinishStart?.Invoke(this); }
+    public void AnimEvent_ShowFinished() =>
+        OnWillFinishStart?.Invoke(this);
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideAnimator/ShowHideAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideAnimator/ShowHideAnimator.cs
@@ -1,20 +1,20 @@
-using System;
+using JetBrains.Annotations;
 using UnityEngine;
 
 [RequireComponent(typeof(Animator))]
 public class ShowHideAnimator : MonoBehaviour
 {
-    public event System.Action<ShowHideAnimator> OnWillFinishHide;
-    public event System.Action<ShowHideAnimator> OnWillFinishStart;
 
     public bool hideOnEnable = true;
     public float animSpeedFactor = 1.0f;
     public bool disableAfterFadeOut;
     public string visibleParam = "visible";
 
-    public bool isVisible => animator.GetBool(visibleParamHash);
-
     private Animator animatorValue;
+
+    private int? visibleParamHashValue = null;
+
+    public bool isVisible => animator.GetBool(visibleParamHash);
 
     private Animator animator
     {
@@ -29,8 +29,6 @@ public class ShowHideAnimator : MonoBehaviour
         }
     }
 
-    private int? visibleParamHashValue = null;
-
     private int visibleParamHash
     {
         get
@@ -41,6 +39,16 @@ public class ShowHideAnimator : MonoBehaviour
             return visibleParamHashValue.Value;
         }
     }
+
+    private void OnEnable()
+    {
+        if ( hideOnEnable )
+        {
+            Hide(true);
+        }
+    }
+    public event System.Action<ShowHideAnimator> OnWillFinishHide;
+    public event System.Action<ShowHideAnimator> OnWillFinishStart;
 
     public void Show(bool instant = false)
     {
@@ -74,13 +82,6 @@ public class ShowHideAnimator : MonoBehaviour
         }
     }
 
+    [UsedImplicitly]
     public void AnimEvent_ShowFinished() { OnWillFinishStart?.Invoke(this); }
-
-    private void OnEnable()
-    {
-        if ( hideOnEnable )
-        {
-            Hide(true);
-        }
-    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideAnimator/ShowHideAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideAnimator/ShowHideAnimator.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 [RequireComponent(typeof(Animator))]
 public class ShowHideAnimator : MonoBehaviour
 {
-
     public bool hideOnEnable = true;
     public float animSpeedFactor = 1.0f;
     public bool disableAfterFadeOut;
@@ -47,6 +46,7 @@ public class ShowHideAnimator : MonoBehaviour
             Hide(true);
         }
     }
+
     public event System.Action<ShowHideAnimator> OnWillFinishHide;
     public event System.Action<ShowHideAnimator> OnWillFinishStart;
 
@@ -72,6 +72,7 @@ public class ShowHideAnimator : MonoBehaviour
             animator.Update(10);
     }
 
+    [UsedImplicitly]
     public void AnimEvent_HideFinished()
     {
         OnWillFinishHide?.Invoke(this);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
@@ -24,7 +24,6 @@ namespace DCL
 
         private void Start()
         {
-
             navMap = navMapSection.GetComponentInChildren<NavmapView>();
             navMap.OnToggle += OnNavMapLoaded;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
@@ -1,0 +1,69 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+namespace DCL
+{
+    /// <summary>
+    /// Hide white images when switching to NavMap.
+    /// FIX issue #2071 <see cref="https://github.com/decentraland/unity-renderer/issues/2071"/>
+    /// </summary>
+    public class NavMapLoadingLogo : MonoBehaviour
+    {
+        [SerializeField] private Image sectionsContent;
+        [SerializeField] private Image radialGradient;
+
+        [SerializeField] private GameObject navMapSection;
+        // Debug.Log(DataStore.i.exploreV2.configureMapInFullscreenMenu.Get().name, DataStore.i.exploreV2.configureMapInFullscreenMenu.Get().gameObject);
+
+        private NavmapView navMap;
+
+        private void Awake()
+        {
+            DataStore.i.HUDs.navmapVisible.OnChange += OnOpeningNavMap;
+            DataStore.i.exploreV2.isOpen.OnChange += OnExploreUiVisibilityChange;
+        }
+
+        private void Start()
+        {
+
+            navMap = navMapSection.GetComponentInChildren<NavmapView>();
+            navMap.OnToggle += OnNavMapLoaded;
+        }
+
+        private void OnDestroy()
+        {
+            DataStore.i.HUDs.navmapVisible.OnChange -= OnOpeningNavMap;
+            DataStore.i.exploreV2.isOpen.OnChange -= OnExploreUiVisibilityChange;
+
+            navMap.OnToggle -= OnNavMapLoaded;
+        }
+
+        private void OnExploreUiVisibilityChange(bool isOpen, bool _)
+        {
+            Debug.Log($"[DataStore.i.exploreV2.isOpen] changed to {isOpen}");
+
+            if (!isOpen && !sectionsContent.enabled)
+            {
+                SetImagesVisibility(visible: true);
+                Debug.Log("enable images");
+            }
+        }
+
+        private void OnOpeningNavMap(bool isShown, bool _)
+        {
+            if (isShown)
+            {
+                SetImagesVisibility(visible: false);
+            }
+        }
+
+        private void OnNavMapLoaded(bool _) =>
+            SetImagesVisibility(visible: true);
+
+        private void SetImagesVisibility(bool visible)
+        {
+            sectionsContent.enabled = visible;
+            radialGradient.enabled = visible;
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
@@ -13,7 +13,6 @@ namespace DCL
         [SerializeField] private Image radialGradient;
 
         [SerializeField] private GameObject navMapSection;
-        // Debug.Log(DataStore.i.exploreV2.configureMapInFullscreenMenu.Get().name, DataStore.i.exploreV2.configureMapInFullscreenMenu.Get().gameObject);
 
         private NavmapView navMap;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
@@ -12,20 +12,12 @@ namespace DCL
         [SerializeField] private Image sectionsContent;
         [SerializeField] private Image radialGradient;
 
-        [SerializeField] private GameObject navMapSection;
-
-        private NavmapView navMap;
-
         private void Awake()
         {
             DataStore.i.HUDs.navmapVisible.OnChange += OnOpeningNavMap;
-            DataStore.i.exploreV2.isOpen.OnChange += OnExploreUiVisibilityChange;
-        }
+            DataStore.i.HUDs.navmapVisible.OnChange += SubscribeToMapRenderer;
 
-        private void Start()
-        {
-            navMap = navMapSection.GetComponentInChildren<NavmapView>();
-            navMap.OnToggle += OnNavMapLoaded;
+            DataStore.i.exploreV2.isOpen.OnChange += OnExploreUiVisibilityChange;
         }
 
         private void OnDestroy()
@@ -33,7 +25,13 @@ namespace DCL
             DataStore.i.HUDs.navmapVisible.OnChange -= OnOpeningNavMap;
             DataStore.i.exploreV2.isOpen.OnChange -= OnExploreUiVisibilityChange;
 
-            navMap.OnToggle -= OnNavMapLoaded;
+            MapRenderer.i.MapVisibilityChanged -= OnNavMapLoaded;
+        }
+
+        private void SubscribeToMapRenderer(bool current, bool previous)
+        {
+            DataStore.i.HUDs.navmapVisible.OnChange -= SubscribeToMapRenderer;
+            MapRenderer.i.MapVisibilityChanged += OnNavMapLoaded;
         }
 
         private void OnExploreUiVisibilityChange(bool isOpen, bool _)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
@@ -40,12 +40,9 @@ namespace DCL
 
         private void OnExploreUiVisibilityChange(bool isOpen, bool _)
         {
-            Debug.Log($"[DataStore.i.exploreV2.isOpen] changed to {isOpen}");
-
             if (!isOpen && !sectionsContent.enabled)
             {
                 SetImagesVisibility(visible: true);
-                Debug.Log("enable images");
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8628ccfd6bcc47d6aaa3d926a0727a12
+timeCreated: 1663068675

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -231,8 +231,6 @@ namespace DCL
             if (waitingForFullscreenHUDOpen)
                 return;
 
-            Debug.Log($"[NavmapView] Request to SetVisible. Visible == {visible}");
-
             if (visible)
             {
                 if (CommonScriptableObjects.isFullscreenHUDOpen.Get())
@@ -257,8 +255,6 @@ namespace DCL
             if (!current)
                 return;
 
-            Debug.Log("[NavmapView] IsFullscreenHUDOpen_OnChange");
-
             SetVisibility_Internal(true);
             waitingForFullscreenHUDOpen = false;
         }
@@ -267,8 +263,6 @@ namespace DCL
         {
             if (MapRenderer.i == null)
                 return;
-
-            Debug.Log($"[NavmapView] SetVisibility_Internal to visible = {visible}");
 
             scrollRect.StopMovement();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -31,8 +31,8 @@ namespace DCL
         [SerializeField] internal Image zoomInPlus;
         [SerializeField] internal Image zoomOutMinus;
         [SerializeField] internal AnimationCurve zoomCurve;
-        private Vector3 atlasOriginalPosition;
 
+        private Vector3 atlasOriginalPosition;
         private RectTransform containerRectTransform;
         private int currentZoomLevel;
         private Color disabledColor = new Color(0f, 0f, 0f, 0.5f);
@@ -42,9 +42,7 @@ namespace DCL
         private RectTransform minimapViewport;
 
         private Color normalColor = new Color(0f, 0f, 0f, 1f);
-
         Vector3 previousScaleSize;
-
         private float scale = 1f;
         private float scaleDuration = 0.2f;
 
@@ -113,6 +111,34 @@ namespace DCL
         }
 
         public event Action<bool> OnToggle;
+
+        public void Initialize()
+        {
+            toastView.gameObject.SetActive(false);
+            scrollRect.gameObject.SetActive(false);
+            DataStore.i.HUDs.isNavMapInitialized.Set(true);
+        }
+
+        public void SetExitButtonActive(bool isActive) =>
+            closeButton.gameObject.SetActive(isActive);
+
+        public void SetAsFullScreenMenuMode(Transform parentTransform)
+        {
+            if (parentTransform == null)
+                return;
+
+            transform.SetParent(parentTransform);
+            transform.localScale = Vector3.one;
+            SetExitButtonActive(false);
+
+            RectTransform rectTransform = transform as RectTransform;
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.one;
+            rectTransform.pivot = new Vector2(0.5f, 0.5f);
+            rectTransform.localPosition = Vector2.zero;
+            rectTransform.offsetMax = Vector2.zero;
+            rectTransform.offsetMin = Vector2.zero;
+        }
 
         private void ResetCameraZoom()
         {
@@ -209,14 +235,8 @@ namespace DCL
             isScaling = false;
         }
 
-        private void OnNavmapVisibleChanged(bool current, bool previous) { SetVisible(current); }
-
-        public void Initialize()
-        {
-            toastView.gameObject.SetActive(false);
-            scrollRect.gameObject.SetActive(false);
-            DataStore.i.HUDs.isNavMapInitialized.Set(true);
-        }
+        private void OnNavmapVisibleChanged(bool current, bool previous) =>
+            SetVisible(current);
 
         private void OnExploreChange(bool current, bool previous)
         {
@@ -317,14 +337,14 @@ namespace DCL
             OnToggle?.Invoke(visible);
         }
 
-        void UpdateCurrentSceneData(Vector2Int current, Vector2Int previous)
+        private void UpdateCurrentSceneData(Vector2Int current, Vector2Int previous)
         {
             const string format = "{0},{1}";
             currentSceneCoordsText.text = string.Format(format, current.x, current.y);
             currentSceneNameText.text = MinimapMetadata.GetMetadata().GetSceneInfo(current.x, current.y)?.name ?? "Unnamed";
         }
 
-        void TriggerToast(int cursorTileX, int cursorTileY)
+        private void TriggerToast(int cursorTileX, int cursorTileY)
         {
             if (toastView.isOpen)
                 CloseToast();
@@ -335,28 +355,10 @@ namespace DCL
             toastView.Populate(new Vector2Int(cursorTileX, cursorTileY), sceneInfo);
         }
 
-        private void CloseToast() { toastView.OnCloseClick(); }
+        private void CloseToast() =>
+            toastView.OnCloseClick();
 
-        public void SetExitButtonActive(bool isActive) { closeButton.gameObject.SetActive(isActive); }
-
-        public void SetAsFullScreenMenuMode(Transform parentTransform)
-        {
-            if (parentTransform == null)
-                return;
-
-            transform.SetParent(parentTransform);
-            transform.localScale = Vector3.one;
-            SetExitButtonActive(false);
-
-            RectTransform rectTransform = transform as RectTransform;
-            rectTransform.anchorMin = Vector2.zero;
-            rectTransform.anchorMax = Vector2.one;
-            rectTransform.pivot = new Vector2(0.5f, 0.5f);
-            rectTransform.localPosition = Vector2.zero;
-            rectTransform.offsetMax = Vector2.zero;
-            rectTransform.offsetMin = Vector2.zero;
-        }
-
-        private void ConfigureMapInFullscreenMenuChanged(Transform currentParentTransform, Transform previousParentTransform) { SetAsFullScreenMenuMode(currentParentTransform); }
+        private void ConfigureMapInFullscreenMenuChanged(Transform currentParentTransform, Transform previousParentTransform) =>
+            SetAsFullScreenMenuMode(currentParentTransform);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Resources/NavMap.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Resources/NavMap.prefab
@@ -108,7 +108,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
@@ -117,6 +117,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -358,7 +359,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
@@ -367,6 +368,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -637,7 +639,6 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 6570458711251006539}
   - {fileID: 7743388073746238951}
   - {fileID: 1360812066862971457}
   - {fileID: 891848572563123208}
@@ -645,7 +646,7 @@ RectTransform:
   - {fileID: 6419990266750301548}
   - {fileID: 5391034735890957258}
   m_Father: {fileID: 3444591781619110103}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -840,7 +841,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -849,6 +850,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -898,7 +900,7 @@ RectTransform:
   m_Children:
   - {fileID: 4534857646857236309}
   m_Father: {fileID: 6165737416504808421}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -986,7 +988,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 4654740177256172370}
   m_HandleRect: {fileID: 6473396510046919356}
   m_Direction: 0
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -1090,7 +1092,7 @@ RectTransform:
   m_Children:
   - {fileID: 4662467640730986799}
   m_Father: {fileID: 6165737416504808421}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -1450,7 +1452,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -1459,6 +1461,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1584,7 +1587,7 @@ RectTransform:
   - {fileID: 818110288745002731}
   - {fileID: 6501498053731834688}
   m_Father: {fileID: 3444591781619110103}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1695,13 +1698,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8136589307586281220}
-  m_Father: {fileID: 6165737416504808421}
+  m_Father: {fileID: 3444591781619110103}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 2000, y: 2000}
+  m_SizeDelta: {x: 2010, y: 2010}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2298163904515817440
 CanvasRenderer:
@@ -1849,7 +1852,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -1858,6 +1861,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -2530,7 +2534,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
@@ -2539,6 +2543,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -3070,7 +3075,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
@@ -3079,6 +3084,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -3278,7 +3284,7 @@ RectTransform:
   - {fileID: 8501676294095397858}
   - {fileID: 4163869784798030674}
   m_Father: {fileID: 6165737416504808421}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -3395,6 +3401,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
+  - {fileID: 6570458711251006539}
   - {fileID: 6165737416504808421}
   - {fileID: 7280576089807808491}
   m_Father: {fileID: 0}
@@ -3661,7 +3668,7 @@ RectTransform:
   m_Children:
   - {fileID: 4562892339457273614}
   m_Father: {fileID: 6165737416504808421}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3908,7 +3915,7 @@ RectTransform:
   m_Children:
   - {fileID: 5041495409987880329}
   m_Father: {fileID: 6165737416504808421}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3996,7 +4003,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 3391553934498204799}
   m_HandleRect: {fileID: 8263587515024556417}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -4332,7 +4339,7 @@ RectTransform:
   m_Children:
   - {fileID: 6646560786880561982}
   m_Father: {fileID: 6165737416504808421}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4567,7 +4574,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -4576,6 +4583,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -1,10 +1,11 @@
-using DCL.Helpers;
+using System;
 using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.UI;
-using UnityEngine.EventSystems;
-using TMPro;
+using DCL.Helpers;
 using KernelConfigurationTypes;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
 namespace DCL
@@ -21,9 +22,9 @@ namespace DCL
         private const int MAX_CURSOR_PARCEL_DISTANCE = 40;
         private const int MAX_SCENE_CHARACTER_TITLE = 29;
         private const string EMPTY_PARCEL_NAME = "Empty parcel";
-        private int NAVMAP_CHUNK_LAYER;
 
-        public static MapRenderer i { get; private set; }
+        public static System.Action<int, int> OnParcelClicked;
+        public static System.Action OnCursorFarFromParcel;
 
         [SerializeField] private float parcelHightlightScale = 1.25f;
         [SerializeField] private Button ParcelHighlightButton;
@@ -33,22 +34,14 @@ namespace DCL
         [SerializeField] private Image parcelHighlighWithContentImagePrefab;
         [SerializeField] private Image selectParcelHighlighImagePrefab;
 
-        private Vector3Variable playerRotation => CommonScriptableObjects.cameraForward;
-        private List<RaycastResult> uiRaycastResults = new List<RaycastResult>();
-        private PointerEventData uiRaycastPointerEventData = new PointerEventData(EventSystem.current);
-
         [HideInInspector] public Vector2Int cursorMapCoords;
         [HideInInspector] public bool showCursorCoords = true;
-        public Vector3 playerGridPosition => Utils.WorldToGridPositionUnclamped(playerWorldPosition.Get());
         public MapAtlas atlas;
         public TextMeshProUGUI highlightedParcelText;
         public Transform overlayContainer;
         public Transform overlayContainerPlayers;
         public Transform globalUserMarkerContainer;
         public RectTransform playerPositionIcon;
-
-        public static System.Action<int, int> OnParcelClicked;
-        public static System.Action OnCursorFarFromParcel;
 
         public float scaleFactor = 1f;
 
@@ -59,24 +52,41 @@ namespace DCL
         public GameObject userIconPrefab;
         public GameObject homePointIconPrefab;
         public UserMarkerObject globalUserMarkerPrefab;
+        private Dictionary<Vector2Int, Image> highlightedLands = new Dictionary<Vector2Int, Image>();
+        private BaseVariable<Vector2Int> homePointCoordinates = DataStore.i.HUDs.homePoint;
+        private RectTransform homePointIcon;
 
-        public MapGlobalUsersPositionMarkerController usersPositionMarkerController { private set; get; }
+        private bool isInitialized = false;
+
+        private Vector2Int lastClickedCursorMapCoords;
+        private Vector3 lastPlayerPosition = new Vector3(float.NegativeInfinity, 0, float.NegativeInfinity);
+        private Vector2Int lastSelectedLand;
+        private int NAVMAP_CHUNK_LAYER;
+        private bool otherPlayersIconsEnabled = true;
+        private List<Vector2Int> ownedEmptyLands = new List<Vector2Int>();
+        private List<Vector2Int> ownedLandsWithContent = new List<Vector2Int>();
+
+        private bool parcelHighlightEnabledValue = false;
+        private BaseVariable<Vector3> playerWorldPosition = DataStore.i.player.playerWorldPosition;
 
         private HashSet<MinimapMetadata.MinimapSceneInfo> scenesOfInterest = new HashSet<MinimapMetadata.MinimapSceneInfo>();
         private Dictionary<MinimapMetadata.MinimapSceneInfo, GameObject> scenesOfInterestMarkers = new Dictionary<MinimapMetadata.MinimapSceneInfo, GameObject>();
+        private PointerEventData uiRaycastPointerEventData = new PointerEventData(EventSystem.current);
+        private List<RaycastResult> uiRaycastResults = new List<RaycastResult>();
         private Dictionary<string, PoolableObject> usersInfoMarkers = new Dictionary<string, PoolableObject>();
-
-        private Vector2Int lastClickedCursorMapCoords;
         private Pool usersInfoPool;
-        private RectTransform homePointIcon;
-
-        private bool parcelHighlightEnabledValue = false;
-        private bool otherPlayersIconsEnabled = true;
 
         List<WorldRange> validWorldRanges = new List<WorldRange>
         {
             new WorldRange(-150, -150, 150, 150) // default range
         };
+
+        public static MapRenderer i { get; private set; }
+
+        private Vector3Variable playerRotation => CommonScriptableObjects.cameraForward;
+        public Vector3 playerGridPosition => Utils.WorldToGridPositionUnclamped(playerWorldPosition.Get());
+
+        public MapGlobalUsersPositionMarkerController usersPositionMarkerController { private set; get; }
 
         public bool parcelHighlightEnabled
         {
@@ -84,23 +94,12 @@ namespace DCL
             {
                 parcelHighlightEnabledValue = value;
                 parcelHighlightImage.gameObject.SetActive(parcelHighlightEnabledValue);
+                MapVisibilityChanged?.Invoke(value);
             }
             get { return parcelHighlightEnabledValue; }
         }
 
         private BaseDictionary<string, Player> otherPlayers => DataStore.i.player.otherPlayers;
-        private Dictionary<Vector2Int, Image> highlightedLands = new Dictionary<Vector2Int, Image>();
-        private List<Vector2Int> ownedLandsWithContent = new List<Vector2Int>();
-        private List<Vector2Int> ownedEmptyLands = new List<Vector2Int>();
-        private Vector2Int lastSelectedLand;
-        private Vector3 lastPlayerPosition = new Vector3(float.NegativeInfinity, 0, float.NegativeInfinity);
-        private BaseVariable<Vector3> playerWorldPosition = DataStore.i.player.playerWorldPosition;
-        private BaseVariable<Vector2Int> homePointCoordinates = DataStore.i.HUDs.homePoint;
-
-        private bool isInitialized = false;
-
-        [HideInInspector]
-        public event System.Action<float, float> OnMovedParcelCursor;
 
         private void Awake()
         {
@@ -108,13 +107,37 @@ namespace DCL
             Initialize();
         }
 
+        void Update()
+        {
+            if ((playerWorldPosition.Get() - lastPlayerPosition).sqrMagnitude >= 0.1f * 0.1f)
+            {
+                lastPlayerPosition = playerWorldPosition.Get();
+                UpdateRendering(Utils.WorldToGridPositionUnclamped(lastPlayerPosition));
+            }
+
+            if (!parcelHighlightEnabled)
+                return;
+
+            UpdateCursorMapCoords();
+
+            UpdateParcelHighlight();
+
+            UpdateParcelHold();
+        }
+
+        public void OnDestroy() { Cleanup(); }
+
+        [HideInInspector]
+        public event System.Action<float, float> OnMovedParcelCursor;
+        public event Action<bool> MapVisibilityChanged;
+
         public void Initialize()
         {
             if (isInitialized)
                 return;
 
             isInitialized = true;
-            
+
             InitializeHomePointIcon();
             EnsurePools();
             atlas.InitializeChunks();
@@ -141,18 +164,15 @@ namespace DCL
             KernelConfig.i.OnChange += OnKernelConfigChanged;
         }
 
-        private void MoveHomePointIcon(Vector2Int current, Vector2Int previous)
-        {
-            homePointIcon.anchoredPosition = MapUtils.CoordsToPosition(new Vector3(current.x, current.y, 0));
-        }
+        private void MoveHomePointIcon(Vector2Int current, Vector2Int previous) { homePointIcon.anchoredPosition = MapUtils.CoordsToPosition(new Vector3(current.x, current.y, 0)); }
 
         private void InitializeHomePointIcon()
         {
             homePointIcon = GameObject.Instantiate(homePointIconPrefab).GetComponent<RectTransform>();
             homePointIcon.gameObject.transform.SetParent(overlayContainer.transform, false);
-            homePointIcon.anchoredPosition = new Vector2(0,0);
+            homePointIcon.anchoredPosition = new Vector2(0, 0);
             homePointIcon.transform.localPosition = new Vector3(homePointIcon.transform.localPosition.x, homePointIcon.transform.localPosition.y, 0);
-            homePointIcon.localScale = new Vector3(2,2,2);
+            homePointIcon.localScale = new Vector3(2, 2, 2);
             homePointIcon.transform.SetAsFirstSibling();
         }
 
@@ -172,28 +192,26 @@ namespace DCL
                     usersInfoPool.ForcePrewarm();
             }
         }
-        
+
         public void SetParcelHighlightActive(bool isAtive) => parcelHighlightImage.enabled = isAtive;
-        
+
         public Vector3 GetParcelHighlightTransform() => parcelHighlightImage.transform.position;
 
         public void SetOtherPlayersIconActive(bool isActive)
         {
             otherPlayersIconsEnabled = isActive;
-            
+
             foreach (PoolableObject poolableObject in usersInfoMarkers.Values)
             {
                 poolableObject.gameObject.SetActive(isActive);
             }
         }
-        
+
         public void SetPlayerIconActive(bool isActive) => playerPositionIcon.gameObject.SetActive(isActive);
 
         public void SetHighlighSize(Vector2Int size) { highlight.ChangeHighlighSize(size); }
 
         public void SetHighlightStyle(MapParcelHighlight.HighlighStyle style) { highlight.SetStyle(style); }
-
-        public void OnDestroy() { Cleanup(); }
 
         public void Cleanup()
         {
@@ -232,7 +250,7 @@ namespace DCL
             {
                 Destroy(kvp.Value.gameObject);
             }
-            
+
             highlightedLands.Clear (); //To Clear out the dictionary
         }
 
@@ -273,7 +291,7 @@ namespace DCL
 
                 CreateHighlightParcel(parcelHighlighImagePrefab, coords, Vector2Int.one);
             }
-            
+
             foreach (Vector2Int coords in landsToHighlightWithContent)
             {
                 if (highlightedLands.ContainsKey(coords))
@@ -295,24 +313,6 @@ namespace DCL
             highlightItem.rectTransform.SetAsLastSibling();
             highlightItem.rectTransform.anchoredPosition = MapUtils.CoordsToPosition(coords);
             highlightedLands.Add(coords, highlightItem);
-        }
-
-        void Update()
-        {
-            if ((playerWorldPosition.Get() - lastPlayerPosition).sqrMagnitude >= 0.1f * 0.1f)
-            {
-                lastPlayerPosition = playerWorldPosition.Get();
-                UpdateRendering(Utils.WorldToGridPositionUnclamped(lastPlayerPosition));
-            }
-
-            if (!parcelHighlightEnabled)
-                return;
-
-            UpdateCursorMapCoords();
-
-            UpdateParcelHighlight();
-
-            UpdateParcelHold();
         }
 
         void UpdateCursorMapCoords()
@@ -417,7 +417,7 @@ namespace DCL
                     distance = Vector2.Distance(centerParcel, parcel);
                     centerParcel = parcel;
                 }
-                
+
             }
 
             (go.transform as RectTransform).anchoredPosition = MapUtils.CoordsToPosition(centerParcel);
@@ -438,10 +438,7 @@ namespace DCL
             }
         }
 
-        private bool IsEmptyParcel(MinimapMetadata.MinimapSceneInfo sceneInfo)
-        {
-            return (sceneInfo.name != null && sceneInfo.name.Equals(EMPTY_PARCEL_NAME));
-        }
+        private bool IsEmptyParcel(MinimapMetadata.MinimapSceneInfo sceneInfo) { return (sceneInfo.name != null && sceneInfo.name.Equals(EMPTY_PARCEL_NAME)); }
 
         private void OnOtherPlayersAdded(string userId, Player player)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseVariable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseVariable.cs
@@ -9,8 +9,8 @@ public class BaseVariable<T> : IBaseVariable<T>, IEquatable<T>
 {
     protected T value;
 
-    public BaseVariable() { value = default; }
-    public BaseVariable(T defaultValue) { value = defaultValue; }
+    public BaseVariable() => value = default;
+    public BaseVariable(T defaultValue) => value = defaultValue;
 
     public event Change<T> OnChange;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseVariable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseVariable.cs
@@ -7,19 +7,20 @@ public delegate void ChangeWithSenderInfo<T>(BaseVariable<T> sender, T current, 
 
 public class BaseVariable<T> : IBaseVariable<T>, IEquatable<T>
 {
-
     protected T value;
 
     public BaseVariable() { value = default; }
     public BaseVariable(T defaultValue) { value = defaultValue; }
+
     public event Change<T> OnChange;
 
-    public T Get() { return value; }
+    public T Get() => value;
 
-    public void Set(T newValue) { Set(newValue, !Equals(newValue)); }
+    public void Set(T newValue) =>
+        Set(newValue, !Equals(newValue));
 
-    public virtual bool Equals(T other) { return EqualityComparer<T>.Default.Equals(value, other); }
-
+    public virtual bool Equals(T other) =>
+        EqualityComparer<T>.Default.Equals(value, other);
     public event ChangeWithSenderInfo<T> OnChangeWithSenderInfo;
 
     public void Set(T newValue, bool notifyEvent)
@@ -34,5 +35,6 @@ public class BaseVariable<T> : IBaseVariable<T>, IEquatable<T>
         }
     }
 
-    public int OnChangeListenersCount() => OnChange == null ? 0 : OnChange.GetInvocationList().Length;
+    public int OnChangeListenersCount() =>
+        OnChange == null ? 0 : OnChange.GetInvocationList().Length;
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseVariable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseVariable.cs
@@ -3,18 +3,24 @@ using System.Collections.Generic;
 
 public delegate void Change<T>(T current, T previous);
 
+public delegate void ChangeWithSenderInfo<T>(BaseVariable<T> sender, T current, T previous);
+
 public class BaseVariable<T> : IBaseVariable<T>, IEquatable<T>
 {
-    public event Change<T> OnChange;
 
     protected T value;
 
     public BaseVariable() { value = default; }
     public BaseVariable(T defaultValue) { value = defaultValue; }
+    public event Change<T> OnChange;
 
     public T Get() { return value; }
 
     public void Set(T newValue) { Set(newValue, !Equals(newValue)); }
+
+    public virtual bool Equals(T other) { return EqualityComparer<T>.Default.Equals(value, other); }
+
+    public event ChangeWithSenderInfo<T> OnChangeWithSenderInfo;
 
     public void Set(T newValue, bool notifyEvent)
     {
@@ -24,10 +30,9 @@ public class BaseVariable<T> : IBaseVariable<T>, IEquatable<T>
         if (notifyEvent)
         {
             OnChange?.Invoke(value, previous);
+            OnChangeWithSenderInfo?.Invoke(this, value, previous);
         }
     }
 
     public int OnChangeListenersCount() => OnChange == null ? 0 : OnChange.GetInvocationList().Length;
-
-    public virtual bool Equals(T other) { return EqualityComparer<T>.Default.Equals(value, other); }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseVariable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseVariable.cs
@@ -21,6 +21,7 @@ public class BaseVariable<T> : IBaseVariable<T>, IEquatable<T>
 
     public virtual bool Equals(T other) =>
         EqualityComparer<T>.Default.Equals(value, other);
+
     public event ChangeWithSenderInfo<T> OnChangeWithSenderInfo;
 
     public void Set(T newValue, bool notifyEvent)

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/SectionSelector/SectionToggle.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/SectionSelector/SectionToggle.cs
@@ -32,12 +32,8 @@ public interface ISectionToggle
     /// <summary>
     /// Invoke the action of selecting the toggle.
     /// </summary>
-    void SelectToggle();
-
-    /// <summary>
-    /// Apply the selection even if the toggle was already off
-    /// </summary>
-    void SelectToggleWithReset();
+    /// <param name="reselectIfAlreadyOn">True for apply the selection even if the toggle was already off.</param>
+    void SelectToggle(bool reselectIfAlreadyOn = false);
 
     /// <summary>
     /// Set the toggle visuals as selected.
@@ -80,11 +76,14 @@ public class SectionToggle : MonoBehaviour, ISectionToggle, IPointerDownHandler
     [SerializeField] private Color unselectedTextColor;
     [SerializeField] private Color unselectedImageColor;
 
-    private void Awake() { ConfigureDefaultOnSelectAction(); }
+    private void Awake() =>
+        ConfigureDefaultOnSelectAction();
 
-    private void OnEnable() { StartCoroutine(ForceToRefreshToggleState()); }
+    private void OnEnable() =>
+        StartCoroutine(ForceToRefreshToggleState());
 
-    public void OnPointerDown(PointerEventData eventData) { SelectToggle(); }
+    public void OnPointerDown(PointerEventData eventData) =>
+        SelectToggle();
 
     public RectTransform pivot => transform as RectTransform;
     public ToggleEvent onSelect => toggle?.onValueChanged;
@@ -146,20 +145,14 @@ public class SectionToggle : MonoBehaviour, ISectionToggle, IPointerDownHandler
         ConfigureDefaultOnSelectAction();
     }
 
-    public void SelectToggle()
+    public void SelectToggle(bool reselectIfAlreadyOn = false)
     {
         if (toggle == null)
             return;
 
-        toggle.isOn = true;
-    }
+        if (reselectIfAlreadyOn)
+            toggle.isOn = false;
 
-    public void SelectToggleWithReset()
-    {
-        if (toggle == null)
-            return;
-
-        toggle.isOn = false;
         toggle.isOn = true;
     }
 

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/SectionSelector/SectionToggle.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/SectionSelector/SectionToggle.cs
@@ -32,8 +32,12 @@ public interface ISectionToggle
     /// <summary>
     /// Invoke the action of selecting the toggle.
     /// </summary>
-    /// <param name="reselectIfAlreadyOn">True for apply the selection even if the toggle was already off.</param>
-    void SelectToggle(bool reselectIfAlreadyOn = false);
+    void SelectToggle();
+
+    /// <summary>
+    /// Apply the selection even if the toggle was already off
+    /// </summary>
+    void SelectToggleWithReset();
 
     /// <summary>
     /// Set the toggle visuals as selected.
@@ -76,12 +80,14 @@ public class SectionToggle : MonoBehaviour, ISectionToggle, IPointerDownHandler
     [SerializeField] private Color unselectedTextColor;
     [SerializeField] private Color unselectedImageColor;
 
-    public RectTransform pivot => transform as RectTransform;
-    public ToggleEvent onSelect => toggle?.onValueChanged;
-
     private void Awake() { ConfigureDefaultOnSelectAction(); }
 
     private void OnEnable() { StartCoroutine(ForceToRefreshToggleState()); }
+
+    public void OnPointerDown(PointerEventData eventData) { SelectToggle(); }
+
+    public RectTransform pivot => transform as RectTransform;
+    public ToggleEvent onSelect => toggle?.onValueChanged;
 
     public SectionToggleModel GetInfo()
     {
@@ -140,19 +146,20 @@ public class SectionToggle : MonoBehaviour, ISectionToggle, IPointerDownHandler
         ConfigureDefaultOnSelectAction();
     }
 
-    public void OnPointerDown(PointerEventData eventData)
-    {
-        SelectToggle();
-    }
-
-    public void SelectToggle(bool reselectIfAlreadyOn = false)
+    public void SelectToggle()
     {
         if (toggle == null)
             return;
 
-        if (reselectIfAlreadyOn)
-            toggle.isOn = false;
+        toggle.isOn = true;
+    }
 
+    public void SelectToggleWithReset()
+    {
+        if (toggle == null)
+            return;
+
+        toggle.isOn = false;
         toggle.isOn = true;
     }
 


### PR DESCRIPTION
## What does this PR change?
Fixes https://github.com/decentraland/unity-renderer/issues/2071

- Add a small controller to disable/enable white background when loading NavMap
- Refactored ExploreV2Controller/View to reduce duplication of the code
- Move responsibility of changing Model from ExploreV2View to ExploreV2Controller

## How to test the changes?
Test 1
1. Open NavMap via shortcut and observe that it loads without the white splash
2. Switch between other tabs (Explore, Backpack, Settings...) and NavMap via UI or Shorcuts and observe no white splash when opening/closing NavMap

Test 2
1. Open NavMap
2. Close ExploreUI via Close button on the right hand side
3. Open Settings via shortcut (P)
4. Observe that Settings are opening on the white background (and you don't see 3d world behind it)

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
