### PR TITLE
fix: nullref exception when requesting allowance for creating channels from channel link detector

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChannelsFeatureFlagService.cs
@@ -64,6 +64,10 @@ namespace DCL.Chat.Channels
         {
             if (!featureFlags.Get().IsFeatureEnabled(FEATURE_FLAG_FOR_USERS_ALLOWED_TO_CREATE_CHANNELS))
                 return false;
+            
+            UserProfile ownUserProfile = userProfileBridge.GetOwn();
+            if (ownUserProfile == null) return false;
+            if (string.IsNullOrEmpty(ownUserProfile.userId)) return false;
 
             FeatureFlagVariantPayload usersAllowedToCreateChannelsPayload = featureFlags
                 .Get()
@@ -73,7 +77,6 @@ namespace DCL.Chat.Channels
                 return false;
 
             UsersAllowedToCreateChannelsVariantPayload allowedUsersData = JsonUtility.FromJson<UsersAllowedToCreateChannelsVariantPayload>(usersAllowedToCreateChannelsPayload.value);
-            UserProfile ownUserProfile = userProfileBridge.GetOwn();
 
             switch (allowedUsersData.mode)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/ChannelLinkDetector.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/ChannelLinkDetector.cs
@@ -14,20 +14,7 @@ public class ChannelLinkDetector : MonoBehaviour, IPointerClickHandler
     internal bool hasNoParseLabel;
     internal List<string> channelsFoundInText = new List<string>();
     private IChannelsFeatureFlagService channelsFeatureFlagService;
-    private bool isAllowedToCreateChannelsDirty = true;
-    private bool lazyAllowedToCreateChannels;
-
-    private bool isAllowedToCreateChannels
-    {
-        get
-        {
-            if (!isAllowedToCreateChannelsDirty) return lazyAllowedToCreateChannels;
-            lazyAllowedToCreateChannels = channelsFeatureFlagService.IsChannelsFeatureEnabled()
-                                          && channelsFeatureFlagService.IsAllowedToCreateChannels();
-            isAllowedToCreateChannelsDirty = false;
-            return lazyAllowedToCreateChannels;
-        }
-    } 
+    private bool isAllowedToCreateChannels = true;
 
     private void Awake()
     {
@@ -40,6 +27,8 @@ public class ChannelLinkDetector : MonoBehaviour, IPointerClickHandler
             && Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>() != null)
         {
             channelsFeatureFlagService = Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>();
+            isAllowedToCreateChannels = channelsFeatureFlagService.IsChannelsFeatureEnabled()
+                                        && channelsFeatureFlagService.IsAllowedToCreateChannels();
             channelsFeatureFlagService.OnAllowedToCreateChannelsChanged += OnAllowedToCreateChannelsChanged;
         }
     }
@@ -56,7 +45,7 @@ public class ChannelLinkDetector : MonoBehaviour, IPointerClickHandler
     }
 
     private void OnAllowedToCreateChannelsChanged(bool isAllowed) =>
-        isAllowedToCreateChannelsDirty = true;
+        isAllowedToCreateChannels = isAllowed && channelsFeatureFlagService.IsChannelsFeatureEnabled();
 
     private void OnTextComponentPreRenderText(TMP_TextInfo textInfo)
     {


### PR DESCRIPTION
## What does this PR change?

Fixes a null reference exception when the channel link detector initializes before the user profile.

## How to test the changes?

There is no specific steps. Its just a race condition that depends of the randomness of the load pipeline.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
