### PR TITLE
Feat: added new auto join channels functionality

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/AutomaticJoinChannel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/AutomaticJoinChannel.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace DCL.Chat.Channels
+{
+    [Serializable]
+    public class AutomaticJoinChannelList
+    {
+        public AutomaticJoinChannel[] automaticJoinChannelList;
+    }
+
+    [Serializable]
+    public class AutomaticJoinChannel
+    {
+        public string channelName;
+        public bool enableNotifications;
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/AutomaticJoinChannel.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Channels/AutomaticJoinChannel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b4d9fc2cabc24b1e8674d1a45382364
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
@@ -17,16 +17,19 @@ namespace DCL.Chat.Channels
 
         private readonly DataStore dataStore;
         private readonly IUserProfileBridge userProfileBridge;
+        private readonly IChatController chatController;
 
         public event Action<bool> OnAllowedToCreateChannelsChanged;
         public event Action<AutomaticJoinChannelList> OnAutoJoinChannelsChanged;
 
-        public ChannelsFeatureFlagService(DataStore dataStore, IUserProfileBridge userProfileBridge)
+        public ChannelsFeatureFlagService(DataStore dataStore, IUserProfileBridge userProfileBridge, IChatController chatController)
         {
             this.dataStore = dataStore;
             this.userProfileBridge = userProfileBridge;
+            this.chatController = chatController;
 
             this.userProfileBridge.GetOwn().OnUpdate += OnUserProfileUpdate;
+            this.chatController.OnInitialized += () => OnAutoJoinChannelsChanged?.Invoke(GetAutoJoinChannelsList());
         }
 
         public bool IsChannelsFeatureEnabled() => featureFlags.Get().IsFeatureEnabled(FEATURE_FLAG_FOR_CHANNELS_FEATURE);
@@ -37,7 +40,6 @@ namespace DCL.Chat.Channels
                 return;
 
             OnAllowedToCreateChannelsChanged?.Invoke(IsAllowedToCreateChannels());
-            OnAutoJoinChannelsChanged?.Invoke(GetAutoJoinChannelsList());
         }
 
         private AutomaticJoinChannelList GetAutoJoinChannelsList()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -9,6 +10,8 @@ namespace DCL.Chat.Channels
         private const string FEATURE_FLAG_FOR_CHANNELS_FEATURE = "matrix_channels_enabled";
         private const string FEATURE_FLAG_FOR_USERS_ALLOWED_TO_CREATE_CHANNELS = "users_allowed_to_create_channels";
         private const string VARIANT_FOR_USERS_ALLOWED_TO_CREATE_CHANNELS = "allowedUsers";
+        private const string FEATURE_FLAG_FOR_AUTOMATIC_JOIN_CHANNELS = "automatic_joined_channels";
+        private const string VARIANT_FOR_AUTOMATIC_JOIN_CHANNELS = "automaticChannels";
 
         private BaseVariable<FeatureFlag> featureFlags => dataStore.featureFlags.flags;
 
@@ -16,6 +19,7 @@ namespace DCL.Chat.Channels
         private readonly IUserProfileBridge userProfileBridge;
 
         public event Action<bool> OnAllowedToCreateChannelsChanged;
+        public event Action<AutomaticJoinChannelList> OnAutoJoinChannelsChanged;
 
         public ChannelsFeatureFlagService(DataStore dataStore, IUserProfileBridge userProfileBridge)
         {
@@ -33,6 +37,20 @@ namespace DCL.Chat.Channels
                 return;
 
             OnAllowedToCreateChannelsChanged?.Invoke(IsAllowedToCreateChannels());
+            OnAutoJoinChannelsChanged?.Invoke(GetAutoJoinChannelsList());
+        }
+
+        private AutomaticJoinChannelList GetAutoJoinChannelsList()
+        {
+            if (!featureFlags.Get().IsFeatureEnabled(FEATURE_FLAG_FOR_AUTOMATIC_JOIN_CHANNELS))
+                return null;
+
+            FeatureFlagVariantPayload ffChannelsList = featureFlags
+                .Get()
+                .GetFeatureFlagVariantPayload($"{FEATURE_FLAG_FOR_AUTOMATIC_JOIN_CHANNELS}:{VARIANT_FOR_AUTOMATIC_JOIN_CHANNELS}");
+
+            AutomaticJoinChannelList autoJoinChannelsList = JsonUtility.FromJson<AutomaticJoinChannelList>(ffChannelsList.value);
+            return autoJoinChannelsList;
         }
 
         private bool IsAllowedToCreateChannels()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChannelsFeatureFlagService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/IChannelsFeatureFlagService.cs
@@ -1,10 +1,13 @@
 using System;
+using DCL.Chat.Channels;
 
 namespace DCL.Chat
 {
     public interface IChannelsFeatureFlagService
     {
         event Action<bool> OnAllowedToCreateChannelsChanged;
+        event Action<AutomaticJoinChannelList> OnAutoJoinChannelsChanged;
+
         bool IsChannelsFeatureEnabled();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDFactory.cs
@@ -75,7 +75,7 @@ public class HUDFactory : IHUDFactory
                     new SocialAnalytics(
                         Environment.i.platform.serviceProviders.analytics,
                         new UserProfileWebInterfaceBridge()),
-                    new ChannelsFeatureFlagService(DataStore.i, new UserProfileWebInterfaceBridge()),
+                    new ChannelsFeatureFlagService(DataStore.i, new UserProfileWebInterfaceBridge(), ChatController.i),
                     new WebInterfaceBrowserBridge());
                 break;
             case HUDElementID.PRIVATE_CHAT_WINDOW:
@@ -120,7 +120,7 @@ public class HUDFactory : IHUDFactory
                         Environment.i.platform.serviceProviders.analytics,
                         new UserProfileWebInterfaceBridge()),
                     new UserProfileWebInterfaceBridge(),
-                    new ChannelsFeatureFlagService(DataStore.i, new UserProfileWebInterfaceBridge()));
+                    new ChannelsFeatureFlagService(DataStore.i, new UserProfileWebInterfaceBridge(), ChatController.i));
                 break;
             case HUDElementID.CHANNELS_CREATE:
                 hudElement = new CreateChannelWindowController(ChatController.i, DataStore.i);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/JoinChannelModalPlugin.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/JoinChannelModalPlugin.cs
