### PR TITLE
fix: [SUB-BRANCH] Open already joined channels from link

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChatChannelsControllerMock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/ChatChannelsControllerMock.cs
@@ -760,5 +760,7 @@ Invite others to join by quoting the channel name in other chats or include it a
             };
             controller.UpdateChannelMembers(JsonUtility.ToJson(msg));
         }
+
+        public Channel GetAllocatedChannelByName(string channelName) => null;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
@@ -264,7 +264,7 @@ public class ChatController : MonoBehaviour, IChatController
         channels.ContainsKey(channelId) ? channels[channelId] : null;
     
     public Channel GetAllocatedChannelByName(string channelName) =>
-        channels.Select(x => x.Value).FirstOrDefault(x => x.Name == channelName);
+        channels.Values.FirstOrDefault(x => x.Name == channelName);
     
     public void GetPrivateMessages(string userId, int limit, string fromMessageId) =>
         WebInterface.GetPrivateMessages(userId, limit, fromMessageId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
@@ -263,6 +263,9 @@ public class ChatController : MonoBehaviour, IChatController
     public Channel GetAllocatedChannel(string channelId) =>
         channels.ContainsKey(channelId) ? channels[channelId] : null;
     
+    public Channel GetAllocatedChannelByName(string channelName) =>
+        channels.Select(x => x.Value).FirstOrDefault(x => x.Name == channelName);
+    
     public void GetPrivateMessages(string userId, int limit, string fromMessageId) =>
         WebInterface.GetPrivateMessages(userId, limit, fromMessageId);
     

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChatController.cs
@@ -36,6 +36,7 @@ public interface IChatController
     void MuteChannel(string channelId);
     void UnmuteChannel(string channelId);
     Channel GetAllocatedChannel(string channelId);
+    Channel GetAllocatedChannelByName(string channelName);
     void GetUnseenMessagesByUser();
     void GetUnseenMessagesByChannel();
     int GetAllocatedUnseenMessages(string userId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/Helpers/ChatController_Mock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/Helpers/ChatController_Mock.cs
@@ -118,4 +118,6 @@ public class ChatController_Mock : IChatController
     public void GetChannelMembers(string channelId, int limit, int skip)
     {
     }
+
+    public Channel GetAllocatedChannelByName(string channelName) => null;
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/JoinChannelComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/JoinChannelComponentController.cs
@@ -66,9 +66,17 @@ public class JoinChannelComponentController : IDisposable
 
     private void OnConfirmJoin(string channelName)
     {
-        channelName = channelName.Replace("#", "").Replace("~", "");
+        channelName = channelName
+            .Replace("#", "")
+            .Replace("~", "")
+            .ToLower();
 
-        chatController.JoinOrCreateChannel(channelName);
+        var alreadyJoinedChannel = chatController.GetAllocatedChannelByName(channelName);
+
+        if (alreadyJoinedChannel == null)
+            chatController.JoinOrCreateChannel(channelName);
+        else
+            dataStore.channels.channelToBeOpenedFromLink.Set(alreadyJoinedChannel.ChannelId);
 
         if (channelsDataStore.channelJoinedSource.Get() == ChannelJoinedSource.Link)
             socialAnalytics.SendChannelLinkClicked(channelName, true, GetChannelLinkSource());

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/Tests/JoinChannelComponentControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/Tests/JoinChannelComponentControllerShould.cs
@@ -86,7 +86,7 @@ public class JoinChannelComponentControllerShould
         joinChannelComponentView.OnConfirmJoin += Raise.Event<Action<string>>(testChannelId);
 
         // Assert
-        chatController.Received(1).JoinOrCreateChannel(testChannelId);
+        chatController.Received(1).JoinOrCreateChannel(testChannelId.ToLower());
         joinChannelComponentView.Received(1).Hide();
         Assert.IsNull(channelsDataStore.currentJoinChannelModal.Get());
     }
@@ -114,6 +114,6 @@ public class JoinChannelComponentControllerShould
         
         joinChannelComponentView.OnConfirmJoin += Raise.Event<Action<string>>(channelId);
 
-        socialAnalytics.Received(1).SendChannelLinkClicked(channelId, true, ChannelLinkSource.Profile);
+        socialAnalytics.Received(1).SendChannelLinkClicked(channelId.ToLower(), true, ChannelLinkSource.Profile);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -345,11 +345,7 @@ public class TaskbarHUDController : IHUD
         worldChatWindowHud.OnOpenChannelLeave += OpenChannelLeaveConfirmation;
     }
 
-    private void OpenPublicChatOnPreviewMode()
-    {
-        publicChatWindow.SetVisibility(false, false);
-        view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
-    }
+    private void OpenPublicChatOnPreviewMode() => view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
 
     private void OpenFriendsWindow()
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -101,8 +101,11 @@ namespace DCL.Chat.HUD
 
         public void SetVisibility(bool visible)
         {
-            if (View.IsActive == visible) return;
+            if (View.IsActive == visible &&
+                dataStore.channels.channelToBeOpenedFromLink.Get() != channelId)
+                return;
 
+            dataStore.channels.channelToBeOpenedFromLink.Set(null, notifyEvent: false);
             SetVisiblePanelList(visible);
             
             if (visible)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -101,10 +101,6 @@ namespace DCL.Chat.HUD
 
         public void SetVisibility(bool visible)
         {
-            if (View.IsActive == visible &&
-                dataStore.channels.channelToBeOpenedFromLink.Get() != channelId)
-                return;
-
             SetVisiblePanelList(visible);
             
             if (visible)
@@ -145,9 +141,7 @@ namespace DCL.Chat.HUD
 
                 channelMembersHUDController.SetAutomaticReloadingActive(false);
                 chatHudController.UnfocusInputField();
-
-                if (dataStore.channels.channelToBeOpenedFromLink.Get() != "nearby")
-                    OnClosed?.Invoke();
+                OnClosed?.Invoke();
 
                 View.Hide();
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -105,7 +105,6 @@ namespace DCL.Chat.HUD
                 dataStore.channels.channelToBeOpenedFromLink.Get() != channelId)
                 return;
 
-            dataStore.channels.channelToBeOpenedFromLink.Set(null, notifyEvent: false);
             SetVisiblePanelList(visible);
             
             if (visible)
@@ -146,9 +145,14 @@ namespace DCL.Chat.HUD
 
                 channelMembersHUDController.SetAutomaticReloadingActive(false);
                 chatHudController.UnfocusInputField();
-                OnClosed?.Invoke();
+
+                if (dataStore.channels.channelToBeOpenedFromLink.Get() != "nearby")
+                    OnClosed?.Invoke();
+
                 View.Hide();
             }
+
+            dataStore.channels.channelToBeOpenedFromLink.Set(null, notifyEvent: false);
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -142,7 +142,6 @@ namespace DCL.Chat.HUD
                 channelMembersHUDController.SetAutomaticReloadingActive(false);
                 chatHudController.UnfocusInputField();
                 OnClosed?.Invoke();
-
                 View.Hide();
             }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -131,6 +131,7 @@ public class WorldChatWindowController : IHUD
             chatController.OnJoinChannelError += HandleJoinChannelError;
             chatController.OnChannelLeaveError += HandleLeaveChannelError;
             chatController.OnChannelLeft += HandleChannelLeft;
