### PR TITLE
Fix: fixed clicking on notification redirecting to non joined channel

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -685,7 +685,7 @@ public class TaskbarHUDController : IHUD
         
         if (chatId == nearbyChannelId)
             OpenPublicChat(nearbyChannelId, true);
-        else if (chatController.GetAllocatedChannel(chatId) != null)
+        else if (chatController.GetAllocatedChannel(chatId) != null && chatController.GetAllocatedChannel(chatId).Joined)
             OpenChannelChat(chatId);
         else if(chatId == conversationListId)
             OpenChatList();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -685,8 +685,13 @@ public class TaskbarHUDController : IHUD
         
         if (chatId == nearbyChannelId)
             OpenPublicChat(nearbyChannelId, true);
-        else if (chatController.GetAllocatedChannel(chatId) != null && chatController.GetAllocatedChannel(chatId).Joined)
-            OpenChannelChat(chatId);
+        else if (chatController.GetAllocatedChannel(chatId) != null)
+        {
+            if(chatController.GetAllocatedChannel(chatId).Joined)
+                OpenChannelChat(chatId);
+            else
+                return;
+        }
         else if(chatId == conversationListId)
             OpenChatList();
         else


### PR DESCRIPTION
* Go to https://play.decentraland.zone/?NETWORK=goerli&ENABLE_NOTIFICATION_CHAT=&renderer-branch=fix/join-channel-notific&kernel-branch=fix%2Fchannels-profiles&realm=artemis&position=99%2C99
* Join a channel
* Receive notifications from that channel
* Leave the channel
* Click on the notification and check if it joins back in the channel