### PR TITLE
feat: SDK7 scene boundaries checker integration

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerHandler.cs
@@ -81,8 +81,8 @@ namespace DCL.ECSComponents
         private void OnLoadSuccess(IParcelScene scene, IDCLEntity entity, Rendereable rendereable)
         {
             // create physic colliders
-            MeshFilter[] meshFilters = gameObject.GetComponentsInChildren<MeshFilter>();
-            physicColliders = SetUpPhysicColliders(meshFilters);
+            entity.meshesInfo.meshRootGameObject = rendereable.container;
+            physicColliders = SetUpPhysicColliders(entity.meshesInfo.meshFilters);
 
             // create pointer colliders and renderers
             (pointerColliders, renderers) = SetUpPointerCollidersAndRenderers(rendereable.renderers);
@@ -130,6 +130,7 @@ namespace DCL.ECSComponents
             physicColliders = null;
             pointerColliders = null;
             renderers = null;
+            entity.meshesInfo.CleanReferences();
 
             if (!string.IsNullOrEmpty(prevLoadedGltf)) { dataStoreEcs7.RemovePendingResource(scene.sceneData.sceneNumber, prevLoadedGltf); }
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshCollider/DCL.ECSComponents.MeshCollider.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshCollider/DCL.ECSComponents.MeshCollider.asmdef
@@ -14,7 +14,8 @@
         "GUID:1dd0780aa6be12b428c8005d0bee46b8",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:a3ceb534947fac14da25035bc5c24788",
-        "GUID:cc6bfabbfe87b7949aa248893f89ce37"
+        "GUID:cc6bfabbfe87b7949aa248893f89ce37",
+        "GUID:8af21c3a612af2645a9953d4b9b3f6d5"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshCollider/MeshColliderHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshCollider/MeshColliderHandler.cs
@@ -30,6 +30,11 @@ namespace DCL.ECSComponents
             colliderGameObject = new GameObject("MeshCollider");
             colliderGameObject.transform.SetParent(entity.gameObject.transform);
             colliderGameObject.transform.ResetLocalTRS();
+
+            if(entity.meshesInfo.meshRootGameObject == null)
+                entity.meshesInfo.meshRootGameObject = colliderGameObject;
+            else
+                entity.meshesInfo.RecalculateBounds();
         }
 
         public void OnComponentRemoved(IParcelScene scene, IDCLEntity entity)
@@ -61,6 +66,11 @@ namespace DCL.ECSComponents
 
             SetColliderLayer(model);
             SetInternalColliderComponents(scene, entity, model);
+
+            if(entity.meshesInfo.meshRootGameObject == null)
+                entity.meshesInfo.meshRootGameObject = colliderGameObject;
+            else
+                entity.meshesInfo.RecalculateBounds();
         }
 
         private void CreateCollider(PBMeshCollider model)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshCollider/MeshColliderHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshCollider/MeshColliderHandler.cs
@@ -33,14 +33,14 @@ namespace DCL.ECSComponents
 
             if(entity.meshesInfo.meshRootGameObject == null)
                 entity.meshesInfo.meshRootGameObject = colliderGameObject;
-            else
-                entity.meshesInfo.RecalculateBounds();
         }
 
         public void OnComponentRemoved(IParcelScene scene, IDCLEntity entity)
         {
             pointerColliderComponent.RemoveCollider(scene, entity, collider);
             physicColliderComponent.RemoveCollider(scene, entity, collider);
+            entity.meshesInfo.colliders.Remove(collider);
+            entity.meshesInfo.RecalculateBounds();
             AssetPromiseKeeper_PrimitiveMesh.i.Forget(primitiveMeshPromise);
             Object.Destroy(colliderGameObject);
         }
@@ -58,6 +58,7 @@ namespace DCL.ECSComponents
             {
                 pointerColliderComponent.RemoveCollider(scene, entity, collider);
                 physicColliderComponent.RemoveCollider(scene, entity, collider);
+                entity.meshesInfo.colliders.Remove(collider);
                 Object.Destroy(collider);
                 collider = null;
 
@@ -69,8 +70,8 @@ namespace DCL.ECSComponents
 
             if(entity.meshesInfo.meshRootGameObject == null)
                 entity.meshesInfo.meshRootGameObject = colliderGameObject;
-            else
-                entity.meshesInfo.RecalculateBounds();
+            entity.meshesInfo.colliders.Add(collider);
+            entity.meshesInfo.RecalculateBounds();
         }
 
         private void CreateCollider(PBMeshCollider model)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshRenderer/DCL.ECSComponents.MeshRenderer.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshRenderer/DCL.ECSComponents.MeshRenderer.asmdef
