### PR TITLE
refactor: UserProfileemotes caused a hiccup

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/BillboardSystem/Tests.meta
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/BillboardSystem/Tests.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: b8b45c0109c14ac9b927c3d5e68b46f8
-timeCreated: 1668452310

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -104,11 +104,10 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
 
     public void SetAvatarExpression(string id, EmoteSource source)
     {
-        var timestamp = (long) (DateTime.UtcNow - epochStart).TotalMilliseconds;
+        long timestamp = (long)(DateTime.UtcNow - epochStart).TotalMilliseconds;
         avatar.expressionTriggerId = id;
         avatar.expressionTriggerTimestamp = timestamp;
         WebInterface.SendExpression(id, timestamp);
-        OnUpdate?.Invoke(this);
         OnAvatarEmoteSet?.Invoke(id, timestamp, source);
     }
 
@@ -127,7 +126,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     }
 
     public void RemoveFromInventory(string wearableId) { inventory.Remove(wearableId); }
-    
+
     public bool ContainsInInventory(string wearableId) => inventory.ContainsKey(wearableId);
 
     public string[] GetInventoryItemsIds() { return inventory.Keys.ToArray(); }
@@ -154,9 +153,9 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
             return;
         blocked.Add(userId);
     }
-    
+
     public void Unblock(string userId) { blocked.Remove(userId); }
-    
+
     public bool HasEquipped(string wearableId) => avatar.wearables.Contains(wearableId);
 
 #if UNITY_EDITOR


### PR DESCRIPTION
fixes #3374 

This could also be considered a fix, but, as this was not a bug, but an intended Update that might not be needed anymore, I considered it a refactor.

The call for update of the whole profile when showing an emote was causing a hiccup in performance, as emotes showing does not change the profile, this call has been removed.

## QA

Showing emotes should act exactly the same as in dev, no further modifications should be observable.