### PR TITLE
fix: sdk7 hotreload

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ComponentCrdtWriteSystem/ComponentCrdtWriteSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ComponentCrdtWriteSystem/ComponentCrdtWriteSystem.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Collections.Generic;
 using DCL;
 using DCL.Controllers;
 using DCL.CRDT;
 using DCL.ECSRuntime;
 using RPC;
+using System;
+using System.Collections.Generic;
 
 public class ComponentCrdtWriteSystem : IDisposable
 {
@@ -20,17 +20,17 @@ public class ComponentCrdtWriteSystem : IDisposable
 
     private readonly RPCContext rpcContext;
     private readonly ISceneController sceneController;
-    private readonly IWorldState worldState;
+    private readonly IReadOnlyDictionary<int, ICRDTExecutor> crdtExecutors;
 
     private readonly Dictionary<int, CRDTProtocol> outgoingCrdt = new Dictionary<int, CRDTProtocol>(60);
     private readonly Queue<MessageData> queuedMessages = new Queue<MessageData>(60);
     private readonly Queue<MessageData> messagesPool = new Queue<MessageData>(60);
 
-    public ComponentCrdtWriteSystem(IWorldState worldState, ISceneController sceneController, RPCContext rpcContext)
+    public ComponentCrdtWriteSystem(IReadOnlyDictionary<int, ICRDTExecutor> crdtExecutors, ISceneController sceneController, RPCContext rpcContext)
     {
         this.sceneController = sceneController;
         this.rpcContext = rpcContext;
-        this.worldState = worldState;
+        this.crdtExecutors = crdtExecutors;
 
         sceneController.OnSceneRemoved += OnSceneRemoved;
     }
@@ -40,7 +40,8 @@ public class ComponentCrdtWriteSystem : IDisposable
         sceneController.OnSceneRemoved -= OnSceneRemoved;
     }
 
