### PR TITLE
Explore sub-sections are not being refreshed when the main menu opens

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsSectionComponentView.cs
@@ -45,6 +45,7 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
     [SerializeField] internal EventsSubSectionComponentView eventsSubSection;
     
     private Canvas canvas;
+    private int currentSelectedIndex = -1;
 
     public override void Awake()
     {
@@ -65,8 +66,14 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
     public void GoToSubsection(int subSectionIndex) =>
         subSectionSelector.GetSection(subSectionIndex)?.SelectToggle(reselectIfAlreadyOn: true);
 
-    public void SetActive(bool isActive) => 
+    public void SetActive(bool isActive)
+    {
         canvas.enabled = isActive;
+
+        highlightsSubSection.SetActive(isActive && currentSelectedIndex == HIGHLIGHTS_SUB_SECTION_INDEX);
+        placesSubSection.SetActive(isActive && currentSelectedIndex == PLACES_SUB_SECTION_INDEX);
+        eventsSubSection.SetActive(isActive && currentSelectedIndex == EVENTS_SUB_SECTION_INDEX);
+    }
 
     public override void RefreshControl()
     {
@@ -87,9 +94,21 @@ public class PlacesAndEventsSectionComponentView : BaseComponentView, IPlacesAnd
 
     internal void CreateSubSectionSelectorMappings()
     {
-        subSectionSelector.GetSection(HIGHLIGHTS_SUB_SECTION_INDEX)?.onSelect.AddListener(highlightsSubSection.SetActive);
-        subSectionSelector.GetSection(PLACES_SUB_SECTION_INDEX)?.onSelect.AddListener(placesSubSection.SetActive);
-        subSectionSelector.GetSection(EVENTS_SUB_SECTION_INDEX)?.onSelect.AddListener(eventsSubSection.SetActive);
+        subSectionSelector.GetSection(HIGHLIGHTS_SUB_SECTION_INDEX)?.onSelect.AddListener((isActive) =>
+        {
+            highlightsSubSection.SetActive(isActive);
+            currentSelectedIndex = HIGHLIGHTS_SUB_SECTION_INDEX;
+        });
+        subSectionSelector.GetSection(PLACES_SUB_SECTION_INDEX)?.onSelect.AddListener((isActive) =>
+        {
+            placesSubSection.SetActive(isActive);
+            currentSelectedIndex = PLACES_SUB_SECTION_INDEX;
+        });
+        subSectionSelector.GetSection(EVENTS_SUB_SECTION_INDEX)?.onSelect.AddListener((isActive) =>
+        {
+            eventsSubSection.SetActive(isActive);
+            currentSelectedIndex = EVENTS_SUB_SECTION_INDEX;
+        });
 
         placesSubSection.SetActive(false);
         eventsSubSection.SetActive(false);


### PR DESCRIPTION
## What does this PR change?
After closing the main menu, if we left open any of the Explore sub-sections (highlights, places or events) and we opened it again after 1 minute (this is the minimum time we have set for refreshing the data), the data inside of the sub-sections was not being refreshed.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/explore-sub-sections-are-not-being-refreshed-when-menu-opens
2. Open the main menu and go to the Explore section.
3. Select any of the 3 sub-sections.
4. Close the main menu and wait for 1min.
5. Open the main menu again.
6. Notice the sub-sections selected is the same as you left open before and its data refreshed.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md