@@ -14,7 +14,8 @@
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:a881b57670b1d2747a6d7f9e32b63230",
-        "GUID:1dd0780aa6be12b428c8005d0bee46b8"
+        "GUID:1dd0780aa6be12b428c8005d0bee46b8",
+        "GUID:8af21c3a612af2645a9953d4b9b3f6d5"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshRenderer/MeshRendererHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/MeshRenderer/MeshRendererHandler.cs
@@ -40,6 +40,11 @@ namespace DCL.ECSComponents
             componentMeshRenderer.sharedMaterial = Utils.EnsureResourcesMaterial("Materials/Default");
             texturizableInternalComponent.AddRenderer(scene, entity, componentMeshRenderer);
             renderersInternalComponent.AddRenderer(scene, entity, componentMeshRenderer);
+
+            if(entity.meshesInfo.meshRootGameObject == null)
+                entity.meshesInfo.meshRootGameObject = componentGameObject;
+            else
+                entity.meshesInfo.RecalculateBounds();
         }
 
         public void OnComponentRemoved(IParcelScene scene, IDCLEntity entity)
@@ -92,6 +97,8 @@ namespace DCL.ECSComponents
             {
                 componentMeshFilter.sharedMesh = shape.mesh;
                 ecs7DataStore.RemovePendingResource(scene.sceneData.sceneNumber, model);
+
+                entity.meshesInfo.UpdateRenderersCollection();
             };
             primitiveMeshPromise.OnFailEvent += (mesh, exception) =>
             {

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/DCL.ECSComponents.Transform.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/DCL.ECSComponents.Transform.asmdef
@@ -11,7 +11,8 @@
         "GUID:97d8897529779cb49bebd400c7f402a6",
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
+        "GUID:5289a39f46259954ca74010d7c9ded16"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/DCL.ECSComponents.Transform.Handler.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/DCL.ECSComponents.Transform.Handler.asmdef
@@ -11,7 +11,8 @@
         "GUID:ac62e852826a4b36aeb22931dad73edb",
         "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
-        "GUID:b1087c5731ff68448a0a9c625bb7e52d"
+        "GUID:b1087c5731ff68448a0a9c625bb7e52d",
+        "GUID:5289a39f46259954ca74010d7c9ded16"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -9,12 +9,14 @@ namespace DCL.ECSComponents
     public class ECSTransformHandler : IECSComponentHandler<ECSTransform>
     {
         private readonly IWorldState worldState;
+        private readonly ISceneBoundsChecker sceneBoundsChecker;
         private readonly IBaseVariable<Vector3> playerTeleportVariable;
 
-        public ECSTransformHandler(IWorldState worldState, IBaseVariable<Vector3> playerTeleportVariable)
+        public ECSTransformHandler(IWorldState worldState, ISceneBoundsChecker sceneBoundsChecker, IBaseVariable<Vector3> playerTeleportVariable)
         {
             ECSTransformUtils.orphanEntities = new KeyValueSet<IDCLEntity, ECSTransformUtils.OrphanEntity>(100);
             this.worldState = worldState;
+            this.sceneBoundsChecker = sceneBoundsChecker;
             this.playerTeleportVariable = playerTeleportVariable;
         }
 
@@ -77,9 +79,9 @@ namespace DCL.ECSComponents
             transform.localScale = model.scale;
 
             if (entity.parentId != model.parentId)
-            {
                 ProcessNewParent(scene, entity, model.parentId);
-            }
+
+            sceneBoundsChecker.AddEntityToBeChecked(entity);
         }
 
         private static void ProcessNewParent(IParcelScene scene, IDCLEntity entity, long parentId)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/DCL.ECSComponents.Transform.Tests.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/DCL.ECSComponents.Transform.Tests.asmdef
@@ -16,7 +16,8 @@
         "GUID:a881b57670b1d2747a6d7f9e32b63230",
         "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
         "GUID:f3eba44237ea4969b29674e332426425",
-        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:5289a39f46259954ca74010d7c9ded16"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformHandlerShould.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using DCL;
+using DCL.Controllers;
 using DCL.ECSComponents;
 using DCL.Models;
 using NSubstitute;
@@ -27,7 +28,7 @@ namespace Tests
 
             worldState = Substitute.For<IWorldState>();
             playerTeleportPosition = Substitute.For<IBaseVariable<Vector3>>();
-            handler = new ECSTransformHandler(worldState, playerTeleportPosition);
+            handler = new ECSTransformHandler(worldState, Substitute.For<ISceneBoundsChecker>(), playerTeleportPosition);
         }
 
         [TearDown]
