### PR TITLE
chore: CI code generation of renderer protocol and ecs7 components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,12 @@ jobs:
           name: "Download LFS files from GitHub's LFS Storage"
           command: |
             while true; do git reset --hard HEAD && git clean -fd && git lfs pull && break; done
+      - run:
+          name: Components and Renderer Protocol code generation
+          command: |
+            cd protocol-gen
+            npm install
+            npm run build-all
       - save_cache:
           name: Store large files in cache
           key: git-lfs-{{ .Branch }}


### PR DESCRIPTION
# What?
The code for the renderer protocol and the ecs7 components is now generated in the CI.

It will replace the existing pushed code.

Note: Add just 7 seconds to the CI

# Why?
The CI will throw an error if there is a misuse of the protocol generation.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
