### PR TITLE
fix: channel infinite loading guest

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
@@ -588,6 +588,18 @@ public class WorldChatWindowControllerShould
         chatController.Received(1).MuteChannel("automatic-channel");
     }
 
+    [Test]
+    public void HideLoadingOfChannelsWhenIsGuest()
+    {
+        chatController.IsInitialized.Returns(false);
+        ownUserProfile.UpdateData(new UserProfileModel {userId = OWN_USER_ID, hasConnectedWeb3 = false});
+        controller.Initialize(view);
+        
+        controller.SetVisibility(true);
+        
+        view.Received(1).HideChannelsLoading();
+    }
+
     private void GivenFriend(string friendId, PresenceStatus presence)
     {
         var friendProfile = ScriptableObject.CreateInstance<UserProfile>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -206,6 +206,11 @@ public class WorldChatWindowController : IHUD
                     RequestJoinedChannels();
                     SetAutomaticChannelsInfoUpdatingActive(true);
                 }
+                else if (ownUserProfile.isGuest)
+                {
+                    // TODO: channels are not allowed for guests. When we support it in the future, remove this call
+                    view.HideChannelsLoading();
+                }
 
                 if (!areUnseenMessajesRequestedByFirstTime)
                     RequestUnreadChannelsMessages();


### PR DESCRIPTION
## What does this PR change?

Fixes an infinite loading displayed in the conversation list when you enter as a guest.

## How to test the changes?

1. Enter as a guest
2. Open the conversation list from the chat button in the taskbar
3. No loading should be displayed in the channel list

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
