### PR TITLE
fix: removal of send chat message to channel metric

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/SocialAnalytics/ISocialAnalytics.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/SocialAnalytics/ISocialAnalytics.cs
@@ -28,7 +28,6 @@ namespace SocialFeaturesAnalytics
         void SendPopulatedChannelJoined(string channelName, ChannelJoinedSource source);
         void SendLeaveChannel(string channelId, ChannelLeaveSource source);
         void SendChannelSearch(string text);
-        void SendMessageSentToChannel(string channelName, int bodyLength, string source);
         void SendChannelLinkClicked(string channel, bool joinAccepted, ChannelLinkSource source);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/SocialAnalytics/SocialAnalytics.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/SocialAnalytics/SocialAnalytics.cs
@@ -29,7 +29,6 @@ namespace SocialFeaturesAnalytics
         private const string POPULATED_CHANNEL_JOINED = "player_joins_channel";
         private const string CHANNEL_LEAVE = "player_leaves_channel";
         private const string CHANNEL_SEARCH = "player_search_channel";
-        private const string MESSAGE_SENT_TO_CHANNEL = "send_chat_message";
         private const string CHANNEL_LINK_CLICK = "player_clicks_channel_link";
         
         public static SocialAnalytics i { get; private set; }
@@ -305,17 +304,6 @@ namespace SocialFeaturesAnalytics
                 ["search"] = text
             };
             analytics.SendAnalytic(CHANNEL_SEARCH, data);
-        }
-
-        public void SendMessageSentToChannel(string channelName, int bodyLength, string source)
-        {
-            var data = new Dictionary<string, string>
-            {
-                ["source"] = source,
-                ["channel"] = channelName,
-                ["length"] = bodyLength.ToString()
-            };
-            analytics.SendAnalytic(MESSAGE_SENT_TO_CHANNEL, data);
         }
 
         public void SendChannelLinkClicked(string channel, bool joinAccepted, ChannelLinkSource source)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -193,7 +193,6 @@ namespace DCL.Chat.HUD
             }
 
             chatController.Send(message);
-            socialAnalytics.SendMessageSentToChannel(channel.Name, message.body.Length, "channel");
         }
 
         private void HandleMessageReceived(ChatMessage message)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelHUDControllerShould.cs
@@ -101,18 +101,6 @@ namespace DCL.Chat.HUD
         }
 
         [Test]
-        public void TrackMessageSentEvent()
-        {
-            chatView.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage
-            {
-                body = "hey",
-                messageType = ChatMessage.Type.PUBLIC
-            });
-            
-            socialAnalytics.Received(1).SendMessageSentToChannel(CHANNEL_NAME, 3, "channel");
-        }
-
-        [Test]
         public void MuteChannel()
         {
             view.OnMuteChanged += Raise.Event<Action<bool>>(true);


### PR DESCRIPTION
## What does this PR change?

Removes the sending of the metric on channel messages. Now it is handled by kernel in this pr: https://github.com/decentraland/kernel/pull/684

## How to test the changes?

1. Open a channel
2. Send messages
3. Everything should keep working as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