@@ -25,7 +25,8 @@ public class JoinChannelModalPlugin : IPlugin
             Resources.Load<StringVariable>("CurrentPlayerInfoCardId"),
             new ChannelsFeatureFlagService(
                 DataStore.i,
-                userProfileWebInterfaceBridge));
+                userProfileWebInterfaceBridge,
+                ChatController.i));
     }
 
     public void Dispose() { joinChannelComponentController.Dispose(); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
@@ -4,6 +4,7 @@ using Cysharp.Threading.Tasks;
 using Channel = DCL.Chat.Channels.Channel;
 using System.Collections.Generic;
 using SocialFeaturesAnalytics;
+using DCL.Chat.Channels;
 
 namespace DCL.Chat.HUD
 {
@@ -54,6 +55,7 @@ namespace DCL.Chat.HUD
             this.view = view;
 
             channelsFeatureFlagService.OnAllowedToCreateChannelsChanged += OnAllowedToCreateChannelsChanged;
+            channelsFeatureFlagService.OnAutoJoinChannelsChanged += OnAutoJoinChannelsChanged;
         }
 
         public void Dispose()
@@ -64,6 +66,7 @@ namespace DCL.Chat.HUD
             loadingCancellationToken.Dispose();
 
             channelsFeatureFlagService.OnAllowedToCreateChannelsChanged -= OnAllowedToCreateChannelsChanged;
+            channelsFeatureFlagService.OnAutoJoinChannelsChanged -= OnAutoJoinChannelsChanged;
         }
 
         private void SetVisiblePanelList(bool visible)
@@ -231,5 +234,18 @@ namespace DCL.Chat.HUD
         }
 
         private void OnAllowedToCreateChannelsChanged(bool isAllowed) => view.SetCreateChannelButtonsActive(isAllowed);
+
+        private void OnAutoJoinChannelsChanged(AutomaticJoinChannelList joinChannelList) 
+        {
+            for(int i=0;i<joinChannelList.automaticJoinChannelList.Length ;i++)
+            {
+                UnityEngine.Debug.Log(joinChannelList.automaticJoinChannelList[i].channelName);
+                dataStore.channels.channelJoinedSource.Set(ChannelJoinedSource.Search);
+                chatController.JoinOrCreateChannel(joinChannelList.automaticJoinChannelList[i].channelName);
+                
+                if(!joinChannelList.automaticJoinChannelList[i].enableNotifications)
+                    chatController.MuteChannel(joinChannelList.automaticJoinChannelList[i].channelName);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fix #3158 
Adds the possibility of defining a feature flag in unleashed to create a list of channels to force users to auto join with the possibility of enabling/disabling the notifications by default

...

## How to test the changes?


1. Go to: https://play.decentraland.zone/?renderer-branch=feat/auto-channel&kernel-branch=fix/channels-messages
2. Verify that the automatically joined channels are the ones typed here: https://features.decentraland.systems/#/features/variants/explorer-automatic_joined_channels
3. Verify that the notifications for those channels are enabled and disabled based on the FF variant definition
4. More info at #3158 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
