### PR TITLE
hotfix: Passport being enabled again on ApplyChanges of AvatarShape

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -138,8 +138,6 @@ namespace DCL
         {
             isGlobalSceneAvatar = scene.sceneData.sceneNumber == EnvironmentSettings.AVATAR_GLOBAL_SCENE_NUMBER;
 
-            DisablePassport();
-
             var model = (AvatarModel) newModel;
 
             bool needsLoading = !model.HaveSameWearablesAndColors(currentAvatar);
@@ -239,8 +237,6 @@ namespace DCL
 
             everythingIsLoaded = true;
             OnAvatarShapeUpdated?.Invoke(entity, this);
-
-            EnablePasssport();
 
             onPointerDown.SetColliderEnabled(isGlobalSceneAvatar);
             onPointerDown.SetOnClickReportEnabled(isGlobalSceneAvatar);


### PR DESCRIPTION
## What does this PR change?

Removes the `DisablePassport() / EnablePassport()` calls from the `ApplyChanges()` update in AvatarShape. This was being called multiple times on a scene, which broke the functionality of the Hide Passport avatar modifier area.

## How to test the changes?

1. Open two sessions of https://play.decentraland.zone/?NETWORK=mainnet&position=-119%2C100&CATALYST=peer-testing.decentraland.org&DEBUG_SCENE_LOG=&renderer-branch=fix%2Fremove-passport-change-on-apply-changes
2. As long as you have the warning message, passports should not be openable. 
3. Go outside the scene until the warning dissapears. Check that passports are openable
4. Go normally to https://play.decentraland.zone/?renderer-branch=fix/remove-passport-change-on-apply-changes. Check that passports are openable as usual

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
