### PR TITLE
Feat: send the user to home after they have been kicked from a world

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/RealmsPlugin/Utils/JumpToHomeController.cs
+++ b/unity-renderer/Assets/DCLPlugins/RealmsPlugin/Utils/JumpToHomeController.cs
@@ -19,17 +19,39 @@ namespace DCLPlugins.RealmPlugin
         [SerializeField] private RectTransform positionWithoutMiniMap;
 
         private BaseCollection<RealmModel> realms => DataStore.i.realm.realmsInfo;
+        private BaseVariable<bool> isWorld => DataStore.i.common.isWorld;
+
         private BaseVariable<bool> jumpHomeButtonVisible => DataStore.i.HUDs.jumpHomeButtonVisible;
         private BaseVariable<bool> minimapVisible => DataStore.i.HUDs.minimapVisible;
         private BaseVariable<bool> exitedThroughButton => DataStore.i.common.exitedWorldThroughGoBackButton;
 
         private RectTransform rectTransform;
 
-        private void Start()
+        private void Awake()
         {
             rectTransform = jumpButton.GetComponent<RectTransform>();
+        }
+
+        private void OnEnable()
+        {
             jumpButton.onClick.AddListener(GoHome);
             jumpHomeButtonVisible.OnChange += SetVisibility;
+            isWorld.OnChange += OnIsWorldChanged;
+        }
+
+        private void OnDisable()
+        {
+            jumpButton.onClick.RemoveListener(GoHome);
+            jumpHomeButtonVisible.OnChange -= SetVisibility;
+            isWorld.OnChange -= OnIsWorldChanged;
+        }
+
+        private void OnIsWorldChanged(bool current, bool previous)
+        {
+            if (JumpedFromWorldToNotWorld())
+                GoHome();
+
+            bool JumpedFromWorldToNotWorld() => previous && current == false;
         }
 
         private void SetVisibility(bool current, bool _)
@@ -60,11 +82,6 @@ namespace DCLPlugins.RealmPlugin
         {
             var currentRealms = realms.Get().ToList();
             return currentRealms.OrderByDescending(e => e.usersCount).FirstOrDefault()?.serverName;
-        }
-
-        private void OnDestroy()
-        {
-            jumpButton.onClick.RemoveListener(GoHome);
         }
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/RealmsPlugin/Utils/JumpToHomeController.cs
+++ b/unity-renderer/Assets/DCLPlugins/RealmsPlugin/Utils/JumpToHomeController.cs
@@ -19,39 +19,17 @@ namespace DCLPlugins.RealmPlugin
         [SerializeField] private RectTransform positionWithoutMiniMap;
 
         private BaseCollection<RealmModel> realms => DataStore.i.realm.realmsInfo;
-        private BaseVariable<bool> isWorld => DataStore.i.common.isWorld;
-
         private BaseVariable<bool> jumpHomeButtonVisible => DataStore.i.HUDs.jumpHomeButtonVisible;
         private BaseVariable<bool> minimapVisible => DataStore.i.HUDs.minimapVisible;
         private BaseVariable<bool> exitedThroughButton => DataStore.i.common.exitedWorldThroughGoBackButton;
 
         private RectTransform rectTransform;
 
-        private void Awake()
+        private void Start()
         {
             rectTransform = jumpButton.GetComponent<RectTransform>();
-        }
-
-        private void OnEnable()
-        {
             jumpButton.onClick.AddListener(GoHome);
             jumpHomeButtonVisible.OnChange += SetVisibility;
-            isWorld.OnChange += OnIsWorldChanged;
-        }
-
-        private void OnDisable()
-        {
-            jumpButton.onClick.RemoveListener(GoHome);
-            jumpHomeButtonVisible.OnChange -= SetVisibility;
-            isWorld.OnChange -= OnIsWorldChanged;
-        }
-
-        private void OnIsWorldChanged(bool current, bool previous)
-        {
-            if (JumpedFromWorldToNotWorld())
-                GoHome();
-
-            bool JumpedFromWorldToNotWorld() => previous && current == false;
         }
 
         private void SetVisibility(bool current, bool _)
@@ -82,6 +60,11 @@ namespace DCLPlugins.RealmPlugin
         {
             var currentRealms = realms.Get().ToList();
             return currentRealms.OrderByDescending(e => e.usersCount).FirstOrDefault()?.serverName;
+        }
+
+        private void OnDestroy()
+        {
+            jumpButton.onClick.RemoveListener(GoHome);
         }
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/RealmsPlugin/Utils/JumpToHomeController.cs
+++ b/unity-renderer/Assets/DCLPlugins/RealmsPlugin/Utils/JumpToHomeController.cs
@@ -22,6 +22,7 @@ namespace DCLPlugins.RealmPlugin
         private BaseVariable<bool> jumpHomeButtonVisible => DataStore.i.HUDs.jumpHomeButtonVisible;
         private BaseVariable<bool> minimapVisible => DataStore.i.HUDs.minimapVisible;
         private BaseVariable<bool> exitedThroughButton => DataStore.i.common.exitedWorldThroughGoBackButton;
+        private BaseVariable<bool> isWorld => DataStore.i.common.isWorld;
 
         private RectTransform rectTransform;
 
@@ -30,6 +31,24 @@ namespace DCLPlugins.RealmPlugin
             rectTransform = jumpButton.GetComponent<RectTransform>();
             jumpButton.onClick.AddListener(GoHome);
             jumpHomeButtonVisible.OnChange += SetVisibility;
+        }
+
+        private void OnEnable()
+        {
+            isWorld.OnChange += OnIsWorldChanged;
+        }
+
+        private void OnDisable()
+        {
+            isWorld.OnChange -= OnIsWorldChanged;
+        }
+
+        private void OnIsWorldChanged(bool current, bool previous)
+        {
+            if (JumpedFromWorldToNotWorld())
+                GoHome();
+
+            bool JumpedFromWorldToNotWorld() => previous && current == false;
         }
 
         private void SetVisibility(bool current, bool _)


### PR DESCRIPTION
## What does this PR change?
Closes  #3780 

- Subscribed `JumpToHomeController` to the `DataStore.i.common.isWorld` change and if it was from World to Non-World, I teleport user to Home

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=feat/go-home-from-world

2. Change realm to the world (`mgoldman.dcl.eth` for example)
3. Then change it back to the non-world (`loki` for example)
4. Observe that you teleported to home (Plaza)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
