### PR TITLE
Fix: incorrect avatar raycasting

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
@@ -21,15 +21,15 @@ namespace DCL.ECSComponents
     public interface IAvatarShape
     {
         /// <summary>
-        /// This will initialize the AvatarShape and set 
+        /// This will initialize the AvatarShape and set
         /// </summary>
         void Init();
-        
+
         /// <summary>
         /// Clean up the avatar shape so we can reutilizate it using the pool
         /// </summary>
         void Cleanup();
-        
+
         /// <summary>
         /// Apply the model of the avatar, it will reload if necessary
         /// </summary>
@@ -43,7 +43,7 @@ namespace DCL.ECSComponents
         /// </summary>
         Transform transform { get; }
     }
-    
+
     public class AvatarShape : MonoBehaviour, IHideAvatarAreaHandler, IPoolableObjectContainer, IAvatarShape, IPoolLifecycleHandler
     {
         private const float AVATAR_Y_AXIS_OFFSET = -0.72f;
@@ -57,8 +57,9 @@ namespace DCL.ECSComponents
         [SerializeField] private GameObject armatureContainer;
 
         [SerializeField] internal AvatarOnPointerDown onPointerDown;
+        [SerializeField] internal AvatarOutlineOnHoverEvent outlineOnHover;
         [SerializeField] internal GameObject playerNameContainer;
-        
+
         internal IAvatarMovementController avatarMovementController;
         internal IPlayerName playerName;
         internal IAvatarReporterController avatarReporterController;
@@ -69,7 +70,7 @@ namespace DCL.ECSComponents
 
         internal Player player = null;
         internal BaseDictionary<string, Player> otherPlayers => DataStore.i.player.otherPlayers;
-        
+
         private IAvatarAnchorPoints anchorPoints = new AvatarAnchorPoints();
         internal IAvatar avatar;
         internal CancellationTokenSource loadingCts;
@@ -79,15 +80,15 @@ namespace DCL.ECSComponents
         public IPoolableObject poolableObject { get; set; }
         internal PBAvatarShape model;
         internal IDCLEntity entity;
-        
+
         private void Awake()
         {
             avatarMovementController = GetComponent<IAvatarMovementController>();
-            
+
             currentPlayerInfoCardId = Resources.Load<StringVariable>(CURRENT_PLAYER_ID);
             Visibility visibility = new Visibility();
             avatarMovementController.SetAvatarTransform(transform);
-            
+
             // Right now the avatars that are not part of the global scene of avatar are not using LOD since
             // AvatarsLodController are no taking them into account. It needs product definition and a refactor to include them
             LOD avatarLOD = new LOD(avatarContainer, visibility, avatarMovementController);
@@ -106,7 +107,7 @@ namespace DCL.ECSComponents
 
             if (avatarReporterController == null)
                 avatarReporterController = new AvatarReporterController(Environment.i.world.state);
-            
+
             onPointerDown.OnPointerDownReport += PlayerClicked;
             onPointerDown.OnPointerEnterReport += PlayerPointerEnter;
             onPointerDown.OnPointerExitReport += PlayerPointerExit;
@@ -126,7 +127,7 @@ namespace DCL.ECSComponents
             playerName = GetComponentInChildren<IPlayerName>();
             playerName?.Hide(true);
         }
-        
+
         private void PlayerClicked()
         {
             if (model == null)
@@ -145,11 +146,11 @@ namespace DCL.ECSComponents
         public async void ApplyModel(IParcelScene scene, IDCLEntity entity, PBAvatarShape newModel)
         {
             this.entity = entity;
-            
+
             isGlobalSceneAvatar = scene.sceneData.sceneNumber == EnvironmentSettings.AVATAR_GLOBAL_SCENE_NUMBER;
 
             DisablePassport();
-            
+
             bool needsLoading = !AvatarUtils.HaveSameWearablesAndColors(model,newModel);
             model = newModel;
 
@@ -189,11 +190,11 @@ namespace DCL.ECSComponents
                 }
                 catch (Exception e)
                 {
-                    // If the load of the avatar fails, we do it silently so the scene continue to operate. 
+                    // If the load of the avatar fails, we do it silently so the scene continue to operate.
                     // The LoadAvatar function will show the error in console already so in order to avoid noise, we just capture the exception
                 }
             }
-            
+
             // If the model contains a value for expressionTriggerId then we try it, if value doesn't exist, we skip
             if(model.HasExpressionTriggerId)
                 avatar.PlayEmote(model.ExpressionTriggerId, model.GetExpressionTriggerTimestamp());
@@ -209,6 +210,8 @@ namespace DCL.ECSComponents
                 },
                 entity, player
             );
+
+            outlineOnHover.Initialize(entity, player.avatar);
 
             avatarCollider.gameObject.SetActive(true);
 
@@ -275,7 +278,7 @@ namespace DCL.ECSComponents
         }
 
         private void PlayerPointerExit() { playerName?.SetForceShow(false); }
-        
+
         private void PlayerPointerEnter() { playerName?.SetForceShow(true); }
 
         internal void UpdatePlayerStatus(IDCLEntity entity, PBAvatarShape model)
@@ -290,7 +293,7 @@ namespace DCL.ECSComponents
             bool isNew = player == null;
             if (isNew)
                 player = new Player();
-            
+
             bool isNameDirty = player.name != model.GetName();
 
             player.id = model.Id;
