### PR TITLE
fix: username links in chat

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntry.cs
@@ -11,11 +11,7 @@ public abstract class ChatEntry : MonoBehaviour
     public abstract ChatEntryModel Model { get; }
     public abstract void Populate(ChatEntryModel model);
     public abstract void SetFadeout(bool enabled);
-    public abstract void DeactivatePreview();
     public abstract void FadeOut();
-    public abstract void ActivatePreview();
-    public abstract void ActivatePreviewInstantly();
-    public abstract void DeactivatePreviewInstantly();
     
     protected IEnumerator InterpolateAlpha(float destinationAlpha, float duration)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -225,7 +225,7 @@ public class ChatHUDView : BaseComponentView, IChatHUDComponentView
             chatEntry.Populate(model);
 
             if (chatEntry.showUserName && model.subType.Equals(ChatEntryModel.SubType.RECEIVED))
-                chatEntry.OnPress += OnOpenContextMenu;
+                chatEntry.OnUserNameClicked += OnOpenContextMenu;
 
             chatEntry.OnTriggerHover += OnMessageTriggerHover;
             chatEntry.OnTriggerHoverGoto += OnMessageCoordinatesTriggerHover;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DateSeparatorEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DateSeparatorEntry.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections;
 using System.Globalization;
 using TMPro;
 using UnityEngine;
-using UnityEngine.UI;
 
 /// <summary>
 /// Special type of entry to be used as date separator in chat conversations.
@@ -12,23 +10,10 @@ public class DateSeparatorEntry : ChatEntry
 {
     [SerializeField] internal TextMeshProUGUI title;
     
-    [Header("Preview Mode")]
-    [SerializeField] private Image previewBackgroundImage;
-    [SerializeField] private Color previewBackgroundColor;
-    [SerializeField] private Color previewFontColor;
-    
     private DateTime timestamp;
     private ChatEntryModel chatEntryModel;
-    private Color originalBackgroundColor;
-    private Color originalFontColor;
 
     public override ChatEntryModel Model => chatEntryModel;
-    
-    private void Awake()
-    {
-        originalBackgroundColor = previewBackgroundImage.color;
-        originalFontColor = title.color;
-    }
 
     public override void Populate(ChatEntryModel model)
     {
@@ -47,26 +32,6 @@ public class DateSeparatorEntry : ChatEntry
 
         fadeEnabled = true;
     }
-
-    public override void DeactivatePreview()
-    {
-        if (!gameObject.activeInHierarchy)
-        {
-            previewBackgroundImage.color = originalBackgroundColor;
-            title.color = originalFontColor;
-            return;
-        }
-        
-        if (previewInterpolationRoutine != null)
-            StopCoroutine(previewInterpolationRoutine);
-
-        if (previewInterpolationAlphaRoutine != null)
-            StopCoroutine(previewInterpolationAlphaRoutine);
-
-        group.alpha = 1;
-        previewInterpolationRoutine =
-            StartCoroutine(InterpolatePreviewColor(originalBackgroundColor, originalFontColor, 0.5f));
-    }
     
     public override void FadeOut()
     {
@@ -80,40 +45,6 @@ public class DateSeparatorEntry : ChatEntry
             StopCoroutine(previewInterpolationAlphaRoutine);
 
         previewInterpolationAlphaRoutine = StartCoroutine(InterpolateAlpha(0, 0.5f));
-    }
-
-    public override void ActivatePreview()
-    {
-        if (!gameObject.activeInHierarchy)
-        {
-            ActivatePreviewInstantly();
-            return;
-        }
-        
-        if (previewInterpolationRoutine != null)
-            StopCoroutine(previewInterpolationRoutine);
-        
-        previewInterpolationRoutine = StartCoroutine(InterpolatePreviewColor(previewBackgroundColor, previewFontColor, 0.5f));
-        
-        previewInterpolationAlphaRoutine = StartCoroutine(InterpolateAlpha(1, 0.5f));
-    }
-    
-    public override void ActivatePreviewInstantly()
-    {
-        if (previewInterpolationRoutine != null)
-            StopCoroutine(previewInterpolationRoutine);
-        
-        previewBackgroundImage.color = previewBackgroundColor;
-        title.color = previewFontColor;
-    }
-    
-    public override void DeactivatePreviewInstantly()
-    {
-        if (previewInterpolationRoutine != null)
-            StopCoroutine(previewInterpolationRoutine);
-        
-        previewBackgroundImage.color = originalBackgroundColor;
-        title.color = originalFontColor;
     }
 
     private string GetDateFormat(DateTime date)
@@ -139,23 +70,4 @@ public class DateSeparatorEntry : ChatEntry
         DateTime result = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         return result.AddMilliseconds(milliseconds);
     }
