### PR TITLE
fix: prevent to access components on `GLTFComponent` that is destroye…

### DIFF
--- a/unity-renderer/Assets/UnityGLTF/Scripts/DownloadQueueHandler/DownloadQueueHandler.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/DownloadQueueHandler/DownloadQueueHandler.cs
@@ -74,7 +74,9 @@ namespace UnityGLTF
             {
                 while (iterator.MoveNext())
                 {
-                    if (iterator.Current == null)
+                    // It is mandatory to call `Equals` instead of `==`
+                    // as behind an interface a Unity Object may be, and `IsNativeObjectAlive` should be checked
+                    if (Equals(iterator.Current, null))
                         continue;
 
                     if (nextToDownload == null)

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -100,7 +100,8 @@ namespace UnityGLTF
         private Settings settings;
 
         private  CancellationTokenSource ctokenSource;
-        
+        private bool scheduledToCleanUp;
+
         private const string GPU_ONLY_MESHES = "use_gpu_only_meshes_variant:enabled";
 
 
@@ -306,7 +307,7 @@ namespace UnityGLTF
                         else
                             OnFailedLoadingAsset?.Invoke(new Exception($"GLTF state finished as: {state}"));
                     }
-                    
+
                     CleanUp();
                     Destroy(loadingPlaceholder);
                     Destroy(this);
@@ -385,7 +386,7 @@ namespace UnityGLTF
                 return;
 #endif
             CleanUp();
-            
+
             if (state != State.COMPLETED)
             {
                 ctokenSource.Cancel();
@@ -394,6 +395,8 @@ namespace UnityGLTF
         }
         private void CleanUp()
         {
+            scheduledToCleanUp = true;
+
             if (state == State.QUEUED)
             {
                 DequeueDownload();
@@ -424,7 +427,7 @@ namespace UnityGLTF
 
         float IDownloadQueueElement.GetSqrDistance()
         {
-            if (mainCamera == null || transform == null)
+            if (scheduledToCleanUp || mainCamera == null || transform == null)
                 return float.MaxValue;
 
             Vector3 cameraPosition = mainCamera.transform.position;


### PR DESCRIPTION
## What does this PR change?

Fixes #3739

I tried to mitigate the issue when the unity members are accessed from the destroyed component, or the component that is already scheduled for destruction as it makes no sense from the logical perspective.

## How to test the changes?

1. GLTF component works as before
2. Exceptions from the connected issue do not occur

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
