### PR TITLE
fix: Wrong positioning of empty direct messages container

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
@@ -398,6 +398,7 @@ namespace DCL.Chat.HUD
         
             scroll.enabled = !visible;
             isLoadingPrivateChannels = visible;
+            UpdateLayout();
         }
 
         private void UpdateHeaders()


### PR DESCRIPTION
## What does this PR change?
The position of the image was wrong. The only way to fix it was closing channels.

![image.png](https://images.zenhubusercontent.com/615af652539a0a743b87eaaa/e16e80b6-f5c4-410a-9ff6-dd7e7ccc573e)

![image (1).png](https://images.zenhubusercontent.com/615af652539a0a743b87eaaa/ccfccc0f-4fc8-44a0-b2bf-6f1d411bda83)

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/wrong-positioning-of-empty-direct-messages-container
2. Close channels & DMs subsections in the conversation list
3. Open channels
4. Open DMs
5. Notice the position of the emty image is correct

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md