### PR TITLE
fix: null reference exception when requesting if a user is allowed to create channels

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
@@ -61,7 +61,8 @@ namespace DCL.Chat.Channels
             switch (allowedUsersData.mode)
             {
                 case AllowChannelsCreationMode.ALLOWLIST:
-                    return allowedUsersData.allowList.Any(userId => userId.ToLower() == ownUserProfile.userId.ToLower());
+                    return allowedUsersData.allowList != null
+                           && allowedUsersData.allowList.Any(userId => userId?.ToLower() == ownUserProfile.userId.ToLower());
                 case AllowChannelsCreationMode.NAMES:
                     return ownUserProfile.hasClaimedName;
                 case AllowChannelsCreationMode.WALLET:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/ChannelsFeatureFlagServiceShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/ChannelsFeatureFlagServiceShould.cs
@@ -1,0 +1,61 @@
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace DCL.Chat.Channels
+{
+    public class ChannelsFeatureFlagServiceShould
+    {
+        private ChannelsFeatureFlagService service;
+        private DataStore dataStore;
+        private IUserProfileBridge userProfileBridge;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dataStore = new DataStore();
+            userProfileBridge = Substitute.For<IUserProfileBridge>();
+            var ownUserProfile = ScriptableObject.CreateInstance<UserProfile>();
+            ownUserProfile.UpdateData(new UserProfileModel
+            {
+                userId = "ownId"
+            });
+            userProfileBridge.GetOwn().Returns(ownUserProfile);
+            service = new ChannelsFeatureFlagService(dataStore, userProfileBridge);
+        }
+
+        [Test]
+        public void NotAllowedWhenListIsNull()
+        {
+            GivenEmptyAllowedUsers();
+
+            Assert.IsFalse(service.IsAllowedToCreateChannels());
+        }
+
+        private void GivenEmptyAllowedUsers()
+        {
+            var featureFlag = new FeatureFlag
+            {
+                flags =
+                {
+                    ["matrix_channels_enabled"] = true,
+                    ["users_allowed_to_create_channels"] = true
+                },
+                variants =
+                {
+                    ["users_allowed_to_create_channels"] = new FeatureFlagVariant
+                    {
+                        enabled = true,
+                        name = "allowedUsers",
+                        payload = new FeatureFlagVariantPayload
+                        {
+                            type = "json",
+                            value = "{}"
+                        }
+                    }
+                }
+            };
+            dataStore.featureFlags.flags.Set(featureFlag);
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/ChannelsFeatureFlagServiceShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/ChannelsFeatureFlagServiceShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f0167c3e8fcf488f8397f48ca2848948
+timeCreated: 1667324192

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/ChatControllerTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/Tests/ChatControllerTests.asmdef
@@ -9,14 +9,18 @@
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
-        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:2995626b54c60644988f134a69a77450"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "NSubstitute.dll",
+        "System.Threading.Tasks.Extensions.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [


### PR DESCRIPTION
## What does this PR change?

Sometimes at the start of the application, an exception was occurring due invalid information in the feature flag data. A null check has been added to fix this issue.

```
NullReferenceException: Object reference not set to an instance of an object
DCL.Chat.Channels.ChannelsFeatureFlagService+<>c__DisplayClass15_0.<IsAllowedToCreateChannels>b__0 (System.String userId) (at Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs:64)
System.Linq.Enumerable.Any[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
DCL.Chat.Channels.ChannelsFeatureFlagService.IsAllowedToCreateChannels () (at Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs:64)
ChannelLinkDetector.Awake () (at Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/ChannelLinkDetector.cs:30)
UnityEngine.Object:Instantiate(DefaultChatEntry)
DefaultChatEntryFactory:Create(ChatEntryModel) (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntryFactory.cs:17)
ChatHUDView:AddEntry(ChatEntryModel, Boolean) (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs:217)
<AddChatMessage>d__30:MoveNext() (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs:87)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1:Run() (at Library/PackageCache/com.cysharp.unitask@e999268305/Runtime/CompilerServices/StateMachineRunner.cs:189)
Cysharp.Threading.Tasks.AwaiterActions:Continuation(Object) (at Library/PackageCache/com.cysharp.unitask@e999268305/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1:TrySetResult(String) (at Library/PackageCache/com.cysharp.unitask@e999268305/Runtime/UniTaskCompletionSource.cs:139)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:SetResult(String)
```

## How to test the changes?

1. Check that the application starts correctly
2. Write a channel link in the chat, for example #global
3. No exceptions should occur
4. The channel link should be displayed correctly if you are allowed to create channels (ask me for permissions in goerly network if needed)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
