### PR TITLE
chore: add extra reviewers

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -12,6 +12,8 @@ reviewGroups:
     - lorux0
     - davidejensen
     - dalkia
+    - Antivortex
+    - popuz
   qa:
     - kwssbocian
     - kwspgoliasz


### PR DESCRIPTION
## What does this PR change?

Updating auto_assign_config.yml to include @Antivortex and @popuz as reviewers.

## How to test the changes?

Above GitHub users will be used in the lottery system for auto review

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