-    public void WriteMessage(int sceneNumber, long entityId, int componentId, byte[] data, long minTimeStamp, ECSComponentWriteType writeType)
+    public void WriteMessage(int sceneNumber, long entityId, int componentId, byte[] data, long minTimeStamp,
+        ECSComponentWriteType writeType)
     {
         MessageData messageData = messagesPool.Count > 0 ? messagesPool.Dequeue() : new MessageData();
 
@@ -68,10 +69,11 @@ public class ComponentCrdtWriteSystem : IDisposable
             var message = queuedMessages.Dequeue();
             messagesPool.Enqueue(message);
 
-            if (!worldState.TryGetScene(message.sceneNumber, out IParcelScene scene))
+            if (!crdtExecutors.TryGetValue(message.sceneNumber, out ICRDTExecutor crdtExecutor))
                 continue;
 
-            CRDTMessage crdt = scene.crdtExecutor.crdtProtocol.Create((int)message.entityId, message.componentId, message.data);
+            CRDTMessage crdt = crdtExecutor.crdtProtocol.Create((int)message.entityId, message.componentId, message.data);
+
             if (message.minTimeStamp >= 0 && message.minTimeStamp > crdt.timestamp)
             {
                 crdt.timestamp = message.minTimeStamp;
@@ -79,15 +81,15 @@ public class ComponentCrdtWriteSystem : IDisposable
 
             if (message.writeType.HasFlag(ECSComponentWriteType.SEND_TO_LOCAL))
             {
-                scene.crdtExecutor.Execute(crdt);
+                crdtExecutor.Execute(crdt);
             }
             else if (message.writeType.HasFlag(ECSComponentWriteType.WRITE_STATE_LOCALLY))
             {
-                scene.crdtExecutor.crdtProtocol.ProcessMessage(crdt);
+                crdtExecutor.crdtProtocol.ProcessMessage(crdt);
             }
             else if (message.writeType.HasFlag(ECSComponentWriteType.EXECUTE_LOCALLY))
             {
-                scene.crdtExecutor.ExecuteWithoutStoringState(crdt.key1, crdt.key2, crdt.data);
+                crdtExecutor.ExecuteWithoutStoringState(crdt.key1, crdt.key2, crdt.data);
             }
 
             if (message.writeType.HasFlag(ECSComponentWriteType.SEND_TO_SCENE))

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECS7Plugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECS7Plugin.cs
@@ -1,3 +1,4 @@
+using DCL.Controllers;
 using DCL.CRDT;
 using DCL.ECSComponents;
 using DCL.ECSRuntime;
@@ -11,25 +12,31 @@ namespace DCL.ECS7
         private readonly IECSComponentWriter componentWriter;
         private readonly ECS7ComponentsComposer componentsComposer;
         private readonly ECSSystemsController systemsController;
+        private readonly ECSComponentsFactory componentsFactory;
+        private readonly ECSComponentsManager componentsManager;
         private readonly InternalECSComponents internalEcsComponents;
         private readonly CrdtExecutorsManager crdtExecutorsManager;
+
+        private readonly BaseList<IParcelScene> loadedScenes;
+        private readonly ISceneController sceneController;
 
         public ECS7Plugin()
         {
             DataStore.i.ecs7.isEcs7Enabled = true;
+            loadedScenes = DataStore.i.ecs7.scenes;
 
-            ISceneController sceneController = Environment.i.world.sceneController;
+            sceneController = Environment.i.world.sceneController;
             Dictionary<int, ICRDTExecutor> crdtExecutors = new Dictionary<int, ICRDTExecutor>(10);
             DataStore.i.rpc.context.crdt.CrdtExecutors = crdtExecutors;
 
-            var componentsFactory = new ECSComponentsFactory();
-            var componentsManager = new ECSComponentsManager(componentsFactory.componentBuilders);
+            componentsFactory = new ECSComponentsFactory();
+            componentsManager = new ECSComponentsManager(componentsFactory.componentBuilders);
             internalEcsComponents = new InternalECSComponents(componentsManager, componentsFactory);
 
             crdtExecutorsManager = new CrdtExecutorsManager(crdtExecutors, componentsManager, sceneController,
                 Environment.i.world.state, DataStore.i.rpc.context.crdt);
 
-            crdtWriteSystem = new ComponentCrdtWriteSystem(Environment.i.world.state, sceneController, DataStore.i.rpc.context);
+            crdtWriteSystem = new ComponentCrdtWriteSystem(crdtExecutors, sceneController, DataStore.i.rpc.context);
             componentWriter = new ECSComponentWriter(crdtWriteSystem.WriteMessage);
 
             componentsComposer = new ECS7ComponentsComposer(componentsFactory, componentWriter, internalEcsComponents);
@@ -41,6 +48,9 @@ namespace DCL.ECS7
                 (ECSComponent<PBBillboard>)componentsManager.GetOrCreateComponent(ComponentID.BILLBOARD));
 
             systemsController = new ECSSystemsController(crdtWriteSystem.LateUpdate, systemsContext);
+
+            sceneController.OnNewSceneAdded += SceneControllerOnOnNewSceneAdded;
+            sceneController.OnSceneRemoved += SceneControllerOnOnSceneRemoved;
         }
 
         public void Dispose()
@@ -51,6 +61,25 @@ namespace DCL.ECS7
             systemsController.Dispose();
             internalEcsComponents.Dispose();
             crdtExecutorsManager.Dispose();
+
+            sceneController.OnNewSceneAdded -= SceneControllerOnOnNewSceneAdded;
+            sceneController.OnSceneRemoved -= SceneControllerOnOnSceneRemoved;
+        }
+
+        private void SceneControllerOnOnNewSceneAdded(IParcelScene scene)
+        {
+            if (scene.sceneData.sdk7)
+            {
+                loadedScenes.Add(scene);
+            }
+        }
+
+        private void SceneControllerOnOnSceneRemoved(IParcelScene scene)
+        {
+            if (scene.sceneData.sdk7)
+            {
+                loadedScenes.Remove(scene);
+            }
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -623,8 +623,6 @@ namespace DCL
                 }
 
                 worldState.AddScene(newScene);
-                if(newScene.sceneData.sdk7)
-                    DataStore.i.ecs7.scenes.Add(newScene);
 
                 sceneSortDirty = true;
 
@@ -698,8 +696,6 @@ namespace DCL
                 return;
 
             worldState.RemoveScene(sceneNumber);
-            if (scene.sceneData.sdk7)
-                DataStore.i.ecs7.scenes.Remove(scene);
 
             DataStore.i.world.portableExperienceIds.Remove(scene.sceneData.id);
 
@@ -820,8 +816,6 @@ namespace DCL
             }
 
             worldState.AddScene(newScene);
-            if(newScene.sceneData.sdk7)
-                DataStore.i.ecs7.scenes.Add(newScene);
 
             OnNewSceneAdded?.Invoke(newScene);
 


### PR DESCRIPTION
after hot-reloading a scene renderer wasn't sending messages back to the scene any more due to an exception