### PR TITLE
fix: ECS7 move player entity

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -112,7 +112,7 @@ namespace DCL.ECSComponents
         {
             // If player is not at the scene that triggered this event
             // we'll ignore it
-            if (scene.sceneData.id != worldState.GetCurrentSceneId())
+            if (scene.sceneData.id != worldState.GetCurrentSceneId() && !scene.isPersistent)
             {
                 return false;
             }
@@ -126,7 +126,7 @@ namespace DCL.ECSComponents
             }
 
             playerTeleportVariable.Set(Utils.GridToWorldPosition(scene.sceneData.basePosition.x, scene.sceneData.basePosition.y)
-                                       + localPosition);
+                                       + localPosition, true);
             return true;
         }
     }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -9,9 +9,9 @@ namespace DCL.ECSComponents
     public class ECSTransformHandler : IECSComponentHandler<ECSTransform>
     {
         private readonly IWorldState worldState;
-        private readonly BaseVariable<Vector3> playerTeleportVariable;
+        private readonly IBaseVariable<Vector3> playerTeleportVariable;
 
-        public ECSTransformHandler(IWorldState worldState, BaseVariable<Vector3> playerTeleportVariable)
+        public ECSTransformHandler(IWorldState worldState, IBaseVariable<Vector3> playerTeleportVariable)
         {
             ECSTransformUtils.orphanEntities = new KeyValueSet<IDCLEntity, ECSTransformUtils.OrphanEntity>(100);
             this.worldState = worldState;
@@ -108,7 +108,7 @@ namespace DCL.ECSComponents
         }
 
         private static bool TryMoveCharacter(IParcelScene scene, Vector3 localPosition,
-            IWorldState worldState, BaseVariable<Vector3> playerTeleportVariable)
+            IWorldState worldState, IBaseVariable<Vector3> playerTeleportVariable)
         {
             // If player is not at the scene that triggered this event
             // we'll ignore it

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformHandlerShould.cs
@@ -15,7 +15,7 @@ namespace Tests
         private ECS7TestScene scene;
         private ECSTransformHandler handler;
         private IWorldState worldState;
-        private BaseVariable<Vector3> playerTeleportPosition;
+        private IBaseVariable<Vector3> playerTeleportPosition;
         private ECS7TestUtilsScenesAndEntities sceneTestHelper;
 
         [SetUp]
@@ -26,7 +26,7 @@ namespace Tests
             entity = scene.CreateEntity(42);
 
             worldState = Substitute.For<IWorldState>();
-            playerTeleportPosition = Substitute.For<BaseVariable<Vector3>>();
+            playerTeleportPosition = Substitute.For<IBaseVariable<Vector3>>();
             handler = new ECSTransformHandler(worldState, playerTeleportPosition);
         }
 
@@ -139,7 +139,8 @@ namespace Tests
 
             Vector3 position = new Vector3(8, 0, 0);
             handler.OnComponentModelUpdated(scene, playerEntity, new ECSTransform() { position = position });
-            playerTeleportPosition.Received(1).Set(Arg.Do<Vector3>(x => Assert.AreEqual(position, x)), true);
+            playerTeleportPosition.Received(1).Set(Arg.Do<Vector3>(x => Assert.AreEqual(position, x)), 
+                true);
         }
 
         [Test]

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformHandlerShould.cs
@@ -127,7 +127,19 @@ namespace Tests
 
             Vector3 position = new Vector3(8, 0, 0);
             handler.OnComponentModelUpdated(scene, playerEntity, new ECSTransform() { position = position });
-            playerTeleportPosition.Received(1).Set(Arg.Do<Vector3>(x => Assert.AreEqual(position, x)));
+            playerTeleportPosition.Received(1).Set(Arg.Do<Vector3>(x => Assert.AreEqual(position, x)), true);
+        }
+
+        [Test]
+        public void MoveCharacterWhenGlobalSceneTriggerIt()
+        {
+            scene.isPersistent = true;
+            worldState.GetCurrentSceneId().Returns("not-temptation");
+            var playerEntity = scene.CreateEntity(SpecialEntityId.PLAYER_ENTITY);
+
+            Vector3 position = new Vector3(8, 0, 0);
+            handler.OnComponentModelUpdated(scene, playerEntity, new ECSTransform() { position = position });
+            playerTeleportPosition.Received(1).Set(Arg.Do<Vector3>(x => Assert.AreEqual(position, x)), true);
         }
 
         [Test]
@@ -139,7 +151,7 @@ namespace Tests
 
             Vector3 position = new Vector3(1000, 0, 0);
             handler.OnComponentModelUpdated(scene, playerEntity, new ECSTransform() { position = position });
-            playerTeleportPosition.DidNotReceive().Set(Arg.Any<Vector3>());
+            playerTeleportPosition.DidNotReceive().Set(Arg.Any<Vector3>(), true);
         }
 
         [Test]
@@ -150,7 +162,7 @@ namespace Tests
 
             Vector3 position = new Vector3(1000, 0, 0);
             handler.OnComponentModelUpdated(scene, playerEntity, new ECSTransform() { position = position });
-            playerTeleportPosition.DidNotReceive().Set(Arg.Any<Vector3>());
+            playerTeleportPosition.DidNotReceive().Set(Arg.Any<Vector3>(), true);
         }
 
         [Test]

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Utils/ECSTransformUtils.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Utils/ECSTransformUtils.cs
@@ -82,6 +82,10 @@ public static class ECSTransformUtils
 
     public static bool IsInsideSceneBoundaries(IParcelScene scene, Vector2Int position)
     {
+        if (scene.isPersistent)
+        {
+            return true;
+        }
         return scene.sceneData.parcels.Contains(position);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/IBaseVariable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/IBaseVariable.cs
@@ -2,5 +2,6 @@
 {
     event Change<T> OnChange;
     void Set(T value);
+    void Set(T newValue, bool notifyEvent);
     T Get();
 }


### PR DESCRIPTION
*fix moving player's entity was not working for global scenes
*fix moving player to the same location as before, it was only working once