### PR TITLE
fix: setting default scene load value to 2

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/DefaultSettingsFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/DefaultSettingsFactory.cs
@@ -15,7 +15,7 @@ namespace DCL.SettingsCommon
         private GeneralSettings defaultGeneralSettings = new GeneralSettings
         {
             mouseSensitivity = 0.6f,
-            scenesLoadRadius = 4,
+            scenesLoadRadius = 2,
             avatarsLODDistance = 16,
             maxNonLODAvatars = DataStore_AvatarsLOD.DEFAULT_MAX_AVATAR,
             voiceChatVolume = 1,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
@@ -113,7 +113,7 @@ namespace DCL.SettingsCommon.Tests
             return new GeneralSettings
             {
                 mouseSensitivity = 0.6f,
-                scenesLoadRadius = 4,
+                scenesLoadRadius = 2,
                 avatarsLODDistance = 16,
                 maxNonLODAvatars = 1,
                 voiceChatVolume = 1,


### PR DESCRIPTION
## What does this PR change?

Set default scene load value to 2

## How to test the changes?

1) Try a cache-free version. The default value for scene load radius should be 2
2) Open your normal DCL account. Go to the settings section. Press Reset All. Scene load radius should default to 2


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
