### PR TITLE
chore: nerf SceneBoundsChecker budget usage and throttle skip

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DCL.Runtime.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DCL.Runtime.asmdef
@@ -51,7 +51,8 @@
         "GUID:9c5f059a5e90447282111db1b779eddb",
         "GUID:37d2c04574c1d480d8c817e2a7c578e7",
         "GUID:f3ff0d2ae2a1ab1459abc81b66a9b4db",
-        "GUID:74aca8d0fa88642fabc061875471dba2"
+        "GUID:74aca8d0fa88642fabc061875471dba2",
+        "GUID:2995626b54c60644988f134a69a77450"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ECSComponentManagerLegacy/ECSComponentManagerLegacy.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ECSComponentManagerLegacy/ECSComponentManagerLegacy.asmdef
@@ -17,7 +17,10 @@
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:44002c75b9995c34d97b8afc551d32eb",
         "GUID:0e39b687cf35c7e40a87f984cdaed9f5",
-        "GUID:8af21c3a612af2645a9953d4b9b3f6d5"
+        "GUID:8af21c3a612af2645a9953d4b9b3f6d5",
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
+        "GUID:2995626b54c60644988f134a69a77450"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ECSComponentManagerLegacy/ECSComponentsManagerLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ECSComponentManagerLegacy/ECSComponentsManagerLegacy.cs
@@ -431,8 +431,7 @@ namespace DCL
                         targetComponent.UpdateFromJSON(json);
                     else
                         targetComponent.UpdateFromModel(data as BaseModel);
-
-                    // this flag avoids bypassing the throttling
+                    
                     wasCreated = true;
                 }
             }
@@ -440,9 +439,12 @@ namespace DCL
             {
                 targetComponent = EntityComponentUpdate(entity, classId, data as string);
             }
+            
+            var isTransform = classId == CLASS_ID_COMPONENT.TRANSFORM;
+            var avoidThrottling = isSBCNerfEnabled ? isTransform && wasCreated : isTransform;
 
             if (targetComponent != null && targetComponent is IOutOfSceneBoundariesHandler)
-                sceneBoundsChecker?.AddEntityToBeChecked(entity, runPreliminaryEvaluation: classId == CLASS_ID_COMPONENT.TRANSFORM && wasCreated && isSBCNerfEnabled);
+                sceneBoundsChecker?.AddEntityToBeChecked(entity, runPreliminaryEvaluation: avoidThrottling);
 
             physicsSyncController.MarkDirty();
             cullingController.MarkDirty();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ECSComponentManagerLegacy/ECSComponentsManagerLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ECSComponentManagerLegacy/ECSComponentsManagerLegacy.cs
@@ -410,6 +410,7 @@ namespace DCL
                 classId = (CLASS_ID_COMPONENT)classIdAsInt;
             }
 
+            bool wasCreated = false;
             if (!HasComponent(entity, classId))
             {
                 targetComponent = componentFactory.CreateComponent((int) classId) as IEntityComponent;
@@ -424,6 +425,8 @@ namespace DCL
                         targetComponent.UpdateFromJSON(json);
                     else
                         targetComponent.UpdateFromModel(data as BaseModel);
+
+                    wasCreated = true;
                 }
             }
             else
@@ -432,7 +435,7 @@ namespace DCL
             }
 
             if (targetComponent != null && targetComponent is IOutOfSceneBoundariesHandler)
