### PR TITLE
chore: stickers in local space

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimationEventHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimationEventHandler.cs
@@ -7,6 +7,7 @@ public class AvatarAnimationEventHandler : MonoBehaviour
 {
     const string ANIM_NAME_KISS = "kiss", ANIM_NAME_MONEY = "money", ANIM_NAME_CLAP = "clap", ANIM_NAME_SNOWFLAKE = "snowfall", ANIM_NAME_HOHOHO = "hohoho";
     const float MIN_EVENT_WAIT_TIME = 0.1f;
+    const float AVATAR_OFFSET = 0.755f; //USE IT WHEN DEALING WITH LOCAL SPACE
 
     AudioEvent footstepLight;
     AudioEvent footstepSlide;
@@ -83,7 +84,7 @@ public class AvatarAnimationEventHandler : MonoBehaviour
             return;
 
         PlayAudioEvent(clap);
-        PlaySticker("clap", handR.position, Vector3.up);
+        PlaySticker("clap", handR.position - transform.position + (Vector3.up * AVATAR_OFFSET), Vector3.up, true);
         UpdateEventTime();
     }
 
@@ -96,7 +97,7 @@ public class AvatarAnimationEventHandler : MonoBehaviour
             return;
 
         PlayAudioEvent(throwMoney);
-        PlaySticker("money", handL.position, handL.rotation.eulerAngles);
+        PlaySticker("money", handL.position - transform.position + (Vector3.up * AVATAR_OFFSET), handL.rotation.eulerAngles, true);
         UpdateEventTime();
     }
 
@@ -116,7 +117,7 @@ public class AvatarAnimationEventHandler : MonoBehaviour
     IEnumerator EmitHeartParticle()
     {
         yield return new WaitForSeconds(0.8f);
-        PlaySticker("heart", handR.position, transform.rotation.eulerAngles);
+        PlaySticker("heart", handR.position - transform.position + (Vector3.up * AVATAR_OFFSET), transform.rotation.eulerAngles, true);
     }
 
     public void AnimEvent_Snowflakes()
@@ -127,17 +128,18 @@ public class AvatarAnimationEventHandler : MonoBehaviour
         if (!AnimationWeightIsOverThreshold(0.2f, ANIM_NAME_SNOWFLAKE))
             return;
 
-        PlaySticker("snowflakes", transform.position, Vector3.zero);
+        PlaySticker("snowflakes", Vector3.up * AVATAR_OFFSET, Vector3.zero, true);
     }
 
-    public void AnimEvent_Hohoho() {
+    public void AnimEvent_Hohoho()
+    {
         if (LastEventWasTooRecent())
             return;
-
+        
         if (!AnimationWeightIsOverThreshold(0.2f, ANIM_NAME_HOHOHO))
             return;
 
-        PlaySticker("hohoho", transform.position + transform.up * 1.5f, Vector3.zero);
+        PlaySticker("hohoho", Vector3.up * (1.5f + AVATAR_OFFSET), Vector3.zero, true);
     }
 
     void PlayAudioEvent(AudioEvent audioEvent)
@@ -183,9 +185,9 @@ public class AvatarAnimationEventHandler : MonoBehaviour
     /// <param name="id">ID string of sticker</param>
     /// <param name="position">Position in world space</param>
     /// <param name="rotation">Euler angles</param>
-    void PlaySticker(string id, Vector3 position, Vector3 direction)
+    void PlaySticker(string id, Vector3 position, Vector3 direction, bool followTransform = false)
     {
         if (stickersController != null)
-            stickersController.PlaySticker(id, position, direction, false);
+            stickersController.PlaySticker(id, position, direction, followTransform);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionClap.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionClap.prefab
@@ -172,7 +172,7 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 0
   moveWithCustomTransform: {fileID: 0}
   scalingMode: 1
   randomSeed: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionHeart.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionHeart.prefab
@@ -172,7 +172,7 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 0
   moveWithCustomTransform: {fileID: 0}
   scalingMode: 1
   randomSeed: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionHohoho.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionHohoho.prefab
@@ -172,7 +172,7 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 0
   moveWithCustomTransform: {fileID: 0}
   scalingMode: 1
   randomSeed: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionMoney.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionMoney.prefab
@@ -172,7 +172,7 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 0
   moveWithCustomTransform: {fileID: 0}
   scalingMode: 1
   randomSeed: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionSnowflakes.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/Prefabs/AvatarExpressionSnowflakes.prefab
@@ -172,7 +172,7 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 0
   moveWithCustomTransform: {fileID: 0}
   scalingMode: 1
   randomSeed: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersController.cs
@@ -14,6 +14,13 @@ namespace DCL
             PlaySticker(id, transform.position, Vector3.zero, true);
         }
 
+        /// <summary>
+        /// Play a sticker
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="position"> if following transform, position must be an offset from the target. Otherwise, it's the particle's world position</param>
+        /// <param name="direction"></param>
+        /// <param name="followTransform"></param>
         public void PlaySticker(string id, Vector3 position, Vector3 direction, bool followTransform)
         {
             if (stickersFactory == null || !stickersFactory.TryGet(id, out GameObject prefab) || isInHideArea)
@@ -31,7 +38,7 @@ namespace DCL
             {
                 FollowObject emoteFollow = emoteGameObject.AddComponent<FollowObject>();
                 emoteFollow.target = transform;
-                emoteFollow.offset = prefab.transform.position;
+                emoteFollow.offset = position;
             }
         }
 


### PR DESCRIPTION
Fixes #2961 

# Test
- Emote stickers should now follow the user.
- Check that every emote with particles (mostly the base ones, clap, kiss, ho ho ho...) show the correct particle.