@@ -309,7 +312,7 @@ namespace DCL.ECSComponents
                 if (isGlobalSceneAvatar)
                 {
                     // TODO: Note: This is having a problem, sometimes the users has been detected as new 2 times and it shouldn't happen
-                    // we should investigate this 
+                    // we should investigate this
                     if (otherPlayers.ContainsKey(player.id))
                         otherPlayers.Remove(player.id);
                     otherPlayers.Add(player.id, player);
@@ -365,7 +368,7 @@ namespace DCL.ECSComponents
         {
             if (entity == null)
                 return;
-            
+
             if (isGlobalSceneAvatar)
             {
                 avatarMovementController.OnTransformChanged(position, rotation, inmediate);
@@ -382,7 +385,7 @@ namespace DCL.ECSComponents
         {
             Cleanup();
         }
-        
+
         public void OnPoolGet()
         {
             initializedPosition = false;
@@ -413,11 +416,11 @@ namespace DCL.ECSComponents
                 otherPlayers.Remove(player.id);
                 player = null;
             }
-            
+
             loadingCts?.Cancel();
             loadingCts?.Dispose();
             loadingCts = null;
-            
+
             currentLazyObserver?.RemoveListener(avatar.SetImpostorTexture);
             avatar.Dispose();
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/Resources/NewAvatarShape.prefab
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/Resources/NewAvatarShape.prefab
@@ -26,6 +26,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8210819811968446249}
   m_RootOrder: 2
@@ -58,6 +59,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 940233138722625532}
   - {fileID: 7377730628817763273}
@@ -79,12 +81,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 528eb0c5369dcaa41bb5b814c2e9ca74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  avatarMovementControllerReference: {fileID: 3504616517296556492}
   avatarContainer: {fileID: 8963989720318013202}
   avatarCollider: {fileID: 6534765647599015563}
   avatarRevealContainer: {fileID: 762005512886389656}
   armatureContainer: {fileID: 8963989720318013202}
   onPointerDown: {fileID: 338606394308916673}
+  outlineOnHover: {fileID: 4900985733649484496}
   playerNameContainer: {fileID: 6128202859544868951}
 --- !u!114 &3504616517296556492
 MonoBehaviour:
@@ -125,6 +127,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1612428930952922234}
   m_RootOrder: 1
@@ -168,6 +171,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 635177030720891857}
   m_Father: {fileID: 1612428930952922234}
@@ -184,6 +188,7 @@ GameObject:
   - component: {fileID: 940233138722625532}
   - component: {fileID: 338606394308916673}
   - component: {fileID: 2534857999325092631}
+  - component: {fileID: 4900985733649484496}
   m_Layer: 9
   m_Name: PointerEventCollider
   m_TagString: Untagged
@@ -201,6 +206,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1612428930952922234}
   m_RootOrder: 0
@@ -232,6 +238,18 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4900985733649484496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6930828014457569972}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb6cb20447764382a9a277c8a9bc31b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7524742732015396865
 GameObject:
   m_ObjectHideFlags: 0
@@ -258,6 +276,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.755, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8210819811968446249}
   m_RootOrder: 0
@@ -290,6 +309,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 762005512886389656}
   - {fileID: 3462401327801288064}
@@ -331,9 +351,8 @@ MonoBehaviour:
     expressionTriggerId: 
     expressionTriggerTimestamp: 0
     deltaTime: 0
+    shouldLoop: 0
   target: {fileID: 1612428930952922234}
-  runMinSpeed: 6
-  walkMinSpeed: 0.1
 --- !u!114 &2077461904248848557
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -372,6 +391,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1612428930952922234}
   m_RootOrder: 3

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
@@ -1,9 +1,5 @@
-using System;
-using DCL.Models;
-using DCL.Components;
 using UnityEngine;
 using TMPro;
-using System.Collections.Generic;
 using DCL;
 using DCL.Helpers;
 

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Interfaces/EventsInterfaces.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/Interfaces/EventsInterfaces.cs
@@ -30,4 +30,6 @@ namespace DCLPlugins.UUIDEventComponentsPlugin.UUIDComponent.Interfaces
     }
 
     public interface IAvatarOnPointerDown : IPointerInputEvent { }
+
+    public interface IUnlockedCursorInputEvent : IPointerEvent { }
 }

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
@@ -80,7 +80,7 @@ namespace DCL
                 if (!DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("avatar_outliner"))
                     return;
 
