### PR TITLE
fix: corrected use of CSF in debugView

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/Resources/DebugSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/Resources/DebugSection.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 6997712442045216261}
   - component: {fileID: 8904861309654669527}
-  - component: {fileID: 3371280741483056261}
   - component: {fileID: 2124020293711335103}
   - component: {fileID: 6734444466552647461}
   - component: {fileID: 7634572129517273144}
@@ -51,20 +50,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 403462928542672843}
   m_CullTransparentMesh: 1
---- !u!114 &3371280741483056261
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 403462928542672843}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 0
-  m_VerticalFit: 2
 --- !u!114 &2124020293711335103
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -83,11 +68,11 @@ MonoBehaviour:
     m_Top: 18
     m_Bottom: 18
   m_ChildAlignment: 0
-  m_Spacing: 8
+  m_Spacing: 23
   m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 0
+  m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1
-  m_ChildControlHeight: 0
+  m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
@@ -271,7 +256,6 @@ GameObject:
   - component: {fileID: 6489635907696110723}
   - component: {fileID: 633659946063038707}
   - component: {fileID: 8389249754344945073}
-  - component: {fileID: 854800757751318757}
   m_Layer: 5
   m_Name: ValuesSection
   m_TagString: Untagged
@@ -296,8 +280,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 205.2875, y: 0}
-  m_SizeDelta: {x: 410.575, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &633659946063038707
 CanvasRenderer:
@@ -333,20 +317,6 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
---- !u!114 &854800757751318757
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1082889930629798795}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 0
-  m_VerticalFit: 1
 --- !u!1 &4688104618899407027
 GameObject:
   m_ObjectHideFlags: 0
@@ -458,7 +428,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 15}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &5622385108211797198
 CanvasRenderer:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/Resources/DebugView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/Resources/DebugView.prefab
@@ -1273,6 +1273,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 640786195690160194, guid: 343005e32016c60479b0584c59812b4b,
         type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 640786195690160194, guid: 343005e32016c60479b0584c59812b4b,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 205.5
       objectReference: {fileID: 0}
@@ -1801,6 +1806,11 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2229608770459445307, guid: 343005e32016c60479b0584c59812b4b,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2297211219257035525, guid: 343005e32016c60479b0584c59812b4b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -2051,6 +2061,16 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -26
       objectReference: {fileID: 0}
+    - target: {fileID: 3261188398848715265, guid: 343005e32016c60479b0584c59812b4b,
+        type: 3}
+      propertyPath: m_ChildControlHeight
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3261188398848715265, guid: 343005e32016c60479b0584c59812b4b,
+        type: 3}
+      propertyPath: m_ChildForceExpandHeight
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3313290511942750072, guid: 343005e32016c60479b0584c59812b4b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -2195,6 +2215,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -126
+      objectReference: {fileID: 0}
+    - target: {fileID: 4422570109012610901, guid: 343005e32016c60479b0584c59812b4b,
+        type: 3}
+      propertyPath: m_VerticalFit
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4548005199230724280, guid: 343005e32016c60479b0584c59812b4b,
         type: 3}
@@ -2530,6 +2555,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5714049155910192880, guid: 343005e32016c60479b0584c59812b4b,
+        type: 3}
+      propertyPath: m_ChildControlHeight
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5730760808255114886, guid: 343005e32016c60479b0584c59812b4b,
         type: 3}


### PR DESCRIPTION
## What does this PR change?

Corrected the DebugView prefab to use the content size fitter according to recomendatios

## How to test the changes?


1. Open the DebugView by using the command /showfps
2. Open and close the sections. They should respond accordingly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
