### PR TITLE
feat: disable channel links if the user is not allowed to create channels

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
@@ -21,8 +21,16 @@ namespace DCL.Chat.Channels
         {
             this.dataStore = dataStore;
             this.userProfileBridge = userProfileBridge;
+        }
+        
+        public void Dispose()
+        {
+            userProfileBridge.GetOwn().OnUpdate -= OnUserProfileUpdate;
+        }
 
-            this.userProfileBridge.GetOwn().OnUpdate += OnUserProfileUpdate;
+        public void Initialize()
+        {
+            userProfileBridge.GetOwn().OnUpdate += OnUserProfileUpdate;
         }
 
         public bool IsChannelsFeatureEnabled() => featureFlags.Get().IsFeatureEnabled(FEATURE_FLAG_FOR_CHANNELS_FEATURE);
@@ -35,7 +43,7 @@ namespace DCL.Chat.Channels
             OnAllowedToCreateChannelsChanged?.Invoke(IsAllowedToCreateChannels());
         }
 
-        private bool IsAllowedToCreateChannels()
+        public bool IsAllowedToCreateChannels()
         {
             if (!featureFlags.Get().IsFeatureEnabled(FEATURE_FLAG_FOR_USERS_ALLOWED_TO_CREATE_CHANNELS))
                 return false;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.asmdef
@@ -11,7 +11,8 @@
         "GUID:99cea83ca76dcd846abed7e61a8c90bd",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
-        "GUID:2995626b54c60644988f134a69a77450"
+        "GUID:2995626b54c60644988f134a69a77450",
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChannelsFeatureFlagService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChannelsFeatureFlagService.cs
@@ -2,9 +2,10 @@ using System;
 
 namespace DCL.Chat
 {
-    public interface IChannelsFeatureFlagService
+    public interface IChannelsFeatureFlagService : IService
     {
         event Action<bool> OnAllowedToCreateChannelsChanged;
         bool IsChannelsFeatureEnabled();
+        bool IsAllowedToCreateChannels();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDFactory.cs
@@ -1,5 +1,6 @@
 using DCL;
 using DCL.Browser;
+using DCL.Chat;
 using DCL.Chat.Channels;
 using DCL.Chat.HUD;
 using DCL.HelpAndSupportHUD;
@@ -75,7 +76,7 @@ public class HUDFactory : IHUDFactory
                     new SocialAnalytics(
                         Environment.i.platform.serviceProviders.analytics,
                         new UserProfileWebInterfaceBridge()),
-                    new ChannelsFeatureFlagService(DataStore.i, new UserProfileWebInterfaceBridge()),
+                    Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>(),
                     new WebInterfaceBrowserBridge());
                 break;
             case HUDElementID.PRIVATE_CHAT_WINDOW:
@@ -120,7 +121,7 @@ public class HUDFactory : IHUDFactory
                         Environment.i.platform.serviceProviders.analytics,
                         new UserProfileWebInterfaceBridge()),
                     new UserProfileWebInterfaceBridge(),
-                    new ChannelsFeatureFlagService(DataStore.i, new UserProfileWebInterfaceBridge()));
+                    Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>());
                 break;
             case HUDElementID.CHANNELS_CREATE:
                 hudElement = new CreateChannelWindowController(ChatController.i, DataStore.i);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/JoinChannelModalPlugin.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/JoinChannelModalPlugin.cs