-                typeToUse = typeof(IAvatarOnPointerDown);
+                typeToUse = typeof(IUnlockedCursorInputEvent);
             }
 
             IWorldState worldState = Environment.i.world.state;

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
@@ -17,9 +17,9 @@ namespace DCL
 {
     public class PointerEventsController
     {
+        private PointerHoverController pointerHoverController;
+
         private static bool renderingEnabled => CommonScriptableObjects.rendererState.Get();
-        public System.Action OnPointerHoverStarts;
-        public System.Action OnPointerHoverEnds;
 
         RaycastHitInfo lastPointerDownEventHitInfo;
         IPointerInputEvent pointerInputUpEvent;
@@ -27,20 +27,13 @@ namespace DCL
 
         Camera charCamera;
 
-        GameObject lastHoveredObject = null;
-        GameObject newHoveredGO = null;
-
-        IPointerEvent newHoveredInputEvent = null;
-        IList<IPointerEvent> lastHoveredEventList = null;
-
         RaycastHit hitInfo;
         PointerEventData uiGraphicRaycastPointerEventData = new PointerEventData(null);
         List<RaycastResult> uiGraphicRaycastResults = new List<RaycastResult>();
         GraphicRaycaster uiGraphicRaycaster;
 
         private IRaycastPointerClickHandler clickHandler;
-        private InputController_Legacy inputControllerLegacy;
-        private InteractionHoverCanvasController hoverCanvas;
+        private readonly InputController_Legacy inputControllerLegacy;
 
         private DataStore_ECS7 dataStoreEcs7 = DataStore.i.ecs7;
 
@@ -48,20 +41,20 @@ namespace DCL
             InteractionHoverCanvasController hoverCanvas)
         {
             this.inputControllerLegacy = inputControllerLegacy;
-            this.hoverCanvas = hoverCanvas;
+            pointerHoverController = new PointerHoverController(inputControllerLegacy, hoverCanvas);
+
+            pointerHoverController.OnPointerHoverStarts += SetHoverCursor;
+            pointerHoverController.OnPointerHoverEnds += SetNormalCursor;
 
             for (int i = 0; i < Enum.GetValues(typeof(WebInterface.ACTION_BUTTON)).Length; i++)
             {
-                var buttonId = (WebInterface.ACTION_BUTTON) i;
+                var buttonId = (WebInterface.ACTION_BUTTON)i;
 
                 if (buttonId == WebInterface.ACTION_BUTTON.ANY)
                     continue;
 
                 inputControllerLegacy.AddListener(buttonId, OnButtonEvent);
             }
-
-            OnPointerHoverStarts += SetHoverCursor;
-            OnPointerHoverEnds += SetNormalCursor;
 
             RetrieveCamera();
 
@@ -94,6 +87,7 @@ namespace DCL
 
             // We use Physics.Raycast() instead of our raycastHandler.Raycast() as that one is slower, sometimes 2x, because it fetches info we don't need here
             Ray ray = Utils.IsCursorLocked ? GetRayFromCamera() : GetRayFromMouse();
+
             bool didHit = Physics.Raycast(ray, out hitInfo, Mathf.Infinity,
                 PhysicsLayers.physicsCastLayerMaskWithoutCharacter);
 
@@ -146,102 +140,20 @@ namespace DCL
                 return;
             }
 
-            if (CollidersManager.i.GetColliderInfo(hitInfo.collider, out ColliderInfo info))
-                newHoveredInputEvent = (IPointerEvent)info.entity.gameObject.GetComponentInChildren(typeToUse);
-            else
-                newHoveredInputEvent = (IPointerEvent)hitInfo.collider.GetComponentInChildren(typeToUse);
+            var targetGO = CollidersManager.i.GetColliderInfo(hitInfo.collider, out var colliderInfo)
+                ? colliderInfo.entity.gameObject
+                : hitInfo.collider.gameObject;
 
             clickHandler = null;
-
-            if (!EventObjectCanBeHovered(info, hitInfo.distance))
-            {
-                UnhoverLastHoveredObject();
-
-                return;
-            }
-
-            newHoveredGO = newHoveredInputEvent.GetTransform().gameObject;
-
-            if (newHoveredGO != lastHoveredObject)
-            {
-                UnhoverLastHoveredObject();
-
-                lastHoveredObject = newHoveredGO;
-
-                lastHoveredEventList = GetPointerEventList(newHoveredInputEvent.entity);
-
-                // NOTE: this case is for the Avatar, since it hierarchy differs from other ECS components
-                if (lastHoveredEventList?.Count == 0)
-                {
-                    lastHoveredEventList = newHoveredGO.GetComponents<IPointerEvent>();
-                }
-
-                OnPointerHoverStarts?.Invoke();
-            }
-
-            // OnPointerDown/OnClick and OnPointerUp should display their hover feedback at different moments
-            if (lastHoveredEventList != null && lastHoveredEventList.Count > 0)
-            {
-                bool isEntityShowingHoverFeedback = false;
-
-                for (int i = 0; i < lastHoveredEventList.Count; i++)
-                {
-                    //If cursor is unlocked we ignore the button being pressed, avatars use case.
-                    if (lastHoveredEventList[i] is IPointerInputEvent e && Utils.IsCursorLocked)
-                    {
-                        bool eventButtonIsPressed = inputControllerLegacy.IsPressed(e.GetActionButton());
-
-                        bool isClick = e.GetEventType() == PointerInputEventType.CLICK;
-                        bool isDown = e.GetEventType() == PointerInputEventType.DOWN;
-                        bool isUp = e.GetEventType() == PointerInputEventType.UP;
-
-                        if (isUp && eventButtonIsPressed)
-                        {
-                            e.SetHoverState(true);
-                            isEntityShowingHoverFeedback = isEntityShowingHoverFeedback || e.ShouldShowHoverFeedback();
-                        }
-                        else if ((isDown || isClick) && !eventButtonIsPressed)
-                        {
-                            e.SetHoverState(true);
-                            isEntityShowingHoverFeedback = isEntityShowingHoverFeedback || e.ShouldShowHoverFeedback();
-                        }
-                        else if (!isEntityShowingHoverFeedback)
-                        {
-                            e.SetHoverState(false);
-                        }
-                    }
-                    else
-                    {
-                        lastHoveredEventList[i].SetHoverState(true);
-                    }
-                }
-            }
-
-            newHoveredGO = null;
-            newHoveredInputEvent = null;
-        }
-
-        private IList<IPointerEvent> GetPointerEventList(IDCLEntity entity)
-        {
-            return entity.gameObject.transform.Cast<Transform>()
-                                    .Select(child => child.GetComponent<IPointerEvent>())
-                                    .Where(pointerComponent => pointerComponent != null)
-                                    .ToArray();
+            pointerHoverController.OnRaycastHit(hitInfo, colliderInfo, targetGO, typeToUse);
         }
 
         private IList<IPointerInputEvent> GetPointerInputEvents(GameObject hitGameObject)
         {
             if (!Utils.IsCursorLocked || Utils.LockedThisFrame())
                 return hitGameObject.GetComponentsInChildren<IAvatarOnPointerDown>();
-            return hitGameObject.GetComponentsInChildren<IPointerInputEvent>();
-        }
 
