### PR TITLE
fix: exception at SceneController stopping messaging processing flow

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -352,11 +352,8 @@ namespace DCL
             }
             catch (Exception e)
             {
-                Exception exception = new Exception(
-                    $"Scene message error. scene: {scene.sceneData.id} method: {method} payload: {JsonUtility.ToJson(msgPayload)}");
-
                 Debug.LogException(e);
-                Debug.LogError(exception);
+                Debug.LogError($"Scene message error. scene: {scene.sceneData.id} method: {method} payload: {JsonUtility.ToJson(msgPayload)}");
             }
 
             if (delayedComponent != null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -352,8 +352,11 @@ namespace DCL
             }
             catch (Exception e)
             {
-                throw new Exception(
-                    $"Scene message error. scene: {scene.sceneData.id} method: {method} payload: {JsonUtility.ToJson(msgPayload)} {e}");
+                Exception exception = new Exception(
+                    $"Scene message error. scene: {scene.sceneData.id} method: {method} payload: {JsonUtility.ToJson(msgPayload)}");
+
+                Debug.LogException(e);
+                Debug.LogError(exception);
             }
 
             if (delayedComponent != null)


### PR DESCRIPTION
## What does this PR change?

Fixed https://github.com/decentraland/unity-renderer/issues/3409

The cause was an exception being thrown and the system falling apart.

This PR does not fix that exception. 

## How to test the changes?

- `/goto -146, 67`
- Wait until everything loads
- Go to the Stadium model at the center of the room and click on the Stadium to teleport at it.
- /showfps
- Run over the people at the sides non-stop.
- After a few laps, the scene messages stop being processed due to an exception being thrown somewhere.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
