### PR TITLE
Stop animations when character and tutorial robot are not rendered

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -505,6 +505,17 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         animEventHandler = animationEventHandler;
     }
 
+    private void OnEnable()
+    {
+        animation.enabled = true;
+    }
+
+    private void OnDisable()
+    {
+        animation.Stop();
+        animation.enabled = false;
+    }
+
     private void OnDestroy()
     {
         if (animEventHandler != null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -507,11 +507,17 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
 
     private void OnEnable()
     {
+        if (animation == null)
+            return;
+
         animation.enabled = true;
     }
 
     private void OnDisable()
     {
+        if (animation == null)
+            return;
+
         animation.Stop();
         animation.enabled = false;
     }

--- a/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_LockTheCursor.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_LockTheCursor.cs
@@ -20,7 +20,7 @@ namespace DCL.Tutorial
                 tutorialController.ShowTeacher3DModel(true);
                 tutorialController.SetTeacherPosition(teacherPositionRef.position);
                 if (tutorialController.configuration.teacher != null &&
-                    tutorialController.configuration.teacher.isHiddenByAnAnimation)
+                    tutorialController.configuration.teacher.IsHiddenByAnimation)
                     tutorialController.configuration.teacher.PlayAnimation(TutorialTeacher.TeacherAnimation.Reset);
             }
             else

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialStep.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialStep.cs
@@ -70,7 +70,7 @@ namespace DCL.Tutorial
                     tutorialController.SetTeacherPosition(teacherPositionRef.position);
 
                     if (tutorialController.configuration.teacher != null &&
-                        tutorialController.configuration.teacher.isHiddenByAnAnimation)
+                        tutorialController.configuration.teacher.IsHiddenByAnimation)
                         tutorialController.configuration.teacher.PlayAnimation(TutorialTeacher.TeacherAnimation.Reset);
                 }
             }

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialTeacher.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialTeacher.cs
@@ -14,17 +14,13 @@ namespace DCL.Tutorial
             Reset
         }
 
-        [SerializeField] internal Animator teacherAnimator;
+        [SerializeField] private Animator teacherAnimator;
+        [SerializeField] private AudioEvent audioEventHappy, audioEventNormal;
 
-        [SerializeField]
-        AudioEvent audioEventHappy, audioEventNormal;
 
-        [HideInInspector] public bool isHiddenByAnAnimation = false;
+        public bool IsHiddenByAnimation { get; private set; } = false;
 
-        /// <summary>
-        /// Play an animation.
-        /// </summary>
-        /// <param name="animation">Animation to play.</param>
+
         public void PlayAnimation(TeacherAnimation animation)
         {
             if (!isActiveAndEnabled)
@@ -35,14 +31,15 @@ namespace DCL.Tutorial
                 case TeacherAnimation.StepCompleted:
                     teacherAnimator.SetTrigger("StepCompleted");
                     PlayHappySound(0.3f);
+                    IsHiddenByAnimation = false;
                     break;
                 case TeacherAnimation.QuickGoodbye:
                     teacherAnimator.SetTrigger("QuickGoodbye");
-                    isHiddenByAnAnimation = true;
+                    IsHiddenByAnimation = true;
                     break;
                 case TeacherAnimation.Reset:
                     teacherAnimator.SetTrigger("Reset");
-                    isHiddenByAnAnimation = false;
+                    IsHiddenByAnimation = false;
                     break;
                 default:
                     break;
@@ -52,5 +49,16 @@ namespace DCL.Tutorial
         public void PlaySpeakSound() { audioEventNormal.PlayScheduled(0.4f); }
 
         public void PlayHappySound(float delay) { audioEventHappy.PlayScheduled(delay); }
+
+        private void OnEnable()
+        {
+            teacherAnimator.enabled = true;
+        }
+
+        private void OnDisable()
+        {
+            teacherAnimator.StopPlayback();
+            teacherAnimator.enabled = false;
+        }
     }
 }

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialTeacher.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialTeacher.cs
@@ -31,7 +31,6 @@ namespace DCL.Tutorial
                 case TeacherAnimation.StepCompleted:
                     teacherAnimator.SetTrigger("StepCompleted");
                     PlayHappySound(0.3f);
-                    IsHiddenByAnimation = false;
                     break;
                 case TeacherAnimation.QuickGoodbye:
                     teacherAnimator.SetTrigger("QuickGoodbye");

--- a/unity-renderer/ProjectSettings/QualitySettings.asset
+++ b/unity-renderer/ProjectSettings/QualitySettings.asset
@@ -21,7 +21,7 @@ QualitySettings:
     skinWeights: 4
     textureQuality: 0
     anisotropicTextures: 2
-    antiAliasing: 8
+    antiAliasing: 4
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 1


### PR DESCRIPTION
Fixes #1794 

When the prefabs containing character animation or tutorial robot are hidden or the specific element containing the animations is hidden, the animations stops. 

QA
once we stop rendering an avatar or the tutorial robot, the preview should stop being animated.

PR in progress, more modifications to catch specific moments when we should stop animations might arise following tests and investigations.