### PR TITLE
feat: joined channels can be opened from the channel browser

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDFactory.cs
@@ -120,7 +120,6 @@ public class HUDFactory : IHUDFactory
                     new SocialAnalytics(
                         Environment.i.platform.serviceProviders.analytics,
                         new UserProfileWebInterfaceBridge()),
-                    new UserProfileWebInterfaceBridge(),
                     Environment.i.serviceLocator.Get<IChannelsFeatureFlagService>());
                 break;
             case HUDElementID.CHANNELS_CREATE:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/JoinChannelComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/JoinChannelHUD/JoinChannelComponentController.cs
@@ -76,7 +76,7 @@ public class JoinChannelComponentController : IDisposable
         if (alreadyJoinedChannel == null)
             chatController.JoinOrCreateChannel(channelName);
         else
-            dataStore.channels.channelToBeOpenedFromLink.Set(alreadyJoinedChannel.ChannelId);
+            dataStore.channels.channelToBeOpened.Set(alreadyJoinedChannel.ChannelId);
 
         if (channelsDataStore.channelJoinedSource.Get() == ChannelJoinedSource.Link)
             socialAnalytics.SendChannelLinkClicked(channelName, true, GetChannelLinkSource());

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ChannelSearchEntry.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ChannelSearchEntry.prefab
@@ -631,19 +631,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   showHideAnimator: {fileID: 0}
-  openChatButton: {fileID: 5926612440724047820}
+  openChatButton: {fileID: 8947407940783313022}
   nameLabel: {fileID: 7628201440103558983}
   model:
     channelId: 
     name: 
     isJoined: 0
     memberCount: 0
+    showOnlyOnlineMembers: 0
     muted: 0
   unreadNotifications: {fileID: 0}
   namePrefix: '#'
   memberCountLabel: {fileID: 7225015788764800492}
   optionsButton: {fileID: 0}
   leaveButton: {fileID: 100716840669198008}
+  joinButton: {fileID: 5926612440724047820}
   leaveButtonContainer: {fileID: 886247146761078123}
   openChatContainer: {fileID: 8385950391394479113}
   joinedContainer: {fileID: 7528068125504281875}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/SearchChannelsWindowMock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/SearchChannelsWindowMock.cs
@@ -12,6 +12,7 @@ public class SearchChannelsWindowMock : MonoBehaviour, ISearchChannelsWindowView
     public event Action<string> OnJoinChannel;
     public event Action<string> OnLeaveChannel;
     public event Action OnCreateChannel;
+    public event Action<string> OnOpenChannel;
     public RectTransform Transform => (RectTransform) transform;
     public int EntryCount { get; }
     public bool IsActive { get; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/TaskbarHUDShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/TaskbarHUDShould.cs
@@ -144,7 +144,7 @@ public class TaskbarHUDShould : IntegrationTestSuite_Legacy
         controller.AddFriendsWindow(friendsHudController);
 
         var channelSearchController = new SearchChannelsWindowController(this.chatController, Substitute.For<IMouseCatcher>(), new DataStore(),
-            Substitute.For<ISocialAnalytics>(), Substitute.For<IUserProfileBridge>(), Substitute.For<IChannelsFeatureFlagService>());
+            Substitute.For<ISocialAnalytics>(), Substitute.For<IChannelsFeatureFlagService>());
         channelSearchController.Initialize(new GameObject("SearchChannelsWindowMock").AddComponent<SearchChannelsWindowMock>());
         controller.AddChannelSearch(channelSearchController);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -137,7 +137,7 @@ namespace DCL.Chat.HUD
                 View.Hide();
             }
 
-            dataStore.channels.channelToBeOpenedFromLink.Set(null, notifyEvent: false);
+            dataStore.channels.channelToBeOpened.Set(null, notifyEvent: false);
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ISearchChannelsWindowView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ISearchChannelsWindowView.cs
@@ -13,6 +13,7 @@ namespace DCL.Chat.HUD
         event Action<string> OnJoinChannel;
         event Action<string> OnLeaveChannel;
         event Action OnCreateChannel;
