### PR TITLE
fix: TriggerSelfUserExpression executing in a background thread

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/EmotesService/EmotesRendererServiceImpl.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/EmotesService/EmotesRendererServiceImpl.cs
@@ -11,8 +11,9 @@ namespace RPC.Services
             EmotesRendererServiceCodeGen.RegisterService(port, new EmotesRendererServiceImpl());
         }
 
-        public UniTask<TriggerSelfUserExpressionResponse> TriggerSelfUserExpression(TriggerSelfUserExpressionRequest request, RPCContext context, CancellationToken ct)
+        public async UniTask<TriggerSelfUserExpressionResponse> TriggerSelfUserExpression(TriggerSelfUserExpressionRequest request, RPCContext context, CancellationToken ct)
         {
+            await UniTask.SwitchToMainThread(ct);
             UserProfile.GetOwnUserProfile().SetAvatarExpression(request.Id, UserProfile.EmoteSource.Command);
             return default;
         }


### PR DESCRIPTION
TriggerSelfUserExpression call is performing some accesses to unity members in a bg thread. 

## Test 

Go to any scene with a self dancing event (like the ongoing event in -123,-126 ). You should dance properly.