### PR TITLE
fix: ReportAvatarFatalError needs to send a json

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -845,6 +845,12 @@ namespace DCL.Interface
             public string userName;
         }
 
+        [Serializable]
+        private class ErrorPayload
+        {
+            public string error;
+        }
+
         public static event Action<string, byte[]> OnBinaryMessageFromEngine;
 
 #if UNITY_WEBGL && !UNITY_EDITOR
@@ -1697,7 +1703,11 @@ namespace DCL.Interface
             SendMessage("RequestUserProfile", stringPayload);
         }
 
-        public static void ReportAvatarFatalError(string payload) { SendJson("ReportAvatarFatalError", payload); }
+        public static void ReportAvatarFatalError(string payload)
+        {
+            ErrorPayload errorPayload = new ErrorPayload() { error = payload };
+            SendMessage("ReportAvatarFatalError", errorPayload);
+        }
 
         public static void UnpublishScene(Vector2Int sceneCoordinates)
         {


### PR DESCRIPTION
## What does this PR change?

Changes the message ReportAvatarFatalError sends from a string to a json

## How to test the changes?



## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