@@ -138,7 +139,7 @@ namespace Tests
 
             Vector3 position = new Vector3(8, 0, 0);
             handler.OnComponentModelUpdated(scene, playerEntity, new ECSTransform() { position = position });
-            playerTeleportPosition.Received(1).Set(Arg.Do<Vector3>(x => Assert.AreEqual(position, x)), 
+            playerTeleportPosition.Received(1).Set(Arg.Do<Vector3>(x => Assert.AreEqual(position, x)),
                 true);
         }
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformParentingSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformParentingSystemShould.cs
@@ -1,4 +1,5 @@
 using DCL;
+using DCL.Controllers;
 using DCL.ECSComponents;
 using DCL.Models;
 using NSubstitute;
@@ -21,7 +22,7 @@ namespace Tests
             scene = sceneTestHelper.CreateScene(666);
             entity = scene.CreateEntity(42);
 
-            handler = new ECSTransformHandler(Substitute.For<IWorldState>(),
+            handler = new ECSTransformHandler(Substitute.For<IWorldState>(), Substitute.For<ISceneBoundsChecker>(),
                 Substitute.For<BaseVariable<Vector3>>());
         }
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/TransformRegister.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/TransformRegister.cs
@@ -11,7 +11,7 @@ namespace DCL.ECSComponents
 
         public TransformRegister(int componentId, ECSComponentsFactory factory, IECSComponentWriter componentWriter)
         {
-            ECSTransformHandler handler = new ECSTransformHandler(Environment.i.world.state, DataStore.i.player.lastTeleportPosition);
+            ECSTransformHandler handler = new ECSTransformHandler(Environment.i.world.state, Environment.i.world.sceneBoundsChecker, DataStore.i.player.lastTeleportPosition);
             factory.AddOrReplaceComponent(componentId, ECSTransformSerialization.Deserialize, () => handler);
             componentWriter.AddOrReplaceComponentSerializer<ECSTransform>(componentId, ECSTransformSerialization.Serialize);
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/PointerInputSystem/Tests/ECS7Plugin.Systems.PointerInput.Tests.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/PointerInputSystem/Tests/ECS7Plugin.Systems.PointerInput.Tests.asmdef
@@ -28,7 +28,8 @@
         "GUID:2c34ba02f1f344b79b6820d6a72de170",
         "GUID:acf268f98c0c4f078ee92d3caf34b5aa",
         "GUID:5e1778ed041a41f7a0c13abb42ca70b6",
-        "GUID:fb529e4714eec4e4da9a3ff3e4da8eee"
+        "GUID:fb529e4714eec4e4da9a3ff3e4da8eee",
+        "GUID:5289a39f46259954ca74010d7c9ded16"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/PointerInputSystem/Tests/ECSPointerInputSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/PointerInputSystem/Tests/ECSPointerInputSystemShould.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using DCL;
+using DCL.Controllers;
 using DCL.ECS7;
 using DCL.ECS7.InternalComponents;
 using DCL.ECSComponents;
@@ -581,7 +582,7 @@ namespace Tests
                 new InternalColliders() { colliders = new List<Collider>() { testEntityCollider } });
 
             // 2. position collider entity inside scene space
-            ECSTransformHandler transformHandler = new ECSTransformHandler(worldState,
+            ECSTransformHandler transformHandler = new ECSTransformHandler(worldState, Substitute.For<ISceneBoundsChecker>(),
                 Substitute.For<BaseVariable<UnityEngine.Vector3>>());
 
             var entityLocalPosition = new UnityEngine.Vector3(8, 1, 8);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfo.cs
@@ -120,9 +120,12 @@ namespace DCL.Models
                 return;
             }
 
