### PR TITLE
chore: ECS7 remove deprecated input code

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
@@ -214,38 +214,20 @@ namespace DCL
 
         private IList<IPointerEvent> GetPointerEventList(IDCLEntity entity)
         {
-            // If an event exist in the new ECS, we got that value, if not it is ECS 6, so we continue as before
-            if (dataStoreEcs7.entityEvents.TryGetValue(entity.entityId, out List<IPointerInputEvent> pointerInputEvent))
-            {
-                return pointerInputEvent.Cast<IPointerEvent>().ToList();
-            }
-            else
-            {
-                var lastHoveredEventList = newHoveredInputEvent.entity.gameObject.transform.Cast<Transform>()
-                                                               .Select(child => child.GetComponent<IPointerEvent>())
-                                                               .Where(pointerComponent => pointerComponent != null)
-                                                               .ToArray();
-
-                return lastHoveredEventList;
-            }
+            return entity.gameObject.transform.Cast<Transform>()
+                                    .Select(child => child.GetComponent<IPointerEvent>())
+                                    .Where(pointerComponent => pointerComponent != null)
+                                    .ToArray();
         }
 
         private IPointerEvent GetPointerEvent(IDCLEntity entity)
         {
-            // If an event exist in the new ECS, we got that value, if not it is ECS 6, so we continue as before
-            if (dataStoreEcs7.entityEvents.TryGetValue(entity.entityId, out List<IPointerInputEvent> pointerInputEvent))
-                return pointerInputEvent.First();
-            else
-                return entity.gameObject.GetComponentInChildren<IPointerEvent>();
+            return entity.gameObject.GetComponentInChildren<IPointerEvent>();
         }
 
-        private IList<IPointerInputEvent> GetPointerInputEvents(IDCLEntity entity, GameObject hitGameObject)
+        private IList<IPointerInputEvent> GetPointerInputEvents(GameObject hitGameObject)
         {
-            // If an event exist in the new ECS, we got that value, if not it is ECS 6, so we continue as before
-            if (entity != null && dataStoreEcs7.entityEvents.TryGetValue(entity.entityId, out List<IPointerInputEvent> pointerInputEvent))
-                return pointerInputEvent;
-            else
-                return hitGameObject.GetComponentsInChildren<IPointerInputEvent>();
+            return hitGameObject.GetComponentsInChildren<IPointerInputEvent>();
         }
 
         private bool EventObjectCanBeHovered(ColliderInfo colliderInfo, float distance)
@@ -492,7 +474,7 @@ namespace DCL
                 else
                     hitGameObject = collider.gameObject;
 
-                IList<IPointerInputEvent> events = GetPointerInputEvents(info.entity, hitGameObject);
+                IList<IPointerInputEvent> events = GetPointerInputEvents(hitGameObject);
 
                 for (var i = 0; i < events.Count; i++)
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_ECS7.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_ECS7.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using DCL.Controllers;
 using DCL.ECS7.UI;
-using DCLPlugins.UUIDEventComponentsPlugin.UUIDComponent.Interfaces;
 using UnityEngine;
 
 namespace DCL
@@ -33,7 +31,6 @@ namespace DCL
 
         public readonly BaseList<IParcelScene> scenes = new BaseList<IParcelScene>();
         public readonly BaseDictionary<string, BaseRefCountedCollection<object>> pendingSceneResources = new BaseDictionary<string, BaseRefCountedCollection<object>>();
-        public readonly BaseDictionary<long, List<IPointerInputEvent>> entityEvents = new BaseDictionary<long, List<IPointerInputEvent>>();
         public readonly BaseDictionary<long, GameObject> shapesReady = new BaseDictionary<long, GameObject>();
         public IUIDataContainer uiDataContainer = new UIDataContainer();
         public bool isEcs7Enabled = false;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Extensions/DataStore_ECS7_Extensions.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Extensions/DataStore_ECS7_Extensions.cs
@@ -1,38 +1,10 @@
-using System.Collections.Generic;
-using DCLPlugins.UUIDEventComponentsPlugin.UUIDComponent.Interfaces;
 using UnityEngine;
 
 namespace DCL
 {
     public static class DataStore_ECS7_Extensions
     {
-        public static void AddPointerEvent( this DataStore_ECS7 self, long entityId, IPointerInputEvent pointerEvent )
-        {
-            if (self.entityEvents.TryGetValue(entityId, out List<IPointerInputEvent> events))
-            {
-               events.Add(pointerEvent);
-            }
-            else
-            {
-                events = new List<IPointerInputEvent>()
-                {
-                    pointerEvent
-                };
-                self.entityEvents.Add(entityId,events);
-            }
-        }
-        
-        public static void RemovePointerEvent( this DataStore_ECS7 self, long entityId, IPointerInputEvent pointerEvent )
-        {
-            if (self.entityEvents.TryGetValue(entityId, out List<IPointerInputEvent> events))
-            {
-                events.Remove(pointerEvent);
-                if (events.Count == 0)
-                    self.entityEvents.Remove(entityId);
-            }
-        }
-        
-        public static void AddPendingResource( this DataStore_ECS7 self, string sceneId, object model )
+        public static void AddPendingResource(this DataStore_ECS7 self, string sceneId, object model)
         {
             if (self.pendingSceneResources.TryGetValue(sceneId, out BaseRefCountedCollection<object> pendingResoruces))
             {
@@ -40,28 +12,28 @@ namespace DCL
             }
             else
             {
-                BaseRefCountedCollection<object>  newCountedCollection = new BaseRefCountedCollection<object>();
+                BaseRefCountedCollection<object> newCountedCollection = new BaseRefCountedCollection<object>();
                 newCountedCollection.IncreaseRefCount(model);
-                self.pendingSceneResources.Add(sceneId,newCountedCollection);
+                self.pendingSceneResources.Add(sceneId, newCountedCollection);
             }
         }
 
-        public static void RemovePendingResource( this DataStore_ECS7 self, string sceneId, object model)
+        public static void RemovePendingResource(this DataStore_ECS7 self, string sceneId, object model)
         {
             if (self.pendingSceneResources.TryGetValue(sceneId, out BaseRefCountedCollection<object> pendingResoruces))
             {
                 pendingResoruces.DecreaseRefCount(model);
             }
         }
-        
-        public static void AddShapeReady( this DataStore_ECS7 self, long entityId, GameObject gameObject )
+
+        public static void AddShapeReady(this DataStore_ECS7 self, long entityId, GameObject gameObject)
         {
-            self.shapesReady.AddOrSet(entityId,gameObject);
+            self.shapesReady.AddOrSet(entityId, gameObject);
         }
 
-        public static void RemoveShapeReady( this DataStore_ECS7 self, long entityId)
+        public static void RemoveShapeReady(this DataStore_ECS7 self, long entityId)
         {
-            if(self.shapesReady.ContainsKey(entityId))
+            if (self.shapesReady.ContainsKey(entityId))
                 self.shapesReady.Remove(entityId);
         }
     }


### PR DESCRIPTION
## What does this PR change?

removed deprecated code used for ECS7 input

## How to test the changes?
https://play.decentraland.zone/?renderer-branch=chore/ecs7-remove-deprecated-input-code
go to genesis plaza, click on events or places pilars.
input should behave as expected.
