### PR TITLE
feat: message feedback whenever you are muted due spam filtering

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -73,6 +73,7 @@ namespace DCL.Chat.HUD
             chatHudController = new ChatHUDController(dataStore, userProfileBridge, false, profanityFilter);
             chatHudController.Initialize(view.ChatHUD);
             chatHudController.OnSendMessage += HandleSendChatMessage;
+            chatHudController.OnMessageSentBlockedBySpam += HandleMessageBlockedBySpam;
 
             if (mouseCatcher != null)
                 mouseCatcher.OnMouseLock += Hide;
@@ -156,6 +157,9 @@ namespace DCL.Chat.HUD
                 mouseCatcher.OnMouseLock -= Hide;
 
             toggleChatTrigger.OnTriggered -= HandleChatInputTriggered;
+            
+            chatHudController.OnSendMessage -= HandleSendChatMessage;
+            chatHudController.OnMessageSentBlockedBySpam -= HandleMessageBlockedBySpam;
 
             if (View != null)
             {
@@ -367,6 +371,18 @@ namespace DCL.Chat.HUD
         {
             chatHudController.FocusInputField();
             MarkChannelMessagesAsRead();
+        }
+        
+        private void HandleMessageBlockedBySpam(ChatMessage message)
+        {
+            chatHudController.AddChatMessage(new ChatEntryModel
+            {
+                timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                bodyText = "You sent too many messages in a short period of time. Please wait and try again later.",
+                messageId = Guid.NewGuid().ToString(),
+                messageType = ChatMessage.Type.SYSTEM,
+                subType = ChatEntryModel.SubType.RECEIVED
+            });
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
@@ -55,6 +55,7 @@ public class PublicChatWindowController : IHUD
             profanityFilter);
         chatHudController.Initialize(view.ChatHUD);
         chatHudController.OnSendMessage += SendChatMessage;
+        chatHudController.OnMessageSentBlockedBySpam += HandleMessageBlockedBySpam;
 
         chatController.OnAddMessage -= HandleMessageReceived;
         chatController.OnAddMessage += HandleMessageReceived;
@@ -87,6 +88,7 @@ public class PublicChatWindowController : IHUD
             chatController.OnAddMessage -= HandleMessageReceived;
 
         chatHudController.OnSendMessage -= SendChatMessage;
+        chatHudController.OnMessageSentBlockedBySpam -= HandleMessageBlockedBySpam;
 
         if (mouseCatcher != null)
             mouseCatcher.OnMouseLock -= Hide;
@@ -204,5 +206,17 @@ public class PublicChatWindowController : IHUD
     {
         if (!View.IsActive) return;
         chatHudController.FocusInputField();
+    }
+    
+    private void HandleMessageBlockedBySpam(ChatMessage message)
+    {
+        chatHudController.AddChatMessage(new ChatEntryModel
+        {
+            timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            bodyText = "You sent too many messages in a short period of time. Please wait and try again later.",
+            messageId = Guid.NewGuid().ToString(),
+            messageType = ChatMessage.Type.SYSTEM,
+            subType = ChatEntryModel.SubType.RECEIVED
+        });
     }
 }


### PR DESCRIPTION
## What does this PR change?

New rules has been applied to messages to be considered spam:
- time between messages lowered to 1000 milliseconds
- at least 10 messages
- 3 minutes of mute

A message has been added in the scroll whenever you try to send a message while you are muted.

## How to test the changes?

1. Open #nearby channel
2. Send messages very fast until you are considered spam. A system message should be received.
3. Open any channel window
4. Send messages very fast until you are considered spam. A system message should be received.
5. Open any private chat window
6. Send messages very fast until you are considered spam. A system message should be received.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