-            lastBoundsCalculationPosition = meshRootGameObjectValue.transform.position;
-            lastBoundsCalculationScale = meshRootGameObjectValue.transform.lossyScale;
-            lastBoundsCalculationRotation = meshRootGameObjectValue.transform.rotation;
+            if (meshRootGameObjectValue != null)
+            {
+                lastBoundsCalculationPosition = meshRootGameObjectValue.transform.position;
+                lastBoundsCalculationScale = meshRootGameObjectValue.transform.lossyScale;
+                lastBoundsCalculationRotation = meshRootGameObjectValue.transform.rotation;
+            }
 
             mergedBoundsValue = MeshesInfoUtils.BuildMergedBounds(renderers, colliders);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfoUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfoUtils.cs
@@ -10,26 +10,29 @@ namespace DCL.Models
         {
             Bounds bounds = new Bounds();
             bool initializedBounds = false;
-            
-            for (int i = 0; i < renderers.Length; i++)
-            {
-                if (renderers[i] == null) continue;
 
-                if (!initializedBounds)
+            if (renderers != null)
+            {
+                for (int i = 0; i < renderers.Length; i++)
                 {
-                    initializedBounds = true;
-                    bounds = GetSafeBounds(renderers[i].bounds, renderers[i].transform.position);
-                }
-                else
-                {
-                    bounds.Encapsulate(GetSafeBounds(renderers[i].bounds, renderers[i].transform.position));
+                    if (renderers[i] == null) continue;
+
+                    if (!initializedBounds)
+                    {
+                        initializedBounds = true;
+                        bounds = GetSafeBounds(renderers[i].bounds, renderers[i].transform.position);
+                    }
+                    else
+                    {
+                        bounds.Encapsulate(GetSafeBounds(renderers[i].bounds, renderers[i].transform.position));
+                    }
                 }
             }
 
             foreach (Collider collider in colliders)
             {
                 if (collider == null) continue;
-                
+
                 if (!initializedBounds)
                 {
                     initializedBounds = true;
@@ -38,7 +41,7 @@ namespace DCL.Models
                 else
                 {
                     bounds.Encapsulate(GetSafeBounds(collider.bounds, collider.transform.position));
-                }   
+                }
             }
 
             return bounds;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -57,7 +57,7 @@ namespace DCL.Controllers
             {
                 // Kinerius: Since the nerf can skip the process a lot faster than before, we need faster rechecks
                 var finalTimeBetweenChecks = isNerfed ? NERFED_TIME_BUDGET : timeBetweenChecks;
-                
+
                 float elapsedTime = Time.realtimeSinceStartup - lastCheckTime;
                 if ((entitiesToCheck.Count > 0) && (finalTimeBetweenChecks <= 0f || elapsedTime >= finalTimeBetweenChecks))
                 {
@@ -95,13 +95,13 @@ namespace DCL.Controllers
                                 if ( messagingManager != null )
                                     messagingManager.timeBudgetCounter -= usedTimeBudget;
                             }
-                            
+
                             timeBudget -= usedTimeBudget;
                         }
                     }
 
                     processEntitiesList(entitiesToCheck);
-                    
+
                     // As we can't modify the hashset while traversing it, we keep track of the entities that should be removed afterwards
                     using (var iterator = checkedEntities.GetEnumerator())
                     {
@@ -110,7 +110,7 @@ namespace DCL.Controllers
                             RemoveEntity(iterator.Current, removeIfPersistent: false, resetState: false);
                         }
                     }
-                    
+
                     if(VERBOSE)
                         logger.Verbose($"Finished checking entities: checked entities {checkedEntities.Count}; entitiesToCheck left: {entitiesToCheck.Count}");
 
@@ -168,9 +168,9 @@ namespace DCL.Controllers
                 if (!isPersistent && !entity.isInsideSceneOuterBoundaries)
                     return;
             }
-    
+
             entitiesToCheck.Add(entity);
-            
+
             if (isPersistent)
                 persistentEntities.Add(entity);
         }
@@ -182,7 +182,7 @@ namespace DCL.Controllers
 
             entitiesToCheck.Remove(entity);
             persistentEntities.Remove(entity);
-            
+
             if(resetState)
                 SetMeshesAndComponentsInsideBoundariesState(entity, true);
         }
@@ -219,7 +219,7 @@ namespace DCL.Controllers
             else
                 EvaluateEntityPosition(entity, onlyOuterBoundsCheck);
         }
