### PR TITLE
fix: Welcome to Genesis plaza should not be shown outside of it

### DIFF
--- a/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
@@ -69,6 +69,8 @@ namespace DCL.Tutorial
             tutorialController.SetTeacherCanvasSortingOrder(defaultTeacherCanvasSortOrder);
 
             CommonScriptableObjects.userMovementKeysBlocked.Set(false);
+
+            CommonScriptableObjects.playerCoords.OnChange -= OnChangePlayerCoords;
         }
 
         internal void OnOkButtonClick() { stepIsFinished = true; }

--- a/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
@@ -12,6 +12,7 @@ namespace DCL.Tutorial
     public class TutorialStep_GenesisGreetings : TutorialStep
     {
         private const int TEACHER_CANVAS_SORT_ORDER_START = 4;
+        private const int GENESIS_PLAZA_TUTORIAL_LOCATION = 3;
 
         [SerializeField]
         Button okButton;
@@ -49,13 +50,6 @@ namespace DCL.Tutorial
                     WebInterface.SendSceneExternalActionEvent(Environment.i.world.state.GetCurrentSceneId(), "tutorial", "begin");
                 }
             }
-
-            Vector2Int currentCoords = CommonScriptableObjects.playerCoords.Get();
-            if (Mathf.Abs(currentCoords.x) > 3 || Mathf.Abs(currentCoords.y) > 3)
-            {
-                stepIsFinished = true;
-                return;
-            }
         }
 
         public override IEnumerator OnStepExecute() { yield return new WaitUntil(() => stepIsFinished); }
@@ -75,5 +69,19 @@ namespace DCL.Tutorial
         }
 
         internal void OnOkButtonClick() { stepIsFinished = true; }
+
+        private void Update()
+        {
+            if (stepIsFinished)
+                return;
+
+            Vector2Int currentCoords = CommonScriptableObjects.playerCoords.Get();
+            if (Mathf.Abs(currentCoords.x) > GENESIS_PLAZA_TUTORIAL_LOCATION ||
+                Mathf.Abs(currentCoords.y) > GENESIS_PLAZA_TUTORIAL_LOCATION)
+            {
+                stepIsFinished = true;
+                return;
+            }
+        }
     }
 }

--- a/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
@@ -24,13 +24,6 @@ namespace DCL.Tutorial
 
         public override void OnStepStart()
         {
-            Vector2Int currentCoords = CommonScriptableObjects.playerCoords.Get();
-            if (Mathf.Abs(currentCoords.x) > 3 || Mathf.Abs(currentCoords.y) > 3)
-            {
-                Destroy(gameObject);
-                return;
-            }
-
             base.OnStepStart();
 
             CommonScriptableObjects.userMovementKeysBlocked.Set(true);
@@ -55,6 +48,13 @@ namespace DCL.Tutorial
                 {
                     WebInterface.SendSceneExternalActionEvent(Environment.i.world.state.GetCurrentSceneId(), "tutorial", "begin");
                 }
+            }
+
+            Vector2Int currentCoords = CommonScriptableObjects.playerCoords.Get();
+            if (Mathf.Abs(currentCoords.x) > 3 || Mathf.Abs(currentCoords.y) > 3)
+            {
+                stepIsFinished = true;
+                return;
             }
         }
 

--- a/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
@@ -24,8 +24,15 @@ namespace DCL.Tutorial
 
         public override void OnStepStart()
         {
+            Vector2Int currentCoords = CommonScriptableObjects.playerCoords.Get();
+            if (Mathf.Abs(currentCoords.x) > 3 || Mathf.Abs(currentCoords.y) > 3)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
             base.OnStepStart();
-            
+
             CommonScriptableObjects.userMovementKeysBlocked.Set(true);
             CommonScriptableObjects.featureKeyTriggersBlocked.Set(true);
 
@@ -63,7 +70,7 @@ namespace DCL.Tutorial
         {
             base.OnStepFinished();
             tutorialController.SetTeacherCanvasSortingOrder(defaultTeacherCanvasSortOrder);
-            
+
             CommonScriptableObjects.userMovementKeysBlocked.Set(false);
         }
 

--- a/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_GenesisGreetings.cs
@@ -27,6 +27,9 @@ namespace DCL.Tutorial
         {
             base.OnStepStart();
 
+            OnChangePlayerCoords(new Vector2Int(0, 0), CommonScriptableObjects.playerCoords.Get());
+            CommonScriptableObjects.playerCoords.OnChange += OnChangePlayerCoords;
+
             CommonScriptableObjects.userMovementKeysBlocked.Set(true);
             CommonScriptableObjects.featureKeyTriggersBlocked.Set(true);
 
@@ -70,14 +73,13 @@ namespace DCL.Tutorial
 
         internal void OnOkButtonClick() { stepIsFinished = true; }
 
-        private void Update()
+        private void OnChangePlayerCoords(Vector2Int prevCoords, Vector2Int coords)
         {
             if (stepIsFinished)
                 return;
 
-            Vector2Int currentCoords = CommonScriptableObjects.playerCoords.Get();
-            if (Mathf.Abs(currentCoords.x) > GENESIS_PLAZA_TUTORIAL_LOCATION ||
-                Mathf.Abs(currentCoords.y) > GENESIS_PLAZA_TUTORIAL_LOCATION)
+            if (Mathf.Abs(coords.x) > GENESIS_PLAZA_TUTORIAL_LOCATION ||
+                Mathf.Abs(coords.y) > GENESIS_PLAZA_TUTORIAL_LOCATION)
             {
                 stepIsFinished = true;
                 return;

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
@@ -75,10 +75,6 @@ namespace DCL.Tutorial
 
         public TutorialController ()
         {
-            Vector2Int currentCoords = CommonScriptableObjects.playerCoords.Get();
-            if (currentCoords.x != 0 || currentCoords.y != 0)
-                return;
-
             tutorialView = CreateTutorialView();
             SetConfiguration(tutorialView.configuration);
         }

--- a/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-renderer/Assets/Tutorial/Scripts/TutorialController.cs
@@ -75,6 +75,10 @@ namespace DCL.Tutorial
 
         public TutorialController ()
         {
+            Vector2Int currentCoords = CommonScriptableObjects.playerCoords.Get();
+            if (currentCoords.x != 0 || currentCoords.y != 0)
+                return;
+
             tutorialView = CreateTutorialView();
             SetConfiguration(tutorialView.configuration);
         }


### PR DESCRIPTION
fixes #3087 

This PR should avoid the tutorial from being fired outside genesis plaza.

QA

In order to check, reproduce the steps described in the linked issue, the tutorial should not be shown anymore.