+            dataStore.channels.channelToBeOpenedFromLink.OnChange += HandleChannelOpenedFromLink;
 
             view.ShowChannelsLoading();
             view.SetSearchAndCreateContainerActive(true);
@@ -165,6 +166,7 @@ public class WorldChatWindowController : IHUD
         friendsController.OnUpdateUserStatus -= HandleUserStatusChanged;
         friendsController.OnUpdateFriendship -= HandleFriendshipUpdated;
         friendsController.OnInitialized -= HandleFriendsControllerInitialization;
+        dataStore.channels.channelToBeOpenedFromLink.OnChange -= HandleChannelOpenedFromLink;
 
         if (ownUserProfile != null)
             ownUserProfile.OnUpdate -= OnUserProfileUpdate;
@@ -532,7 +534,15 @@ public class WorldChatWindowController : IHUD
         view.RemovePublicChat(channelId);
         socialAnalytics.SendLeaveChannel(channelId, dataStore.channels.channelLeaveSource.Get());
     }
-    
+
+    private void HandleChannelOpenedFromLink(string channelId, string previousChannelId)
+    {
+        if (string.IsNullOrEmpty(channelId))
+            return;
+
+        OpenPublicChat(channelId);
+    }
+
     private void RequestUnreadMessages() => chatController.GetUnseenMessagesByUser();
 
     private void RequestUnreadChannelsMessages() => chatController.GetUnseenMessagesByChannel();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Channels.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Channels.cs
@@ -1,4 +1,4 @@
-﻿namespace DCL
+namespace DCL
 {
     public class DataStore_Channels
     {
@@ -9,5 +9,6 @@
         public readonly BaseVariable<string> currentChannelLimitReached = new BaseVariable<string>();
         public readonly BaseVariable<string> joinChannelError = new BaseVariable<string>();
         public readonly BaseVariable<string> leaveChannelError = new BaseVariable<string>();
+        public readonly BaseVariable<string> channelToBeOpenedFromLink = new BaseVariable<string>();
     }
 }


### PR DESCRIPTION
## What does this PR change?
If you click on a link of a channel where you are already joined, it should redirect to this channel instead of trying to join it.

## How to test the changes?
https://play.decentraland.zone/?renderer-branch=fix/open-joined-channels-from-link&kernel-branch=feat/feature-flag-for-channels

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md