### PR TITLE
fix: try to cope with desktop native crashes on quit

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/MapTexturePlugin/MapTexturePlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/MapTexturePlugin/MapTexturePlugin.cs
@@ -20,6 +20,9 @@ public class MapTexturePlugin : IPlugin
         DataStore.i.HUDs.mapMainTexture.Set(Resources.Load<Texture2D>("MapDefault"));
         DataStore.i.HUDs.mapEstatesTexture.Set(Resources.Load<Texture2D>("MapDefaultEstates"));
 
+        if (!SystemInfo.SupportsTextureFormat(TextureFormat.ETC2_RGBA8))
+            return;
+
         DownloadTexture(MAIN_TEXTURE_URL, DataStore.i.HUDs.mapMainTexture, cts.Token);
         DownloadTexture(ESTATES_TEXTURE_URL, DataStore.i.HUDs.mapEstatesTexture, cts.Token);
     }

--- a/unity-renderer/Assets/DCLPlugins/MapTexturePlugin/MapTexturePlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/MapTexturePlugin/MapTexturePlugin.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -13,6 +14,15 @@ public class MapTexturePlugin : IPlugin
 
     private CancellationTokenSource cts;
 
+    private static readonly TextureFormat?[] PRIORITIZED_FORMATS =
+    {
+        // available for iOS/Android WebGL player
+        TextureFormat.ETC2_RGBA8,
+        TextureFormat.BC7,
+        TextureFormat.DXT5,
+        TextureFormat.RGBA32
+    };
+
     public MapTexturePlugin()
     {
         cts = new CancellationTokenSource();
@@ -20,14 +30,16 @@ public class MapTexturePlugin : IPlugin
         DataStore.i.HUDs.mapMainTexture.Set(Resources.Load<Texture2D>("MapDefault"));
         DataStore.i.HUDs.mapEstatesTexture.Set(Resources.Load<Texture2D>("MapDefaultEstates"));
 
-        if (!SystemInfo.SupportsTextureFormat(TextureFormat.ETC2_RGBA8))
+        var textureFormat = PRIORITIZED_FORMATS.FirstOrDefault(f => SystemInfo.SupportsTextureFormat(f.Value));
+
+        if (textureFormat == null)
             return;
 
-        DownloadTexture(MAIN_TEXTURE_URL, DataStore.i.HUDs.mapMainTexture, cts.Token);
-        DownloadTexture(ESTATES_TEXTURE_URL, DataStore.i.HUDs.mapEstatesTexture, cts.Token);
+        DownloadTexture(MAIN_TEXTURE_URL, DataStore.i.HUDs.mapMainTexture, textureFormat.Value, cts.Token);
+        DownloadTexture(ESTATES_TEXTURE_URL, DataStore.i.HUDs.mapEstatesTexture, textureFormat.Value, cts.Token);
     }
 
-    private static async UniTaskVoid DownloadTexture(string url, BaseVariable<Texture> textureVariable, CancellationToken ct)
+    private static async UniTaskVoid DownloadTexture(string url, BaseVariable<Texture> textureVariable, TextureFormat textureFormat, CancellationToken ct)
     {
         while (true)
         {


### PR DESCRIPTION
## What does this PR change?

Fixes
```
Texture creation failed. 'ETC2_RGBA8' is not supported on this platform. Use 'SystemInfo.SupportsTextureFormat' C# API to check format support.
NullReferenceException
  at (wrapper managed-to-native) UnityEngine.Texture.set_filterMode(UnityEngine.Texture,UnityEngine.FilterMode)
  at MapTexturePlugin.DownloadTexture (System.String url, BaseVariable`1[T] textureVariable, System.Threading.CancellationToken ct) [0x000b7] in <e20afafb71674baaa3ffc73363f12a8c>:0 
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:LogException(Exception)
Cysharp.Threading.Tasks.UniTaskScheduler:PublishUnobservedTaskException(Exception)
<DownloadTexture>d__5:MoveNext()
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskVoid`1:Run()
Cysharp.Threading.Tasks.Internal.PooledDelegate`1:Run(AsyncOperation)
UnityEngine.AsyncOperation:InvokeCompletionEvent()
```
Potentially fixes
```
STACK_TEXT:  
0000004b`f98fb490 00007ff8`a75af435     : 00000000`00000000 0000004b`f98fb620 0000004b`f98fb591 0000004b`f98fbc80 : UnityPlayer!core::hash_map<MonoScriptKeyNameOnly,PPtr<MonoScript>,core::hash<MonoScriptKeyNameOnly>,std::equal_to<MonoScriptKeyNameOnly> >::find+0x51
0000004b`f98fb4d0 00007ff8`a75c992b     : 00007ff8`a8629208 00007ff8`a8a1e810 00007ff8`a86bdba8 00007ff8`a86bdbb8 : UnityPlayer!MonoManager::GetMonoClassWithAssemblyName+0x175
0000004b`f98fb5f0 00007ff8`a75bc88b     : 0000004b`f98fbd60 00007ff8`a86bdba8 00000192`50d13408 0000004b`f98fba58 : UnityPlayer!scripting_class_from_fullname+0x5b
0000004b`f98fb640 00007ff8`a7644e3b     : 0000004b`f98fbd60 0000004b`f98fb7d0 00000192`50d13408 0000004b`f98fba58 : UnityPlayer!OptionalType+0x3b
0000004b`f98fb6d0 00007ff8`a763c665     : 00000192`115d6d80 00007ff8`a75cdd96 00000000`00000063 00007ff8`a7207789 : UnityPlayer!InitializeCoreScriptingClasses+0x6b
0000004b`f98fbc80 00007ff8`a75f3e43     : 00000191`f040f240 0000004b`f98fbe68 0000004b`f98fbde0 00000192`d09a22c8 : UnityPlayer!GetCoreScriptingClassesPtr+0x15
0000004b`f98fbcb0 00007ff8`a78f2513     : 00000192`d09a22c8 fffffe6d`2f65dd37 00000000`00000000 00000191`f040fcb0 : UnityPlayer!ManagedReferencesTransferState::ManagedReferencesTransferState+0x73
0000004b`f98fbce0 00007ff8`a78f260a     : 0000004b`f98f0009 00000000`00000000 00000191`f040f240 00007ff8`a65d74f4 : UnityPlayer!TransferScriptingObject<JSONRead>+0xf3
0000004b`f98fbe20 00007ff8`a78fe46e     : 00000000`00000000 0000004b`f98fbed0 0000004b`f98fbff8 00000192`50d13300 : UnityPlayer!TransferScriptingObject<JSONRead>+0x2a
0000004b`f98fbe50 00007ff8`a70de81d     : 00000192`d09a22c8 00000193`a156f460 00000000`00000000 00000193`771af600 : UnityPlayer!FromJsonInternal+0x10e
0000004b`f98fbef0 00000193`7e8a0888     : 00000193`771af600 00000192`d09a22c8 00000000`00000000 00000192`af11841b : UnityPlayer!JsonUtility_CUSTOM_FromJsonInternal+0x1bd
0000004b`f98fbfe0 00000000`00000000     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : 0x00000193`7e8a0888
```

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?renderer-branch={branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