+        event Action<string> OnOpenChannel;
         RectTransform Transform { get; }
         int EntryCount { get; }
         bool IsActive { get; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatEntry.cs
@@ -15,6 +15,7 @@ namespace DCL.Chat.HUD
         [SerializeField] internal TMP_Text memberCountLabel;
         [SerializeField] internal Button optionsButton;
         [SerializeField] internal Button leaveButton;
+        [SerializeField] internal Button joinButton;
         [SerializeField] internal GameObject leaveButtonContainer;
         [SerializeField] internal GameObject openChatContainer;
         [SerializeField] internal GameObject joinedContainer;
@@ -26,6 +27,7 @@ namespace DCL.Chat.HUD
 
         public event Action<PublicChatEntry> OnOpenChat;
         public event Action<PublicChatEntry> OnLeave;
+        public event Action<PublicChatEntry> OnJoin;
         public event Action<PublicChatEntry> OnOpenOptions;
 
         public static PublicChatEntry Create()
@@ -43,6 +45,9 @@ namespace DCL.Chat.HUD
         
             if (leaveButton)
                 leaveButton.onClick.AddListener(() => OnLeave?.Invoke(this));
+            
+            if (joinButton)
+                joinButton.onClick.AddListener(() => OnJoin?.Invoke(this));
         }
 
         public void Initialize(IChatController chatController)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowComponentView.cs
@@ -39,6 +39,7 @@ namespace DCL.Chat.HUD
         public event Action<string> OnJoinChannel;
         public event Action<string> OnLeaveChannel;
         public event Action OnCreateChannel;
+        public event Action<string> OnOpenChannel;
 
         public RectTransform Transform => (RectTransform) transform;
         public int EntryCount => channelList.Count();
@@ -106,8 +107,10 @@ namespace DCL.Chat.HUD
                     showOnlyOnlineMembers: false, channel.Muted));
 
             var entry = channelList.Get(channel.ChannelId);
-            entry.OnOpenChat -= HandleJoinRequest;
-            entry.OnOpenChat += HandleJoinRequest;
+            entry.OnJoin -= HandleJoinRequest;
+            entry.OnJoin += HandleJoinRequest;
+            entry.OnOpenChat -= HandleOpenChat;
+            entry.OnOpenChat += HandleOpenChat;
             entry.OnLeave -= HandleLeaveRequest;
             entry.OnLeave += HandleLeaveRequest;
 
@@ -178,6 +181,8 @@ namespace DCL.Chat.HUD
         }
 
         private void HandleJoinRequest(PublicChatEntry entry) => OnJoinChannel?.Invoke(entry.Model.channelId);
+
+        private void HandleOpenChat(PublicChatEntry entry) => OnOpenChannel?.Invoke(entry.Model.channelId);
 
         private void HandleLeaveRequest(PublicChatEntry entry) => OnLeaveChannel?.Invoke(entry.Model.channelId);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/SearchChannelsWindowController.cs
@@ -1,10 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
-using Channel = DCL.Chat.Channels.Channel;
-using System.Collections.Generic;
 using SocialFeaturesAnalytics;
-using DCL.Chat.Channels;
+using Channel = DCL.Chat.Channels.Channel;
 
 namespace DCL.Chat.HUD
 {
@@ -17,7 +16,6 @@ namespace DCL.Chat.HUD
         private readonly IMouseCatcher mouseCatcher;
         private readonly DataStore dataStore;
         private readonly ISocialAnalytics socialAnalytics;
-        private readonly IUserProfileBridge userProfileBridge;
         private readonly IChannelsFeatureFlagService channelsFeatureFlagService;
         private ISearchChannelsWindowView view;
         private DateTime loadStartedTimestamp = DateTime.MinValue;
@@ -38,14 +36,12 @@ namespace DCL.Chat.HUD
             IMouseCatcher mouseCatcher,
             DataStore dataStore,
             ISocialAnalytics socialAnalytics,
-            IUserProfileBridge userProfileBridge,
             IChannelsFeatureFlagService channelsFeatureFlagService)
         {
             this.chatController = chatController;
             this.mouseCatcher = mouseCatcher;
             this.dataStore = dataStore;
             this.socialAnalytics = socialAnalytics;
-            this.userProfileBridge = userProfileBridge;
             this.channelsFeatureFlagService = channelsFeatureFlagService;
         }
 
