### PR TITLE
fix: nested prefab null reference exception fix

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
@@ -98,6 +98,8 @@ public class CatalogController : MonoBehaviour
             return;
 
         AddWearablesToCatalog(request.wearables);
+        
+        
 
         if (!string.IsNullOrEmpty(request.context))
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
@@ -98,8 +98,6 @@ public class CatalogController : MonoBehaviour
             return;
 
         AddWearablesToCatalog(request.wearables);
-        
-        
 
         if (!string.IsNullOrEmpty(request.context))
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/EmotesCustomization/EmotesCustomizationSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Resources/EmotesCustomization/EmotesCustomizationSection.prefab
@@ -1232,6 +1232,98 @@ RectTransform:
   m_AnchoredPosition: {x: -9.5, y: 30}
   m_SizeDelta: {x: -39, y: 60}
   m_Pivot: {x: 0.5, y: 0}
+--- !u!1 &5844838289788328315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7289964697046869131}
+  - component: {fileID: 562371801626375352}
+  - component: {fileID: 6747147349481462609}
+  - component: {fileID: 5504772256985452013}
+  m_Layer: 5
+  m_Name: EmoteSlotSelector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7289964697046869131
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5844838289788328315}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 9154448218146335532}
+  m_Father: {fileID: 4623429712703141772}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 645}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &562371801626375352
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5844838289788328315}
+  m_CullTransparentMesh: 1
+--- !u!114 &6747147349481462609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5844838289788328315}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.78823537, g: 0.8000001, b: 0.82745105, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: f02af068e11cb4902a1a4faad10b890a, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 2
+--- !u!114 &5504772256985452013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5844838289788328315}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86305f54f225dea4798088a19ffbe769, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  emotesSlots: {fileID: 6598929307786099729}
+  model:
+    selectedSlot: -1
 --- !u!1 &6912453401298887337
 GameObject:
   m_ObjectHideFlags: 0
@@ -1475,6 +1567,364 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 702.4685, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &575195052635206558
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.30901694
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.95105654
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 6
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
+--- !u!1001 &1342535260079962774
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.30901697
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.95105654
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
 --- !u!1001 &1387269628721425343
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1730,503 +2180,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1387269628721425343}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1893445734464678603
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 4623429712703141772}
-    m_Modifications:
-    - target: {fileID: 991722930978460545, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 991722930978460545, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 991722930978460545, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 991722930978460545, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 991722930978460545, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 991722930978460545, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1677680516503830783, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1677680516503830783, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1677680516503830783, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1677680516503830783, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1677680516503830783, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1677680516503830783, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2181035820963151441, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2181035820963151441, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2181035820963151441, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2181035820963151441, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2181035820963151441, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2181035820963151441, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2317091022563364502, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 2347189190376591063, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2347189190376591063, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2347189190376591063, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2347189190376591063, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2347189190376591063, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2347189190376591063, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2575832557660664823, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2575832557660664823, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2575832557660664823, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2575832557660664823, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2575832557660664823, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2575832557660664823, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3135212720287308901, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3135212720287308901, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3135212720287308901, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3135212720287308901, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3135212720287308901, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3135212720287308901, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3647806334888989702, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3647806334888989702, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3647806334888989702, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3647806334888989702, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3647806334888989702, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3647806334888989702, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854468221142845342, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 4038870843545947340, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4038870843545947340, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4038870843545947340, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4038870843545947340, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4038870843545947340, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4038870843545947340, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4887116751190318093, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5180388724616294810, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5278757386700981447, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5430170892352205744, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Name
-      value: EmoteSlotSelector
-      objectReference: {fileID: 0}
-    - target: {fileID: 5666556392705759071, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5666556392705759071, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5666556392705759071, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5666556392705759071, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5666556392705759071, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5666556392705759071, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5790773920897469604, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 6368449931779089206, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 6578792898680774166, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627472821592301143, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627472821592301143, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627472821592301143, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627472821592301143, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627472821592301143, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627472821592301143, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7299768730189234663, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7321425754717908624, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7824481957453779006, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8511024466512757568, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 200
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 645
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 66043666108feb84996a4049b847b646, type: 3}
---- !u!114 &5504772256985452013 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6206593531515365158, guid: 66043666108feb84996a4049b847b646,
-    type: 3}
-  m_PrefabInstance: {fileID: 1893445734464678603}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86305f54f225dea4798088a19ffbe769, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &7289964697046869131 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 9182266355299323456, guid: 66043666108feb84996a4049b847b646,
-    type: 3}
-  m_PrefabInstance: {fileID: 1893445734464678603}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3655325203274959849
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2272,7 +2225,7 @@ PrefabInstance:
     - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 679.4685
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
         type: 3}
@@ -2317,7 +2270,7 @@ PrefabInstance:
     - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 15
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
         type: 3}
