### PR TITLE
fix: avoid infinity values on VideoProgressEvent message

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -791,19 +791,19 @@ namespace DCL.Interface
             public int receivedLimit;
             public int receivedSkip;
         }
-        
+
         [Serializable]
         private class LeaveChannelPayload
         {
             public string channelId;
         }
-        
+
         [Serializable]
         private class CreateChannelPayload
         {
             public string channelId;
         }
-        
+
         public struct MuteChannelPayload
         {
             public string channelId;
@@ -1557,7 +1557,7 @@ namespace DCL.Interface
             gotoEvent.y = y;
             SendMessage("LoadingHUDReadyForTeleport", gotoEvent);
         }
-        
+
         public static void JumpIn(int x, int y, string serverName, string layerName)
         {
             jumpInPayload.realm.serverName = serverName;
@@ -1568,7 +1568,7 @@ namespace DCL.Interface
 
             SendMessage("JumpIn", jumpInPayload);
         }
-        
+
         public static void JumpInHome(string mostPopulatedRealm)
         {
             jumpInPayload.realm.serverName = mostPopulatedRealm;
@@ -1739,7 +1739,7 @@ namespace DCL.Interface
                 videoTextureId = videoClipId,
                 status = videoStatus,
                 currentOffset = currentOffset,
-                videoLength = length
+                videoLength = float.IsInfinity(length) ? float.MaxValue : length
             };
 
             SendMessage("VideoProgressEvent", progressEvent);
@@ -1812,7 +1812,7 @@ namespace DCL.Interface
             getPrivateMessagesPayload.fromMessageId = fromMessageId;
             SendMessage("GetPrivateMessages", getPrivateMessagesPayload);
         }
-        
+
         public static void MarkChannelMessagesAsSeen(string channelId)
         {
             markChannelMessagesAsSeenPayload.channelId = channelId;
@@ -1940,7 +1940,7 @@ namespace DCL.Interface
         {
             SendMessage("UpdateMemoryUsage");
         }
-        
+
         public static void RequestAudioDevices() => SendMessage("RequestAudioDevices");
 
         public static void SetInputAudioDevice(string inputDeviceId)


### PR DESCRIPTION
## What does this PR change?

Fixes an error reported by serializing an infinity value when reporting video progress.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.org/?renderer-branch=hotfix/infinity-video-length
2. Go to `108,-120` and check that video is working OK and no errors are reported

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
