### PR TITLE
fix: Passport description disappears after friend request

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
@@ -33,11 +33,11 @@ public class PlayerInfoCardHUDView : MonoBehaviour
     [SerializeField] internal TabsMapping[] tabsMapping;
     [SerializeField] internal Button hideCardButton;
 
-    [Space] [SerializeField] internal RawImage avatarPicture;
+    [Space][SerializeField] internal RawImage avatarPicture;
     [SerializeField] internal Image blockedAvatarOverlay;
     [SerializeField] internal TextMeshProUGUI name;
 
-    [Header("Friends")] [SerializeField] internal GameObject friendStatusContainer;
+    [Header("Friends")][SerializeField] internal GameObject friendStatusContainer;
     [SerializeField] internal Button requestSentButton;
     [SerializeField] internal Button addFriendButton;
     [SerializeField] internal GameObject alreadyFriendsContainer;
@@ -45,12 +45,12 @@ public class PlayerInfoCardHUDView : MonoBehaviour
     [SerializeField] internal Button acceptRequestButton;
     [SerializeField] internal Button rejectRequestButton;
 
-    [Header("Passport")] [SerializeField] internal TextMeshProUGUI description;
+    [Header("Passport")][SerializeField] internal TextMeshProUGUI description;
 
-    [Header("Trade")] [SerializeField] private RectTransform wearablesContainer;
+    [Header("Trade")][SerializeField] private RectTransform wearablesContainer;
     [SerializeField] private GameObject emptyCollectiblesImage;
 
-    [Header("Block")] [SerializeField] internal Button reportPlayerButton;
+    [Header("Block")][SerializeField] internal Button reportPlayerButton;
     [SerializeField] internal Button blockPlayerButton;
     [SerializeField] internal Button unblockPlayerButton;
 
@@ -154,7 +154,11 @@ public class PlayerInfoCardHUDView : MonoBehaviour
 
     public void SetName(string name) => this.name.text = name;
 
-    public void SetDescription(string description) => this.description.text = description;
+    public void SetDescription(string description)
+    {
+        if (description != null)
+            this.description.text = description;
+    }
 
     public void HideFriendshipInteraction()
     {


### PR DESCRIPTION
fixes #3077 

After sending a friend request, the profile was being uploaded with a null description, without a null checking, the description disappeared.

##QA

When you send a friend request through the passport (PlayerInfo in the code), the description should not disappear, should remain there.