### PR TITLE
fix: chat taskbar navigation

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -131,7 +131,7 @@ public class TaskbarHUDController : IHUD
         else
         {
             friendsHud?.SetVisibility(false);
-            OpenPublicChatOnPreviewMode();
+            ToggleOffChatIcon();
         }
 
         OnAnyTaskbarButtonClicked?.Invoke();
@@ -147,14 +147,14 @@ public class TaskbarHUDController : IHUD
 
         if (show)
         {
-            OpenPublicChatOnPreviewMode();
+            ToggleOffChatIcon();
             ShowEmotes();
         }
         else
         {
             view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Emotes);
             isEmotesVisible.Set(false);
-            OpenPublicChatOnPreviewMode();
+            ToggleOffChatIcon();
         }
 
         OnAnyTaskbarButtonClicked?.Invoke();
@@ -180,7 +180,7 @@ public class TaskbarHUDController : IHUD
         else
         {
             isExperiencesViewerOpen.Set(false);
-            OpenPublicChatOnPreviewMode();
+            ToggleOffChatIcon();
         }
 
         OnAnyTaskbarButtonClicked?.Invoke();
@@ -230,7 +230,7 @@ public class TaskbarHUDController : IHUD
         else
         {
             CloseFriendsWindow();
-            OpenPublicChatOnPreviewMode();
+            ToggleOffChatIcon();
         }
     }
 
@@ -284,14 +284,8 @@ public class TaskbarHUDController : IHUD
     {
         if (show)
         {
-            chatBackWindow = publicChatWindow;
-            var openedWindow = OpenLastActiveChatWindow(chatToggleTargetWindow);
-            if (openedWindow == publicChatWindow)
-                publicChatWindow.SetVisibility(true);
-            else if (openedWindow == privateChatWindow)
-                privateChatWindow.SetVisibility(true);
-            else if (openedWindow == channelChatWindow)
-                channelChatWindow.SetVisibility(true);
+            chatBackWindow = worldChatWindowHud;
+            OpenWorldChatWindow();
         }
         else
         {
@@ -303,17 +297,10 @@ public class TaskbarHUDController : IHUD
 
     private void MouseCatcher_OnMouseUnlock()
     {
-        // TODO: temporary deactivated current window fadein/fadeout until we get the full chat notifications feature implemented
-        // view.leftWindowContainerAnimator.Show();
-        // view.RestoreLastToggle();
     }
 
     private void MouseCatcher_OnMouseLock()
     {
-        // TODO: temporary deactivated current window fadein/fadeout until we get the full chat notifications feature implemented
-        // view.leftWindowContainerAnimator.Hide();
-        // view.ToggleAllOff();
-
         CloseFriendsWindow();
         CloseChatList();
         CloseVoiceChatWindow();
@@ -322,7 +309,7 @@ public class TaskbarHUDController : IHUD
         if (!privateChatWindow.View.IsActive
             && !publicChatWindow.View.IsActive
             && !channelChatWindow.View.IsActive)
-            OpenPublicChatOnPreviewMode();
+            ToggleOffChatIcon();
     }
 
     public void AddWorldChatWindow(WorldChatWindowController controller)
@@ -343,12 +330,12 @@ public class TaskbarHUDController : IHUD
         worldChatWindowHud = controller;
 
         view.ShowChatButton();
-        worldChatWindowHud.OnCloseView += OpenPublicChatOnPreviewMode;
+        worldChatWindowHud.OnCloseView += ToggleOffChatIcon;
         worldChatWindowHud.OnOpenChannelCreation += OpenChannelCreation;
         worldChatWindowHud.OnOpenChannelLeave += OpenChannelLeaveConfirmation;
     }
 
-    private void OpenPublicChatOnPreviewMode() => view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
+    private void ToggleOffChatIcon() => view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Chat);
 
     private void OpenFriendsWindow()
     {
@@ -424,6 +411,21 @@ public class TaskbarHUDController : IHUD
         view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
 
         return visibleWindow;
+    }
+
+    private void OpenWorldChatWindow()
+    {
+        privateChatWindow.SetVisibility(false);
+        publicChatWindow.SetVisibility(false);
+        channelChatWindow?.SetVisibility(false);
+        searchChannelsHud.SetVisibility(false);
+        friendsHud?.SetVisibility(false);
+        isEmotesVisible.Set(false);
+        isExperiencesViewerOpen.Set(false);
+        voiceChatHud?.SetVisibility(false);
+        isPromoteChannelsToastVisible.Set(false);
+        worldChatWindowHud.SetVisibility(true);
+        view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
     }
 
     private void CloseAnyChatWindow()
