### PR TITLE
Fix: avoid showing top notification when coming from open chat

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs
@@ -22,6 +22,7 @@ namespace DCL.Chat.Notifications
         private BaseVariable<Transform> notificationPanelTransform => dataStore.HUDs.notificationPanelTransform;
         private BaseVariable<Transform> topNotificationPanelTransform => dataStore.HUDs.topNotificationPanelTransform;
         private BaseVariable<HashSet<string>> visibleTaskbarPanels => dataStore.HUDs.visibleTaskbarPanels;
+        private BaseVariable<string> openedChat => DataStore.i.HUDs.openedChat;
         private CancellationTokenSource fadeOutCT = new CancellationTokenSource();
         private UserProfile ownUserProfile;
 
@@ -82,7 +83,10 @@ namespace DCL.Chat.Notifications
                         mainChatNotificationView.AddNewChatNotification(privateModel);
 
                         if (topNotificationPanelTransform.Get().gameObject.activeInHierarchy)
-                            topNotificationView.AddNewChatNotification(privateModel);
+                        {
+                            if(message.sender != openedChat.Get())
+                                topNotificationView.AddNewChatNotification(privateModel);
+                        }
                         break;
                     case ChatMessage.Type.PUBLIC:
                         var publicModel = new PublicChannelMessageNotificationModel(message.messageId,
@@ -91,7 +95,10 @@ namespace DCL.Chat.Notifications
                         mainChatNotificationView.AddNewChatNotification(publicModel);
 
                         if (topNotificationPanelTransform.Get().gameObject.activeInHierarchy)
-                            topNotificationView.AddNewChatNotification(publicModel);
+                        {
+                            if(channel?.ChannelId != openedChat.Get())
+                                topNotificationView.AddNewChatNotification(publicModel);
+                        }
                         break;
                 }
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs
@@ -22,7 +22,7 @@ namespace DCL.Chat.Notifications
         private BaseVariable<Transform> notificationPanelTransform => dataStore.HUDs.notificationPanelTransform;
         private BaseVariable<Transform> topNotificationPanelTransform => dataStore.HUDs.topNotificationPanelTransform;
         private BaseVariable<HashSet<string>> visibleTaskbarPanels => dataStore.HUDs.visibleTaskbarPanels;
-        private BaseVariable<string> openedChat => DataStore.i.HUDs.openedChat;
+        private BaseVariable<string> openedChat => dataStore.HUDs.openedChat;
         private CancellationTokenSource fadeOutCT = new CancellationTokenSource();
         private UserProfile ownUserProfile;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -51,6 +51,7 @@ public class TaskbarHUDController : IHUD
     internal BaseVariable<Transform> topNotificationPanelTransform => DataStore.i.HUDs.topNotificationPanelTransform;
     internal BaseVariable<bool> isExperiencesViewerOpen => DataStore.i.experiencesViewer.isOpen;
     internal BaseVariable<int> numOfLoadedExperiences => DataStore.i.experiencesViewer.numOfLoadedExperiences;
+    internal BaseVariable<string> openedChat => DataStore.i.HUDs.openedChat;
 
     public TaskbarHUDController(IChatController chatController)
     {
@@ -372,6 +373,7 @@ public class TaskbarHUDController : IHUD
 
     public void OpenPrivateChat(string userId)
     {
+        openedChat.Set(userId);
         privateChatWindow.Setup(userId);
         worldChatWindowHud.SetVisibility(false);
         publicChatWindow.SetVisibility(false);
@@ -434,6 +436,7 @@ public class TaskbarHUDController : IHUD
 
     public void OpenChannelChat(string channelId)
     {
+        openedChat.Set(channelId);
         channelChatWindow?.Setup(channelId);
         channelChatWindow?.SetVisibility(true);
         publicChatWindow?.SetVisibility(false);
@@ -454,6 +457,7 @@ public class TaskbarHUDController : IHUD
 
     public void OpenPublicChat(string channelId, bool focusInputField)
     {
+        openedChat.Set(channelId);
         publicChatWindow?.Setup(channelId);
         publicChatWindow?.SetVisibility(true, focusInputField);
         channelChatWindow?.SetVisibility(false);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_HUDs.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_HUDs.cs
@@ -28,6 +28,7 @@ namespace DCL
         public readonly BaseVariable<Transform> topNotificationPanelTransform = new BaseVariable<Transform>(null);
         public readonly BaseVariable<bool> isSceneUIEnabled = new BaseVariable<bool>(true);
         public readonly BaseVariable<HashSet<string>> visibleTaskbarPanels = new BaseVariable<HashSet<string>>(new HashSet<string>());
+        public readonly BaseVariable<string> openedChat = new BaseVariable<string>("");
         public readonly BaseRefCounter<AvatarModifierAreaID> avatarAreaWarnings = new BaseRefCounter<AvatarModifierAreaID>();
         public readonly BaseVariable<Vector2Int> homePoint = new BaseVariable<Vector2Int>(new Vector2Int(0,0));
         public readonly BaseVariable<Dictionary<string, Queue<IUIRefreshable>>> dirtyShapes = new BaseVariable<Dictionary<string, Queue<IUIRefreshable>>>(new Dictionary<string, Queue<IUIRefreshable>>());


### PR DESCRIPTION
## What does this PR change?

When we have a chat open, avoids showing top notifications coming from that chat

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/notification-same-panel&kernel-branch=fix/channels-profiles
2. Open different chats (nearby, channel, private)
3. Receive messages in the open chat
4. Verify that the top notification doesn't show the new message in the opened chat

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
