### PR TITLE
fix: Private conversations left alive in the converdation list after unfriend

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
@@ -164,6 +164,7 @@ namespace DCL.Chat.HUD
 
         public void RemovePrivateChat(string userId)
         {
+            privateChatsCreationQueue.Remove(userId);
             directChatList.Remove(userId);
             searchResultsList.Remove(userId);
             UpdateHeaders();


### PR DESCRIPTION
## What does this PR change?
Sometimes, when we remove one of our a friends, his private conversation left alive in the conversations list. Now, this private message should be removed correctly.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/private-conversations-left-alive-in-conversations-list
2. Start a private conversation with a friend.
3. Remove this friend.
4. Notice the DM entry disappears from the conversations list.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md