### PR TITLE
fix: Replace non supported characters in chats

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -40,16 +40,14 @@ namespace DCL.Chat.HUD
         public override event Action OnCancelHover;
         public override event Action OnCancelGotoHover;
 
-        public override void Populate(ChatEntryModel chatEntryModel)
-        {
-            chatEntryModel.bodyText = ReplaceNonSupportedCharacteres(body.font, chatEntryModel.bodyText, '?');
+        public override void Populate(ChatEntryModel chatEntryModel) =>
             PopulateTask(chatEntryModel, populationTaskCancellationTokenSource.Token).Forget();
-        }
 
         private async UniTask PopulateTask(ChatEntryModel chatEntryModel, CancellationToken cancellationToken)
         {
             model = chatEntryModel;
 
+            chatEntryModel.bodyText = ReplaceNonSupportedCharacteres(body.font, chatEntryModel.bodyText, '?');
             chatEntryModel.bodyText = RemoveTabs(chatEntryModel.bodyText);
             var userString = GetUserString(chatEntryModel);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL.Helpers;
 using DCL.Interface;
 using DCL.SettingsCommon;
+using System;
+using System.Threading;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -40,8 +40,11 @@ namespace DCL.Chat.HUD
         public override event Action OnCancelHover;
         public override event Action OnCancelGotoHover;
 
-        public override void Populate(ChatEntryModel chatEntryModel) =>
+        public override void Populate(ChatEntryModel chatEntryModel)
+        {
+            chatEntryModel.bodyText = ReplaceNonSupportedCharacteres(body.font, chatEntryModel.bodyText, '?');
             PopulateTask(chatEntryModel, populationTaskCancellationTokenSource.Token).Forget();
+        }
 
         private async UniTask PopulateTask(ChatEntryModel chatEntryModel, CancellationToken cancellationToken)
         {
@@ -314,6 +317,24 @@ namespace DCL.Chat.HUD
             //NOTE(Brian): ContentSizeFitter doesn't fare well with tabs, so i'm replacing these
             //             with spaces.
             return text.Replace("\t", "    ");
+        }
+
+        private string ReplaceNonSupportedCharacteres(TMP_FontAsset font, string bodyText, char replacementChar)
+        {
+            bool isBodyFormatSupported = font.HasCharacters(bodyText, out uint[] missing, searchFallbacks: true, tryAddCharacter: true);
+
+            if (!isBodyFormatSupported)
+            {
+                if (missing != null && missing.Length > 0)
+                {
+                    for (int i = 0; i < missing.Length; i++)
+                    {
+                        bodyText = bodyText.Replace(((char)missing[i]), replacementChar);
+                    }
+                }
+            }
+
+            return bodyText;
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?
We were receiving huge hiccups when we opened a chat that contained messages with non-supported characteres for the font we use.

![image](https://user-images.githubusercontent.com/64659061/200611206-d1e3f083-7f6e-4e06-b83d-0afb8580e02d.png)

It seems the process to replace and calculate the size of all these texts is too expensive and it was provoking the hiccups. It happened specially when we had a lot of "corrupted" messages in the same chat.

As solution, before putting a text into the chat, we are identifying all the non-supported characters contained and replacing manually by the `?` character.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/replace-non-supported-characters-in-chats
2. Open a chat with non-supported characters.
3. Notice all these characters are replaced by the '?' character and you don't have any hiccup.
4. Check the CJK charactes keep working as before.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md