### PR TITLE
hotfix: nfts not displayed due to owner deprecated field

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/OpenSea.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/OpenSea.cs
@@ -90,11 +90,6 @@ namespace DCL.Helpers.NFT.Markets
             ret.assetContract.address = response.asset_contract.address;
             ret.assetContract.name = response.asset_contract.name;
 
-            if (!string.IsNullOrEmpty(response.owner?.address))
-            {
-                ret.owner = response.owner.address;
-            }
-
             if (response.num_sales != null)
             {
                 ret.numSales = response.num_sales.Value;
@@ -120,7 +115,7 @@ namespace DCL.Helpers.NFT.Markets
                 ret.backgroundColor = backgroundColor;
             }
 
-            OrderInfo sellOrder = GetSellOrder(response.sell_orders, response.owner.address);
+            OrderInfo sellOrder = GetSellOrder(response.sell_orders, response.top_ownerships);
             if (sellOrder != null)
             {
                 ret.currentPrice = PriceToFloatingPointString(sellOrder.current_price, sellOrder.payment_token_contract);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/Types.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/Types.cs
@@ -22,7 +22,7 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
         public string description;
         public string external_link;
         public AssetContract asset_contract = null;
-        public AccountInfo owner = null;
+        public OwnershipInfo[] top_ownerships;
         public string permalink;
         public AssetSaleInfo last_sale = null;
         public OrderInfo[] sell_orders = null;


### PR DESCRIPTION
## What does this PR change?

The owner field of the NFTs info has been deprecated for some time (https://decentralandteam.slack.com/archives/C02CNQT2D3M/p1669332675907709?thread_ts=1669322928.379659&cid=C02CNQT2D3M). 

Recently, this field started sending a null value, which caused the NFTs to not be displayed in explorer. This PR fixes that issue by removing the `owner` field references and replaced them with `top_ownerships.`

## How to test the changes?

1. Go to the NFT gallery in Genesis Plaza and check that NFTs are displayed correctly
2. Go to Tru Band 26,-118 and check that NFTs are displayed correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
