### PR TITLE
fix: materials in geometry render queue sometimes have cutoff

### DIFF
--- a/unity-renderer/Assets/Rendering/Utils/ShaderUtils.cs
+++ b/unity-renderer/Assets/Rendering/Utils/ShaderUtils.cs
@@ -60,7 +60,7 @@ namespace DCL.Helpers
         public static readonly string Transparent = "Transparent";
         public static readonly string TransparentCutout = "TransparentCutout";
         public static readonly string Opaque = "Opaque";
-        
+
         //Avatar specific properties
         public static readonly int EyesTexture = Shader.PropertyToID("_EyesTexture");
         public static readonly int EyeTint = Shader.PropertyToID("_EyeTint");
@@ -77,6 +77,8 @@ namespace DCL.Helpers
             int originalRenderQueue = material.renderQueue;
             material.shader = Shader.Find("DCL/Universal Render Pipeline/Lit");
             material.renderQueue = originalRenderQueue;
+            float cutoff = material.GetFloat(Cutoff);
+
             if (material.HasTexture( BumpMap) && material.GetTexture(BumpMap) != null)
                 material.EnableKeyword(NormalMapKeyword);
             if (material.HasTexture(MetallicGlossMap) && material.GetTexture(MetallicGlossMap) != null)
@@ -93,7 +95,7 @@ namespace DCL.Helpers
                 return;
             }
 
-            if (originalRenderQueue > 2600)
+            if (originalRenderQueue > 2600 || cutoff > 0)
             {
                 material.SetOverrideTag(RenderType, TransparentCutout);
                 material.SetInt(SrcBlend, (int)BlendMode.One);


### PR DESCRIPTION
Fix some materials not being tagged as alpha tested properly.

## Test
You can test the pineapple hat here:  https://play.decentraland.zone/?renderer-branch=fix/alpha-cutoff-upgrade-2021&WITH_COLLECTIONS=fd575e10-5871-49e8-b625-caaf0a0f0deb&NETWORK=goerli

This PR changes the way we detect alphatested materials. A thoroughtful test is required to ensure no regressions in how the world looks.
Test in a default WebGL environment (Asset Bundles enabled) and take a look at wearables and assets in general to spot differences with production.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
