### PR TITLE
Pooling Stickers Controller

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
@@ -49,6 +49,15 @@ namespace DCL
 
         public int usedObjectsCount { get { return usedObjects.Count; } }
 
+        public Pool(string name, GameObject original, int maxPrewarmCount)
+        {
+            if (PoolManager.USE_POOL_CONTAINERS)
+                container = new GameObject("Pool - " + name);
+
+            this.original = original;
+            this.maxPrewarmCount = maxPrewarmCount;
+        }
+
         public Pool(string name, int maxPrewarmCount)
         {
             if (PoolManager.USE_POOL_CONTAINERS)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersController.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersController.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:4016c129fc7e2bd4eba9d6ee09f42a69",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:cc6bfabbfe87b7949aa248893f89ce37"
+        "GUID:cc6bfabbfe87b7949aa248893f89ce37",
+        "GUID:82873c2d9c9cbe94391e6b33e5153865"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersController.cs
@@ -1,13 +1,21 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace DCL
 {
     public class StickersController : MonoBehaviour
     {
+        private const int POOL_PREWARM_COUNT = 10;
+        private Dictionary<string, Pool> pools = new Dictionary<string, Pool>();
         private StickersFactory stickersFactory;
         private bool isInHideArea;
 
-        private void Awake() { stickersFactory = Resources.Load<StickersFactory>("StickersFactory"); }
+        private void Awake()
+        {
+            stickersFactory = Resources.Load<StickersFactory>("StickersFactory");
+
+            ConfigurePools();
+        }
 
         public void PlaySticker(string id)
         {
@@ -38,6 +46,29 @@ namespace DCL
         public void ToggleHideArea(bool entered)
         {
             isInHideArea = entered;
+        }
+
+        internal void ConfigurePools()
+        {
+            List<StickersFactory.StickerFactoryEntry> stickers = stickersFactory.GetStickersList();
+
+            foreach (StickersFactory.StickerFactoryEntry stricker in stickers)
+            {
+                string nameID = $"Sticker {stricker.id}";
+                Pool pool = PoolManager.i.GetPool(nameID);
+                if (pool == null)
+                {
+                    pool = PoolManager.i.AddPool(
+                        nameID,
+                        Instantiate(stricker.stickerPrefab),
+                        maxPrewarmCount: POOL_PREWARM_COUNT,
+                        isPersistent: true);
+
+                    pool.ForcePrewarm();
+                }
+
+                pools.Add(stricker.id, pool);
+            }
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersController.cs
@@ -31,15 +31,15 @@ namespace DCL
             if (DCL.Configuration.EnvironmentSettings.RUNNING_TESTS)
                 return;
 
-            GameObject emoteGameObject = Instantiate(prefab);
-            emoteGameObject.transform.position += position;
-            emoteGameObject.transform.rotation = Quaternion.Euler(prefab.transform.rotation.eulerAngles + direction);
+            GameObject sticker = pools[id].Get().gameObject;
+            sticker.transform.position += position;
+            sticker.transform.rotation = Quaternion.Euler(prefab.transform.rotation.eulerAngles + direction);
 
             if (followTransform)
             {
-                FollowObject emoteFollow = emoteGameObject.AddComponent<FollowObject>();
-                emoteFollow.target = transform;
-                emoteFollow.offset = prefab.transform.position;
+                FollowObject stickerFollow = sticker.AddComponent<FollowObject>();
+                stickerFollow.target = transform;
+                stickerFollow.offset = prefab.transform.position;
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/StickersController/StickersFactory.cs
@@ -1,5 +1,7 @@
+using DCL;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "StickersFactory", menuName = "Variables/StickersFactory")]
@@ -25,6 +27,11 @@ public class StickersFactory : ScriptableObject
         {
             stickers.Add(stickersList[i].id, stickersList[i].stickerPrefab);
         }
+    }
+
+    public List<StickerFactoryEntry> GetStickersList()
+    {
+        return new List<StickerFactoryEntry>(stickersList);
     }
 
     public bool TryGet(string id, out GameObject stickerPrefab)


### PR DESCRIPTION
fixes #3169 

## Task
Use the DCL pooling system to instantiate stickers instead of instantiating and destroying a virtually infinite amount of elements

## QA
- The stickers refactor changed how stickers are instantiated, but there should be no visible changes for them
- If more than 10 stickers of the same exact time exist at the same time, only the last 10 will be visible, the other ones will get destroyed. (Only 10 stickers of the same exact time can be present at a given moment)
