### PR TITLE
fix: Typo on "disable for other users"

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackView.cs
@@ -156,7 +156,7 @@ namespace DCL.AvatarModifierAreaFeedback
                 case AvatarModifierAreaID.HIDE_AVATAR:
                     return "\u2022  The avatars are hidden";
                 case AvatarModifierAreaID.DISABLE_PASSPORT:
-                    return "\u2022  Your passport is disable for\n    other players";
+                    return "\u2022  Your passport is disabled for\n    other players";
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
Signed-off-by: Esteban Ordano <esteban@decentraland.org>

## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `Fixes #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/typo-disabled
2. Go in a passport disabled area
3. Verify that the message displayed is `Your passport is disabled for other players`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
