### PR TITLE
Fix: profanity filter not disabled on name

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Tests/PlayerNameShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Tests/PlayerNameShould.cs
@@ -119,6 +119,7 @@ public class PlayerNameShould : MonoBehaviour
     [TestCase("fuckfaceboob", "****face****")]
     public void ApplyProfanityFilteringToOffensiveNames(string originalName, string displayedName)
     {
+        DataStore.i.settings.profanityChatFilteringEnabled.Set(true);
         var defaultName = playerName.nameText.text;
         playerName.SetName(originalName);
         Assert.IsTrue(displayedName.Equals(playerName.nameText.text) || defaultName.Equals(playerName.nameText.text));


### PR DESCRIPTION
Fixes #3144

Fixes the profanity filter disabled but not affecting the head floating names on avatars.

## How to test the changes?

Log in with two instances, disable the profanity filter on one account, and set a swear word as a name on the other.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
