### PR TITLE
clear unseen messages at the start of the session for each joined channel

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
@@ -563,6 +563,23 @@ public class WorldChatWindowControllerShould
         browserBridge.Received(1).OpenUrl("https://docs.decentraland.org/player/blockchain-integration/get-a-wallet/");
     }
 
+    [Test]
+    public void ClearOfflineMessagesOnlyTheFirstTime()
+    {
+        controller.Initialize(view);
+        chatController.ClearReceivedCalls();
+
+        chatController.OnChannelUpdated += Raise.Event<Action<Channel>>(
+            new Channel("channelId", "channelName", 0, 1, true, false, ""));
+        chatController.OnChannelUpdated += Raise.Event<Action<Channel>>(
+            new Channel("otherChannelId", "otherChannelName", 0, 1, true, false, ""));
+        chatController.OnChannelUpdated += Raise.Event<Action<Channel>>(
+            new Channel("channelId", "channelName", 0, 1, true, false, ""));
+        
+        chatController.Received(1).MarkChannelMessagesAsSeen("channelId");
+        chatController.Received(1).MarkChannelMessagesAsSeen("otherChannelId");
+    }
+
     private void GivenFriend(string friendId, PresenceStatus presence)
     {
         var friendProfile = ScriptableObject.CreateInstance<UserProfile>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -30,6 +30,7 @@ public class WorldChatWindowController : IHUD
     private readonly IBrowserBridge browserBridge;
     private readonly Dictionary<string, PublicChatModel> publicChannels = new Dictionary<string, PublicChatModel>();
     private readonly Dictionary<string, ChatMessage> lastPrivateMessages = new Dictionary<string, ChatMessage>();
+    private readonly HashSet<string> channelsClearedUnseenNotifications = new HashSet<string>();
     private BaseVariable<HashSet<string>> visibleTaskbarPanels => dataStore.HUDs.visibleTaskbarPanels;
     private int hiddenDMs;
     private string currentSearch = "";
@@ -497,6 +498,17 @@ public class WorldChatWindowController : IHUD
         
         view.SetPublicChat(model);
         view.HideChannelsLoading();
+
+        // we clear the unseen messages to avoid showing many of them while the user was offline
+        // TODO: we should consider avoid clearing when the channel is private in the future
+        ClearOfflineUnseenMessages(channelId);
+    }
+
+    private void ClearOfflineUnseenMessages(string channelId)
+    {
+        if (channelsClearedUnseenNotifications.Contains(channelId)) return;
+        chatController.MarkChannelMessagesAsSeen(channelId);
+        channelsClearedUnseenNotifications.Add(channelId);
     }
 
     private void HandleChannelJoined(Channel channel)


### PR DESCRIPTION
## What does this PR change?

To avoid overwhelming the user with many unseen messages from channels, clear them at the start of the session for each channel joined.

## How to test the changes?

1. Start receiving channel messages while online. Unseen message counter should go up.
2. Go offline
3. Receive more message in different channels
4. Go online
5. Go to the conversation list
6. The unseen message counter should be reset to 0 to each joined channel

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
