### PR TITLE
test: reduce culling controller budget

### DIFF
--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/CullingControllerSettings.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/CullingControllerSettings.cs
@@ -10,7 +10,7 @@ namespace DCL.Rendering
     public class CullingControllerSettings
     {
         [NonSerialized]
-        public float maxTimeBudget = 4 / 1000f;
+        public float maxTimeBudget = 0.5f / 1000f;
 
         public bool enableObjectCulling = true;
         public bool enableShadowCulling = true;


### PR DESCRIPTION
## Changes

- Reduced culling controller budget from 4 ms to 0.5 ms 

## Expected changes

- Higher FPS
- More stable FPS (less fluctuations)

## Possible Issues

- When walking around genesis plaza or the world, some objects might appear in your face slower than before ( if they are already loaded ) 

# Results

position: 0,0 
realm: offline
wait a few seconds after everything loads and then go down the waterfall and run the tool for 30 secs

THIS PR
```
 * PERFORMANCE SCORE (0-100) -> 94
 * lowest frame time -> 31.8ms
 * average frame time -> 37.1ms
 * highest frame time -> 100.0ms
 * 1 percentile frame time -> 32.7ms
 * 50 percentile frame time -> 35.9ms
 * 99 percentile frame time -> 51.4ms
 * error percentage -> ±0.9%
 * total hiccups (>0.05ms frames) -> 9 (1.11% of frames were hiccups)
 * total hiccups time (seconds) -> 0.710701
 * total frames -> 808
 * total frames time (seconds) -> 30.00316
```

PROD
```
* PERFORMANCE SCORE (0-100) -> 90
 * lowest frame time -> 33.6ms
 * average frame time -> 40.7ms
 * highest frame time -> 59.8ms
 * 1 percentile frame time -> 34.2ms
 * 50 percentile frame time -> 40.1ms
 * 99 percentile frame time -> 49.6ms
 * error percentage -> ±0.6%
 * total hiccups (>0.05ms frames) -> 5 (0.68% of frames were hiccups)
 * total hiccups time (seconds) -> 0.2673988
 * total frames -> 738
 * total frames time (seconds) -> 30.00173
```