@@ -13,19 +13,15 @@ public class JoinChannelModalPlugin : IPlugin
 
     public JoinChannelModalPlugin()
     {
-        UserProfileWebInterfaceBridge userProfileWebInterfaceBridge = new UserProfileWebInterfaceBridge();
-
         joinChannelComponentController = new JoinChannelComponentController(
             JoinChannelComponentView.Create(),
             ChatController.i,
             DataStore.i,
             new SocialAnalytics(
                 Environment.i.platform.serviceProviders.analytics,
-                userProfileWebInterfaceBridge),
+                new UserProfileWebInterfaceBridge()),
             Resources.Load<StringVariable>("CurrentPlayerInfoCardId"),
-            new ChannelsFeatureFlagService(
-                DataStore.i,
-                userProfileWebInterfaceBridge));
+            Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>());
     }
 
     public void Dispose() { joinChannelComponentController.Dispose(); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/Tests/JoinChannelHUDTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/Tests/JoinChannelHUDTests.asmdef
@@ -10,7 +10,8 @@
         "DataStore",
         "ChatController",
         "BaseVariable",
-        "SocialAnalytics"
+        "SocialAnalytics",
+        "IService"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowHUDTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowHUDTests.asmdef
@@ -27,7 +27,8 @@
         "GUID:fb9a2201bd406994ba1bb611dce74e70",
         "GUID:3bdb7fe910cce8d4888137cded3ba4a2",
         "GUID:82a93299762ed164a99e475bc89d323c",
-        "GUID:4d7712e4b2446440a8af21fd3ce8690e"
+        "GUID:4d7712e4b2446440a8af21fd3ce8690e",
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.asmdef
@@ -50,7 +50,8 @@
         "GUID:7ac9f9c835ec1084ab35e3f9b176cf1e",
         "GUID:570a7a92aac340549a8afe536c29f47a",
         "GUID:7d068775c9a144e8af0bd529031f9d1d",
-        "GUID:b75dc662b69c26c40bf39793301425c5"
+        "GUID:b75dc662b69c26c40bf39793301425c5",
+        "GUID:28f74c468a54948bfa9f625c5d428f56"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.cs
@@ -1,4 +1,6 @@
-﻿using DCL.Controllers;
+﻿using DCL.Chat;
+using DCL.Chat.Channels;
+using DCL.Controllers;
 using DCL.Emotes;
 using DCL.Rendering;
 using DCL.Services;
@@ -40,7 +42,9 @@ namespace DCL
             // HUD
             result.Register<IHUDFactory>(() => new HUDFactory());
             result.Register<IHUDController>(() => new HUDController());
-
+            result.Register<IChannelsFeatureFlagService>(() =>
+                new ChannelsFeatureFlagService(DataStore.i, new UserProfileWebInterfaceBridge()));
+            
             result.Register<IAudioDevicesService>(() => new WebBrowserAudioDevicesService(WebBrowserAudioDevicesBridge.GetOrCreate()));
 
             return result;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/ChannelLinkDetector.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/ChannelLinkDetector.cs
@@ -22,10 +22,15 @@ public class ChannelLinkDetector : MonoBehaviour, IPointerClickHandler
             return;
 
         textComponent.OnPreRenderText += OnTextComponentPreRenderText;
-        channelsFeatureFlagService = Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>();
-        isAllowedToCreateChannels = channelsFeatureFlagService.IsChannelsFeatureEnabled()
-                                    && channelsFeatureFlagService.IsAllowedToCreateChannels();
-        channelsFeatureFlagService.OnAllowedToCreateChannelsChanged += OnAllowedToCreateChannelsChanged;
+        
+        if (Environment.i != null
+            && Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>() != null)
+        {
+            channelsFeatureFlagService = Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>();
+            isAllowedToCreateChannels = channelsFeatureFlagService.IsChannelsFeatureEnabled()
+                                        && channelsFeatureFlagService.IsAllowedToCreateChannels();
+            channelsFeatureFlagService.OnAllowedToCreateChannelsChanged += OnAllowedToCreateChannelsChanged;
+        }
     }
 
     private void OnDestroy()
@@ -34,7 +39,9 @@ public class ChannelLinkDetector : MonoBehaviour, IPointerClickHandler
             return;
 
         textComponent.OnPreRenderText -= OnTextComponentPreRenderText;
-        channelsFeatureFlagService.OnAllowedToCreateChannelsChanged -= OnAllowedToCreateChannelsChanged;
+        
+        if (channelsFeatureFlagService != null)
+            channelsFeatureFlagService.OnAllowedToCreateChannelsChanged -= OnAllowedToCreateChannelsChanged;
     }
 
     private void OnAllowedToCreateChannelsChanged(bool isAllowed) =>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/UIHelpers.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/UIHelpers.asmdef
@@ -8,7 +8,10 @@
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:d076a2c146613441bb926f5b49a88a9f",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca"
+        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca",
+        "GUID:eb95615676ca6984687c5ae7774d6309",
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
+        "GUID:fbcc413e192ef9048811d47ab0aca0c0"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?

Channel links (like #channel-example) are disabled if the user is not able to create channels through feature flag.

## How to test the changes?

1. Login with a user that is able to create channels
2. Write #any-channel in chat
3. The channel link should work
4. Login with a user that is not able to create channels
5. Write #any-channel in chat
6. The channel link should not work

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
