### PR TITLE
feat: video streaming performance improvement

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -143,7 +143,7 @@ var WebVideoPlayer = {
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            ext.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT, 
+            ext.SRGB_EXT, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -33,8 +33,9 @@ var WebVideoPlayer = {
         };
         
         videos[Pointer_stringify(videoId)] = videoData;
-
-        if ('requestVideoFrameCallback' in HTMLVideoElement.prototype) {    
+        
+        // this function is not supported by Firefox
+        if ('requestVideoFrameCallback' in HTMLVideoElement.prototype) {     
             const onNewFrame = function (now, metadata) {
                 videoData.newFrame = true;
                 vid.requestVideoFrameCallback(onNewFrame);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -138,12 +138,11 @@ var WebVideoPlayer = {
         const textureId = videos[id].textureId;
         
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
-        const ext = GLctx.getExtension('EXT_sRGB');
-
+        
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            ext.SRGB_EXT, 
+            GLctx.SRGB8,
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -142,7 +142,7 @@ var WebVideoPlayer = {
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            GLctx.SRGB, 
+            GLctx.SRGB8, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -140,14 +140,15 @@ var WebVideoPlayer = {
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
         const ext = GLctx.getExtension('EXT_sRGB');
 
-        GLctx.texImage2D(
+        GLctx.texSubImage2D(
             GLctx.TEXTURE_2D,
             0,
-            GLctx.SRGB_ALPHA, 
+            0,
+            0,
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,
-            GLctx.RGBA,
+            ext.SRGB_ALPHA_EXT,
             GLctx.UNSIGNED_BYTE,
             videos[id].video
         );

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -140,15 +140,14 @@ var WebVideoPlayer = {
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
         const ext = GLctx.getExtension('EXT_sRGB');
 
-        GLctx.texSubImage2D(
+        GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            0,
-            0,
+            ext.SRGB_ALPHA_EXT, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,
-            ext.SRGB_ALPHA_EXT,
+            GLctx.RGBA,
             GLctx.UNSIGNED_BYTE,
             videos[id].video
         );

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -41,8 +41,6 @@ var WebVideoPlayer = {
             };
                     
             vid.requestVideoFrameCallback(onNewFrame);
-        } else if ('seekToNextFrame' in HTMLVideoElement.prototype) {
-            // TODO: firefox implementation 
         } else {
             videoData.useUpdateOptimization = false; // we ignore optimization if not supported
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -138,15 +138,16 @@ var WebVideoPlayer = {
         const textureId = videos[id].textureId;
         
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
+        const ext = GLctx.getExtension('EXT_sRGB');
 
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            GLctx.SRGB8, 
+            ext.SRGB_ALPHA_EXT, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,
-            GLctx.RGBA,
+            ext.SRGB_ALPHA_EXT,
             GLctx.UNSIGNED_BYTE,
             videos[id].video
         );

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -139,10 +139,11 @@ var WebVideoPlayer = {
 
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
 
+        // Warning! Profile performance when changing internalFormat and format parameters! For more details see PR: https://github.com/decentraland/unity-renderer/pull/3344 
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            GLctx.RGBA,
+            GLctx.RGBA, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -142,7 +142,7 @@ var WebVideoPlayer = {
         
         const textureId = videos[id].textureId;
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
-        GLctx.texStorage2D(
+        GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
             GLctx.SRGB8_ALPHA8,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -136,18 +136,18 @@ var WebVideoPlayer = {
         if (videos[id].state !== 4) return; //PLAYING
 
         const textureId = videos[id].textureId;
-
+        const ext = gl.getExtension('EXT_sRGB');
+        
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
 
-        // Warning! Profile performance when changing internalFormat and format parameters! For more details see PR: https://github.com/decentraland/unity-renderer/pull/3344 
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            GLctx.RGBA, 
+            ext.SRGB_EXT, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,
-            GLctx.RGBA,
+            ext.SRGB_EXT,
             GLctx.UNSIGNED_BYTE,
             videos[id].video
         );

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -19,16 +19,19 @@ var WebVideoPlayer = {
         vid.autoplay = false;
         
         if ('requestVideoFrameCallback' in HTMLVideoElement.prototype) {
+           console.log("VIDEO PLAYER: supported");
+           
            const onNewFrame = function (now, metadata) {
                 // newFrame = true
                 // Re-register the callback to be notified about the next frame.
                 console.log("VIDEO PLAYER: new Frame");
                 video.requestVideoFrameCallback(onNewFrame);
             };
-            onNewFrame();
+            video.requestVideoFrameCallback(onNewFrame);
         } else if ('seekToNextFrame' in HTMLVideoElement.prototype) {
             console.log("VIDEO PLAYER: firefox implementation");
         } else {
+            console.log("VIDEO PLAYER: ignoreNewFrameOptimization");
             ignoreNewFrameOptimization = true // we ignore the optimization of the newFrame=true/false, we always copy the texture
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -133,17 +133,15 @@ var WebVideoPlayer = {
 
     WebVideoPlayerTextureUpdate: function (videoId) {
         const id = Pointer_stringify(videoId);
-
         if (videos[id].state !== 4) return; //PLAYING
 
         const quality = videos[id].video.getVideoPlaybackQuality();
-        console.log("frames = " + quality.totalVideoFrames + "  current = " + videos[id].playedFrame);
+        if( quality.totalVideoFrames == videos[id].playedFrame) return;
+        
         videos[id].playedFrame = quality.totalVideoFrames;
         
         const textureId = videos[id].textureId;
-        
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
-
         GLctx.texStorage2D(
             GLctx.TEXTURE_2D,
             0,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -19,7 +19,7 @@ var WebVideoPlayer = {
         vid.autoplay = false;
         
         if ('requestVideoFrameCallback' in HTMLVideoElement.prototype) {
-            const onNewFrame = (now, metadata) => {
+           const onNewFrame = function (now, metadata) {
                 // newFrame = true
                 // Re-register the callback to be notified about the next frame.
                 console.log("VIDEO PLAYER: new Frame");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -146,10 +146,8 @@ var WebVideoPlayer = {
     },
 
     WebVideoPlayerTextureUpdate: function (videoId) {
-        const id = Pointer_stringify(videoId);
+        const videoData = videos[Pointer_stringify(videoId)];
         
-        const videoData = videos[id];
-
         if (videoData.state !== 4) return; //PLAYING
 
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[videoData.textureId]);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -143,11 +143,11 @@ var WebVideoPlayer = {
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            ext.SRGB_ALPHA_EXT, 
+            GLctx.SRGB_ALPHA, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,
-            ext.SRGB_ALPHA_EXT,
+            GLctx.RGBA,
             GLctx.UNSIGNED_BYTE,
             videos[id].video
         );

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -143,7 +143,7 @@ var WebVideoPlayer = {
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            ext.SRGB_ALPHA_EXT, 
+            ext.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -25,9 +25,9 @@ var WebVideoPlayer = {
                 // newFrame = true
                 // Re-register the callback to be notified about the next frame.
                 console.log("VIDEO PLAYER: new Frame");
-                video.requestVideoFrameCallback(onNewFrame);
+                vid.requestVideoFrameCallback(onNewFrame);
             };
-            video.requestVideoFrameCallback(onNewFrame);
+            vid.requestVideoFrameCallback(onNewFrame);
         } else if ('seekToNextFrame' in HTMLVideoElement.prototype) {
             console.log("VIDEO PLAYER: firefox implementation");
         } else {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -26,7 +26,8 @@ var WebVideoPlayer = {
             video: vid,
             state: videoState.NONE,
             error: "",
-            textureId: texId
+            textureId: texId,
+            playedFrame: 0
         };
 
         videos[Pointer_stringify(videoId)] = videoData;
@@ -135,12 +136,25 @@ var WebVideoPlayer = {
 
         if (videos[id].state !== 4) return; //PLAYING
 
+        const quality = videos[id].video.getVideoPlaybackQuality();
+        console.log("frames = " + quality.totalVideoFrames + "  current = " + videos[id].playedFrame);
+        videos[id].playedFrame = quality.totalVideoFrames;
+        
         const textureId = videos[id].textureId;
         
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
 
-        GLctx.texStorage2D(GLctx.TEXTURE_2D, 1, GLctx.SRGB8_ALPHA8, videos[id].video.videoWidth, videos[id].video.videoHeight);
-        GLctx.texSubImage2D(GLctx.TEXTURE_2D, 0, 0, 0, GLctx.RGBA, GLctx.UNSIGNED_BYTE, videos[id].video);
+        GLctx.texStorage2D(
+            GLctx.TEXTURE_2D,
+            0,
+            GLctx.SRGB8_ALPHA8,
+            videos[id].video.videoWidth,
+            videos[id].video.videoHeight,
+            0,
+            GLctx.RGBA,
+            GLctx.UNSIGNED_BYTE,
+            videos[id].video
+        );
     },
 
     WebVideoPlayerPlay: function (videoId, startTime) {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -143,6 +143,9 @@ var WebVideoPlayer = {
             GLctx.TEXTURE_2D,
             0,
             GLctx.RGBA,
+            videos[id].video.videoWidth,
+            videos[id].video.videoHeight,
+            0,
             GLctx.RGBA,
             GLctx.UNSIGNED_BYTE,
             videos[id].video

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -136,18 +136,17 @@ var WebVideoPlayer = {
         if (videos[id].state !== 4) return; //PLAYING
 
         const textureId = videos[id].textureId;
-        const ext = gl.getExtension('EXT_sRGB');
         
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
 
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            ext.SRGB_EXT, 
+            GLctx.SRGB, 
             videos[id].video.videoWidth,
             videos[id].video.videoHeight,
             0,
-            ext.SRGB_EXT,
+            GLctx.RGBA,
             GLctx.UNSIGNED_BYTE,
             videos[id].video
         );

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -32,7 +32,7 @@ var WebVideoPlayer = {
             console.log("VIDEO PLAYER: firefox implementation");
         } else {
             console.log("VIDEO PLAYER: ignoreNewFrameOptimization");
-            ignoreNewFrameOptimization = true // we ignore the optimization of the newFrame=true/false, we always copy the texture
+            // ignoreNewFrameOptimization = true // we ignore the optimization of the newFrame=true/false, we always copy the texture
         }
 
         var textureObject = GLctx.createTexture();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -138,18 +138,9 @@ var WebVideoPlayer = {
         const textureId = videos[id].textureId;
         
         GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[textureId]);
-        
-        GLctx.texImage2D(
-            GLctx.TEXTURE_2D,
-            0,
-            GLctx.SRGB8,
-            videos[id].video.videoWidth,
-            videos[id].video.videoHeight,
-            0,
-            GLctx.RGBA,
-            GLctx.UNSIGNED_BYTE,
-            videos[id].video
-        );
+
+        GLctx.texStorage2D(GLctx.TEXTURE_2D, 1, GLctx.SRGB8_ALPHA8, videos[id].video.videoWidth, videos[id].video.videoHeight);
+        GLctx.texSubImage2D(GLctx.TEXTURE_2D, 0, 0, 0, GLctx.RGBA, GLctx.UNSIGNED_BYTE, videos[id].video);
     },
 
     WebVideoPlayerPlay: function (videoId, startTime) {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -142,10 +142,7 @@ var WebVideoPlayer = {
         GLctx.texImage2D(
             GLctx.TEXTURE_2D,
             0,
-            GLctx.SRGB8_ALPHA8,
-            videos[id].video.videoWidth,
-            videos[id].video.videoHeight,
-            0,
+            GLctx.RGBA,
             GLctx.RGBA,
             GLctx.UNSIGNED_BYTE,
             videos[id].video


### PR DESCRIPTION
## What does this PR change?

- update video texture only when video frame is updated and not on browser frame update or Unity frame update

more details on [notion page](https://www.notion.so/decentraland/Video-Streaming-10-2022-5bd80fbea58e41d3a07793ba08565fda) 

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=feat%2Fvideo-streaming-performance&NETWORK=mainnet&position=-74%2C-99&CATALYST=peer-testing.decentraland.org&realm=peer-testing.decentraland.org&DEBUG_SCENE_LOG=&island=Idw
2. Run `/showfps` command in the chat
3. Press on the screen to play video and 
4. Observe it until it get sharp
5. Observe no fps drop at all (stable ~60 fps)

Additionally you can compare with https://play.decentraland.zone/?rNETWORK=mainnet&position=-74%2C-99&CATALYST=peer-testing.decentraland.org&realm=peer-testing.decentraland.org&DEBUG_SCENE_LOG=&island=Idw. However, now I see only 5-7 fps drop (compared to 20 fps drop as it was one week ago 🤔 I don't know why)

There is also test-scene with music video https://play.decentraland.zone/?renderer-branch=feat%2Fvideo-streaming-performance&NETWORK=mainnet&position=53%2C53&CATALYST=peer-testing.decentraland.org&DEBUG_SCENE_LOG=&island=Ikj
## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
