### PR TITLE
refactor: Player name optimization

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -31,12 +31,38 @@ public class PlayerName : MonoBehaviour, IPlayerName
     internal BaseVariable<float> namesOpacity => DataStore.i.HUDs.avatarNamesOpacity;
     internal BaseVariable<bool> namesVisible => DataStore.i.HUDs.avatarNamesVisible;
 
-    internal float alpha;
-    internal float targetAlpha;
-    internal float previousAlphaStep;
     internal bool forceShow = false;
     internal Color backgroundOriginalColor;
     internal List<string> hideConstraints = new List<string>();
+
+    private float alpha;
+    private float targetAlpha;
+
+
+    internal float Alpha 
+    {
+        get => alpha;
+        set
+        {
+            alpha = Mathf.Clamp01(value);
+            if (alpha < 0.01f)
+            {
+                UpdateVisuals(0);
+                SetRenderersVisible(false);
+                return;
+            }
+
+            UpdateVisuals(alpha);
+            SetRenderersVisible(true);
+        }
+    }
+
+    internal float TargetAlpha
+    {
+        get => targetAlpha;
+        set => targetAlpha = Mathf.Clamp01(value);
+    }
+
 
     private void Awake()
     {
@@ -74,14 +100,13 @@ public class PlayerName : MonoBehaviour, IPlayerName
             UpdateVisuals(0);
             return;
         }
-        
+
+        float previousAlphaStep = GetNearestAlphaStep(alpha);
         float finalTargetAlpha = forceShow ? TARGET_ALPHA_SHOW : targetAlpha;
         alpha = Mathf.MoveTowards(alpha, finalTargetAlpha, ALPHA_TRANSITION_STEP_PER_SECOND * deltaTime);
         float currentAlphaStep = GetNearestAlphaStep(alpha);
         if (currentAlphaStep == previousAlphaStep)
             return;
-
-        previousAlphaStep = currentAlphaStep;
 
         if (currentAlphaStep == 0)
         {
@@ -89,6 +114,8 @@ public class PlayerName : MonoBehaviour, IPlayerName
             SetRenderersVisible(false);
             return;
         }
+        else
+            SetRenderersVisible(true);
 
         Vector3 cameraPosition = CommonScriptableObjects.cameraPosition.Get();
         Vector3 cameraRight = CommonScriptableObjects.cameraRight.Get();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -106,10 +106,13 @@ public class PlayerName : MonoBehaviour, IPlayerName
         alpha = Mathf.MoveTowards(alpha, finalTargetAlpha, ALPHA_TRANSITION_STEP_PER_SECOND * deltaTime);
         float currentAlphaStep = GetNearestAlphaStep(alpha);
 
-        if (currentAlphaStep == 0 && previousAlphaStep != currentAlphaStep)
+        if (currentAlphaStep == 0)
         {
-            UpdateVisuals(0);
-            SetRenderersVisible(false);
+            if (previousAlphaStep != currentAlphaStep)
+            {
+                UpdateVisuals(0);
+                SetRenderersVisible(false);
+            }
             return;
         }
         else

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -182,7 +182,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
 
     internal float GetNearestAlphaStep(float alpha)
     {
-        return Mathf.Floor(alpha / ALPHA_STEPS) * ALPHA_STEPS;
+        return Mathf.Floor(alpha * ALPHA_STEPS) / ALPHA_STEPS;
     }
 
     internal void ScalePivotByDistance(float distanceToCamera) { pivot.transform.localScale = Vector3.one * 0.15f * distanceToCamera; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -106,7 +106,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
         alpha = Mathf.MoveTowards(alpha, finalTargetAlpha, ALPHA_TRANSITION_STEP_PER_SECOND * deltaTime);
         float currentAlphaStep = GetNearestAlphaStep(alpha);
 
-        if (currentAlphaStep == 0)
+        if (currentAlphaStep == 0 && previousAlphaStep != currentAlphaStep)
         {
             UpdateVisuals(0);
             SetRenderersVisible(false);
@@ -114,6 +114,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
         }
         else
             SetRenderersVisible(true);
+
 
         Vector3 cameraPosition = CommonScriptableObjects.cameraPosition.Get();
         Vector3 cameraRight = CommonScriptableObjects.cameraRight.Get();
@@ -124,11 +125,15 @@ public class PlayerName : MonoBehaviour, IPlayerName
          * instead we should have a provider so all the subsystems can use it
          */
         float distanceToCamera = Vector3.Distance(cameraPosition, gameObject.transform.position);
-        float resolvedAlpha = forceShow ? TARGET_ALPHA_SHOW : ResolveAlphaByDistance(alpha, distanceToCamera, forceShow);
-        UpdateVisuals(resolvedAlpha);
         ScalePivotByDistance(distanceToCamera);
         LookAtCamera(cameraRight, cameraRotation.eulerAngles);
         pivot.transform.localPosition = Vector3.up * GetPivotYOffsetByDistance(distanceToCamera);
+
+        float resolvedAlpha = forceShow ? TARGET_ALPHA_SHOW : ResolveAlphaByDistance(alpha, distanceToCamera, forceShow);
+        float resolvedAlphaStep = GetNearestAlphaStep(resolvedAlpha);
+        float canvasAlphaStep = GetNearestAlphaStep(canvasGroup.alpha);
+        if (resolvedAlphaStep != canvasAlphaStep)
+            UpdateVisuals(resolvedAlpha);
     }
 
     internal void LookAtCamera(Vector3 cameraRight, Vector3 cameraEulerAngles)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -109,7 +109,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
 
         float finalTargetAlpha = forceShow ? TARGET_ALPHA_SHOW : targetAlpha;
         alpha = Mathf.MoveTowards(alpha, finalTargetAlpha, ALPHA_TRANSITION_STEP_PER_SECOND * deltaTime);
