### PR TITLE
hotfix 20220917

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -203,7 +203,6 @@ namespace DCL
                 Vector3 prevScale = thisTransform.localScale;
                 Vector3 prevPos = thisTransform.localPosition;
                 thisTransform.SetParent(null);
-                thisTransform.localPosition = Vector3.one * 9999;
                 thisTransform.localScale = Vector3.one;
                 
                 avatar.Load(wearableItems, emotes.ToList(), new AvatarSettings

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -202,7 +202,7 @@ namespace DCL
                 Transform prevParent = thisTransform.parent;
                 Vector3 prevScale = thisTransform.localScale;
                 Vector3 prevPos = thisTransform.localPosition;
-                thisTransform.SetParent(null);
+                thisTransform.SetParent(null, true);
                 thisTransform.localScale = Vector3.one;
                 
                 avatar.Load(wearableItems, emotes.ToList(), new AvatarSettings


### PR DESCRIPTION
## What does this PR change?

- Fixed avatar with no eyes due to a floating point precision error.
- Fixed hologram not being visible while avatar was being loaded

## How to test the changes?

Go to wondermine and inspect all possible avatars, they should have eyes as expected.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
