### PR TITLE
Destroy particles on finish refactor

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/DestroyParticlesOnFinish.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/Utils/DestroyParticlesOnFinish.cs
@@ -1,14 +1,30 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 public class DestroyParticlesOnFinish : MonoBehaviour
 {
+    private const int INDEX_AMOUNT = 10;
+
     [SerializeField] private ParticleSystem particles;
+    private int index;
+
+
+    private void Awake()
+    {
+        if (particles == null)
+        {
+            Destroy(this);
+            return;
+        }
+
+        index = Random.Range(0, INDEX_AMOUNT);
+    }
 
     public void FixedUpdate()
     {
+        if (Time.frameCount % INDEX_AMOUNT != index)
+            return;
+
         if (particles != null && !particles.IsAlive())
-        {
             Destroy(gameObject);
-        }
     }
 }


### PR DESCRIPTION
fixes #3168 

## Changes
Destroy particles on finish now will:
- Remove itself as a component if no particles are attached, (the variable is private and can not be updated later)
- Sectioned the calls for fixed update based on a random index for each component, as there are 10 possible indexes, performance cost should cost about 10% of the previous one.

## QA
- No behavior changes on the particles should be observable, particles should keep acting exactly the same as in production.