### PR TITLE
fix: update owned wearables after losing focus

### DIFF
--- a/unity-renderer/Assets/DCLServices/ApplicationFocus.meta
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f33f0bd3fa3e68419323aef76566643
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.asmdef
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "ApplicationFocusService",
+    "rootNamespace": "",
+    "references": [
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.asmdef.meta
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b75dc662b69c26c40bf39793301425c5
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.cs
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ApplicationFocusService : IApplicationFocusService
+{
+
+    public event Action OnApplicationFocus;
+    public event Action OnApplicationFocusLost;
+
+    public void Initialize()
+    {
+        Application.focusChanged += FocusChange;
+    }
+    private void FocusChange(bool focus)
+    {
+        if (focus)
+        {
+            OnFocusGained();
+        }
+        else
+        {
+            OnFocusLost();
+        }
+    }
+
+    internal void OnFocusGained()
+    {
+        OnApplicationFocus?.Invoke();
+    }
+    
+    internal void OnFocusLost()
+    {
+        OnApplicationFocusLost?.Invoke();
+    }
+    
+    public void Dispose()
+    {
+        Application.focusChanged -= FocusChange;
+    }
+
+}

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.cs
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.cs
@@ -8,13 +8,18 @@ public class ApplicationFocusService : IApplicationFocusService
 
     public event Action OnApplicationFocus;
     public event Action OnApplicationFocusLost;
+    private bool currentFocusState;
 
     public void Initialize()
     {
         Application.focusChanged += FocusChange;
+        currentFocusState = Application.isFocused;
     }
     private void FocusChange(bool focus)
     {
+        if (currentFocusState == focus)
+            return;
+        
         if (focus)
         {
             OnFocusGained();
@@ -23,6 +28,7 @@ public class ApplicationFocusService : IApplicationFocusService
         {
             OnFocusLost();
         }
+        currentFocusState = focus;
     }
 
     internal void OnFocusGained()

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.cs.meta
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/ApplicationFocusService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31e7b52c91256284db8b071085597062
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/AssemblyInfo.cs
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ApplicationFocusServiceTests")]

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/AssemblyInfo.cs.meta
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 337e68742dfe908438aa5f8fe56a6a77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/IApplicationFocusService.cs
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/IApplicationFocusService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using DCL;
+using UnityEngine;
+
+public interface IApplicationFocusService : IService
+{
+
+    event Action OnApplicationFocus; 
+    event Action OnApplicationFocusLost; 
+
+}

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/IApplicationFocusService.cs.meta
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/IApplicationFocusService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7da3faaf978d18242ab49915a4115030
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests.meta
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bedae7cc5f080944898696e7ef8a68cb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests/ApplicationFocusServiceShould.cs
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests/ApplicationFocusServiceShould.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using UnityEditor.VersionControl;
+
+public class ApplicationFocusServiceShould
+{
+
+    private ApplicationFocusService applicationFocusService;
+    private bool applicationHasFocus;
+
+    
+    [SetUp]
+    public void SetUp()
+    {
+        applicationFocusService = new ApplicationFocusService();
+        applicationFocusService.Initialize();
+    }
+
+    [Test]
+    public void FocusGained()
+    {
+        applicationHasFocus = false;
+        applicationFocusService.OnApplicationFocus += ApplicationFocused;
+        applicationFocusService.OnFocusGained();
+        Assert.IsTrue(applicationHasFocus);
+        applicationFocusService.OnApplicationFocus -= ApplicationFocused;
+    }
+    
+    [Test]
+    public void FocusLost()
+    {
+        applicationHasFocus = true;
+        applicationFocusService.OnApplicationFocusLost += ApplicationLostFocus;
+        applicationFocusService.OnFocusLost();
+        Assert.IsFalse(applicationHasFocus);
+        applicationFocusService.OnApplicationFocusLost -= ApplicationLostFocus;
+    }
+    
+    private void ApplicationFocused()
+    {
+        applicationHasFocus = true;
+    }
+    
+    private void ApplicationLostFocus()
+    {
+        applicationHasFocus = false;
+    }
+
+}

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests/ApplicationFocusServiceShould.cs.meta
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests/ApplicationFocusServiceShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad570fbb31be866499247a2817376842
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests/ApplicationFocusServiceTests.asmdef
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests/ApplicationFocusServiceTests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "ApplicationFocusServiceTests",
+    "rootNamespace": "",
+    "references": [
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:b75dc662b69c26c40bf39793301425c5"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "NSubstitute.dll",
+        "nunit.framework.dll",
+        "System.Threading.Tasks.Extensions.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests/ApplicationFocusServiceTests.asmdef.meta
+++ b/unity-renderer/Assets/DCLServices/ApplicationFocus/Tests/ApplicationFocusServiceTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c1c0bc790e657f4b9e5c8d6909b3745
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/AvatarEditorHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/AvatarEditorHUD.asmdef
@@ -53,7 +53,8 @@
         "GUID:f1da3a87177414c899cd25121a9d74d9",
         "GUID:8705acb5462cf2c49aef7efa961ad469",
         "GUID:ce5ce184029b7f34c9188d4ae2aeb3d7",
-        "GUID:f342ce4813b58d84586a4577257fc0b9"
+        "GUID:f342ce4813b58d84586a4577257fc0b9",
+        "GUID:b75dc662b69c26c40bf39793301425c5"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -182,7 +182,7 @@ public class AvatarEditorHUDController : IHUD
         if(string.IsNullOrEmpty(userProfile.userId))
             return;
         
-        // If wearables are loaded, we are in wearable cooldown and we haven't lost focus, we dont fetch owned wearables
+        // If wearables are loaded, we are in wearable cooldown and we haven't lost focus, we dont fetch again owned wearables
         if (AreWearablesAlreadyLoaded() && IsWearableUpdateInCooldown() && !lostFocus)
             return;
         

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -55,7 +55,7 @@ public class AvatarEditorHUDController : IHUD
     private ColorList hairColorList;
     private bool prevMouseLockState = false;
     private int ownedWearablesRemainingRequests = LOADING_OWNED_WEARABLES_RETRIES;
-    private int ownedWearableEmotesRequestRetryTime = 60;
+    private const int ownedWearableEmotesRequestRetryTime = 60;
     private bool ownedWearablesAlreadyLoaded = false;
     private List<Nft> ownedNftCollectionsL1 = new List<Nft>();
     private List<Nft> ownedNftCollectionsL2 = new List<Nft>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -182,9 +182,8 @@ public class AvatarEditorHUDController : IHUD
         if(string.IsNullOrEmpty(userProfile.userId))
             return;
         
-        // If there is more than 1 minute that we have checked the owned wearables; or we lost the app focus, we try it again
-        // This is done in order to retrieved the wearables after you has claimed them
-        if (IsWearableUpdateInCooldown() && AreWearablesAlreadyLoaded() && !lostFocus)
+        // If wearables are loaded, we are in wearable cooldown and we haven't lost focus, we dont fetch owned wearables
+        if (AreWearablesAlreadyLoaded() && IsWearableUpdateInCooldown() && !lostFocus)
             return;
         
         lostFocus = false;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -728,4 +728,12 @@ public class AvatarEditorHUDView : MonoBehaviour, IPointerDownHandler
             isAvatarDirty = false;
         }
     }
+
+    private void OnApplicationFocus(bool hasFocus)
+    {
+        if (!hasFocus)
+        {
+            controller.LostFocus();
+        }
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -729,11 +729,4 @@ public class AvatarEditorHUDView : MonoBehaviour, IPointerDownHandler
         }
     }
 
