### PR TITLE
fix: gltfast importer wont work if the package name changes

### DIFF
--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.atteneder.draco": "4.0.2",
-    "com.decentraland.gltfast": "https://github.com/decentraland/glTFast.git",
+    "com.atteneder.gltfast": "https://github.com/decentraland/glTFast.git",
     "com.brunomikoski.animationsequencer": "0.3.8",
     "com.coffee.ui-particle": "4.1.6",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -54,9 +54,9 @@
       "depth": 0,
       "source": "git",
       "dependencies": {
-        "com.decentraland.gltfast": "https://github.com/decentraland/glTFast.git"
+        "com.atteneder.gltfast": "5.0.0-exp.1"
       },
-      "hash": "e9b72220a5c30d736ff3993366b2c598364d976e"
+      "hash": "6a549b969fd6d87577b6a8c18a1d776d28194ed2"
     },
     "com.decentraland.webgl-ime-input": {
       "version": "https://github.com/decentraland/webgl-ime-input.git",

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -9,6 +9,18 @@
       },
       "url": "https://package.openupm.com"
     },
+    "com.atteneder.gltfast": {
+      "version": "https://github.com/decentraland/glTFast.git",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.mathematics": "1.2.6",
+        "com.unity.burst": "1.6.6"
+      },
+      "hash": "daf38ff52e9a685a969c0dd2d890fb6e11e835cf"
+    },
     "com.brunomikoski.animationsequencer": {
       "version": "0.3.8",
       "depth": 0,
@@ -30,18 +42,6 @@
       "dependencies": {},
       "hash": "c7eedf85c79e2ce06658c8060ca38a282f2ca7ab"
     },
-    "com.decentraland.gltfast": {
-      "version": "https://github.com/decentraland/glTFast.git",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.mathematics": "1.2.6",
-        "com.unity.burst": "1.6.6"
-      },
-      "hash": "14064402ba24a8bed6a4d0bd243659049fdeb30b"
-    },
     "com.decentraland.rpc-csharp": {
       "version": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src",
       "depth": 0,
@@ -56,7 +56,7 @@
       "dependencies": {
         "com.decentraland.gltfast": "https://github.com/decentraland/glTFast.git"
       },
-      "hash": "aff0919b0d688b6711e578454a5b6c438d5de9f1"
+      "hash": "e9b72220a5c30d736ff3993366b2c598364d976e"
     },
     "com.decentraland.webgl-ime-input": {
       "version": "https://github.com/decentraland/webgl-ime-input.git",


### PR DESCRIPTION
## What does this PR change?

Just changed the dependency with the old package name

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