-    
-    private IEnumerator InterpolatePreviewColor(Color backgroundColor, Color fontColor, float duration)
-    {
-        var t = 0f;
-        
-        while (t < duration)
-        {
-            t += Time.deltaTime;
-
-            previewBackgroundImage.color = Color.Lerp(previewBackgroundImage.color, backgroundColor, t / duration);
-            title.color = Color.Lerp(title.color, fontColor, t / duration);
-            
-            yield return null;
-        }
-
-        previewBackgroundImage.color = backgroundColor;
-        title.color = fontColor;
-    }
-    
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
@@ -65,57 +65,7 @@ public class DefaultChatEntryShould
         
         await UniTask.DelayFrame(4);
 
-        Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
-    });
-    
-    [UnityTest]
-    public IEnumerator ShowUnderlineOnHoverPublic() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PublicChatEntryReceived");
-        
-        var message = new ChatEntryModel
-        {
-            messageType = ChatMessage.Type.PUBLIC,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.RECEIVED
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
-        entry.OnPointerEnter(new PointerEventData(null));
-
-        Assert.AreEqual("<b><color=#438FFF><u>user-test</u></color>:</b> test message", entry.body.text);
-        
-        entry.OnPointerExit(new PointerEventData(null));
-        Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
-    });
-    
-    [UnityTest]
-    public IEnumerator ShowUnderlineOnHoverWhisper() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PublicChatEntryReceived");
-        
-        var message = new ChatEntryModel
-        {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.RECEIVED
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
-        entry.OnPointerEnter(new PointerEventData(null));
-
-        Assert.AreEqual("<b><color=#438FFF><u>From user-test</u></color>:</b> test message", entry.body.text);
-        
-        entry.OnPointerExit(new PointerEventData(null));
-        Assert.AreEqual("<b><color=#5EBD3D>From user-test</color>:</b> test message", entry.body.text);
+        Assert.AreEqual("<b><link=username://user-test>user-test</link>:</b> test message", entry.body.text);
     });
     
     [UnityTest]
@@ -157,7 +107,7 @@ public class DefaultChatEntryShould
         
         await UniTask.DelayFrame(4);
 
-        Assert.AreEqual("<b><color=#5EBD3D>From user-test</color>:</b> test message", entry.body.text);
+        Assert.AreEqual("<b><color=#5EBD3D>From <link=username://user-test>user-test</link></color>:</b> test message", entry.body.text);
     });
     
     [UnityTest]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Utils/CoordinateUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Utils/CoordinateUtils.cs
@@ -14,7 +14,10 @@ public class CoordinateUtils
     public const int MAX_Y_COORDINATE = 158;
     public const int MIN_Y_COORDINATE = -150;
 
-    public static bool IsCoordinateInRange(int x, int y) { return (x <= MAX_X_COORDINATE && x >= MIN_X_COORDINATE && y <= MAX_Y_COORDINATE && y >= MIN_Y_COORDINATE); }
+    public static bool IsCoordinateInRange(int x, int y)
+    {
+        return x <= MAX_X_COORDINATE && x >= MIN_X_COORDINATE && y <= MAX_Y_COORDINATE && y >= MIN_Y_COORDINATE;
+    }
 
     public static List<string> GetTextCoordinates(string text)
     {
@@ -22,22 +25,23 @@ public class CoordinateUtils
         List<string> matchingWords = new List<string>();
         foreach (var item in text.Split(' '))
         {
-            var match = filter.Match(item.ToString());
+            var match = filter.Match(item);
             int x;
             int y;
             if (match.Success)
             {
-                Int32.TryParse(item.ToString().Split(',')[0], out x);
-                Int32.TryParse(item.ToString().Split(',')[1], out y);
+                Int32.TryParse(item.Split(',')[0], out x);
+                Int32.TryParse(item.Split(',')[1], out y);
 
                 if (IsCoordinateInRange(x, y))
                     matchingWords.Add(match.Value);
             }
         }
+
         return matchingWords;
     }
 
-    public static bool HasValidTextCoordinates(string text) 
+    public static bool HasValidTextCoordinates(string text)
     {
         return GetTextCoordinates(text).Count > 0;
     }


### PR DESCRIPTION
## What does this PR change?

Add links for usernames in chat messages. This fixes the issue that the contextual menu was being opened when clicking on a channel link. Also the scene coordinates links got fixes, since they were dissapearing after hovering with the mouse.

## How to test the changes?

1. Go to any public chat
2. Receive a message with coordinates and channel links, for example: "100,100 hello #channel"
3. Click on the user name, it should display the user contextual menu
4. Click on the scene coordinate, it should display the jumpin modal
5. Click on the channel link, it should display the join channel modal
6. None of the cases should overlap between them

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
