### PR TITLE
fix: chat max entry limit for nearby channel and custom channels

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
@@ -6,496 +6,417 @@ using DCL.Chat.WebApi;
 using DCL.Interface;
 using JetBrains.Annotations;
 using UnityEngine;
-using Random = UnityEngine.Random;
 
-public class ChatController : MonoBehaviour, IChatController
+namespace DCL.Chat
 {
-    private const string NEARBY_CHANNEL_DESCRIPTION = "Talk to the people around you. If you move far away from someone you will lose contact. All whispers will be displayed.";
-    private const string NEARBY_CHANNEL_ID = "nearby";
-    
-    public static ChatController i { get; private set; }
-
-    private readonly Dictionary<string, int> unseenMessagesByUser = new Dictionary<string, int>();
-    private readonly Dictionary<string, int> unseenMessagesByChannel = new Dictionary<string, int>();
-    private readonly Dictionary<string, Channel> channels = new Dictionary<string, Channel>();
-    private readonly List<ChatMessage> messages = new List<ChatMessage>();
-    private bool chatAlreadyInitialized;
-    private int totalUnseenMessages; 
-
-    public event Action<Channel> OnChannelUpdated;
-    public event Action<Channel> OnChannelJoined;
-    public event Action<string, ChannelErrorCode> OnJoinChannelError;
-    public event Action<string> OnChannelLeft;
-    public event Action<string, ChannelErrorCode> OnChannelLeaveError;
-    public event Action<string, ChannelErrorCode> OnMuteChannelError;
-    public event Action OnInitialized;
-    public event Action<ChatMessage> OnAddMessage;
-    public event Action<int> OnTotalUnseenMessagesUpdated;
-    public event Action<string, int> OnUserUnseenMessagesUpdated;
-    public event Action<string, ChannelMember[]> OnUpdateChannelMembers;
-    public event Action<string, Channel[]> OnChannelSearchResult;
-    public event Action<string, int> OnChannelUnseenMessagesUpdated;
-
-    // since kernel does not calculate the #nearby channel unseen messages, it is handled on renderer side
-    public int TotalUnseenMessages => totalUnseenMessages
-                                      + (unseenMessagesByChannel.ContainsKey(NEARBY_CHANNEL_ID) 
-                                          ? unseenMessagesByChannel[NEARBY_CHANNEL_ID]
-                                          : 0);
-
-    public void Awake()
+    public partial class ChatController : MonoBehaviour, IChatController
     {
-        i = this;
-        
-        channels[NEARBY_CHANNEL_ID] = new Channel(NEARBY_CHANNEL_ID, NEARBY_CHANNEL_ID, 0, 0, true, false,
-            NEARBY_CHANNEL_DESCRIPTION);
-    }
+        private const string NEARBY_CHANNEL_DESCRIPTION =
+            "Talk to the people around you. If you move far away from someone you will lose contact. All whispers will be displayed.";
 
-    // called by kernel
-    [PublicAPI]
-    public void InitializeChat(string json)
-    {
-        if (chatAlreadyInitialized)
-            return;
+        private const string NEARBY_CHANNEL_ID = "nearby";
 
-        var msg = JsonUtility.FromJson<InitializeChatPayload>(json);
+        public static ChatController i { get; private set; }
 
-        totalUnseenMessages = msg.totalUnseenMessages;
-        OnInitialized?.Invoke();
-        OnTotalUnseenMessagesUpdated?.Invoke(TotalUnseenMessages);
-        chatAlreadyInitialized = true;
-    }
+        private readonly Dictionary<string, int> unseenMessagesByUser = new Dictionary<string, int>();
+        private readonly Dictionary<string, int> unseenMessagesByChannel = new Dictionary<string, int>();
+        private readonly Dictionary<string, Channel> channels = new Dictionary<string, Channel>();
+        private readonly List<ChatMessage> messages = new List<ChatMessage>();
+        private bool chatAlreadyInitialized;
+        private int totalUnseenMessages;
 
-    // called by kernel
-    [PublicAPI]
-    public void AddMessageToChatWindow(string jsonMessage) =>
-        AddMessage(JsonUtility.FromJson<ChatMessage>(jsonMessage));
+        public event Action<Channel> OnChannelUpdated;
+        public event Action<Channel> OnChannelJoined;
+        public event Action<string, ChannelErrorCode> OnJoinChannelError;
+        public event Action<string> OnChannelLeft;
+        public event Action<string, ChannelErrorCode> OnChannelLeaveError;
+        public event Action<string, ChannelErrorCode> OnMuteChannelError;
+        public event Action OnInitialized;
+        public event Action<ChatMessage> OnAddMessage;
+        public event Action<int> OnTotalUnseenMessagesUpdated;
+        public event Action<string, int> OnUserUnseenMessagesUpdated;
+        public event Action<string, ChannelMember[]> OnUpdateChannelMembers;
+        public event Action<string, Channel[]> OnChannelSearchResult;
+        public event Action<string, int> OnChannelUnseenMessagesUpdated;
 
-    // called by kernel
-    [PublicAPI]
-    public void AddChatMessages(string jsonMessage)
-    {
-        var messages = JsonUtility.FromJson<ChatMessageListPayload>(jsonMessage);
+        // since kernel does not calculate the #nearby channel unseen messages, it is handled on renderer side
+        public int TotalUnseenMessages => totalUnseenMessages
+                                          + (unseenMessagesByChannel.ContainsKey(NEARBY_CHANNEL_ID)
+                                              ? unseenMessagesByChannel[NEARBY_CHANNEL_ID]
+                                              : 0);
 
-        if (messages == null) return;
-
-        foreach (var message in messages.messages)
-            AddMessage(message);
-    }
-
-    // called by kernel
-    [PublicAPI]
-    public void UpdateTotalUnseenMessages(string json)
-    {
-        var msg = JsonUtility.FromJson<UpdateTotalUnseenMessagesPayload>(json);
-        totalUnseenMessages = msg.total;
-        OnTotalUnseenMessagesUpdated?.Invoke(TotalUnseenMessages);
-    }
-
-    // called by kernel
-    [PublicAPI]
-    public void UpdateUserUnseenMessages(string json)
-    {
-        var msg = JsonUtility.FromJson<UpdateUserUnseenMessagesPayload>(json);
-        unseenMessagesByUser[msg.userId] = msg.total;
-        OnUserUnseenMessagesUpdated?.Invoke(msg.userId, msg.total);
-    }
-
-    // called by kernel
-    [PublicAPI]
-    public void UpdateTotalUnseenMessagesByUser(string json)
-    {
-        var msg = JsonUtility.FromJson<UpdateTotalUnseenMessagesByUserPayload>(json);
-
-        foreach (var unseenMessages in msg.unseenPrivateMessages)
+        public void Awake()
         {
-            var userId = unseenMessages.userId;
-            var count = unseenMessages.count;
-            unseenMessagesByUser[userId] = count;
-            OnUserUnseenMessagesUpdated?.Invoke(userId, count);
+            i = this;
+
+            channels[NEARBY_CHANNEL_ID] = new Channel(NEARBY_CHANNEL_ID, NEARBY_CHANNEL_ID, 0, 0, true, false,
+                NEARBY_CHANNEL_DESCRIPTION);
         }
-    }
 
-    // called by kernel
-    [PublicAPI]
-    public void UpdateTotalUnseenMessagesByChannel(string json)
-    {
-        var msg = JsonUtility.FromJson<UpdateTotalUnseenMessagesByChannelPayload>(json);
-        foreach (var unseenMessages in msg.unseenChannelMessages)
-            UpdateTotalUnseenMessagesByChannel(unseenMessages.channelId, unseenMessages.count);
-    }
-
-    // called by kernel
-    [PublicAPI]
-    public void UpdateChannelMembers(string payload)
-    {
-        var msg = JsonUtility.FromJson<UpdateChannelMembersPayload>(payload);
-        OnUpdateChannelMembers?.Invoke(msg.channelId, msg.members);
-    }
-    
-    [PublicAPI]
-    public void UpdateChannelInfo(string payload)
-    {
-        var msg = JsonUtility.FromJson<ChannelInfoPayloads>(payload);
-        var anyChannelLeft = false;
-
-        foreach (var channelInfo in msg.channelInfoPayload)
+        // called by kernel
+        [PublicAPI]
+        public void InitializeChat(string json)
         {
-            var channelId = channelInfo.channelId;
-            var channel = new Channel(channelId, channelInfo.name, channelInfo.unseenMessages, channelInfo.memberCount, channelInfo.joined, channelInfo.muted, channelInfo.description);
-            var justLeft = !channel.Joined;
+            if (chatAlreadyInitialized)
+                return;
+
+            var msg = JsonUtility.FromJson<InitializeChatPayload>(json);
+
+            totalUnseenMessages = msg.totalUnseenMessages;
+            OnInitialized?.Invoke();
+            OnTotalUnseenMessagesUpdated?.Invoke(TotalUnseenMessages);
+            chatAlreadyInitialized = true;
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void AddMessageToChatWindow(string jsonMessage) =>
+            AddMessage(JsonUtility.FromJson<ChatMessage>(jsonMessage));
+
+        // called by kernel
+        [PublicAPI]
+        public void AddChatMessages(string jsonMessage)
+        {
+            var messages = JsonUtility.FromJson<ChatMessageListPayload>(jsonMessage);
+
+            if (messages == null) return;
+
+            foreach (var message in messages.messages)
+                AddMessage(message);
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void UpdateTotalUnseenMessages(string json)
+        {
+            var msg = JsonUtility.FromJson<UpdateTotalUnseenMessagesPayload>(json);
+            totalUnseenMessages = msg.total;
+            OnTotalUnseenMessagesUpdated?.Invoke(TotalUnseenMessages);
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void UpdateUserUnseenMessages(string json)
+        {
+            var msg = JsonUtility.FromJson<UpdateUserUnseenMessagesPayload>(json);
+            unseenMessagesByUser[msg.userId] = msg.total;
+            OnUserUnseenMessagesUpdated?.Invoke(msg.userId, msg.total);
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void UpdateTotalUnseenMessagesByUser(string json)
+        {
+            var msg = JsonUtility.FromJson<UpdateTotalUnseenMessagesByUserPayload>(json);
+
+            foreach (var unseenMessages in msg.unseenPrivateMessages)
+            {
+                var userId = unseenMessages.userId;
+                var count = unseenMessages.count;
+                unseenMessagesByUser[userId] = count;
+                OnUserUnseenMessagesUpdated?.Invoke(userId, count);
+            }
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void UpdateTotalUnseenMessagesByChannel(string json)
+        {
+            var msg = JsonUtility.FromJson<UpdateTotalUnseenMessagesByChannelPayload>(json);
+            foreach (var unseenMessages in msg.unseenChannelMessages)
+                UpdateTotalUnseenMessagesByChannel(unseenMessages.channelId, unseenMessages.count);
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void UpdateChannelMembers(string payload)
+        {
+            var msg = JsonUtility.FromJson<UpdateChannelMembersPayload>(payload);
+            OnUpdateChannelMembers?.Invoke(msg.channelId, msg.members);
+        }
+
+        [PublicAPI]
+        public void UpdateChannelInfo(string payload)
+        {
+            var msg = JsonUtility.FromJson<ChannelInfoPayloads>(payload);
+            var anyChannelLeft = false;
+
+            foreach (var channelInfo in msg.channelInfoPayload)
+            {
+                var channelId = channelInfo.channelId;
+                var channel = new Channel(channelId, channelInfo.name, channelInfo.unseenMessages, channelInfo.memberCount,
+                    channelInfo.joined, channelInfo.muted, channelInfo.description);
+                var justLeft = !channel.Joined;
+
+                if (channels.ContainsKey(channelId))
+                {
+                    justLeft = channels[channelId].Joined && !channel.Joined;
+                    channels[channelId].CopyFrom(channel);
+                }
+                else
+                    channels[channelId] = channel;
+
+                if (justLeft)
+                {
+                    OnChannelLeft?.Invoke(channelId);
+                    anyChannelLeft = true;
+                }
+
+                if (anyChannelLeft)
+                {
+                    // TODO (responsibility issues): extract to another class
+                    AudioScriptableObjects.leaveChannel.Play(true);
+                }
+
+                OnChannelUpdated?.Invoke(channel);
+            }
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void JoinChannelConfirmation(string payload)
+        {
+            var msg = JsonUtility.FromJson<ChannelInfoPayloads>(payload);
+
+            if (msg.channelInfoPayload.Length == 0)
+                return;
+
+            var channelInfo = msg.channelInfoPayload[0];
+            var channel = new Channel(channelInfo.channelId, channelInfo.name, channelInfo.unseenMessages,
+                channelInfo.memberCount, channelInfo.joined, channelInfo.muted, channelInfo.description);
+            var channelId = channel.ChannelId;
 
             if (channels.ContainsKey(channelId))
-            {
-                justLeft = channels[channelId].Joined && !channel.Joined;
                 channels[channelId].CopyFrom(channel);
-            }
             else
                 channels[channelId] = channel;
 
-            if (justLeft)
-            {
-                OnChannelLeft?.Invoke(channelId);
-                anyChannelLeft = true;
-            }
-
-            if (anyChannelLeft)
-            {
-                // TODO (responsibility issues): extract to another class
-                AudioScriptableObjects.leaveChannel.Play(true);
-            }
-
+            OnChannelJoined?.Invoke(channel);
             OnChannelUpdated?.Invoke(channel);
+
+            // TODO (responsibility issues): extract to another class
+            AudioScriptableObjects.joinChannel.Play(true);
+
+            SendChannelWelcomeMessage(channel);
         }
-    }
 
-    // called by kernel
-    [PublicAPI]
-    public void JoinChannelConfirmation(string payload)
-    {
-        var msg = JsonUtility.FromJson<ChannelInfoPayloads>(payload);
-
-        if (msg.channelInfoPayload.Length == 0)
-            return;
-
-        var channelInfo = msg.channelInfoPayload[0];
-        var channel = new Channel(channelInfo.channelId, channelInfo.name, channelInfo.unseenMessages, channelInfo.memberCount, channelInfo.joined, channelInfo.muted, channelInfo.description);
-        var channelId = channel.ChannelId;
-        
-        if (channels.ContainsKey(channelId))
-            channels[channelId].CopyFrom(channel);
-        else
-            channels[channelId] = channel;
-        
-        OnChannelJoined?.Invoke(channel);
-        OnChannelUpdated?.Invoke(channel);
-
-        // TODO (responsibility issues): extract to another class
-        AudioScriptableObjects.joinChannel.Play(true);
-        
-        SendChannelWelcomeMessage(channel);
-    }
-
-    // called by kernel
-    [PublicAPI]
-    public void JoinChannelError(string payload)
-    {
-        var msg = JsonUtility.FromJson<JoinChannelErrorPayload>(payload);
-        OnJoinChannelError?.Invoke(msg.channelId, (ChannelErrorCode) msg.errorCode);
-    }
-
-    // called by kernel
-    [PublicAPI]
-    public void LeaveChannelError(string payload)
-    {
-        var msg = JsonUtility.FromJson<JoinChannelErrorPayload>(payload);
-        OnChannelLeaveError?.Invoke(msg.channelId, (ChannelErrorCode) msg.errorCode);
-    }
-
-    // called by kernel
-    [PublicAPI]
-    public void MuteChannelError(string payload)
-    {
-        var msg = JsonUtility.FromJson<MuteChannelErrorPayload>(payload);
-        OnMuteChannelError?.Invoke(msg.channelId, (ChannelErrorCode) msg.errorCode);
-    }
-
-    // called by kernel
-    [PublicAPI]
-    public void UpdateChannelSearchResults(string payload)
-    {
-        var msg = JsonUtility.FromJson<ChannelSearchResultsPayload>(payload);
-        var channelsResult = new Channel[msg.channels.Length];
-
-        for (var i = 0; i < msg.channels.Length; i++)
+        // called by kernel
+        [PublicAPI]
+        public void JoinChannelError(string payload)
         {
-            var channelPayload = msg.channels[i];
-            var channelId = channelPayload.channelId;
-            var channel = new Channel(channelId, channelPayload.name, channelPayload.unseenMessages, channelPayload.memberCount,
-                channelPayload.joined, channelPayload.muted, channelPayload.description);
+            var msg = JsonUtility.FromJson<JoinChannelErrorPayload>(payload);
+            OnJoinChannelError?.Invoke(msg.channelId, (ChannelErrorCode) msg.errorCode);
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void LeaveChannelError(string payload)
+        {
+            var msg = JsonUtility.FromJson<JoinChannelErrorPayload>(payload);
+            OnChannelLeaveError?.Invoke(msg.channelId, (ChannelErrorCode) msg.errorCode);
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void MuteChannelError(string payload)
+        {
+            var msg = JsonUtility.FromJson<MuteChannelErrorPayload>(payload);
+            OnMuteChannelError?.Invoke(msg.channelId, (ChannelErrorCode) msg.errorCode);
+        }
+
+        // called by kernel
+        [PublicAPI]
+        public void UpdateChannelSearchResults(string payload)
+        {
+            var msg = JsonUtility.FromJson<ChannelSearchResultsPayload>(payload);
+            var channelsResult = new Channel[msg.channels.Length];
+
+            for (var i = 0; i < msg.channels.Length; i++)
+            {
+                var channelPayload = msg.channels[i];
+                var channelId = channelPayload.channelId;
+                var channel = new Channel(channelId, channelPayload.name, channelPayload.unseenMessages,
+                    channelPayload.memberCount,
+                    channelPayload.joined, channelPayload.muted, channelPayload.description);
+
+                if (channels.ContainsKey(channelId))
+                    channels[channelId].CopyFrom(channel);
+                else
+                    channels[channelId] = channel;
+
+                channelsResult[i] = channel;
+            }
+
+            OnChannelSearchResult?.Invoke(msg.since, channelsResult);
+        }
+
+        public void JoinOrCreateChannel(string channelId) => WebInterface.JoinOrCreateChannel(channelId);
+
+        public void LeaveChannel(string channelId) => WebInterface.LeaveChannel(channelId);
+
+        public void GetChannelMessages(string channelId, int limit, string fromMessageId) =>
+            WebInterface.GetChannelMessages(channelId, limit, fromMessageId);
+
+        public void GetJoinedChannels(int limit, int skip) => WebInterface.GetJoinedChannels(limit, skip);
+
+        public void GetChannelsByName(int limit, string name, string paginationToken = null) =>
+            WebInterface.GetChannels(limit, paginationToken, name);
+
+        public void GetChannels(int limit, string paginationToken) =>
+            WebInterface.GetChannels(limit, paginationToken, string.Empty);
+
+        public void MuteChannel(string channelId)
+        {
+            if (channelId == NEARBY_CHANNEL_ID)
+            {
+                var channel = GetAllocatedChannel(NEARBY_CHANNEL_ID);
+                var payload = new ChannelInfoPayloads
+                {
+                    channelInfoPayload = new[]
+                    {
+                        new ChannelInfoPayload
+                        {
+                            description = channel.Description,
+                            joined = channel.Joined,
+                            channelId = channel.ChannelId,
+                            muted = true,
+                            name = channel.Name,
+                            memberCount = channel.MemberCount,
+                            unseenMessages = channel.UnseenMessages
+                        }
+                    }
+                };
+
+                UpdateChannelInfo(JsonUtility.ToJson(payload));
+            }
+            else
+                WebInterface.MuteChannel(channelId, true);
+        }
+
+        public void UnmuteChannel(string channelId)
+        {
+            if (channelId == NEARBY_CHANNEL_ID)
+            {
+                var channel = GetAllocatedChannel(NEARBY_CHANNEL_ID);
+                var payload = new ChannelInfoPayloads
+                {
+                    channelInfoPayload = new[]
+                    {
+                        new ChannelInfoPayload
+                        {
+                            description = channel.Description,
+                            joined = channel.Joined,
+                            channelId = channel.ChannelId,
+                            muted = false,
+                            name = channel.Name,
+                            memberCount = channel.MemberCount,
+                            unseenMessages = channel.UnseenMessages
+                        }
+                    }
+                };
+
+                UpdateChannelInfo(JsonUtility.ToJson(payload));
+            }
+            else
+                WebInterface.MuteChannel(channelId, false);
+        }
+
+        public Channel GetAllocatedChannel(string channelId) =>
+            channels.ContainsKey(channelId) ? channels[channelId] : null;
+
+        public Channel GetAllocatedChannelByName(string channelName) =>
+            channels.Values.FirstOrDefault(x => x.Name == channelName);
+
+        public void GetPrivateMessages(string userId, int limit, string fromMessageId) =>
+            WebInterface.GetPrivateMessages(userId, limit, fromMessageId);
+
+        public void MarkChannelMessagesAsSeen(string channelId)
+        {
+            if (channelId == NEARBY_CHANNEL_ID)
+            {
+                UpdateTotalUnseenMessagesByChannel(NEARBY_CHANNEL_ID, 0);
+                OnTotalUnseenMessagesUpdated?.Invoke(TotalUnseenMessages);
+            }
+
+            WebInterface.MarkChannelMessagesAsSeen(channelId);
+        }
+
+        public List<ChatMessage> GetAllocatedEntries() => new List<ChatMessage>(messages);
+
+        public void GetUnseenMessagesByUser() => WebInterface.GetUnseenMessagesByUser();
+
+        public void GetUnseenMessagesByChannel() => WebInterface.GetUnseenMessagesByChannel();
+
+        public int GetAllocatedUnseenMessages(string userId) =>
+            unseenMessagesByUser.ContainsKey(userId) ? unseenMessagesByUser[userId] : 0;
+
+        public int GetAllocatedUnseenChannelMessages(string channelId) =>
+            !string.IsNullOrEmpty(channelId)
+                ? unseenMessagesByChannel.ContainsKey(channelId) ? unseenMessagesByChannel[channelId] : 0
+                : 0;
+
+        public void CreateChannel(string channelId) => WebInterface.CreateChannel(channelId);
+
+        public List<ChatMessage> GetPrivateAllocatedEntriesByUser(string userId)
+        {
+            return messages
+                .Where(x => (x.sender == userId || x.recipient == userId) && x.messageType == ChatMessage.Type.PRIVATE)
+                .ToList();
+        }
+
+        public void GetChannelInfo(string[] channelIds) => WebInterface.GetChannelInfo(channelIds);
+
+        public void GetChannelMembers(string channelId, int limit, int skip, string name) =>
+            WebInterface.GetChannelMembers(channelId, limit, skip, name);
+
+        public void GetChannelMembers(string channelId, int limit, int skip) =>
+            WebInterface.GetChannelMembers(channelId, limit, skip, string.Empty);
+
+        public void Send(ChatMessage message) => WebInterface.SendChatMessage(message);
+
+        public void MarkMessagesAsSeen(string userId) => WebInterface.MarkMessagesAsSeen(userId);
+
+        private void SendChannelWelcomeMessage(Channel channel)
+        {
+            var message =
+                new ChatMessage(ChatMessage.Type.SYSTEM, "", @$"This is the start of the channel #{channel.Name}.\n
+Invite others to join by quoting the channel name in other chats or include it as a part of your bio.")
+                {
+                    recipient = channel.ChannelId,
+                    timestamp = 0,
+                    isChannelMessage = true,
+                    messageId = Guid.NewGuid().ToString()
+                };
+
+            AddMessage(message);
+        }
+
+        private void AddMessage(ChatMessage message)
+        {
+            if (message == null) return;
+
+            messages.Add(message);
+
+            if (message.messageType == ChatMessage.Type.PUBLIC && string.IsNullOrEmpty(message.recipient))
+            {
+                if (!unseenMessagesByChannel.ContainsKey(NEARBY_CHANNEL_ID))
+                    unseenMessagesByChannel[NEARBY_CHANNEL_ID] = 0;
+
+                UpdateTotalUnseenMessagesByChannel(NEARBY_CHANNEL_ID, unseenMessagesByChannel[NEARBY_CHANNEL_ID] + 1);
+                OnTotalUnseenMessagesUpdated?.Invoke(TotalUnseenMessages);
+            }
+
+            OnAddMessage?.Invoke(message);
+        }
+
+        private void UpdateTotalUnseenMessagesByChannel(string channelId, int count)
+        {
+            unseenMessagesByChannel[channelId] = count;
 
             if (channels.ContainsKey(channelId))
-                channels[channelId].CopyFrom(channel);
-            else
-                channels[channelId] = channel;
+                channels[channelId].UnseenMessages = count;
 
-            channelsResult[i] = channel;
+            OnChannelUnseenMessagesUpdated?.Invoke(channelId, count);
         }
-
-        OnChannelSearchResult?.Invoke(msg.since, channelsResult);
-    }
-    
-    public void JoinOrCreateChannel(string channelId) => WebInterface.JoinOrCreateChannel(channelId);
-
-    public void LeaveChannel(string channelId) => WebInterface.LeaveChannel(channelId);
-
-    public void GetChannelMessages(string channelId, int limit, string fromMessageId) => WebInterface.GetChannelMessages(channelId, limit, fromMessageId);
-
-    public void GetJoinedChannels(int limit, int skip) => WebInterface.GetJoinedChannels(limit, skip);
-
-    public void GetChannelsByName(int limit, string name, string paginationToken = null) => WebInterface.GetChannels(limit, paginationToken, name);
-
-    public void GetChannels(int limit, string paginationToken) => WebInterface.GetChannels(limit, paginationToken, string.Empty);
-
-    public void MuteChannel(string channelId)
-    {
-        if (channelId == NEARBY_CHANNEL_ID)
-        {
-            var channel = GetAllocatedChannel(NEARBY_CHANNEL_ID);
-            var payload = new ChannelInfoPayloads
-            {
-                channelInfoPayload = new[]
-                {
-                    new ChannelInfoPayload
-                    {
-                        description = channel.Description,
-                        joined = channel.Joined,
-                        channelId = channel.ChannelId,
-                        muted = true,
-                        name = channel.Name,
-                        memberCount = channel.MemberCount,
-                        unseenMessages = channel.UnseenMessages
-                    }
-                }
-            };
-            
-            UpdateChannelInfo(JsonUtility.ToJson(payload));
-        }
-        else
-            WebInterface.MuteChannel(channelId, true);
-    }
-
-    public void UnmuteChannel(string channelId)
-    {
-        if (channelId == NEARBY_CHANNEL_ID)
-        {
-            var channel = GetAllocatedChannel(NEARBY_CHANNEL_ID);
-            var payload = new ChannelInfoPayloads
-            {
-                channelInfoPayload = new[]
-                {
-                    new ChannelInfoPayload
-                    {
-                        description = channel.Description,
-                        joined = channel.Joined,
-                        channelId = channel.ChannelId,
-                        muted = false,
-                        name = channel.Name,
-                        memberCount = channel.MemberCount,
-                        unseenMessages = channel.UnseenMessages
-                    }
-                }
-            };
-            
-            UpdateChannelInfo(JsonUtility.ToJson(payload));
-        }
-        else
-            WebInterface.MuteChannel(channelId, false);
-    }
-
-    public Channel GetAllocatedChannel(string channelId) =>
-        channels.ContainsKey(channelId) ? channels[channelId] : null;
-    
-    public Channel GetAllocatedChannelByName(string channelName) =>
-        channels.Values.FirstOrDefault(x => x.Name == channelName);
-    
-    public void GetPrivateMessages(string userId, int limit, string fromMessageId) =>
-        WebInterface.GetPrivateMessages(userId, limit, fromMessageId);
-    
-    public void MarkChannelMessagesAsSeen(string channelId)
-    {
-        if (channelId == NEARBY_CHANNEL_ID)
-        {
-            UpdateTotalUnseenMessagesByChannel(NEARBY_CHANNEL_ID, 0);
-            OnTotalUnseenMessagesUpdated?.Invoke(TotalUnseenMessages);
-        }
-            
-        WebInterface.MarkChannelMessagesAsSeen(channelId);
-    }
-
-    public List<ChatMessage> GetAllocatedEntries() => new List<ChatMessage>(messages);
-    
-    public void GetUnseenMessagesByUser() => WebInterface.GetUnseenMessagesByUser();
-
-    public void GetUnseenMessagesByChannel() => WebInterface.GetUnseenMessagesByChannel();
-
-    public int GetAllocatedUnseenMessages(string userId) =>
-        unseenMessagesByUser.ContainsKey(userId) ? unseenMessagesByUser[userId] : 0;
-
-    public int GetAllocatedUnseenChannelMessages(string channelId) => 
-        !string.IsNullOrEmpty(channelId) 
-            ? unseenMessagesByChannel.ContainsKey(channelId) ? unseenMessagesByChannel[channelId] : 0
-            : 0;
-
-    public void CreateChannel(string channelId) => WebInterface.CreateChannel(channelId);
-
-    public List<ChatMessage> GetPrivateAllocatedEntriesByUser(string userId)
-    {
-        return messages
-            .Where(x => (x.sender == userId || x.recipient == userId) && x.messageType == ChatMessage.Type.PRIVATE)
-            .ToList();
-    }
-    
-    public void GetChannelInfo(string[] channelIds) => WebInterface.GetChannelInfo(channelIds);
-
-    public void GetChannelMembers(string channelId, int limit, int skip, string name) =>
-        WebInterface.GetChannelMembers(channelId, limit, skip, name);
-
-    public void GetChannelMembers(string channelId, int limit, int skip) =>
-        WebInterface.GetChannelMembers(channelId, limit, skip, string.Empty);
-
-    public void Send(ChatMessage message) => WebInterface.SendChatMessage(message);
-
-    public void MarkMessagesAsSeen(string userId) => WebInterface.MarkMessagesAsSeen(userId);
-    
-    private void SendChannelWelcomeMessage(Channel channel)
-    {
-        var message =
-            new ChatMessage(ChatMessage.Type.SYSTEM, "", @$"This is the start of the channel #{channel.Name}.\n
-Invite others to join by quoting the channel name in other chats or include it as a part of your bio.")
-            {
-                recipient = channel.ChannelId,
-                timestamp = 0,
-                isChannelMessage = true,
-                messageId = Guid.NewGuid().ToString()
-            };
-
-        AddMessage(message);
-    }
-
-    private void AddMessage(ChatMessage message)
-    {
-        if (message == null) return;
-
-        messages.Add(message);
-        
-        if (message.messageType == ChatMessage.Type.PUBLIC && string.IsNullOrEmpty(message.recipient))
-        {
-            if (!unseenMessagesByChannel.ContainsKey(NEARBY_CHANNEL_ID))
-                unseenMessagesByChannel[NEARBY_CHANNEL_ID] = 0;
-
-            UpdateTotalUnseenMessagesByChannel(NEARBY_CHANNEL_ID, unseenMessagesByChannel[NEARBY_CHANNEL_ID] + 1);
-            OnTotalUnseenMessagesUpdated?.Invoke(TotalUnseenMessages);
-        }
-        
-        OnAddMessage?.Invoke(message);
-    }
-
-    private void UpdateTotalUnseenMessagesByChannel(string channelId, int count)
-    {
-        unseenMessagesByChannel[channelId] = count;
-
-        if (channels.ContainsKey(channelId))
-            channels[channelId].UnseenMessages = count;
-            
-        OnChannelUnseenMessagesUpdated?.Invoke(channelId, count);
-    }
-
-    [ContextMenu("Fake Public Message")]
-    public void FakePublicMessage()
-    {
-        UserProfile ownProfile = UserProfile.GetOwnUserProfile();
-        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        var bodyLength = Random.Range(5, 30);
-        var bodyText = "";
-        for (var i = 0; i < bodyLength; i++)
-            bodyText += chars[Random.Range(0, chars.Length)];
-        
-        var model = new UserProfileModel
-        {
-            userId = "test user 1",
-            name = "test user 1",
-        };
-
-        UserProfileController.i.AddUserProfileToCatalog(model);
-
-        var model2 = new UserProfileModel()
-        {
-            userId = "test user 2",
-            name = "test user 2",
-        };
-
-        UserProfileController.i.AddUserProfileToCatalog(model2);
-
-        var msg = new ChatMessage()
-        {
-            body = bodyText,
-            sender = model.userId,
-            messageType = ChatMessage.Type.PUBLIC,
-            timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-        };
-
-        var msg2 = new ChatMessage()
-        {
-            body = bodyText,
-            sender = ownProfile.userId,
-            messageType = ChatMessage.Type.PUBLIC,
-            timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-        };
-
-        AddMessageToChatWindow(JsonUtility.ToJson(msg));
-        AddMessageToChatWindow(JsonUtility.ToJson(msg2));
-    }
-    
-    [ContextMenu("Fake Private Message")]
-    public void FakePrivateMessage()
-    {
-        UserProfile ownProfile = UserProfile.GetOwnUserProfile();
-
-        var model = new UserProfileModel()
-        {
-            userId = "test user 1",
-            name = "test user 1",
-        };
-
-        UserProfileController.i.AddUserProfileToCatalog(model);
-
-        var model2 = new UserProfileModel()
-        {
-            userId = "test user 2",
-            name = "test user 2",
-        };
-
-        UserProfileController.i.AddUserProfileToCatalog(model2);
-
-        var msg = new ChatMessage()
-        {
-            body = "test message",
-            sender = model.userId,
-            recipient = ownProfile.userId,
-            messageType = ChatMessage.Type.PRIVATE,
-            timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-        };
-
-        var msg2 = new ChatMessage()
-        {
-            body = "test message 2",
-            recipient = model2.userId,
-            sender = ownProfile.userId,
-            messageType = ChatMessage.Type.PRIVATE,
-            timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-        };
-
-        AddMessageToChatWindow(JsonUtility.ToJson(msg));
-        AddMessageToChatWindow(JsonUtility.ToJson(msg2));
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatControllerContextMenuUtility.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatControllerContextMenuUtility.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using DCL.Interface;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace DCL.Chat
+{
+    public partial class ChatController
+    {
+        private IEnumerator Start()
+        {
+            yield return new WaitForSeconds(20f);
+            AddManyFakeMessagesToNearby();
+        }
+
+        [ContextMenu("Fake Public Message")]
+        public void FakePublicMessage()
+        {
+            UserProfile ownProfile = UserProfile.GetOwnUserProfile();
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            var bodyLength = Random.Range(5, 30);
+            var bodyText = "";
+            for (var i = 0; i < bodyLength; i++)
+                bodyText += chars[Random.Range(0, chars.Length)];
+
+            var model = new UserProfileModel
+            {
+                userId = "test user 1",
+                name = "test user 1",
+            };
+
+            UserProfileController.i.AddUserProfileToCatalog(model);
+
+            var model2 = new UserProfileModel()
+            {
+                userId = "test user 2",
+                name = "test user 2",
+            };
+
+            UserProfileController.i.AddUserProfileToCatalog(model2);
+
+            var msg = new ChatMessage()
+            {
+                body = bodyText,
+                sender = model.userId,
+                messageType = ChatMessage.Type.PUBLIC,
+                timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            };
+
+            var msg2 = new ChatMessage()
+            {
+                body = bodyText,
+                sender = ownProfile.userId,
+                messageType = ChatMessage.Type.PUBLIC,
+                timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            };
+
+            AddMessageToChatWindow(JsonUtility.ToJson(msg));
+            AddMessageToChatWindow(JsonUtility.ToJson(msg2));
+        }
+
+        [ContextMenu("Fake Private Message")]
+        public void FakePrivateMessage()
+        {
+            UserProfile ownProfile = UserProfile.GetOwnUserProfile();
+
+            var model = new UserProfileModel()
+            {
+                userId = "test user 1",
+                name = "test user 1",
+            };
+
+            UserProfileController.i.AddUserProfileToCatalog(model);
+
+            var model2 = new UserProfileModel()
+            {
+                userId = "test user 2",
+                name = "test user 2",
+            };
+
+            UserProfileController.i.AddUserProfileToCatalog(model2);
+
+            var msg = new ChatMessage()
+            {
+                body = "test message",
+                sender = model.userId,
+                recipient = ownProfile.userId,
+                messageType = ChatMessage.Type.PRIVATE,
+                timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            };
+
+            var msg2 = new ChatMessage()
+            {
+                body = "test message 2",
+                recipient = model2.userId,
+                sender = ownProfile.userId,
+                messageType = ChatMessage.Type.PRIVATE,
+                timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            };
+
+            AddMessageToChatWindow(JsonUtility.ToJson(msg));
+            AddMessageToChatWindow(JsonUtility.ToJson(msg2));
+        }
+
+        [ContextMenu("Add fake messages to nearby")]
+        public void AddManyFakeMessagesToNearby()
+        {
+            var users = new List<UserProfileModel>();
+            
+            for (var i = 0; i < 10; i++)
+            {
+                var userId = Guid.NewGuid().ToString();
+                var userProfile = new UserProfileModel
+                {
+                    userId = userId,
+                    name = $"TestUser{i}"
+                };
+
+                UserProfileController.i.AddUserProfileToCatalog(userProfile);
+                users.Add(userProfile);
+            }
+
+            for (var i = 0; i < 100; i++)
+            {
+                var user = users[Random.Range(0, users.Count)];
+                
+                var msg = new ChatMessage
+                {
+                    body = "test message",
+                    sender = user.userId,
+                    recipient = null,
+                    messageType = ChatMessage.Type.PUBLIC,
+                    timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    isChannelMessage = true,
+                    messageId = Guid.NewGuid().ToString(),
+                    senderName = user.name
+                };
+                
+                AddMessageToChatWindow(JsonUtility.ToJson(msg));
+            }
+        }
+        
+        [ContextMenu("Add fake messages to global")]
+        public void AddManyFakeMessagesToUnityChannel()
+        {
+            var users = new List<UserProfileModel>();
+            
+            for (var i = 0; i < 10; i++)
+            {
+                var userId = Guid.NewGuid().ToString();
+                var userProfile = new UserProfileModel
+                {
+                    userId = userId,
+                    name = $"TestUser{i}"
+                };
+
+                UserProfileController.i.AddUserProfileToCatalog(userProfile);
+                users.Add(userProfile);
+            }
+
+            for (var i = 0; i < 100; i++)
+            {
+                var user = users[Random.Range(0, users.Count)];
+                
+                var msg = new ChatMessage
+                {
+                    body = "test message",
+                    sender = user.userId,
+                    recipient = GetAllocatedChannelByName("global").ChannelId,
+                    messageType = ChatMessage.Type.PUBLIC,
+                    timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    isChannelMessage = true,
+                    messageId = Guid.NewGuid().ToString(),
+                    senderName = user.name
+                };
+                
+                AddMessageToChatWindow(JsonUtility.ToJson(msg));
+            }
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatControllerContextMenuUtility.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatControllerContextMenuUtility.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c51a528d681a4e239038bfdd7aa1358e
+timeCreated: 1667230759

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -87,7 +87,7 @@ public class ChatHUDController : IDisposable
         view.AddEntry(chatEntryModel, setScrollPositionToBottom);
 
         if (limitMaxEntries && view.EntryCount > MAX_CHAT_ENTRIES)
-            view.RemoveFirstEntry();
+            view.RemoveOldestEntry();
         
         if (string.IsNullOrEmpty(chatEntryModel.senderId)) return;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -242,13 +242,14 @@ public class ChatHUDView : BaseComponentView, IChatHUDComponentView
             scrollRect.verticalNormalizedPosition = 0;
     }
 
-    public void RemoveFirstEntry()
+    public void RemoveOldestEntry()
     {
         if (entries.Count <= 0) return;
         var firstEntry = GetFirstEntry();
-        if (firstEntry == null) return;
-        Destroy(firstEntry.gameObject);
+        if (!firstEntry) return;
         entries.Remove(firstEntry.Model.messageId);
+        // must use immediate, for some reason the object is not getting destroyed with Destroy(firstEntry.gameObject)
+        DestroyImmediate(firstEntry.gameObject);
         UpdateLayout();
     }
 
@@ -374,8 +375,9 @@ public class ChatHUDView : BaseComponentView, IChatHUDComponentView
         for (var i = 0; i < chatEntriesContainer.childCount; i++)
         {
             var firstChildTransform = chatEntriesContainer.GetChild(i);
+            if (!firstChildTransform) continue;
             var entry = firstChildTransform.GetComponent<ChatEntry>();
-            if (entry == null) continue;
+            if (!entry) continue;
             firstEntry = entry;
             break;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
@@ -18,7 +18,7 @@ public interface IChatHUDComponentView
     void OnMessageCancelHover();
     void AddEntry(ChatEntryModel model, bool setScrollPositionToBottom = false);
     void Dispose();
-    void RemoveFirstEntry();
+    void RemoveOldestEntry();
     void ClearAllEntries();
     void ResetInputField(bool loseFocus = false);
     void FocusInputField();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -65,7 +65,7 @@ public class ChatHUDControllerShould
 
         await controller.AddChatMessage(msg);
 
-        view.Received(1).RemoveFirstEntry();
+        view.Received(1).RemoveOldestEntry();
     });
 
     [UnityTest]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationBadge/UnreadWorldNotificationBadge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationBadge/UnreadWorldNotificationBadge.cs
@@ -1,3 +1,4 @@
+using DCL.Chat;
 using TMPro;
 using UnityEngine;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Tests/HUDTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Tests/HUDTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using DCL;
+using DCL.Chat;
 using DCL.Helpers;
 using NUnit.Framework;
 using UnityEngine;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -202,7 +202,8 @@ namespace DCL.Chat.HUD
             UpdateOldestMessage(message);
 
             message.isChannelMessage = true;
-            chatHudController.AddChatMessage(message, limitMaxEntries: false);
+            // TODO: right now the channel history is disabled, but we must find a workaround to support history + max message limit allocation for performance reasons 
+            chatHudController.AddChatMessage(message, limitMaxEntries: true);
 
             if (View.IsActive)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -1,3 +1,4 @@
+using DCL.Chat;
 using DCL.Components;
 using DCL.Configuration;
 using DCL.Controllers;


### PR DESCRIPTION
## What does this PR change?

A max of 30 messages will be displayed at most, for #nearby and the rest of #custom-channels.

## How to test the changes?

1. Open the nearby chat
## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