-        private bool EventObjectCanBeHovered(ColliderInfo colliderInfo, float distance)
-        {
-            return newHoveredInputEvent != null &&
-                   newHoveredInputEvent.IsAtHoverDistance(distance) &&
-                   newHoveredInputEvent.IsVisible() &&
-                   AreSameEntity(newHoveredInputEvent, colliderInfo);
+            return hitGameObject.GetComponentsInChildren<IPointerInputEvent>();
         }
 
         private void ResolveGenericRaycastHandlers(IRaycastPointerHandler raycastHandlerTarget)
@@ -279,35 +191,16 @@ namespace DCL
             }
         }
 
-        void UnhoverLastHoveredObject()
+        private void UnhoverLastHoveredObject()
         {
-            if (lastHoveredObject == null)
-            {
-                if (hoverCanvas != null)
-                    hoverCanvas.SetHoverState(false);
-
-                return;
-            }
-
-            OnPointerHoverEnds?.Invoke();
-
-            for (int i = 0; i < lastHoveredEventList.Count; i++)
-            {
-                if (lastHoveredEventList[i] == null)
-                    continue;
-
-                lastHoveredEventList[i].SetHoverState(false);
-            }
-
-            lastHoveredEventList = null;
-            lastHoveredObject = null;
+            pointerHoverController.ResetHoveredObject();
         }
 
         public void Dispose()
         {
             for (int i = 0; i < Enum.GetValues(typeof(WebInterface.ACTION_BUTTON)).Length; i++)
             {
-                var buttonId = (WebInterface.ACTION_BUTTON) i;
+                var buttonId = (WebInterface.ACTION_BUTTON)i;
 
                 if (buttonId == WebInterface.ACTION_BUTTON.ANY)
                     continue;
@@ -315,13 +208,8 @@ namespace DCL
                 inputControllerLegacy.RemoveListener(buttonId, OnButtonEvent);
             }
 
-            lastHoveredObject = null;
-            newHoveredGO = null;
-            newHoveredInputEvent = null;
-            lastHoveredEventList = null;
-
-            OnPointerHoverStarts -= SetHoverCursor;
-            OnPointerHoverEnds -= SetNormalCursor;
+            pointerHoverController.OnPointerHoverStarts -= SetHoverCursor;
+            pointerHoverController.OnPointerHoverEnds -= SetNormalCursor;
 
             Environment.i.platform.updateEventHandler.RemoveListener(IUpdateEventHandler.EventType.Update, Update);
             Utils.OnCursorLockChanged -= HandleCursorLockChanges;
@@ -329,13 +217,13 @@ namespace DCL
 
         void RetrieveCamera()
         {
-            if (charCamera == null)
-            {
-                charCamera = Camera.main;
-            }
+            if (charCamera == null) { charCamera = Camera.main; }
         }
 
-        public Ray GetRayFromCamera() { return charCamera.ScreenPointToRay(new Vector3(Screen.width / 2, Screen.height / 2, 0)); }
+        public Ray GetRayFromCamera()
+        {
+            return charCamera.ScreenPointToRay(new Vector3(Screen.width / 2, Screen.height / 2, 0));
+        }
 
         public Ray GetRayFromMouse()
         {
@@ -357,7 +245,6 @@ namespace DCL
                     if (!DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("avatar_outliner"))
                         return;
                 }
-
             }
 
             if (charCamera == null)
@@ -373,14 +260,8 @@ namespace DCL
 
             var globalLayer = pointerEventLayer & ~PhysicsLayers.physicsCastLayerMask;
 
