### PR TITLE
Fix: fixed duplicated private chat notifications

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs
@@ -25,6 +25,7 @@ namespace DCL.Chat.Notifications
         private BaseVariable<string> openedChat => dataStore.HUDs.openedChat;
         private CancellationTokenSource fadeOutCT = new CancellationTokenSource();
         private UserProfile ownUserProfile;
+        private List<string> notificationEntries;
 
         public ChatNotificationController(DataStore dataStore,
             IMainChatNotificationsComponentView mainChatNotificationView,
@@ -36,6 +37,7 @@ namespace DCL.Chat.Notifications
             this.userProfileBridge = userProfileBridge;
             this.mainChatNotificationView = mainChatNotificationView;
             this.topNotificationView = topNotificationView;
+            notificationEntries = new List<string>();
             mainChatNotificationView.OnResetFade += ResetFadeOut;
             topNotificationView.OnResetFade += ResetFadeOut;
             mainChatNotificationView.OnPanelFocus += TogglePanelBackground;
@@ -68,7 +70,12 @@ namespace DCL.Chat.Notifications
                     ? "nearby"
                     : message.recipient);
                 if (channel?.Muted ?? false) return;
-                
+
+                if(notificationEntries.Contains(message.messageId))
+                    return;
+                else
+                    notificationEntries.Add(message.messageId);
+
                 var peerId = ExtractPeerId(message);
                 var peerProfile = userProfileBridge.Get(peerId);
                 var peerName = peerProfile?.userName ?? peerId;
@@ -80,11 +87,10 @@ namespace DCL.Chat.Notifications
                         var privateModel = new PrivateChatMessageNotificationModel(message.messageId,
                             message.sender, message.body, message.timestamp, peerName, peerProfilePicture);
 
-                        mainChatNotificationView.AddNewChatNotification(privateModel);
-
-                        if (topNotificationPanelTransform.Get().gameObject.activeInHierarchy)
+                        if(message.sender != openedChat.Get())
                         {
-                            if(message.sender != openedChat.Get())
+                            mainChatNotificationView.AddNewChatNotification(privateModel);
+                            if (topNotificationPanelTransform.Get().gameObject.activeInHierarchy)
                                 topNotificationView.AddNewChatNotification(privateModel);
                         }
                         break;
@@ -92,11 +98,10 @@ namespace DCL.Chat.Notifications
                         var publicModel = new PublicChannelMessageNotificationModel(message.messageId,
                             message.body, channel?.Name ?? message.recipient, channel?.ChannelId, message.timestamp, peerName);
 
-                        mainChatNotificationView.AddNewChatNotification(publicModel);
-
-                        if (topNotificationPanelTransform.Get().gameObject.activeInHierarchy)
+                        if(channel?.ChannelId != openedChat.Get())
                         {
-                            if(channel?.ChannelId != openedChat.Get())
+                            mainChatNotificationView.AddNewChatNotification(publicModel);
+                            if (topNotificationPanelTransform.Get().gameObject.activeInHierarchy)
                                 topNotificationView.AddNewChatNotification(publicModel);
                         }
                         break;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -315,6 +315,7 @@ public class TaskbarHUDController : IHUD
         CloseVoiceChatWindow();
         isExperiencesViewerOpen.Set(false);
 
+        openedChat.Set("");
         if (!privateChatWindow.View.IsActive
             && !publicChatWindow.View.IsActive
             && !channelChatWindow.View.IsActive)


### PR DESCRIPTION
Fixes the issue that caused notifications to be duplicated for private messages when opening the first time.

To test: 
* go to https://play.decentraland.zone/?NETWORK=goerli&ENABLE_NOTIFICATION_CHAT=&renderer-branch=fix/duplicated-notification&kernel-branch=fix%2Fchannels-profiles&realm=artemis&position=99%2C99
* Check private messages
* Open a new conversation from interacting with the notification
* Verify that notifications appear only when necessary and are not duplicated