### PR TITLE
chore: updated hardcoded heap size limit

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/FPSDisplay/MetricsModules/MemoryJSDebugMetricModule.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/FPSDisplay/MetricsModules/MemoryJSDebugMetricModule.cs
@@ -13,12 +13,13 @@ public class MemoryJSDebugMetricModule : IDebugMetricModule
 
     private BaseVariable<float> jsUsedHeapSize => DataStore.i.debugConfig.jsUsedHeapSize;
     private BaseVariable<float> jsTotalHeapSize => DataStore.i.debugConfig.jsTotalHeapSize;
-
+    private BaseVariable<float> jsHeapSizeLimit => DataStore.i.debugConfig.jsHeapSizeLimit;
+    
     public void SetUpModule(Dictionary<DebugValueEnum, Func<string>> updateValueDictionary)
     {
         updateValueDictionary.Add(DebugValueEnum.Memory_Used_JS_Heap_Size, () =>  GetMemoryMetric(jsUsedHeapSize.Get() / BYTES_TO_MEGABYTES));
         updateValueDictionary.Add(DebugValueEnum.Memory_Total_JS_Heap_Size, () => GetMemoryMetric(jsTotalHeapSize.Get() / BYTES_TO_MEGABYTES));
-        updateValueDictionary.Add(DebugValueEnum.Memory_Limit_JS_Heap_Size, () => $"2048 Mb");
+        updateValueDictionary.Add(DebugValueEnum.Memory_Limit_JS_Heap_Size, () => GetMemoryMetric(jsHeapSizeLimit.Get() / BYTES_TO_MEGABYTES));
     }
 
     public void UpdateModule() { WebInterface.UpdateMemoryUsage(); }


### PR DESCRIPTION
## What does this PR change?

Removed hardcoded number for the `jsHeapSizeLimit`.

## How to test the changes?
When using /showfps command in chat and `jsHeapSizeLimit `should show 4GB instead of 2GB
![Screen Shot 2022-11-04 at 09 52 22](https://user-images.githubusercontent.com/7305682/200310305-a2103b29-1ae4-46af-9ac6-a1c7324c6d42.png)


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