-                sceneBoundsChecker?.AddEntityToBeChecked(entity, runPreliminaryEvaluation: classId == CLASS_ID_COMPONENT.TRANSFORM);
+                sceneBoundsChecker?.AddEntityToBeChecked(entity, runPreliminaryEvaluation: classId == CLASS_ID_COMPONENT.TRANSFORM && wasCreated);
 
             physicsSyncController.MarkDirty();
             cullingController.MarkDirty();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -8,9 +8,10 @@ namespace DCL.Controllers
 {
     public class SceneBoundsChecker : ISceneBoundsChecker
     {
+        private const float TIME_BUDGET = 0.5f / 1000f;
         public event Action<IDCLEntity, bool> OnEntityBoundsCheckerStatusChanged;
         public bool enabled => entitiesCheckRoutine != null;
-        public float timeBetweenChecks { get; set; } = 0.5f;
+        public float timeBetweenChecks { get; set; } = TIME_BUDGET;
         public int entitiesToCheckCount => entitiesToCheck.Count;
 
         private const bool VERBOSE = false;
@@ -53,11 +54,12 @@ namespace DCL.Controllers
                 if ((entitiesToCheck.Count > 0) && (timeBetweenChecks <= 0f || elapsedTime >= timeBetweenChecks))
                 {
                     //TODO(Brian): Remove later when we implement a centralized way of handling time budgets
-                    var messagingManager = Environment.i.messaging.manager as MessagingControllersManager;
+                    //var messagingManager = Environment.i.messaging.manager as MessagingControllersManager;
+                    var timeBudget = TIME_BUDGET;
 
                     void processEntitiesList(HashSet<IDCLEntity> entities)
                     {
-                        if (messagingManager != null && messagingManager.timeBudgetCounter <= 0f)
+                        if (timeBudget <= 0f)
                         {
                             if(VERBOSE)
                                 logger.Verbose("Time budget reached, escaping entities processing until next iteration... ");
@@ -67,7 +69,7 @@ namespace DCL.Controllers
                         using HashSet<IDCLEntity>.Enumerator iterator = entities.GetEnumerator();
                         while (iterator.MoveNext())
                         {
-                            if (messagingManager != null && messagingManager.timeBudgetCounter <= 0f)
+                            if (timeBudget <= 0f)
                             {
                                 if(VERBOSE)
                                     logger.Verbose("Time budget reached, escaping entities processing until next iteration... ");
@@ -80,9 +82,8 @@ namespace DCL.Controllers
                             checkedEntities.Add(iterator.Current);
 
                             float finishTime = Time.realtimeSinceStartup;
-
-                            if ( messagingManager != null )
-                                messagingManager.timeBudgetCounter -= (finishTime - startTime);
+                            
+                            timeBudget -= (finishTime - startTime);
                         }
                     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -53,11 +53,11 @@ namespace DCL.Controllers
         // TODO: Improve MessagingControllersManager.i.timeBudgetCounter usage once we have the centralized budget controller for our immortal coroutines
         private IEnumerator CheckEntities()
         {
-            // Kinerius: Since the nerf can skip the process a lot faster than before, we need faster rechecks
-            var finalTimeBetweenChecks = isNerfed ? NERFED_TIME_BUDGET : timeBetweenChecks;
-            
             while (true)
             {
+                // Kinerius: Since the nerf can skip the process a lot faster than before, we need faster rechecks
+                var finalTimeBetweenChecks = isNerfed ? NERFED_TIME_BUDGET : timeBetweenChecks;
+                
                 float elapsedTime = Time.realtimeSinceStartup - lastCheckTime;
                 if ((entitiesToCheck.Count > 0) && (finalTimeBetweenChecks <= 0f || elapsedTime >= finalTimeBetweenChecks))
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -8,10 +8,11 @@ namespace DCL.Controllers
 {
     public class SceneBoundsChecker : ISceneBoundsChecker
     {
-        private const float TIME_BUDGET = 0.5f / 1000f;
+        private const float NERFED_TIME_BUDGET = 0.5f / 1000f;
+        private const float RECHECK_BUDGET = 0.5f;
         public event Action<IDCLEntity, bool> OnEntityBoundsCheckerStatusChanged;
         public bool enabled => entitiesCheckRoutine != null;
-        public float timeBetweenChecks { get; set; } = TIME_BUDGET;
+        public float timeBetweenChecks { get; set; } = RECHECK_BUDGET;
         public int entitiesToCheckCount => entitiesToCheck.Count;
 
         private const bool VERBOSE = false;
@@ -22,6 +23,8 @@ namespace DCL.Controllers
         private ISceneBoundsFeedbackStyle feedbackStyle;
         private Coroutine entitiesCheckRoutine = null;
         private float lastCheckTime;
+        private MessagingControllersManager messagingManager;
+        private bool isNerfed;
 
         public void Initialize()
         {
@@ -31,6 +34,8 @@ namespace DCL.Controllers
         public SceneBoundsChecker(ISceneBoundsFeedbackStyle feedbackStyle = null)
         {
             this.feedbackStyle = feedbackStyle ?? new SceneBoundsFeedbackStyle_Simple();
+            messagingManager = Environment.i.messaging.manager as MessagingControllersManager;
+            isNerfed = DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("NERF_SBC");
         }
 
         public void SetFeedbackStyle(ISceneBoundsFeedbackStyle feedbackStyle)
@@ -47,19 +52,20 @@ namespace DCL.Controllers
 
         // TODO: Improve MessagingControllersManager.i.timeBudgetCounter usage once we have the centralized budget controller for our immortal coroutines
         private IEnumerator CheckEntities()
-        {   
+        {
+            // Kinerius: Since the nerf can skip the process a lot faster than before, we need faster rechecks
+            var finalTimeBetweenChecks = isNerfed ? NERFED_TIME_BUDGET : timeBetweenChecks;
+            
             while (true)
             {
                 float elapsedTime = Time.realtimeSinceStartup - lastCheckTime;
-                if ((entitiesToCheck.Count > 0) && (timeBetweenChecks <= 0f || elapsedTime >= timeBetweenChecks))
+                if ((entitiesToCheck.Count > 0) && (finalTimeBetweenChecks <= 0f || elapsedTime >= finalTimeBetweenChecks))
                 {
-                    //TODO(Brian): Remove later when we implement a centralized way of handling time budgets
-                    //var messagingManager = Environment.i.messaging.manager as MessagingControllersManager;
-                    var timeBudget = TIME_BUDGET;
+                    var timeBudget = NERFED_TIME_BUDGET;
 
                     void processEntitiesList(HashSet<IDCLEntity> entities)
                     {
-                        if (timeBudget <= 0f)
+                        if (IsTimeBudgetDepleted(timeBudget))
                         {
                             if(VERBOSE)
                                 logger.Verbose("Time budget reached, escaping entities processing until next iteration... ");
@@ -69,7 +75,7 @@ namespace DCL.Controllers
                         using HashSet<IDCLEntity>.Enumerator iterator = entities.GetEnumerator();
                         while (iterator.MoveNext())
                         {
-                            if (timeBudget <= 0f)
+                            if (IsTimeBudgetDepleted(timeBudget))
                             {
                                 if(VERBOSE)
                                     logger.Verbose("Time budget reached, escaping entities processing until next iteration... ");
@@ -82,8 +88,15 @@ namespace DCL.Controllers
                             checkedEntities.Add(iterator.Current);
 
                             float finishTime = Time.realtimeSinceStartup;
+                            float usedTimeBudget = finishTime - startTime;
+
+                            if (!isNerfed)
+                            {
+                                if ( messagingManager != null )
+                                    messagingManager.timeBudgetCounter -= usedTimeBudget;
+                            }
                             
-                            timeBudget -= (finishTime - startTime);
+                            timeBudget -= usedTimeBudget;
                         }
                     }
 
@@ -109,6 +122,7 @@ namespace DCL.Controllers
                 yield return null;
             }
         }
+        private bool IsTimeBudgetDepleted(float timeBudget) { return isNerfed ? timeBudget <= 0f : messagingManager != null && messagingManager.timeBudgetCounter <= 0f; }
 
         public void Restart()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -27,6 +27,7 @@ namespace SceneBoundariesCheckerTests
             coreComponentsPlugin = new CoreComponentsPlugin();
             scene = TestUtils.CreateTestScene() as ParcelScene;
             scene.isPersistent = false;
+            Environment.i.world.sceneBoundsChecker.timeBetweenChecks = 0f;
             TestUtils_NFT.RegisterMockedNFTShape(Environment.i.world.componentFactory);
             
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -27,7 +27,6 @@ namespace SceneBoundariesCheckerTests
             coreComponentsPlugin = new CoreComponentsPlugin();
             scene = TestUtils.CreateTestScene() as ParcelScene;
             scene.isPersistent = false;
-            Environment.i.world.sceneBoundsChecker.timeBetweenChecks = 0f;
             TestUtils_NFT.RegisterMockedNFTShape(Environment.i.world.componentFactory);
             
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -419,16 +419,13 @@ namespace DCL
             while (true)
             {
                 maxTimeForDecode = CommonScriptableObjects.rendererState.Get() ? MAX_TIME_FOR_DECODE : float.MaxValue;
-
-                if (chunksToDecode.Count > 0)
+                
+                if (chunksToDecode.TryDequeue(out string chunk))
                 {
-                    if (chunksToDecode.TryDequeue(out string chunk))
-                    {
-                        EnqueueChunk(chunk);
+                    EnqueueChunk(chunk);
 
-                        if (Time.realtimeSinceStartup - start < maxTimeForDecode)
-                            continue;
-                    }
+                    if (Time.realtimeSinceStartup - start < maxTimeForDecode)
+                        continue;
                 }
 
                 yield return null;


### PR DESCRIPTION
## What does this PR change?

Nerfed the CPU budget of the SceneBoundsChecker from 20ms to 0.5ms
Nerfed the throttle ignore of the Entitities to check from Created/Updated to just Created.

Added feature flag `NERF_SBC`

## How to test

use this link: https://play.decentraland.zone/?renderer-branch=test/nerf-sbc&ENABLE_NERF_SBC

- We should do a smoke test and report any anomaly caused by objects out of their scene boundaries not disappearing fast enough.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
