### PR TITLE
chore: move pool container out of sight

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using DCL.Configuration;
 using UnityEngine;
 using DCL.Helpers;
 using UnityEngine.Assertions;
@@ -54,7 +55,10 @@ namespace DCL
         public Pool(string name, int maxPrewarmCount)
         {
             if (PoolManager.USE_POOL_CONTAINERS)
+            {
                 container = new GameObject("Pool - " + name);
+                container.transform.position = EnvironmentSettings.MORDOR;
+            }
 
             this.maxPrewarmCount = maxPrewarmCount;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/PoolManager.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/PoolManager.asmdef
@@ -9,7 +9,8 @@
         "GUID:4973650d2444c4561a15d50f24d91cd9",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:cc6bfabbfe87b7949aa248893f89ce37"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Fixes #3417 

Move the pool container away from 0,0,0.
This will mitigate the issue with objects spawning in other scenes.

# Test
The issue described in the ticket shouldnt appear anymore.