### PR TITLE
fix: Channel members are being requested twice

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChannelMembersComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChannelMembersComponentView.cs
@@ -87,7 +87,7 @@ namespace DCL.Chat.HUD
 
         public override void Hide(bool instant = false) => gameObject.SetActive(false);
 
-        public void ClearSearchInput() => searchBar.ClearSearch();
+        public void ClearSearchInput(bool notify = true) => searchBar.ClearSearch(notify);
 
         public void HideLoading()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChannelMembersHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChannelMembersHUDController.cs
@@ -70,7 +70,7 @@ namespace DCL.Chat.HUD
             {
                 LoadMembers();
                 SetAutomaticReloadingActive(true);
-                view.ClearSearchInput();
+                view.ClearSearchInput(notify: false);
             }
             else
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IChannelMembersComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IChannelMembersComponentView.cs
@@ -15,7 +15,7 @@ namespace DCL.Chat.HUD
         void Set(ChannelMemberEntryModel user);
         void Show(bool instant = false);
         void Hide(bool instant = false);
-        void ClearSearchInput();
+        void ClearSearchInput(bool notify = true);
         void HideLoading();
         void ShowLoadingMore();
         void HideLoadingMore();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChannelMembersHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChannelMembersHUDControllerShould.cs
@@ -57,7 +57,7 @@ public class ChannelMembersHUDControllerShould
         // Assert
         if (isVisible)
         {
-            channelMembersComponentView.Received(1).ClearSearchInput();
+            channelMembersComponentView.Received(1).ClearSearchInput(false);
             channelMembersComponentView.Received(1).Show();
             channelMembersComponentView.Received(1).ClearAllEntries();
             channelMembersComponentView.Received(1).ShowLoading();
@@ -79,7 +79,7 @@ public class ChannelMembersHUDControllerShould
         channelMembersHUDController.SetVisibility(true);
 
         // Assert
-        channelMembersComponentView.Received(1).ClearSearchInput();
+        channelMembersComponentView.Received(1).ClearSearchInput(false);
         channelMembersComponentView.Received(1).Show();
         channelMembersComponentView.Received(1).ClearAllEntries();
         channelMembersComponentView.Received(1).ShowLoading();


### PR DESCRIPTION
## What does this PR change?
Data was being requested 2 times when the channel memebers list was open.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/channel-members-are-being-requested-twice
2. Open any channel.
3. Open the list of members.
3. Notice (from code) the `GetChannelMembers` message is being sent to kernel only once.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md