### PR TITLE
fix: TextShape billboard

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/BillboardSystem/Tests.meta
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/BillboardSystem/Tests.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: b8b45c0109c14ac9b927c3d5e68b46f8
-timeCreated: 1668452310

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
@@ -65,6 +65,23 @@ namespace DCL.Components
 
         public override string componentName => "text";
 
+
+        private bool CameraFound
+        {
+            get
+            {
+                if (!cameraFound)
+                {
+                    mainCamera = Camera.main;
+                    if (mainCamera != null)
+                        cameraFound = true;
+                }
+
+                return cameraFound;
+            }
+        }
+
+
         private void Awake()
         {
             model = new Model();
@@ -79,14 +96,7 @@ namespace DCL.Components
         private void OnUpdate()
         {
             // Cameras are not detected while loading, so we can not load the camera on Awake or Start
-            if (!cameraFound)
-            {
-                mainCamera = Camera.main;
-                if (mainCamera != null)
-                    cameraFound = true;
-            }
-
-            if (cachedModel.billboard && mainCamera != null)
+            if (cachedModel.billboard && CameraFound)
                 transform.forward = mainCamera.transform.forward;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
@@ -61,26 +61,35 @@ namespace DCL.Components
         private Model cachedModel;
         private Material cachedFontMaterial;
         private Camera mainCamera;
+        private bool cameraFound;
 
         public override string componentName => "text";
 
         private void Awake()
         {
             model = new Model();
-            mainCamera = Camera.main;
 
             cachedFontMaterial = new Material(text.fontSharedMaterial);
             text.fontSharedMaterial = cachedFontMaterial;
             text.text = string.Empty;
-            
+
             Environment.i.platform.updateEventHandler.AddListener(IUpdateEventHandler.EventType.Update, OnUpdate);
         }
 
         private void OnUpdate()
         {
+            // Cameras are not detected while loading, so we can not load the camera on Awake or Start
+            if (!cameraFound)
+            {
+                mainCamera = Camera.main;
+                if (mainCamera != null)
+                    cameraFound = true;
+            }
+
             if (cachedModel.billboard && mainCamera != null)
                 transform.forward = mainCamera.transform.forward;
         }
+
 
         new public Model GetModel() { return cachedModel; }
 
@@ -89,20 +98,20 @@ namespace DCL.Components
             if (rectTransform == null)
                 yield break;
 
-            Model model = (Model) newModel;
+            Model model = (Model)newModel;
             cachedModel = model;
             PrepareRectTransform();
 
             // We avoid using even yield break; as this instruction skips a frame and we don't want that.
-            if ( !DCLFont.IsFontLoaded(scene, model.font) )
+            if (!DCLFont.IsFontLoaded(scene, model.font))
             {
                 yield return DCLFont.WaitUntilFontIsReady(scene, model.font);
             }
 
             DCLFont.SetFontFromComponent(scene, model.font, text);
-            
+
             ApplyModelChanges(text, model);
-            
+
             if (entity.meshRootGameObject == null)
                 entity.meshesInfo.meshRootGameObject = gameObject;
 
@@ -114,7 +123,7 @@ namespace DCL.Components
             text.text = model.value;
 
             text.color = new Color(model.color.r, model.color.g, model.color.b, model.visible ? model.opacity : 0);
-            text.fontSize = (int) model.fontSize;
+            text.fontSize = (int)model.fontSize;
             text.richText = true;
             text.overflowMode = TextOverflowModes.Overflow;
             text.enableAutoSizing = model.fontAutoSize;
@@ -122,10 +131,10 @@ namespace DCL.Components
             text.margin =
                 new Vector4
                 (
-                    (int) model.paddingLeft,
-                    (int) model.paddingTop,
-                    (int) model.paddingRight,
-                    (int) model.paddingBottom
+                    (int)model.paddingLeft,
+                    (int)model.paddingTop,
+                    (int)model.paddingRight,
+                    (int)model.paddingBottom
                 );
 
             text.alignment = GetAlignment(model.vTextAlign, model.hTextAlign);
@@ -228,7 +237,7 @@ namespace DCL.Components
             }
         }
 
-        public override int GetClassId() { return (int) CLASS_ID_COMPONENT.TEXT_SHAPE; }
+        public override int GetClassId() { return (int)CLASS_ID_COMPONENT.TEXT_SHAPE; }
 
         public override void Cleanup()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
@@ -79,9 +79,7 @@ namespace DCL.Components
         private void OnUpdate()
         {
             if (cachedModel.billboard && mainCamera != null)
-            {
                 transform.forward = mainCamera.transform.forward;
-            }
         }
 
         new public Model GetModel() { return cachedModel; }


### PR DESCRIPTION
fixes #3342 

This issue was fixed by adding a Debug.Log... and then removing it.
Found something similar in the past, sometimes Unity seems to create a "cache" on how certain methods work, like a "precompilation status", once any change is done to that code directly, it updates and starts behaving as expected again.

For this issue, I don't know if the solution will just work on my end or on everyone else's to, let's see what QA finds.

In order to create a meaningful change so it can be committed, I removed the brackets of the single lined if.

## QA

Very weird behavior about Unity compilation, it works on my end now, but it could perfectly not work at all on others.

- Go to coordinates (-53, 1) approx.
- In the woods of a set of scenes called **Salmonomicon** you will be able to see a text over the head of a floating head.
- This text should be rotating along the **y** axis looking at the camera.
- If the text does not rotate towards the camera when you move around the floating head, in your end is not working.