### PR TITLE
fix: non-functional showInfo button be shown in backack emotes 

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/EmotesCustomization/EmotesCustomizationSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/EmotesCustomization/EmotesCustomizationSection.prefab
@@ -182,7 +182,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -191,6 +191,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -316,7 +317,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
@@ -325,6 +326,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -450,7 +452,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
@@ -459,6 +461,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1138,7 +1141,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 4.7576}
+  m_AnchoredPosition: {x: 0, y: 4.7575684}
   m_SizeDelta: {x: -8, y: 4.7576}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &651341217421461078
@@ -1226,7 +1229,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -9.5, y: 30.00003}
+  m_AnchoredPosition: {x: -9.5, y: 30}
   m_SizeDelta: {x: -39, y: 60}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!1 &6912453401298887337
@@ -1372,7 +1375,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -1381,6 +1384,7 @@ MonoBehaviour:
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1413,7 +1417,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8492592820780035306
 RectTransform:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentController.cs
@@ -9,12 +9,16 @@ namespace DCL.EmotesCustomization
     public class EmotesCustomizationComponentController : IEmotesCustomizationComponentController
     {
         internal const int NUMBER_OF_SLOTS = 10;
+        internal string bodyShapeId;
 
-        internal bool isEmotesCustomizationSectionOpen => exploreV2DataStore.isOpen.Get() && view.isActive;
-
-        internal IEmotesCustomizationComponentView view;
+        internal DataStore_EmotesCustomization emotesCustomizationDataStore;
+        internal DataStore_Emotes emotesDataStore;
+        internal BaseDictionary<string, EmoteCardComponentView> emotesInLoadingState = new BaseDictionary<string, EmoteCardComponentView>();
         internal InputAction_Hold equipInputAction;
-        internal InputAction_Hold showInfoInputAction;
+        internal DataStore_ExploreV2 exploreV2DataStore;
+        internal DataStore_HUDs hudsDataStore;
+        internal Dictionary<string, WearableItem> ownedEmotes = new Dictionary<string, WearableItem>();
+        // internal InputAction_Hold showInfoInputAction;
         internal InputAction_Trigger shortcut0InputAction;
         internal InputAction_Trigger shortcut1InputAction;
         internal InputAction_Trigger shortcut2InputAction;
@@ -25,14 +29,10 @@ namespace DCL.EmotesCustomization
         internal InputAction_Trigger shortcut7InputAction;
         internal InputAction_Trigger shortcut8InputAction;
         internal InputAction_Trigger shortcut9InputAction;
-        internal BaseDictionary<string, EmoteCardComponentView> emotesInLoadingState = new BaseDictionary<string, EmoteCardComponentView>();
 
-        internal DataStore_EmotesCustomization emotesCustomizationDataStore;
-        internal DataStore_Emotes emotesDataStore;
-        internal DataStore_ExploreV2 exploreV2DataStore;
-        internal DataStore_HUDs hudsDataStore;
-        internal Dictionary<string, WearableItem> ownedEmotes = new Dictionary<string, WearableItem>();
-        internal string bodyShapeId;
+        internal IEmotesCustomizationComponentView view;
+
+        internal bool isEmotesCustomizationSectionOpen => exploreV2DataStore.isOpen.Get() && view.isActive;
 
         public event Action<string> onEmotePreviewed;
         public event Action<string> onEmoteEquipped;
@@ -40,7 +40,7 @@ namespace DCL.EmotesCustomization
         public event Action<string> onEmoteSell;
 
         public IEmotesCustomizationComponentView Initialize(
-            DataStore_EmotesCustomization emotesCustomizationDataStore, 
+            DataStore_EmotesCustomization emotesCustomizationDataStore,
             DataStore_Emotes emotesDataStore,
             DataStore_ExploreV2 exploreV2DataStore,
             DataStore_HUDs hudsDataStore)
@@ -116,7 +116,7 @@ namespace DCL.EmotesCustomization
             emotesCustomizationDataStore.equippedEmotes.OnSet -= OnEquippedEmotesSet;
             emotesDataStore.animations.OnAdded -= OnAnimationAdded;
             equipInputAction.OnFinished -= OnEquipInputActionTriggered;
-            showInfoInputAction.OnFinished -= OnShowInfoInputActionTriggered;
+            // showInfoInputAction.OnFinished -= OnShowInfoInputActionTriggered;
             shortcut0InputAction.OnTriggered -= OnNumericShortcutInputActionTriggered;
             shortcut1InputAction.OnTriggered -= OnNumericShortcutInputActionTriggered;
             shortcut2InputAction.OnTriggered -= OnNumericShortcutInputActionTriggered;
@@ -181,10 +181,8 @@ namespace DCL.EmotesCustomization
             view.RemoveEmote(emoteId);
             UpdateEmoteSlots();
         }
-        
 
-        internal void OnAnimationAdded((string bodyshapeId, string emoteId) values, EmoteClipData emoteClipData) 
-        { RefreshEmoteLoadingState(values.emoteId); }
+        internal void OnAnimationAdded((string bodyshapeId, string emoteId) values, EmoteClipData emoteClipData) { RefreshEmoteLoadingState(values.emoteId); }
 
         internal void RefreshEmoteLoadingState(string emoteId)
         {
@@ -282,8 +280,8 @@ namespace DCL.EmotesCustomization
             equipInputAction = Resources.Load<InputAction_Hold>("DefaultConfirmAction");
             equipInputAction.OnFinished += OnEquipInputActionTriggered;
 
-            showInfoInputAction = Resources.Load<InputAction_Hold>("ZoomIn");
-            showInfoInputAction.OnFinished += OnShowInfoInputActionTriggered;
+            // showInfoInputAction = Resources.Load<InputAction_Hold>("ZoomIn");
+            // showInfoInputAction.OnFinished += OnShowInfoInputActionTriggered;
 
             shortcut0InputAction = Resources.Load<InputAction_Trigger>("ToggleShortcut0");
             shortcut0InputAction.OnTriggered += OnNumericShortcutInputActionTriggered;


### PR DESCRIPTION
## What does this PR change?
Fixes https://github.com/decentraland/unity-renderer/issues/3051

ItemInfoShortcutInfo gameObject was disabled insiede EmotesCustomizationSection.prefab to hide non-functional button (until the time implementation for it will be ready).
![image](https://user-images.githubusercontent.com/35366872/191739206-d81de69c-c2d4-4d38-b35a-90d7795f6ea0.png)

## How to test the changes?
1. Open Backpack->Emotes UI
2. Observe no `+` `ShowInfo ` button to be displayed below `E` `EQUIP / UNEQUIP` button

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
