### PR TITLE
chore: set default scene radius back to 4

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/DefaultSettingsFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/DefaultSettingsFactory.cs
@@ -15,7 +15,7 @@ namespace DCL.SettingsCommon
         private GeneralSettings defaultGeneralSettings = new GeneralSettings
         {
             mouseSensitivity = 0.6f,
-            scenesLoadRadius = 2,
+            scenesLoadRadius = 4,
             avatarsLODDistance = 16,
             maxNonLODAvatars = DataStore_AvatarsLOD.DEFAULT_MAX_AVATAR,
             voiceChatVolume = 1,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/Tests/ProxySettingsRepositoryShould.cs
@@ -113,7 +113,7 @@ namespace DCL.SettingsCommon.Tests
             return new GeneralSettings
             {
                 mouseSensitivity = 0.6f,
-                scenesLoadRadius = 2,
+                scenesLoadRadius = 4,
                 avatarsLODDistance = 16,
                 maxNonLODAvatars = 1,
                 voiceChatVolume = 1,


### PR DESCRIPTION
## What does this PR change?

Reverting changes to default settings load radius from 2 to 4

## How to test the changes?

Enter the world and go to the settings menu. Scene load radius should show 4.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
