### PR TITLE
fix: SDK7 scene not updating

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestScene.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestScene.cs
@@ -22,11 +22,6 @@ public class ECS7TestScene : IParcelScene
     public ContentProvider contentProvider { get; } = new ContentProvider();
     public bool isPersistent { set; get; } = false;
     public bool isPortableExperience { get; set; } = false;
-
-    public void MarkInitMessagesDone()
-    {
-    }
-
     public bool IsInitMessageDone() =>
         true;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IParcelScene.cs
@@ -37,7 +37,6 @@ namespace DCL.Controllers
         void GetWaitingComponentsDebugInfo();
         void SetEntityParent(long entityId, long parentId);
         void RemoveEntity(long id, bool removeImmediatelyFromEntitiesList = true);
-        void MarkInitMessagesDone();
         bool IsInitMessageDone();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Context/CRDTServiceContext.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Context/CRDTServiceContext.cs
@@ -10,6 +10,7 @@ namespace RPC.Context
         public readonly Dictionary<int, CRDTProtocol> scenesOutgoingCrdts = new Dictionary<int, CRDTProtocol>(24);
         public IMessagingControllersManager MessagingControllersManager;
         public IWorldState WorldState;
+        public ISceneController SceneController;
         public Action<int, CRDTMessage> CrdtMessageReceived;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/RPC.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/RPC.cs
@@ -33,6 +33,7 @@ namespace DCL
 
             context.crdt.MessagingControllersManager = Environment.i.messaging.manager;
             context.crdt.WorldState = Environment.i.world.state;
+            context.crdt.SceneController = Environment.i.world.sceneController;
 
             RPCServerBuilder.BuildDefaultServer(context);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/CRDTService/CRDTServiceImpl.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/CRDTService/CRDTServiceImpl.cs
@@ -1,12 +1,14 @@
-using System;
-using System.IO;
-using System.Threading;
 using Cysharp.Threading.Tasks;
+using DCL;
 using DCL.Controllers;
 using DCL.CRDT;
+using DCL.Models;
 using Google.Protobuf;
 using KernelCommunication;
 using rpc_csharp;
+using System;
+using System.IO;
+using System.Threading;
 using UnityEngine;
 using BinaryWriter = KernelCommunication.BinaryWriter;
 
@@ -58,7 +60,14 @@ namespace RPC.Services
                     // kernel won't be sending that message for those scenes
                     if (scene.sceneData.sdk7 && !scene.IsInitMessageDone())
                     {
-                        scene.MarkInitMessagesDone();
+                        context.crdt.SceneController.EnqueueSceneMessage(new QueuedSceneMessage_Scene()
+                        {
+                            sceneNumber = messages.SceneNumber,
+                            tag = "scene",
+                            payload = new Protocol.SceneReady(),
+                            method = MessagingTypes.INIT_DONE,
+                            type = QueuedSceneMessage.Type.SCENE_MESSAGE
+                        });
                     }
                 }
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/CRDTService/RPC.Services.CRDTService.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/CRDTService/RPC.Services.CRDTService.asmdef
@@ -14,7 +14,8 @@
         "GUID:3047fd2f05bcaae498a99a3f9321f9a8",
         "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
         "GUID:97d8897529779cb49bebd400c7f402a6",
-        "GUID:a881b57670b1d2747a6d7f9e32b63230"
+        "GUID:a881b57670b1d2747a6d7f9e32b63230",
+        "GUID:132013f160565434195ba5960832b346"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -668,11 +668,6 @@ namespace DCL.Controllers
             OnLoadingStateUpdated?.Invoke(loadingProgress);
         }
 
-        public void MarkInitMessagesDone()
-        {
-            sceneLifecycleHandler.SetInitMessagesDone();
-        }
-
         public bool IsInitMessageDone()
         {
             return sceneLifecycleHandler.state == SceneLifecycleHandler.State.READY

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -305,8 +305,10 @@ namespace DCL
 
                     case MessagingTypes.INIT_DONE:
                         {
-                            scene.MarkInitMessagesDone();
-
+                        if (!scene.IsInitMessageDone())
+                        {
+                            scene.sceneLifecycleHandler.SetInitMessagesDone();
+                        }
                             break;
                         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -305,10 +305,10 @@ namespace DCL
 
                     case MessagingTypes.INIT_DONE:
                         {
-                        if (!scene.IsInitMessageDone())
-                        {
-                            scene.sceneLifecycleHandler.SetInitMessagesDone();
-                        }
+                            if (!scene.IsInitMessageDone())
+                            {
+                                scene.sceneLifecycleHandler.SetInitMessagesDone();
+                            }
                             break;
                         }
 


### PR DESCRIPTION
fixed regression introduced here: https://github.com/decentraland/unity-renderer/pull/3645
sdk7 scenes were not being updated due to a conflict with kernel init message and crdt service marking scene as initialized.
*removed `MarkInitMessagesDone` from `IParcelScene` and use enqueue init message to `SceneController` instead to avoid any conflict