### PR TITLE
Fix: AssetBundles detection commands stop working when triggered again outside the initial range

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ABDetectorPlugin/ABDetectorTracker.cs
+++ b/unity-renderer/Assets/DCLPlugins/ABDetectorPlugin/ABDetectorTracker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using DCL.Controllers;
 using UnityEngine;
@@ -105,7 +105,8 @@ namespace DCL
         {
             foreach (KeyValuePair<Renderer,Material[]> keyValuePair in rendererDict)
             {
-                keyValuePair.Key.materials = keyValuePair.Value;
+                if (keyValuePair.Key != null)
+                    keyValuePair.Key.materials = keyValuePair.Value;
             }
         
             rendererDict.Clear();


### PR DESCRIPTION
fixes #3191 

## Cause
A null reference exception was being fired when triggering again from outside initial range.
The renderers for the initial calculation where already destroyed but we were trying to access their materials, as the method for recalculation came after destroying the previous ones, all the process was blocked by the null ref.

## QA
Steps to reproduce the error in the issue:

- Log in with either a guest or a wallet account.
- Use the command "/detectabs" to turn on detection of AssetBundles for the nearby loaded tiles.
- Go beyond the range of the loaded tiles until you encounter non-highlighted tiles and walk into one such tile.
- When standing on a non-highlighted tile use the "/detectabs" command again.
- Notice new nearby tiles not being highlighted.
- Use any combination of "/detectabs" and "/detectabs off".
- Observe the nearby tiles.

How is supposed to work after this fix:
All AB detection commands continue working after using "/detectabs" command on an initially non-highlighted tile.