-        if (ChechHide(alpha))
+        if (CheckAndUpdateVisibility(alpha))
             return;
 
         Vector3 cameraPosition = CommonScriptableObjects.cameraPosition.Get();
@@ -126,7 +126,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
         pivot.transform.localPosition = Vector3.up * GetPivotYOffsetByDistance(distanceToCamera);
 
         float resolvedAlpha = forceShow ? TARGET_ALPHA_SHOW : ResolveAlphaByDistance(alpha, distanceToCamera, forceShow);
-        if (ChechHide(resolvedAlpha))
+        if (CheckAndUpdateVisibility(resolvedAlpha))
             return;
 
         SetRenderersVisible(true);
@@ -138,7 +138,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
 
 
         // Local Methods
-        bool ChechHide(float checkAlpha)
+        bool CheckAndUpdateVisibility(float checkAlpha)
         {
             if (checkAlpha < MINIMUM_ALPHA_TO_SHOW)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -105,8 +105,6 @@ public class PlayerName : MonoBehaviour, IPlayerName
         float finalTargetAlpha = forceShow ? TARGET_ALPHA_SHOW : targetAlpha;
         alpha = Mathf.MoveTowards(alpha, finalTargetAlpha, ALPHA_TRANSITION_STEP_PER_SECOND * deltaTime);
         float currentAlphaStep = GetNearestAlphaStep(alpha);
-        if (currentAlphaStep == previousAlphaStep)
-            return;
 
         if (currentAlphaStep == 0)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -13,7 +13,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
     internal const int FORCE_CANVAS_SORTING_ORDER = 40;
     internal static readonly int TALKING_ANIMATOR_BOOL = Animator.StringToHash("Talking");
     internal const float ALPHA_TRANSITION_STEP_PER_SECOND =  1f / 0.25f;
-    internal const float ALPHA_STEPS = 16f;
+    internal const float ALPHA_STEPS = 32f;
     internal const float TARGET_ALPHA_SHOW = 1;
     internal const float TARGET_ALPHA_HIDE = 0;
     internal const int BACKGROUND_HEIGHT = 30;
@@ -37,6 +37,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
 
     private float alpha;
     private float targetAlpha;
+    private bool renderersVisible;
 
 
     internal float Alpha 
@@ -90,7 +91,11 @@ public class PlayerName : MonoBehaviour, IPlayerName
 
     private void SetRenderersVisible(bool value)
     {
+        if (renderersVisible == value) 
+            return;
+
         canvasRenderers.ForEach(c => c.SetAlpha(value ? 1f : 0f));
+        renderersVisible = value;
     }
 
     internal void Update(float deltaTime)
@@ -101,23 +106,19 @@ public class PlayerName : MonoBehaviour, IPlayerName
             return;
         }
 
-        float previousAlphaStep = GetNearestAlphaStep(alpha);
         float finalTargetAlpha = forceShow ? TARGET_ALPHA_SHOW : targetAlpha;
         alpha = Mathf.MoveTowards(alpha, finalTargetAlpha, ALPHA_TRANSITION_STEP_PER_SECOND * deltaTime);
         float currentAlphaStep = GetNearestAlphaStep(alpha);
 
-        if (currentAlphaStep == 0)
+        if (currentAlphaStep <= 1)
         {
-            if (previousAlphaStep != currentAlphaStep)
+            if (renderersVisible)
             {
                 UpdateVisuals(0);
                 SetRenderersVisible(false);
             }
             return;
         }
-        else
-            SetRenderersVisible(true);
-
 
         Vector3 cameraPosition = CommonScriptableObjects.cameraPosition.Get();
         Vector3 cameraRight = CommonScriptableObjects.cameraRight.Get();
