### PR TITLE
fix: The emotes wheel gets stuck on the main screen

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesWheelHUD/EmotesWheelController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/EmotesWheelHUD/EmotesWheelController.cs
@@ -154,7 +154,7 @@ namespace DCL.EmotesWheel
 
         public void SetVisibility_Internal(bool visible)
         {
-            if (isStartMenuOpen.Get())
+            if (visible && isStartMenuOpen.Get())
                 return;
 
             if (emoteJustTriggeredFromShortcut.Get())


### PR DESCRIPTION
## What does this PR change?
Fix the next problem: Entering the menu while the emotes wheel is open results in the wheel getting stuck on the screen after the player leaves the menu. The player is able to use the wheel to play the emote animation, however, it is impossible to close the wheel.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/the-emotes-wheel-gets-stuck-on-the-main-screen
2. Load into the game as a guest or via a wallet.
3. Press 'B' to open the emotes wheel.
4. Press 'I' to enter the menu.
5. Return to the game by closing the menu.
6. Press the X icon near the wheel to exit the emotes wheel.
7. Notice the Emotes Wheel is closed and you can open it again pressing B or clicking in the taskbar button.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md