@@ -539,7 +541,7 @@ public class TaskbarHUDController : IHUD
 
         privateChatWindow = controller;
 
-        controller.OnClosed += OpenPublicChatOnPreviewMode;
+        controller.OnClosed += ToggleOffChatIcon;
     }
 
     public void AddPublicChatChannel(PublicChatWindowController controller)
@@ -559,7 +561,7 @@ public class TaskbarHUDController : IHUD
 
         publicChatWindow = controller;
 
-        controller.OnClosed += OpenPublicChatOnPreviewMode;
+        controller.OnClosed += ToggleOffChatIcon;
     }
 
     private void HandlePublicChannelPreviewModeChanged(bool isPreviewMode)
@@ -610,7 +612,7 @@ public class TaskbarHUDController : IHUD
         friendsHud.OnViewClosed += () =>
         {
             view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Friends);
-            OpenPublicChatOnPreviewMode();
+            ToggleOffChatIcon();
         };
     }
 
@@ -710,7 +712,7 @@ public class TaskbarHUDController : IHUD
             return;
 
         view.ToggleOff(TaskbarHUDView.TaskbarButtonType.Experiences);
-        OpenPublicChatOnPreviewMode();
+        ToggleOffChatIcon();
     }
 
     private void NumOfLoadedExperiencesChanged(int current, int previous)
@@ -795,7 +797,7 @@ public class TaskbarHUDController : IHUD
 
         channelChatWindow = controller;
 
-        controller.OnClosed += OpenPublicChatOnPreviewMode;
+        controller.OnClosed += ToggleOffChatIcon;
         controller.OnOpenChannelLeave += OpenChannelLeaveConfirmation;
     }
 
@@ -811,7 +813,7 @@ public class TaskbarHUDController : IHUD
         controller.OnClosed += () =>
         {
             controller.SetVisibility(false);
-            OpenPublicChatOnPreviewMode();
+            ToggleOffChatIcon();
         };
         controller.OnBack += GoBackFromChat;
         controller.OnOpenChannelCreation += OpenChannelCreation;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/TaskbarHUDShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/TaskbarHUDShould.cs
@@ -173,8 +173,8 @@ public class TaskbarHUDShould : IntegrationTestSuite_Legacy
         view.friendsButton.toggleButton.onClick.Invoke();
         view.chatButton.toggleButton.onClick.Invoke();
 
-        Assert.IsTrue(controller.publicChatWindow.View.IsActive);
-        Assert.IsFalse(controller.worldChatWindowHud.View.IsActive);
+        Assert.IsTrue(controller.worldChatWindowHud.View.IsActive);
+        Assert.IsFalse(controller.publicChatWindow.View.IsActive);
         Assert.IsFalse(controller.friendsHud.View.IsActive());
         Assert.IsFalse(view.friendsButton.lineOnIndicator.isVisible);
     }


### PR DESCRIPTION
## What does this PR change?

We have a bug only the first time you click on the chat button in the taskbar, it opens the nearby channel instead of the conversation list. This is worst now that we have the toast for promoting channels. This change will force always to open the conversation list when clicking the chat buton in the taskbar.

## How to test the changes?

1. Click the chat button in the taskbar
2. Should open the conversation list
3. Navigate between different chats: privates, channels and nearby
4. Press ENTER, it should open the last active chat window
5. Click the chat button in the taskbar, it should open the conversation list

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