-        
+
         private void EvaluateMeshBounds(IDCLEntity entity, bool onlyOuterBoundsCheck = false)
         {
             // TODO: Can we cache the MaterialTransitionController somewhere to avoid this GetComponent() call?
@@ -230,23 +230,23 @@ namespace DCL.Controllers
             var loadWrapper = Environment.i.world.state.GetLoaderForEntity(entity);
             if (loadWrapper != null && !loadWrapper.alreadyLoaded)
                 return;
-            
+
             entity.isInsideSceneOuterBoundaries = entity.scene.IsInsideSceneOuterBoundaries(entity.meshesInfo.mergedBounds);
-            
+
             if (!entity.isInsideSceneOuterBoundaries)
                 SetMeshesAndComponentsInsideBoundariesState(entity, false);
 
             if (onlyOuterBoundsCheck)
                 return;
-                
+
             SetMeshesAndComponentsInsideBoundariesState(entity, IsEntityMeshInsideSceneBoundaries(entity));
         }
-        
+
         private void EvaluateEntityPosition(IDCLEntity entity, bool onlyOuterBoundsCheck = false)
         {
             Vector3 entityGOPosition = entity.gameObject.transform.position;
             entity.isInsideSceneOuterBoundaries = entity.scene.IsInsideSceneOuterBoundaries(entityGOPosition);
-            
+
             if (!entity.isInsideSceneOuterBoundaries)
             {
                 SetComponentsInsideBoundariesValidState(entity, false);
@@ -255,7 +255,7 @@ namespace DCL.Controllers
 
             if (onlyOuterBoundsCheck)
                 return;
-            
+
             bool isInsideBoundaries = entity.scene.IsInsideSceneBoundaries(entityGOPosition + CommonScriptableObjects.worldOffset.Get());
             SetComponentsInsideBoundariesValidState(entity, isInsideBoundaries);
             SetEntityInsideBoundariesState(entity, isInsideBoundaries);
@@ -264,15 +264,18 @@ namespace DCL.Controllers
         private void EvaluateAvatarMeshBounds(IDCLEntity entity, bool onlyOuterBoundsCheck = false)
         {
             Vector3 entityGOPosition = entity.gameObject.transform.position;
-            
-            // Heuristic using the entity scale for the size of the avatar bounds, otherwise we should configure the 
-            // entity's meshRootGameObject, etc. after its GPU skinning runs and use the regular entity mesh evaluation 
+
+            // Heuristic using the entity scale for the size of the avatar bounds, otherwise we should configure the
+            // entity's meshRootGameObject, etc. after its GPU skinning runs and use the regular entity mesh evaluation
             Bounds avatarBounds = new Bounds();
             avatarBounds.center = entityGOPosition;
             avatarBounds.size = entity.gameObject.transform.lossyScale;
-            
+
+            if(entity.scene.sceneData.sdk7)
+                Debug.Log("EvaluateAvatarMeshBounds()");
+
             entity.isInsideSceneOuterBoundaries = entity.scene.IsInsideSceneOuterBoundaries(avatarBounds);
-            
+
             if (!entity.isInsideSceneOuterBoundaries)
             {
                 SetComponentsInsideBoundariesValidState(entity, false);
@@ -281,7 +284,7 @@ namespace DCL.Controllers
 
             if (onlyOuterBoundsCheck)
                 return;
-            
+
             bool isInsideBoundaries = entity.scene.IsInsideSceneBoundaries(avatarBounds);
             SetComponentsInsideBoundariesValidState(entity, isInsideBoundaries);
             SetEntityInsideBoundariesState(entity, isInsideBoundaries);
@@ -291,7 +294,7 @@ namespace DCL.Controllers
         {
             if (entity.isInsideSceneBoundaries == isInsideBoundaries)
                 return;
-            
+
             entity.isInsideSceneBoundaries = isInsideBoundaries;
             OnEntityBoundsCheckerStatusChanged?.Invoke(entity, isInsideBoundaries);
         }
@@ -306,14 +309,14 @@ namespace DCL.Controllers
 
         public bool IsEntityMeshInsideSceneBoundaries(IDCLEntity entity)
         {
-            if (entity.meshesInfo == null 
-                || entity.meshesInfo.meshRootGameObject == null 
+            if (entity.meshesInfo == null
+                || entity.meshesInfo.meshRootGameObject == null
                 || entity.meshesInfo.mergedBounds == null)
                 return false;
 
             // 1st check (full mesh AABB)
             bool isInsideBoundaries = entity.scene.IsInsideSceneBoundaries(entity.meshesInfo.mergedBounds);
-            
+
             // 2nd check (submeshes & colliders AABB)
             if (!isInsideBoundaries)
             {
@@ -322,7 +325,7 @@ namespace DCL.Controllers
 
             return isInsideBoundaries;
         }
-        
+
         private bool AreSubmeshesInsideBoundaries(IDCLEntity entity)
         {
             for (int i = 0; i < entity.meshesInfo.renderers.Length; i++)
@@ -357,7 +360,7 @@ namespace DCL.Controllers
             SetEntityMeshesInsideBoundariesState(entity.meshesInfo, isInsideBoundaries);
             SetEntityCollidersInsideBoundariesState(entity.meshesInfo, isInsideBoundaries);
             SetComponentsInsideBoundariesValidState(entity, isInsideBoundaries);
-            
+
             // Should always be set last as entity.isInsideSceneBoundaries is checked to avoid re-running code unnecessarily
             SetEntityInsideBoundariesState(entity, isInsideBoundaries);
         }
@@ -371,11 +374,11 @@ namespace DCL.Controllers
         {
             if (meshesInfo == null || meshesInfo.colliders.Count == 0 || !meshesInfo.currentShape.HasCollisions())
                 return;
-            
+
             foreach (Collider collider in meshesInfo.colliders)
             {
                 if (collider == null) continue;
-                
+
                 if (collider.enabled != isInsideBoundaries)
                     collider.enabled = isInsideBoundaries;
             }
@@ -385,10 +388,10 @@ namespace DCL.Controllers
         {
             if(entity.isInsideSceneBoundaries == isInsideBoundaries || !DataStore.i.sceneBoundariesChecker.componentsCheckSceneBoundaries.ContainsKey(entity.entityId))
                 return;
-            
+
             foreach (IOutOfSceneBoundariesHandler component in DataStore.i.sceneBoundariesChecker.componentsCheckSceneBoundaries[entity.entityId])
             {
-                component.UpdateOutOfBoundariesState(isInsideBoundaries);   
+                component.UpdateOutOfBoundariesState(isInsideBoundaries);
             }
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -358,7 +358,7 @@ namespace DCL.Controllers
         private void SetMeshesAndComponentsInsideBoundariesState(IDCLEntity entity, bool isInsideBoundaries)
         {
             SetEntityMeshesInsideBoundariesState(entity.meshesInfo, isInsideBoundaries);
-            SetEntityCollidersInsideBoundariesState(entity.meshesInfo, isInsideBoundaries);
+            SetEntityCollidersInsideBoundariesState(entity, isInsideBoundaries);
             SetComponentsInsideBoundariesValidState(entity, isInsideBoundaries);
 
             // Should always be set last as entity.isInsideSceneBoundaries is checked to avoid re-running code unnecessarily
@@ -370,12 +370,14 @@ namespace DCL.Controllers
             feedbackStyle.ApplyFeedback(meshesInfo, isInsideBoundaries);
         }
 
-        private void SetEntityCollidersInsideBoundariesState(MeshesInfo meshesInfo, bool isInsideBoundaries)
+        private void SetEntityCollidersInsideBoundariesState(IDCLEntity entity, bool isInsideBoundaries)
         {
-            if (meshesInfo == null || meshesInfo.colliders.Count == 0 || !meshesInfo.currentShape.HasCollisions())
-                return;
+            if (entity.meshesInfo == null
+                || entity.meshesInfo.colliders.Count == 0
+                || (!entity.scene.sceneData.sdk7 && !entity.meshesInfo.currentShape.HasCollisions())
+                ) return;
 
-            foreach (Collider collider in meshesInfo.colliders)
+            foreach (Collider collider in entity.meshesInfo.colliders)
             {
                 if (collider == null) continue;
 


### PR DESCRIPTION
https://github.com/decentraland/unity-renderer/issues/3494

- Integrated `GltfContainer`, `MeshRenderer` and `MeshCollider` components to entity `MeshesInfo` to automatically work with current Scene Bounds Checker.