@@ -2421,6 +2374,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0b08d9ca8421644db83c1bd3f2e2e48, type: 3}
+--- !u!224 &3360905887761755250 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+    type: 3}
+  m_PrefabInstance: {fileID: 3655325203274959849}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &737305017821576015 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4071603596337262758, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
@@ -2433,12 +2392,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d49a3b742109ef0499aa2a13d3e0bedf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3360905887761755250 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
-    type: 3}
-  m_PrefabInstance: {fileID: 3655325203274959849}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4487051458237195214
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2943,3 +2896,1622 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bcfcb464d995fcd4999aa0cdcc20be98, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &4943660594520962880
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.00000004371139
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
+--- !u!1001 &6277102367019702928
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.95105654
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.30901706
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
+--- !u!1001 &6778047546148135998
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5877853
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.809017
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
+--- !u!1001 &7123186655167707300
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.80901706
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.5877852
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 8
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
+--- !u!1001 &7139655493980753079
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 7289964697046869131}
+    m_Modifications:
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 184
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4071603596337262758, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: model.itemSize.x
+      value: 184
+      objectReference: {fileID: 0}
+    - target: {fileID: 4071603596337262758, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: model.itemSize.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4071603596337262758, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: model.constraintCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4071603596337262758, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: model.spaceBetweenItems.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4071603596337262758, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: model.spaceBetweenItems.y
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829080691771640198, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_Spacing.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829080691771640198, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_Spacing.y
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829080691771640198, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_CellSize.x
+      value: 184
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829080691771640198, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_CellSize.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829080691771640198, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_ConstraintCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8413359027062790288, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotsGrid
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0b08d9ca8421644db83c1bd3f2e2e48, type: 3}
+--- !u!224 &9154448218146335532 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2026062374757361563, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+    type: 3}
+  m_PrefabInstance: {fileID: 7139655493980753079}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6598929307786099729 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4071603596337262758, guid: a0b08d9ca8421644db83c1bd3f2e2e48,
+    type: 3}
+  m_PrefabInstance: {fileID: 7139655493980753079}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d49a3b742109ef0499aa2a13d3e0bedf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &7623120821864147478
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.58778524
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.80901706
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
+--- !u!1001 &7703149663124182838
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.809017
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.58778524
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7339447326239381492, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
+--- !u!1001 &8166385654464063501
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090959044808528653, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.hasSeparator
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}
+--- !u!1001 &8919303567260152007
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9154448218146335532}
+    m_Modifications:
+    - target: {fileID: 15081824087338214, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 864803757783915505, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2649585802804597545, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_text
+      value: None
+      objectReference: {fileID: 0}
+    - target: {fileID: 2936501350912794315, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.95105654
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850750219364270930, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.309017
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5989498347712335370, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6600916271879440534, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691934938566017297, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_Name
+      value: EmoteSlotCard1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7339447326239381492, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.rarity
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.emoteName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875235463942680543, guid: fc8ae579143d63741bc0f33c409ca892,
+        type: 3}
+      propertyPath: model.slotNumber
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc8ae579143d63741bc0f33c409ca892, type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteSlotSelectorComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteSlotSelectorComponentView.cs
@@ -122,7 +122,10 @@ namespace DCL.EmotesCustomization
         internal List<EmoteSlotCardComponentView> GetAllSlots()
         {
             if (emotesSlots == null)
+            {
+                Debug.LogError("EmotesSlotSelectorComponentView: emotesSlots are accessed before serialized reference was initialized");
                 return new List<EmoteSlotCardComponentView>();
+            }
             
             return emotesSlots
                 .GetItems()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteSlotSelectorComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmoteSlotSelectorComponentView.cs
@@ -121,6 +121,9 @@ namespace DCL.EmotesCustomization
 
         internal List<EmoteSlotCardComponentView> GetAllSlots()
         {
+            if (emotesSlots == null)
+                return new List<EmoteSlotCardComponentView>();
+            
             return emotesSlots
                 .GetItems()
                 .Select(x => x as EmoteSlotCardComponentView)


### PR DESCRIPTION
## What does this PR change?

This PR fixes null reference exception happening in GetAllSlots method of EmoteSlotSelectorComponentView class for a user who has custom wearables. The exception happens during emote customization UI initialization, field emotesSlots (a serialized field of EmoteSlotSelectorComponentView) is null on that frame. This field is accessed on the same frame when game object of EmotesCustomizationSection is instantiated and the field is part of nested prefab EmoteSlotSelector but accessed with a chain of public methods before nested prefab EmoteSlotSelector is fully initialized with its instantiated parent.

Solution is to unpack EmoteSlotSelector prefab and make it part of EmotesCustomizationSection. This is the only usage of this nested prefab.

## How to test the changes?

Test everything regarding emotes and wearables:

If custom emotes and wearables are being selected, saved and loaded without issues.
If custom emotes and wearables appear on an avatar from his perspective and peer perspective.
If both embedded and custom emotes play without any issues.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md