### PR TITLE
fix: Player online status is not visible in the Chat window

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/WorldChatWindowViewMock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Tests/WorldChatWindowViewMock.cs
@@ -66,6 +66,10 @@ public class WorldChatWindowViewMock : MonoBehaviour, IWorldChatWindowView
     {
     }
 
+    public void RefreshPrivateChatPresence(string userId, bool isOnline)
+    {
+    }
+
     public void Dispose()
     {
         if (isDestroyed) return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/CollapsableDirectChatListComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/CollapsableDirectChatListComponentView.cs
@@ -77,6 +77,12 @@ public class CollapsableDirectChatListComponentView : CollapsableSortedListCompo
         }
     }
 
+    public void RefreshPresence(string userId, bool isOnline)
+    {
+        if (Entries.TryGetValue(userId, out PrivateChatEntry directMessage))
+            directMessage.SetPresence(isOnline);
+    }
+
     private void CreateEntry(string userId)
     {
         entryPool = GetEntryPool();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IWorldChatWindowView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IWorldChatWindowView.cs
@@ -30,6 +30,7 @@ public interface IWorldChatWindowView
     void ShowPrivateChatsLoading();
     void HidePrivateChatsLoading();
     void RefreshBlockedDirectMessages(List<string> blockedUsers);
+    void RefreshPrivateChatPresence(string userId, bool isOnline);
     void Dispose();
     void DisableSearchMode();
     void HideMoreChatsToLoadHint();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PrivateChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PrivateChatEntry.cs
@@ -94,7 +94,7 @@ namespace DCL.Chat.HUD
             blockedContainer.SetActive(isBlocked);
         }
 
-        private void SetPresence(bool isOnline)
+        public void SetPresence(bool isOnline)
         {
             model.isOnline = isOnline;
             onlineStatusContainer.SetActive(isOnline && !model.isBlocked);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
@@ -201,6 +201,21 @@ namespace DCL.Chat.HUD
             directChatList.RefreshBlockedEntries(blockedUsers);
         }
 
+        public void RefreshPrivateChatPresence(string userId, bool isOnline)
+        {
+            if (!ContainsPrivateChannel(userId))
+                return;
+
+            if (privateChatsCreationQueue.ContainsKey(userId))
+            {
+                PrivateChatModel refreshedPrivateChatModel = privateChatsCreationQueue[userId];
+                refreshedPrivateChatModel.isOnline = isOnline;
+                privateChatsCreationQueue[userId] = refreshedPrivateChatModel;
+            }
+            else
+                directChatList.RefreshPresence(userId, isOnline);
+        }
+
         public void HideMoreChatsToLoadHint()
         {
             loadMoreEntriesContainer.SetActive(false);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowController.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using DCL.Browser;
 using UnityEngine;
 using Channel = DCL.Chat.Channels.Channel;
+using DCL.Chat.HUD;
 
 public class WorldChatWindowController : IHUD
 {
@@ -341,6 +342,10 @@ public class WorldChatWindowController : IHUD
         {
             // show only private chats from friends. Change it whenever the catalyst supports to send pms to any user
             view.RemovePrivateChat(userId);
+        }
+        else
+        {
+            view.RefreshPrivateChatPresence(userId, status.presence == PresenceStatus.ONLINE);
         }
     }
 


### PR DESCRIPTION
## What does this PR change?
The online status of the players was not visible in the chat window where we show the private conversations.

![image.png](https://images.zenhubusercontent.com/603cdb58edb53386a3d0d8d5/8ffd435f-a71e-4f81-9a95-a4688c12d115)

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/player-online-status-is-not-visible-in-the-chat-window
2. Talk to a friend that is online
3. Check the Chat panel an see the online status of that player

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md