@@ -135,6 +136,8 @@ public class PlayerName : MonoBehaviour, IPlayerName
         float resolvedAlpha = forceShow ? TARGET_ALPHA_SHOW : ResolveAlphaByDistance(alpha, distanceToCamera, forceShow);
         float resolvedAlphaStep = GetNearestAlphaStep(resolvedAlpha);
         float canvasAlphaStep = GetNearestAlphaStep(canvasGroup.alpha);
+        SetRenderersVisible(true);
+
         if (resolvedAlphaStep != canvasAlphaStep)
             UpdateVisuals(resolvedAlpha);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Tests/PlayerNameShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Tests/PlayerNameShould.cs
@@ -13,7 +13,7 @@ public class PlayerNameShould : MonoBehaviour
     public void BeInitializedProperly()
     {
         Assert.AreEqual(PlayerName.DEFAULT_CANVAS_SORTING_ORDER, playerName.canvas.sortingOrder);
-        Assert.AreEqual(PlayerName.TARGET_ALPHA_SHOW, playerName.alpha);
+        Assert.AreEqual(PlayerName.TARGET_ALPHA_SHOW, playerName.Alpha);
         Assert.AreEqual(playerName.backgroundOriginalColor, playerName.background.color);
         Assert.IsTrue(playerName.gameObject.activeSelf);
         Assert.IsTrue(playerName.canvas.enabled);
@@ -67,8 +67,8 @@ public class PlayerNameShould : MonoBehaviour
     [Test]
     public void DisableRenderersIfHidden()
     {
-        playerName.alpha = 0;
-        playerName.targetAlpha = 0;
+        playerName.Alpha = 0;
+        playerName.TargetAlpha = 0;
         playerName.Update(float.MaxValue);
 
         var canvasRenderers = playerName.canvasRenderers;
@@ -81,21 +81,21 @@ public class PlayerNameShould : MonoBehaviour
     [Test]
     public void StepTowardsAlphaTargetProperly_Ascending()
     {
-        playerName.alpha = 0;
-        playerName.targetAlpha = 1;
+        playerName.Alpha = 0;
+        playerName.TargetAlpha = 1;
         playerName.Update(0.01f);
 
-        Assert.AreEqual(PlayerName.ALPHA_TRANSITION_STEP_PER_SECOND * 0.01f, playerName.alpha);
+        Assert.AreEqual(PlayerName.ALPHA_TRANSITION_STEP_PER_SECOND * 0.01f, playerName.Alpha);
     }
 
     [Test]
     public void StepTowardsAlphaTargetProperly_Descending()
     {
-        playerName.alpha = 1;
-        playerName.targetAlpha = 0;
+        playerName.Alpha = 1;
+        playerName.TargetAlpha = 0;
         playerName.Update(0.01f);
 
-        Assert.AreEqual(1f - PlayerName.ALPHA_TRANSITION_STEP_PER_SECOND * 0.01f, playerName.alpha);
+        Assert.AreEqual(1f - PlayerName.ALPHA_TRANSITION_STEP_PER_SECOND * 0.01f, playerName.Alpha);
     }
 
     [Test]

--- a/unity-renderer/ProjectSettings/PackageManagerSettings.asset
+++ b/unity-renderer/ProjectSettings/PackageManagerSettings.asset
@@ -31,6 +31,7 @@ MonoBehaviour:
     - com.brunomikoski
     - com.demigiant
     - com.coffee.ui-particle
+    - com.madsbangh.easybuttons
     m_IsDefault: 0
     m_Capabilities: 0
   m_UserSelectedRegistryName: 
@@ -45,6 +46,7 @@ MonoBehaviour:
       - com.brunomikoski
       - com.demigiant
       - com.coffee.ui-particle
+      - com.madsbangh.easybuttons
       m_IsDefault: 0
       m_Capabilities: 0
     m_Modified: 0
@@ -54,4 +56,5 @@ MonoBehaviour:
     - com.brunomikoski
     - com.demigiant
     - com.coffee.ui-particle
+    - com.madsbangh.easybuttons
     m_SelectedScopeIndex: 0


### PR DESCRIPTION
fixes #3170 

Currently the alpha for the player name works in steps, this PR avoids recalculating new alpha values every frame if the alpha has not changed or has not been modified to a different step.
The only difference is the alpha will have a discrete amount of possible values instead of being a continuous one.
With this current PR the amount of steps is stored in the constant `ALPHA_STEPS`.
In order to get the discrete available values, these are all the values from 0 to 1 that are multiples of `1f / ALPHA_STEPS`

## QA

- The player name alpha should work very similar to dev / production, alpha values are as such: 0, 0.0625, 0.125... multiples of 0.0625 from 0 to 1