-    private void OnApplicationFocus(bool hasFocus)
-    {
-        if (!hasFocus)
-        {
-            controller.LostFocus();
-        }
-    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.asmdef
@@ -47,7 +47,8 @@
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:f342ce4813b58d84586a4577257fc0b9",
         "GUID:ce5ce184029b7f34c9188d4ae2aeb3d7",
-        "GUID:7ac9f9c835ec1084ab35e3f9b176cf1e"
+        "GUID:7ac9f9c835ec1084ab35e3f9b176cf1e",
+        "GUID:b75dc662b69c26c40bf39793301425c5"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.cs
@@ -34,6 +34,7 @@ namespace DCL
 
             result.Register<IMessagingControllersManager>(() => new MessagingControllersManager());
             result.Register<IEmotesCatalogService>(() => new EmotesCatalogService(EmotesCatalogBridge.GetOrCreate(), Resources.Load<EmbeddedEmotesSO>("EmbeddedEmotes").emotes));
+            result.Register<IApplicationFocusService>(() => new ApplicationFocusService());
 
             // HUD
             result.Register<IHUDFactory>(() => new HUDFactory());


### PR DESCRIPTION
## What does this PR change?

Fixes #2996. If we assume that the player went to the marketplace to buy a wearable, we force an update of the owned wearables when DCL lost focus

## How to test the changes?

1. Follow this guide to get Polygon money into your GOERLI account (https://www.notion.so/decentraland/Set-up-a-wallet-for-testing-e23afcc6c74d49009781667dee493822)
2. Open DCL and open the backpack in GOERLI. You should not have any collectibles. Go to `market.decentraland.zone `(IMPORTANT, use zone as market address)
3. Buy this hat https://market.decentraland.zone/contracts/0xc9b1cd286279dca22ff22abb9ebc24a5f15fa24c/tokens/1 (Looks like the only wearable that currently works)
4. Go back to DCL. Check that the hat appears

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