-            if (evt == InputController_Legacy.EVENT.BUTTON_DOWN)
-            {
-                ProcessButtonDown(buttonId, useRaycast, enablePointerEvent, pointerEventLayer, globalLayer);
-            }
-            else if (evt == InputController_Legacy.EVENT.BUTTON_UP)
-            {
-                ProcessButtonUp(buttonId, useRaycast, enablePointerEvent, pointerEventLayer, globalLayer);
-            }
+            if (evt == InputController_Legacy.EVENT.BUTTON_DOWN) { ProcessButtonDown(buttonId, useRaycast, enablePointerEvent, pointerEventLayer, globalLayer); }
+            else if (evt == InputController_Legacy.EVENT.BUTTON_UP) { ProcessButtonUp(buttonId, useRaycast, enablePointerEvent, pointerEventLayer, globalLayer); }
 
             if (dataStoreEcs7.isEcs7Enabled)
             {
@@ -396,6 +277,7 @@ namespace DCL
             IWorldState worldState = Environment.i.world.state;
 
             int currentSceneNumber = worldState.GetCurrentSceneNumber();
+
             if (currentSceneNumber <= 0)
                 return;
 
@@ -411,6 +293,7 @@ namespace DCL
             raycastGlobalLayerHitInfo = raycastInfoGlobalLayer.hitInfo;
 
             RaycastResultInfo raycastInfoPointerEventLayer = null;
+
             if (pointerInputUpEvent != null || dataStoreEcs7.isEcs7Enabled)
             {
                 // Raycast for pointer event components
@@ -426,10 +309,7 @@ namespace DCL
                 bool isSameEntityThatWasPressed = AreCollidersFromSameEntity(raycastInfoPointerEventLayer.hitInfo,
                     lastPointerDownEventHitInfo);
 
-                if (!isOnClickComponentBlocked && isSameEntityThatWasPressed && enablePointerEvent)
-                {
-                    pointerInputUpEvent.Report(buttonId, ray, raycastInfoPointerEventLayer.hitInfo.hit);
-                }
+                if (!isOnClickComponentBlocked && isSameEntityThatWasPressed && enablePointerEvent) { pointerInputUpEvent.Report(buttonId, ray, raycastInfoPointerEventLayer.hitInfo.hit); }
 
                 pointerInputUpEvent = null;
             }
@@ -438,9 +318,11 @@ namespace DCL
 
             // Raycast for global pointer events (for each PE scene)
             List<string> currentPortableExperienceIds = DataStore.i.Get<DataStore_World>().portableExperienceIds.Get().ToList();
+
             for (int i = 0; i < currentPortableExperienceIds.Count; i++)
             {
                 IParcelScene pexSene = worldState.GetPortableExperienceScene(currentPortableExperienceIds[i]);
+
                 if (pexSene != null)
                 {
                     raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer, pexSene);
@@ -458,6 +340,7 @@ namespace DCL
             IWorldState worldState = Environment.i.world.state;
 
             int currentSceneNumber = worldState.GetCurrentSceneNumber();
+
             if (currentSceneNumber <= 0)
                 return;
 
@@ -523,9 +406,11 @@ namespace DCL
 
             // Raycast for global pointer events (for each PE scene)
             IEnumerable<string> currentPortableExperienceSceneIds = DataStore.i.world.portableExperienceIds.Get();
+
             foreach (var pexSceneId in currentPortableExperienceSceneIds)
             {
                 IParcelScene pexSene = worldState.GetPortableExperienceScene(pexSceneId);
+
                 if (pexSene != null)
                 {
                     raycastInfoGlobalLayer = raycastHandler.Raycast(ray, charCamera.farClipPlane, globalLayer, pexSene);
@@ -648,20 +533,13 @@ namespace DCL
             bool entityBHasEvent = entityB != null && EntityHasPointerEvent(entityB);
 
             // If both entities has OnClick/PointerEvent component
-            if (entityAHasEvent && entityBHasEvent)
-            {
-                return entityA == entityB;
-            }
+            if (entityAHasEvent && entityBHasEvent) { return entityA == entityB; }
+
             // If only one of them has OnClick/PointerEvent component
-            else if (entityAHasEvent ^ entityBHasEvent)
-            {
-                return false;
-            }
+            else if (entityAHasEvent ^ entityBHasEvent) { return false; }
+
             // None of them has OnClick/PointerEvent component
-            else
-            {
-                return colliderInfoA.entity == colliderInfoB.entity;
-            }
+            else { return colliderInfoA.entity == colliderInfoB.entity; }
         }
 
         private void HandleCursorLockChanges(bool isLocked)
@@ -672,10 +550,19 @@ namespace DCL
                 UnhoverLastHoveredObject();
         }
 
-        private void HideOrShowCursor(bool isCursorLocked) { DataStore.i.Get<DataStore_Cursor>().cursorVisible.Set(isCursorLocked); }
+        private void HideOrShowCursor(bool isCursorLocked)
+        {
+            DataStore.i.Get<DataStore_Cursor>().cursorVisible.Set(isCursorLocked);
+        }
 
-        private void SetHoverCursor() { DataStore.i.Get<DataStore_Cursor>().cursorType.Set(DataStore_Cursor.CursorType.HOVER); }
+        private void SetHoverCursor()
+        {
+            DataStore.i.Get<DataStore_Cursor>().cursorType.Set(DataStore_Cursor.CursorType.HOVER);
+        }
 
-        private void SetNormalCursor() { DataStore.i.Get<DataStore_Cursor>().cursorType.Set(DataStore_Cursor.CursorType.NORMAL); }
+        private void SetNormalCursor()
+        {
+            DataStore.i.Get<DataStore_Cursor>().cursorType.Set(DataStore_Cursor.CursorType.NORMAL);
+        }
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerHoverController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerHoverController.cs
@@ -1,0 +1,177 @@
+﻿using DCL.Components;
+using DCL.Helpers;
+using DCLPlugins.UUIDEventComponentsPlugin.UUIDComponent.Interfaces;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DCL
+{
+    public class PointerHoverController
+    {
+        /// <summary>
+        /// There is only one hovered object at a time
+        /// but it contain listeners with different activation range
+        /// </summary>
+        private struct PointerEventInfo
+        {
+            /// <summary>
+            /// The root object hit by raycast
+            /// </summary>
+            public GameObject GameObject;
+
+            /// <summary>
+            /// Listeners that were activated when they became within the range.
+            /// </summary>
+            public List<IPointerEvent> ActiveListeners;
+
+            /// <summary>
+            /// Listeners that were not active
+            /// </summary>
+            public List<IPointerEvent> InactiveListeners;
+        }
+
+        public event Action OnPointerHoverStarts;
+        public event Action OnPointerHoverEnds;
+
+        private PointerEventInfo currentHoveredObjectInfo = new ()
+        {
+            ActiveListeners = new List<IPointerEvent>(),
+            InactiveListeners = new List<IPointerEvent>()
+        };
+
+        private readonly InputController_Legacy inputControllerLegacy;
+        private readonly InteractionHoverCanvasController hoverCanvas;
+
+        public bool IsObjectHovered => currentHoveredObjectInfo.GameObject;
+
+        public PointerHoverController(InputController_Legacy inputControllerLegacy, InteractionHoverCanvasController hoverCanvas)
+        {
+            this.inputControllerLegacy = inputControllerLegacy;
+            this.hoverCanvas = hoverCanvas;
+        }
+
+        public void OnRaycastHit(RaycastHit hit, ColliderInfo colliderInfo, GameObject targetObject,
+            Type typeToUse)
+        {
+            if (targetObject == currentHoveredObjectInfo.GameObject)
+            {
+                ResolveActiveListeners(hit.distance, colliderInfo, typeToUse);
+            }
+            else
+            {
+                ResetHoveredObject();
+                targetObject.GetComponentsInChildren(currentHoveredObjectInfo.InactiveListeners);
+                ResolveActiveListeners(hit.distance, colliderInfo, typeToUse);
+
+                // if the object was hovered but no listeners could accept it,
+                // count it as it was not hovered at all
+                if (currentHoveredObjectInfo.ActiveListeners.Count > 0)
+                {
+                    currentHoveredObjectInfo.GameObject = targetObject;
+                    OnPointerHoverStarts?.Invoke();
+                }
+            }
+        }
+
+        private void ResolveActiveListeners(float distance, ColliderInfo colliderInfo, Type typeToUse)
+        {
+            var inactiveListenersCount = currentHoveredObjectInfo.InactiveListeners.Count;
+
+            foreach (var activeListener in currentHoveredObjectInfo.ActiveListeners)
+            {
+                if (!EventObjectCanBeHovered(typeToUse, activeListener, colliderInfo, distance))
+                {
+                    // Deactivate Listener
+                    activeListener.SetHoverState(false);
+                    currentHoveredObjectInfo.InactiveListeners.Add(activeListener);
+                }
+            }
+
+            var index = 0;
+
+            while (inactiveListenersCount > 0)
+            {
+                var inactiveListener = currentHoveredObjectInfo.InactiveListeners[index];
+
+                if (EventObjectCanBeHovered(typeToUse, inactiveListener, colliderInfo, distance))
+                {
+                    currentHoveredObjectInfo.ActiveListeners.Add(inactiveListener);
+                    currentHoveredObjectInfo.InactiveListeners.RemoveAt(index);
+                }
+                else index++;
+
+                inactiveListenersCount--;
+            }
+
+            bool isEntityShowingHoverFeedback = false;
+
+            // Maintain the previous logic to notify about hover state every frame
+            foreach (IPointerEvent activeListener in currentHoveredObjectInfo.ActiveListeners)
+                isEntityShowingHoverFeedback = SetHoverActive(activeListener, isEntityShowingHoverFeedback);
+        }
+
+        private bool SetHoverActive(IPointerEvent pointerEvent, bool isEntityShowingHoverFeedback)
+        {
+            // It's a copy of old logic, it's not entirely clear why it functions this way exactly
+
+            // OnPointerDown/OnClick and OnPointerUp should display their hover feedback at different moments
+            // If cursor is unlocked we ignore the button being pressed, avatars use case.
+            if (pointerEvent is IPointerInputEvent e && Utils.IsCursorLocked)
+            {
+                bool eventButtonIsPressed = inputControllerLegacy.IsPressed(e.GetActionButton());
+
+                switch (e.GetEventType())
+                {
+                    case PointerInputEventType.UP when eventButtonIsPressed:
+                    case PointerInputEventType.CLICK when !eventButtonIsPressed:
+                    case PointerInputEventType.DOWN when !eventButtonIsPressed:
+                        e.SetHoverState(true);
+                        return isEntityShowingHoverFeedback || e.ShouldShowHoverFeedback();
+                }
+
+                if (!isEntityShowingHoverFeedback)
+                    e.SetHoverState(false);
+            }
+            else pointerEvent.SetHoverState(true);
+
+            return isEntityShowingHoverFeedback;
+        }
+
+        private static bool EventObjectCanBeHovered(Type typeToUse, IPointerEvent pointerEvent, ColliderInfo colliderInfo, float distance) =>
+            typeToUse.IsInstanceOfType(pointerEvent) &&
+            pointerEvent.IsAtHoverDistance(distance) &&
+            pointerEvent.IsVisible() &&
+            AreSameEntity(pointerEvent, colliderInfo);
+
+        private static bool AreSameEntity(IPointerEvent pointerInputEvent, ColliderInfo colliderInfo) =>
+            pointerInputEvent != null && colliderInfo.entity != null &&
+            pointerInputEvent.entity == colliderInfo.entity;
+
+        public void ResetHoveredObject()
+        {
+            if (currentHoveredObjectInfo.GameObject != null)
+            {
+                foreach (var listener in currentHoveredObjectInfo.ActiveListeners)
+                {
+                    // Respect Unity GO lifecycle
+                    if (Equals(listener, null))
+                        continue;
+
+                    listener.SetHoverState(false);
+                }
+
+                currentHoveredObjectInfo.GameObject = null;
+                currentHoveredObjectInfo.ActiveListeners.Clear();
+                currentHoveredObjectInfo.InactiveListeners.Clear();
+
+                OnPointerHoverEnds?.Invoke();
+            }
+            else
+            {
+                if (hoverCanvas != null)
+                    hoverCanvas.SetHoverState(false);
+            }
+        }
+    }
+}

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerHoverController.cs.meta
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerHoverController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 44bb227abc2e43e2ad66e08183c408ce
+timeCreated: 1672334260

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOnPointerDown.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOnPointerDown.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using DCL.Controllers;
 using DCL.Interface;
 using UnityEngine;
@@ -37,8 +36,10 @@ namespace DCL.Components
             bool isHoveringDirty = state != isHovering;
             isHovering = state;
             eventHandler?.SetFeedbackState(model.showFeedback, state && passportEnabled, model.button, model.hoverText);
+
             if (!isHoveringDirty)
                 return;
+
             if (isHovering)
                 OnPointerEnterReport?.Invoke();
             else
@@ -49,6 +50,7 @@ namespace DCL.Components
         {
             if (!isHovering)
                 return;
+
             isHovering = false;
             OnPointerExitReport?.Invoke();
         }
@@ -79,7 +81,7 @@ namespace DCL.Components
         }
 
         public bool IsAtHoverDistance(float distance) =>
-            true;
+            distance <= model.distance;
 
         public bool IsVisible()
         {
@@ -108,6 +110,7 @@ namespace DCL.Components
             if (onClickReportEnabled && ShouldReportOnClickEvent(buttonId, out IParcelScene playerScene))
             {
                 AudioScriptableObjects.buttonClick.Play(true);
+
                 WebInterface.ReportAvatarClick(
                     playerScene.sceneData.sceneNumber,
                     avatarPlayer.id,
@@ -157,31 +160,22 @@ namespace DCL.Components
             avatarPlayer = null;
         }
 
-        public void OnPoolGet()
-        {
-        }
+        public void OnPoolGet() { }
 
         private bool ShouldReportOnClickEvent(WebInterface.ACTION_BUTTON buttonId, out IParcelScene playerScene)
         {
             playerScene = null;
 
-            if (buttonId != WebInterface.ACTION_BUTTON.POINTER)
-            {
-                return false;
-            }
+            if (buttonId != WebInterface.ACTION_BUTTON.POINTER) { return false; }
 
-            if (avatarPlayer == null)
-            {
-                return false;
-            }
+            if (avatarPlayer == null) { return false; }
 
             int playerSceneNumber = CommonScriptableObjects.sceneNumber.Get();
-            if (playerSceneNumber <= 0)
-            {
-                return false;
-            }
+
+            if (playerSceneNumber <= 0) { return false; }
 
             playerScene = WorldStateUtils.GetCurrentScene();
+
             return playerScene?.IsInsideSceneBoundaries(
                 PositionUtils.UnityToWorldPosition(avatarPlayer.worldPosition)) ?? false;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOutlineOnHoverEvent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOutlineOnHoverEvent.cs
@@ -1,0 +1,71 @@
+﻿using AvatarSystem;
+using DCL.Models;
+using DCLPlugins.UUIDEventComponentsPlugin.UUIDComponent.Interfaces;
+using UnityEngine;
+
+namespace DCL.Components
+{
+    /// <summary>
+    /// Complementary class to detect avatar outlining only,
+    /// It does not live on its own and should coexist with `AvatarOnPointerDown`
+    /// </summary>
+    public class AvatarOutlineOnHoverEvent : MonoBehaviour, IPointerEvent, IPoolLifecycleHandler
+    {
+        private IAvatar avatar;
+
+        private bool isHovered;
+
+        public void Initialize(IDCLEntity entity, IAvatar avatar)
+        {
+            this.entity = entity;
+            this.avatar = avatar;
+        }
+
+        private void ResetAvatarOutlined()
+        {
+            DataStore.i.outliner.avatarOutlined.Set((null, -1, -1));
+        }
+
+        private void SetAvatarOutlined()
+        {
+            if (avatar.status == IAvatar.Status.Loaded)
+            {
+                var renderer = avatar.GetMainRenderer();
+
+                if (renderer != null)
+                    DataStore.i.outliner.avatarOutlined.Set((renderer, renderer.GetComponent<MeshFilter>().sharedMesh.subMeshCount, avatar.extents.y));
+            }
+        }
+
+        public Transform GetTransform() =>
+            transform;
+
+        public IDCLEntity entity { get; private set; }
+
+        public void SetHoverState(bool state)
+        {
+            if (isHovered != state)
+            {
+                isHovered = state;
+
+                if (isHovered)
+                    SetAvatarOutlined();
+                else
+                    ResetAvatarOutlined();
+            }
+        }
+
+        public bool IsAtHoverDistance(float distance) =>
+            true;
+
+        public bool IsVisible() =>
+            true;
+
+        public void OnPoolRelease()
+        {
+            avatar = null;
+        }
+
+        public void OnPoolGet() { }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOutlineOnHoverEvent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOutlineOnHoverEvent.cs
@@ -9,7 +9,7 @@ namespace DCL.Components
     /// Complementary class to detect avatar outlining only,
     /// It does not live on its own and should coexist with `AvatarOnPointerDown`
     /// </summary>
-    public class AvatarOutlineOnHoverEvent : MonoBehaviour, IPointerEvent, IPoolLifecycleHandler
+    public class AvatarOutlineOnHoverEvent : MonoBehaviour, IUnlockedCursorInputEvent, IPoolLifecycleHandler
     {
         private IAvatar avatar;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOutlineOnHoverEvent.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOutlineOnHoverEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fb6cb20447764382a9a277c8a9bc31b3
+timeCreated: 1672387932

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -34,6 +34,7 @@ namespace DCL
         [SerializeField] private GameObject armatureContainer;
 
         [SerializeField] internal AvatarOnPointerDown onPointerDown;
+        [SerializeField] internal AvatarOutlineOnHoverEvent outlineOnHover;
         [SerializeField] internal GameObject playerNameContainer;
         internal IPlayerName playerName;
         internal IAvatarReporterController avatarReporterController;
@@ -231,6 +232,8 @@ namespace DCL
                 entity, player
             );
 
+            outlineOnHover.Initialize(entity, player.avatar);
+
             avatarCollider.gameObject.SetActive(true);
 
             everythingIsLoaded = true;
@@ -256,20 +259,11 @@ namespace DCL
 
         private void PlayerPointerExit()
         {
-            DataStore.i.outliner.avatarOutlined.Set((null, -1, -1));
             playerName?.SetForceShow(false);
         }
 
         private void PlayerPointerEnter()
         {
-            if (avatar.status == IAvatar.Status.Loaded)
-            {
-                var renderer = avatar.GetMainRenderer();
-
-                if (renderer != null)
-                    DataStore.i.outliner.avatarOutlined.Set((renderer, renderer.GetComponent<MeshFilter>().sharedMesh.subMeshCount, avatar.extents.y));
-            }
-
             playerName?.SetForceShow(true);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -26,6 +26,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4675848658069725358}
   m_RootOrder: 2
@@ -58,6 +59,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4331657482804467835}
   - {fileID: 6301578636949877838}
@@ -86,6 +88,7 @@ MonoBehaviour:
   avatarRevealContainer: {fileID: 4288110136316019743}
   armatureContainer: {fileID: 5582000225371496597}
   onPointerDown: {fileID: 3865137627712764486}
+  outlineOnHover: {fileID: 1771187575892058067}
   playerNameContainer: {fileID: 7213221244455466960}
   everythingIsLoaded: 0
 --- !u!114 &122622683908687435
@@ -128,6 +131,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4288110136316019743}
   - {fileID: 80406326182283783}
@@ -209,6 +213,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2842120016485600253}
   m_RootOrder: 3
@@ -224,6 +229,7 @@ GameObject:
   - component: {fileID: 4331657482804467835}
   - component: {fileID: 3865137627712764486}
   - component: {fileID: 1314168606903342224}
+  - component: {fileID: 1771187575892058067}
   m_Layer: 9
   m_Name: PointerEventCollider
   m_TagString: Untagged
@@ -241,6 +247,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2842120016485600253}
   m_RootOrder: 0
@@ -272,6 +279,18 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1771187575892058067
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5854254909640412467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb6cb20447764382a9a277c8a9bc31b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6448032256406529926
 GameObject:
   m_ObjectHideFlags: 0
@@ -298,6 +317,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.755, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4675848658069725358}
   m_RootOrder: 0
@@ -328,6 +348,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4161845772322530390}
   m_Father: {fileID: 2842120016485600253}
@@ -360,6 +381,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2842120016485600253}
   m_RootOrder: 1


### PR DESCRIPTION
## What does this PR change?

Closes #3859

**Definition of problem:**
Raycasting for passport is limited by range, while raycasting for outlining is unlimited. But they both were handled by a single piece of code that was very coupled. 

**Approach**
Detach avatar outlining from other functionality.

**Solution**
`PointerEventsController` is junk and without refactoring, it was impossible to approach properly. I had to extract all the functionality related to hovering to a separate class:
- The logic there was unclear so I modified it to be more consistent
- I tried to preserve the previous behavior
- Add an independent control of hovering so now there can be different `IPointerEvent`s with completely independent logic on the same object, and it will work correctly.
- It allowed me to introduce `AvatarOutlineOnHoverEvent` that handles outline detection only and move there a piece of logic from `AvatarShape` (that was in the wrong domain anyway)


## How to test the changes?

- Test Avatar and other objects Input (clicks, up, down, hovering): I had to modify the system behind them so I may expect some hiccups. 
- Behavior of Passport raycasting and Avatar Outling should work as expected regardless of the feature flag.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