@@ -98,6 +94,7 @@ namespace DCL.Chat.HUD
                 view.OnJoinChannel += HandleJoinChannel;
                 view.OnLeaveChannel += HandleLeaveChannel;
                 view.OnCreateChannel += OpenChannelCreationWindow;
+                view.OnOpenChannel += NavigateToChannel;
                 chatController.OnChannelSearchResult += ShowRequestedChannels;
                 chatController.OnChannelUpdated += UpdateChannelInfo;
                 
@@ -118,6 +115,14 @@ namespace DCL.Chat.HUD
                 ClearListeners();
                 view.Hide();
             }
+        }
+
+        private void NavigateToChannel(string channelId)
+        {
+            var channel = chatController.GetAllocatedChannel(channelId);
+            if (channel == null) return;
+            if (!channel.Joined) return;
+            dataStore.channels.channelToBeOpened.Set(channelId, true);
         }
 
         private void OpenChannelCreationWindow()
@@ -210,6 +215,7 @@ namespace DCL.Chat.HUD
             view.OnJoinChannel -= HandleJoinChannel;
             view.OnLeaveChannel -= HandleLeaveChannel;
             view.OnCreateChannel -= OpenChannelCreationWindow;
+            view.OnOpenChannel -= NavigateToChannel;
         }
 
         private async UniTask WaitTimeoutThenHideLoading(CancellationToken cancellationToken)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -133,7 +133,7 @@ public class WorldChatWindowController : IHUD
             chatController.OnJoinChannelError += HandleJoinChannelError;
             chatController.OnChannelLeaveError += HandleLeaveChannelError;
             chatController.OnChannelLeft += HandleChannelLeft;
-            dataStore.channels.channelToBeOpenedFromLink.OnChange += HandleChannelOpenedFromLink;
+            dataStore.channels.channelToBeOpened.OnChange += HandleChannelOpened;
 
             view.ShowChannelsLoading();
             view.SetSearchAndCreateContainerActive(true);
@@ -171,7 +171,7 @@ public class WorldChatWindowController : IHUD
         friendsController.OnUpdateUserStatus -= HandleUserStatusChanged;
         friendsController.OnUpdateFriendship -= HandleFriendshipUpdated;
         friendsController.OnInitialized -= HandleFriendsControllerInitialization;
-        dataStore.channels.channelToBeOpenedFromLink.OnChange -= HandleChannelOpenedFromLink;
+        dataStore.channels.channelToBeOpened.OnChange -= HandleChannelOpened;
 
         if (ownUserProfile != null)
             ownUserProfile.OnUpdate -= OnUserProfileUpdate;
@@ -574,7 +574,7 @@ public class WorldChatWindowController : IHUD
         socialAnalytics.SendLeaveChannel(channel?.Name ?? channelId, dataStore.channels.channelLeaveSource.Get());
     }
 
-    private void HandleChannelOpenedFromLink(string channelId, string previousChannelId)
+    private void HandleChannelOpened(string channelId, string previousChannelId)
     {
         if (string.IsNullOrEmpty(channelId))
             return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Channels.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Channels.cs
@@ -9,7 +9,7 @@ namespace DCL
         public readonly BaseVariable<string> currentChannelLimitReached = new BaseVariable<string>();
         public readonly BaseVariable<string> joinChannelError = new BaseVariable<string>();
         public readonly BaseVariable<string> leaveChannelError = new BaseVariable<string>();
-        public readonly BaseVariable<string> channelToBeOpenedFromLink = new BaseVariable<string>();
+        public readonly BaseVariable<string> channelToBeOpened = new BaseVariable<string>();
         public readonly BaseVariable<bool> isPromoteToastVisible = new BaseVariable<bool>();
     }
 }


### PR DESCRIPTION
## What does this PR change?

Added the functionality of open channels from the channel browser.
You must have already joined the channel to do so.

## How to test the changes?

1. Make sure you have joined any channel
2. Open the channel browser
3. Click in any of the channels which are marked as `joined`
4. The channel window should be opened
5. Check that the rest of the channel browser features are working as expected
6. Check that the channels are listed correctly in the conversation list

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
