### PR TITLE
fix: sdk7 hotreload test

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECS7Plugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECS7Plugin.cs
@@ -14,6 +14,8 @@ namespace DCL.ECS7
         private readonly InternalECSComponents internalEcsComponents;
         private readonly CrdtExecutorsManager crdtExecutorsManager;
 
+        internal readonly ECSComponentsManager componentsManager;
+
         public ECS7Plugin()
         {
             DataStore.i.ecs7.isEcs7Enabled = true;
@@ -23,7 +25,7 @@ namespace DCL.ECS7
             DataStore.i.rpc.context.crdt.CrdtExecutors = crdtExecutors;
 
             var componentsFactory = new ECSComponentsFactory();
-            var componentsManager = new ECSComponentsManager(componentsFactory.componentBuilders);
+            componentsManager = new ECSComponentsManager(componentsFactory.componentBuilders);
             internalEcsComponents = new InternalECSComponents(componentsManager, componentsFactory);
 
             crdtExecutorsManager = new CrdtExecutorsManager(crdtExecutors, componentsManager, sceneController,

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Tests/ECS7HotReload.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Tests/ECS7HotReload.cs
@@ -1,14 +1,9 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
 using Cysharp.Threading.Tasks;
 using DCL;
 using DCL.Controllers;
 using DCL.CRDT;
 using DCL.ECS7;
 using DCL.ECSComponents;
-using DCL.ECSRuntime;
 using DCL.Models;
 using Decentraland.Renderer.RendererServices;
 using Google.Protobuf;
@@ -19,15 +14,42 @@ using RPC;
 using rpc_csharp;
 using rpc_csharp.transport;
 using RPC.Services;
+using System;
+using System.Collections;
+using System.IO;
 using UnityEngine;
 using UnityEngine.TestTools;
 using BinaryWriter = KernelCommunication.BinaryWriter;
 using Environment = DCL.Environment;
+using Object = UnityEngine.Object;
 
 namespace Tests
 {
     public class ECS7HotReload
     {
+        private ECS7Plugin ecs7Plugin;
+        private GameObject testGameObjectForReferences;
+
+        [SetUp]
+        public void SetUp()
+        {
+            LoadEnvironment();
+            ecs7Plugin = new ECS7Plugin();
+            testGameObjectForReferences = new GameObject("TEMP_FOR_TESTING");
+
+            DataStore.i.camera.transform.Set(testGameObjectForReferences.transform);
+            DataStore.i.world.avatarTransform.Set(testGameObjectForReferences.transform);
+            CommonScriptableObjects.rendererState.Set(true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ecs7Plugin.Dispose();
+            DataStore.Clear();
+            CommonScriptableObjects.UnloadAll();
+            Object.DestroyImmediate(testGameObjectForReferences);
+        }
 
         [UnityTest]
         public IEnumerator HotReloadSceneCorrectly()
@@ -37,6 +59,7 @@ namespace Tests
                 const int SCENE_NUMBER = 666;
                 const int ENTITY_ID = 500;
                 const int COMPONENT_ID = ComponentID.MESH_RENDERER;
+
                 IMessage COMPONENT_DATA = new PBMeshRenderer()
                 {
                     Box = new PBMeshRenderer.Types.BoxMesh()
@@ -59,14 +82,11 @@ namespace Tests
 
                 try
                 {
-                    LoadEnvironment();
-                    ECSComponentsManager componentsManager = LoadEcs7Dependencies();
-
                     context.crdt.MessagingControllersManager = Environment.i.messaging.manager;
                     context.crdt.WorldState = Substitute.For<IWorldState>();
 
                     ClientCRDTService clientCrdtService = await CreateClientCrdtService(clientTransport);
-                    await LoadScene(SCENE_NUMBER).ToCoroutine();
+                    await LoadScene(SCENE_NUMBER);
 
                     IParcelScene scene = Environment.i.world.state.GetScene(SCENE_NUMBER);
                     Assert.NotNull(scene);
@@ -88,8 +108,10 @@ namespace Tests
                     IDCLEntity entity = scene.GetEntityById(ENTITY_ID);
                     Assert.NotNull(entity);
 
-                    var component = componentsManager.GetComponent(COMPONENT_ID);
+                    var component = ecs7Plugin.componentsManager.GetComponent(COMPONENT_ID);
                     Assert.IsTrue(component.HasComponent(scene, entity));
+
+                    await UniTask.Yield();
 
                     // Do hot reload
                     await UnloadScene(SCENE_NUMBER);
@@ -115,9 +137,10 @@ namespace Tests
                     entity = scene.GetEntityById(ENTITY_ID);
                     Assert.NotNull(entity);
 
-                    component = componentsManager.GetComponent(COMPONENT_ID);
+                    component = ecs7Plugin.componentsManager.GetComponent(COMPONENT_ID);
                     Assert.IsTrue(component.HasComponent(scene, entity));
 
+                    await UniTask.Yield();
                 }
                 catch (Exception e)
                 {
@@ -126,24 +149,8 @@ namespace Tests
                 finally
                 {
                     rpcServer.Dispose();
-                    DataStore.Clear();
                 }
             });
-        }
-
-        private static ECSComponentsManager LoadEcs7Dependencies()
-        {
-            ISceneController sceneController = Environment.i.world.sceneController;
-            Dictionary<int, ICRDTExecutor> crdtExecutors = new Dictionary<int, ICRDTExecutor>(1);
-
-            ECSComponentsFactory componentsFactory = new ECSComponentsFactory();
-            ECSComponentsManager componentsManager = new ECSComponentsManager(componentsFactory.componentBuilders);
-            var crdtExecutorsManager = new CrdtExecutorsManager(crdtExecutors, componentsManager, sceneController,
-                Environment.i.world.state, DataStore.i.rpc.context.crdt);
-            var componentsComposer = new ECS7ComponentsComposer(componentsFactory,
-                Substitute.For<IECSComponentWriter>(),
-                Substitute.For<IInternalECSComponents>());
-            return componentsManager;
         }
 
         private static void LoadEnvironment()
@@ -159,7 +166,8 @@ namespace Tests
             {
                 basePosition = new Vector2Int(0, 0),
                 parcels = new Vector2Int[] { new Vector2Int(0, 0) },
-                sceneNumber = sceneNumber
+                sceneNumber = sceneNumber,
+                sdk7 = true
             };
 
             Environment.i.world.sceneController.LoadParcelScenes(JsonUtility.ToJson(scene));
@@ -172,6 +180,7 @@ namespace Tests
                 method = MessagingTypes.INIT_DONE,
                 payload = new Protocol.SceneReady()
             };
+
             Environment.i.world.sceneController.EnqueueSceneMessage(message);
 
             await UniTask.WaitWhile(() => Environment.i.messaging.manager.HasScenePendingMessages(sceneNumber));

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Tests/ECS7Plugin.Tests.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Tests/ECS7Plugin.Tests.asmdef
@@ -32,7 +32,9 @@
         "GUID:3509dee42d344efa97defa29ec7c351b",
         "GUID:5c497d137ccf6054880aae69dbaea398",
         "GUID:9cccce9925d3495d8a5e4fa5b25f54a5",
-        "GUID:7eb48a6a47db4795bdee44a726fa8338"
+        "GUID:7eb48a6a47db4795bdee44a726fa8338",
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
related to fix: https://github.com/decentraland/unity-renderer/pull/3870
test should fail before merging that fix but pass after it is merged

* fix test to be able to catch more errors, since hot-reload wasn't working properly and test wasn't failing as it should