### PR TITLE
Chore: double call in explore v2 on select

### DIFF
--- a/unity-renderer/.editorconfig
+++ b/unity-renderer/.editorconfig
@@ -62,17 +62,6 @@ dotnet_naming_rule.interfaces_should_be_pascal_case_with_i_prefix.symbols = inte
 dotnet_naming_rule.interfaces_should_be_pascal_case_with_i_prefix.style = i_prefix_pascal_case_style
 dotnet_naming_rule.interfaces_should_be_pascal_case_with_i_prefix.severity = warning
 
-# Asynchronous methods end with "Async"
-dotnet_naming_style.async_postfix_pascal_case_style.capitalization = pascal_case
-dotnet_naming_style.async_postfix_pascal_case_style.required_suffix = Async
-
-dotnet_naming_symbols.async_methods.applicable_kinds = method
-dotnet_naming_symbols.async_methods.required_modifiers = async
-
-dotnet_naming_rule.async_methods_should_be_pascal_case_with_async_suffix.symbols = async_methods
-dotnet_naming_rule.async_methods_should_be_pascal_case_with_async_suffix.style = async_postfix_pascal_case_style
-dotnet_naming_rule.async_methods_should_be_pascal_case_with_async_suffix.severity = warning
-
 
 #### CAPITALS_SNAKE_CASE ####
 dotnet_naming_style.capital_snake_case_style.capitalization = all_upper

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2ComponentRealmsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2ComponentRealmsController.cs
@@ -1,0 +1,113 @@
+// unset:none
+using DCL;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Variables.RealmsInfo;
+
+public class ExploreV2ComponentRealmsController: IDisposable
+{
+    private readonly DataStore_Realm realmModel;
+    private readonly IExploreV2MenuComponentView view;
+
+    internal readonly List<RealmRowComponentModel> currentAvailableRealms = new ();
+
+    public ExploreV2ComponentRealmsController(DataStore_Realm realmModel, IExploreV2MenuComponentView view)
+    {
+        this.realmModel = realmModel;
+        this.view = view;
+    }
+
+    public void Initialize()
+    {
+        realmModel.realmName.OnChange += UpdateRealmInfo;
+        realmModel.realmsInfo.OnSet += UpdateAvailableRealmsInfo;
+
+        UpdateRealmInfo(realmModel.realmName.Get());
+        UpdateAvailableRealmsInfo(realmModel.realmsInfo.Get());
+    }
+
+    public void Dispose()
+    {
+        realmModel.realmName.OnChange -= UpdateRealmInfo;
+        realmModel.realmsInfo.OnSet -= UpdateAvailableRealmsInfo;
+    }
+
+    internal void UpdateRealmInfo(string realmName, string _ = "")
+    {
+        if (string.IsNullOrEmpty(realmName))
+            return;
+
+        // Get the name of the current realm
+        view.currentRealmViewer.SetRealm(realmName);
+        view.currentRealmSelectorModal.SetCurrentRealm(realmName);
+
+        // Calculate number of users in the current realm
+        var realmList = DataStore.i.realm.realmsInfo.Get()?.ToList();
+        RealmModel currentRealmModel = realmList?.FirstOrDefault(r => r.serverName == realmName);
+        var realmUsers = 0;
+
+        if (currentRealmModel != null)
+            realmUsers = currentRealmModel.usersCount;
+
+        view.currentRealmViewer.SetNumberOfUsers(realmUsers);
+    }
+
+    internal void UpdateAvailableRealmsInfo(IEnumerable<RealmModel> currentRealmList)
+    {
+        var realmList = currentRealmList?.ToList();
+
+        if (!NeedToRefreshRealms(realmList))
+            return;
+
+        currentAvailableRealms.Clear();
+
+        if (realmList != null)
+        {
+            string serverName = ServerNameForCurrentRealm();
+
+            foreach (RealmModel realm in realmList)
+                currentAvailableRealms.Add(new RealmRowComponentModel
+                {
+                    name = realm.serverName,
+                    players = realm.usersCount,
+                    isConnected = realm.serverName == serverName,
+                });
+        }
+
+        view.currentRealmSelectorModal.SetAvailableRealms(currentAvailableRealms);
+    }
+
+    private bool NeedToRefreshRealms(IEnumerable<RealmModel> newRealmList)
+    {
+        if (newRealmList == null)
+            return true;
+
+        var needToRefresh = false;
+
+        IEnumerable<RealmModel> realmModels = newRealmList as RealmModel[] ?? newRealmList.ToArray();
+
+        if (realmModels.Count() != currentAvailableRealms.Count)
+            needToRefresh = true;
+        else
+            foreach (RealmModel realm in realmModels)
+                if (!currentAvailableRealms.Exists(x => x.name == realm.serverName && x.players == realm.usersCount))
+                {
+                    needToRefresh = true;
+                    break;
+                }
+
+        return needToRefresh;
+    }
+
+    private static string ServerNameForCurrentRealm()
+    {
+        if (DataStore.i.realm.playerRealm.Get() != null)
+            return DataStore.i.realm.playerRealm.Get().serverName;
+
+        if (DataStore.i.realm.playerRealmAboutConfiguration.Get() != null)
+            return DataStore.i.realm.playerRealmAboutConfiguration.Get().RealmName;
+
+        return "";
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2ComponentRealmsController.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2ComponentRealmsController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bfb7efb14c56494dbca13cb9b6dad052
+timeCreated: 1672841375

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -207,13 +207,20 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
         if (currentOpenSection == ExploreSection.Backpack)
             view.ConfigureEncapsulatedSection(ExploreSection.Backpack, DataStore.i.exploreV2.configureBackpackInFullscreenMenu);
 
-        foreach (var visibilityVar in sectionsByVisiblityVar.Keys)
-            visibilityVar.Set(currentOpenSection == sectionsByVisiblityVar[visibilityVar]);
+        ChangeVisibilityVarForSwitchedSections();
 
         profileCardIsOpen.Set(false);
     }
 
-    internal void SetVisibilityOnOpenChanged(bool open, bool _ = false) => SetVisibility_Internal(open);
+    private void ChangeVisibilityVarForSwitchedSections()
+    {
+        foreach (BaseVariable<bool> visibilityVar in sectionsByVisiblityVar.Keys)
+            if (visibilityVar.Get() != (currentOpenSection == sectionsByVisiblityVar[visibilityVar]))
+                visibilityVar.Set(currentOpenSection == sectionsByVisiblityVar[visibilityVar]);
+    }
+
+    internal void SetVisibilityOnOpenChanged(bool open, bool _ = false) =>
+        SetVisibility_Internal(open);
 
     internal void CurrentSectionIndexChanged(int current, int previous)
     {
@@ -266,9 +273,10 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
         {
             if (currentSectionIndex.Get() != (int)section)
                 currentSectionIndex.Set((int)section);
+            // else
+            //     view.GoToSection(section);
 
             SetSectionTargetVisibility(section, toVisible: true);
-            view.GoToSection(section);
         }
         else if (currentOpenSection == section)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -151,10 +151,10 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
         }
     }
 
-    internal IExploreV2MenuComponentView CreateView() =>
+    protected internal virtual IExploreV2MenuComponentView CreateView() =>
         ExploreV2MenuComponentView.Create();
 
-    internal IExploreV2Analytics CreateAnalyticsController() =>
+    internal virtual IExploreV2Analytics CreateAnalyticsController() =>
         new ExploreV2Analytics.ExploreV2Analytics();
 
     internal void InitializePlacesAndEventsSection()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -65,12 +65,12 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
             { ExploreSection.Quest, (isQuestInitialized, questVisible) },
             { ExploreSection.Settings, (isSettingsPanelInitialized, settingsVisible) },
         };
-
         sectionsByInitVar = sectionsVariables.ToDictionary(pair => pair.Value.initVar, pair => pair.Key);
         sectionsByVisibilityVar = sectionsVariables.ToDictionary(pair => pair.Value.visibilityVar, pair => pair.Key);
 
         mouseCatcher = SceneReferences.i?.mouseCatcher;
         exploreV2Analytics = CreateAnalyticsController();
+
         view = CreateView();
         SetVisibility(false);
 
@@ -301,112 +301,5 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
     {
         SetVisibility(false);
         exploreV2Analytics.SendStartMenuVisibility(false, fromShortcut ? ExploreUIVisibilityMethod.FromShortcut : ExploreUIVisibilityMethod.FromClick);
-    }
-}
-
-public class ExploreV2ComponentRealmsController: IDisposable
-{
-    private readonly DataStore_Realm realmModel;
-    private readonly IExploreV2MenuComponentView view;
-
-    internal readonly List<RealmRowComponentModel> currentAvailableRealms = new ();
-
-    public ExploreV2ComponentRealmsController(DataStore_Realm realmModel, IExploreV2MenuComponentView view)
-    {
-        this.realmModel = realmModel;
-        this.view = view;
-    }
-
-    public void Initialize()
-    {
-        realmModel.realmName.OnChange += UpdateRealmInfo;
-        realmModel.realmsInfo.OnSet += UpdateAvailableRealmsInfo;
-
-        UpdateRealmInfo(realmModel.realmName.Get());
-        UpdateAvailableRealmsInfo(realmModel.realmsInfo.Get());
-    }
-
-    public void Dispose()
-    {
-        realmModel.realmName.OnChange -= UpdateRealmInfo;
-        realmModel.realmsInfo.OnSet -= UpdateAvailableRealmsInfo;
-    }
-
-    internal void UpdateRealmInfo(string realmName, string _ = "")
-    {
-        if (string.IsNullOrEmpty(realmName))
-            return;
-
-        // Get the name of the current realm
-        view.currentRealmViewer.SetRealm(realmName);
-        view.currentRealmSelectorModal.SetCurrentRealm(realmName);
-
-        // Calculate number of users in the current realm
-        var realmList = DataStore.i.realm.realmsInfo.Get()?.ToList();
-        RealmModel currentRealmModel = realmList?.FirstOrDefault(r => r.serverName == realmName);
-        var realmUsers = 0;
-
-        if (currentRealmModel != null)
-            realmUsers = currentRealmModel.usersCount;
-
-        view.currentRealmViewer.SetNumberOfUsers(realmUsers);
-    }
-
-    internal void UpdateAvailableRealmsInfo(IEnumerable<RealmModel> currentRealmList)
-    {
-        var realmList = currentRealmList?.ToList();
-
-        if (!NeedToRefreshRealms(realmList))
-            return;
-
-        currentAvailableRealms.Clear();
-
-        if (realmList != null)
-        {
-            string serverName = ServerNameForCurrentRealm();
-
-            foreach (RealmModel realmModel in realmList)
-                currentAvailableRealms.Add(new RealmRowComponentModel
-                {
-                    name = realmModel.serverName,
-                    players = realmModel.usersCount,
-                    isConnected = realmModel.serverName == serverName,
-                });
-        }
-
-        view.currentRealmSelectorModal.SetAvailableRealms(currentAvailableRealms);
-    }
-
-    private bool NeedToRefreshRealms(IEnumerable<RealmModel> newRealmList)
-    {
-        if (newRealmList == null)
-            return true;
-
-        var needToRefresh = false;
-
-        IEnumerable<RealmModel> realmModels = newRealmList as RealmModel[] ?? newRealmList.ToArray();
-
-        if (realmModels.Count() != currentAvailableRealms.Count)
-            needToRefresh = true;
-        else
-            foreach (RealmModel realm in realmModels)
-                if (!currentAvailableRealms.Exists(x => x.name == realm.serverName && x.players == realm.usersCount))
-                {
-                    needToRefresh = true;
-                    break;
-                }
-
-        return needToRefresh;
-    }
-
-    private static string ServerNameForCurrentRealm()
-    {
-        if (DataStore.i.realm.playerRealm.Get() != null)
-            return DataStore.i.realm.playerRealm.Get().serverName;
-
-        if (DataStore.i.realm.playerRealmAboutConfiguration.Get() != null)
-            return DataStore.i.realm.playerRealmAboutConfiguration.Get().RealmName;
-
-        return "";
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentController.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using Variables.RealmsInfo;
 
 /// <summary>
 /// Main controller for the feature "Explore V2".
@@ -17,12 +16,12 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
     internal IExploreV2MenuComponentView view;
     internal IExploreV2Analytics exploreV2Analytics;
-    private ExploreV2ComponentRealmsController realmController;
 
     internal IPlacesAndEventsSectionComponentController placesAndEventsSectionController;
 
     internal ExploreSection currentOpenSection;
     internal Dictionary<BaseVariable<bool>, ExploreSection> sectionsByVisibilityVar;
+    private ExploreV2ComponentRealmsController realmController;
 
     private MouseCatcher mouseCatcher;
     private Dictionary<BaseVariable<bool>, ExploreSection> sectionsByInitVar;
@@ -42,8 +41,8 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
     internal BaseVariable<bool> isSettingsPanelInitialized => DataStore.i.settings.isInitialized;
     internal BaseVariable<bool> settingsVisible => DataStore.i.settings.settingsPanelVisible;
 
+    internal BaseVariable<int> currentSectionIndex => DataStore.i.exploreV2.currentSectionIndex;
     private UserProfile ownUserProfile => UserProfile.GetOwnUserProfile();
-    private BaseVariable<int> currentSectionIndex => DataStore.i.exploreV2.currentSectionIndex;
     private BaseVariable<bool> isPlacesAndEventsSectionInitialized => DataStore.i.exploreV2.isPlacesAndEventsSectionInitialized;
     private BaseVariable<bool> isPromoteChannelsToastVisible => DataStore.i.channels.isPromoteToastVisible;
 
@@ -65,6 +64,7 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
             { ExploreSection.Quest, (isQuestInitialized, questVisible) },
             { ExploreSection.Settings, (isSettingsPanelInitialized, settingsVisible) },
         };
+
         sectionsByInitVar = sectionsVariables.ToDictionary(pair => pair.Value.initVar, pair => pair.Key);
         sectionsByVisibilityVar = sectionsVariables.ToDictionary(pair => pair.Value.visibilityVar, pair => pair.Key);
 
@@ -76,11 +76,12 @@ public class ExploreV2MenuComponentController : IExploreV2MenuComponentControlle
 
         realmController = new ExploreV2ComponentRealmsController(DataStore.i.realm, view);
         realmController.Initialize();
+        view.currentRealmViewer.onLogoClick?.AddListener(view.ShowRealmSelectorModal);
 
         ownUserProfile.OnUpdate += UpdateProfileInfo;
         UpdateProfileInfo(ownUserProfile);
         view.currentProfileCard.onClick?.AddListener(() => { profileCardIsOpen.Set(!profileCardIsOpen.Get()); });
-        view.currentRealmViewer.onLogoClick?.AddListener(view.ShowRealmSelectorModal);
+
         view.OnCloseButtonPressed += OnCloseButtonPressed;
         view.OnAfterShowAnimation += OnAfterShowAnimation;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -223,32 +223,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
             sectionSelector.GetSection(sectionId)?.onSelect.RemoveAllListeners();
     }
 
-    public void ShowRealmSelectorModal() =>
-        realmSelectorModal.Show();
-
-    /// <summary>
-    /// Instantiates (if does not already exists) a realm selector modal from the given prefab.
-    /// </summary>
-    /// <returns>An instance of a realm modal modal.</returns>
-    internal RealmSelectorComponentView ConfigureRealmSelectorModal()
-    {
-        RealmSelectorComponentView realmSelectorView;
-
-        var existingModal = GameObject.Find(REALM_SELECTOR_MODAL_ID);
-
-        if (existingModal != null)
-            realmSelectorView = existingModal.GetComponent<RealmSelectorComponentView>();
-        else
-        {
-            realmSelectorView = Instantiate(realmSelectorModalPrefab);
-            realmSelectorView.name = REALM_SELECTOR_MODAL_ID;
-        }
-
-        realmSelectorView.Hide(true);
-
-        return realmSelectorView;
-    }
-
     private void IsSomeModalOpen_OnChange(bool current, bool previous)
     {
         closeAction.OnTriggered -= OnCloseActionTriggered;
@@ -279,4 +253,30 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
     private void OnCloseActionTriggered(DCLAction_Trigger action) =>
         OnCloseButtonPressed?.Invoke(true);
+
+    public void ShowRealmSelectorModal() =>
+        realmSelectorModal.Show();
+
+    /// <summary>
+    /// Instantiates (if does not already exists) a realm selector modal from the given prefab.
+    /// </summary>
+    /// <returns>An instance of a realm modal modal.</returns>
+    internal RealmSelectorComponentView ConfigureRealmSelectorModal()
+    {
+        RealmSelectorComponentView realmSelectorView;
+
+        var existingModal = GameObject.Find(REALM_SELECTOR_MODAL_ID);
+
+        if (existingModal != null)
+            realmSelectorView = existingModal.GetComponent<RealmSelectorComponentView>();
+        else
+        {
+            realmSelectorView = Instantiate(realmSelectorModalPrefab);
+            realmSelectorView.name = REALM_SELECTOR_MODAL_ID;
+        }
+
+        realmSelectorView.Hide(true);
+
+        return realmSelectorView;
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -366,10 +366,12 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
                     sectionView.Show();
 
                 OnSectionOpen?.Invoke(sectionId);
+                Debug.Log($"VV: OnSectionOpened SHOW {sectionId}");
             }
             else if (sectionView != null) // If not an explorer Section, because we do not Show/Hide it
             {
                 sectionView.Hide();
+                Debug.Log($"VV: OnSectionOpened HIDE {sectionId}");
             }
         };
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -1,125 +1,9 @@
+using DCL;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using DCL;
-using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.Events;
-
-public interface IExploreV2MenuComponentView : IDisposable
-{
-
-    /// <summary>
-    /// Real viewer component.
-    /// </summary>
-    IRealmViewerComponentView currentRealmViewer { get; }
-
-    /// <summary>
-    /// Realm Selector component.
-    /// </summary>
-    IRealmSelectorComponentView currentRealmSelectorModal { get; }
-
-    /// <summary>
-    /// Profile card component.
-    /// </summary>
-    IProfileCardComponentView currentProfileCard { get; }
-
-    /// <summary>
-    /// Places and Events section component.
-    /// </summary>
-    IPlacesAndEventsSectionComponentView currentPlacesAndEventsSection { get; }
-
-    /// <summary>
-    /// Transform used to positionate the top menu tooltips.
-    /// </summary>
-    RectTransform currentTopMenuTooltipReference { get; }
-
-    /// <summary>
-    /// Transform used to positionate the places and events section tooltips.
-    /// </summary>
-    RectTransform currentPlacesAndEventsTooltipReference { get; }
-
-    /// <summary>
-    /// Transform used to positionate the backpack section tooltips.
-    /// </summary>
-    RectTransform currentBackpackTooltipReference { get; }
-
-    /// <summary>
-    /// Transform used to positionate the map section tooltips.
-    /// </summary>
-    RectTransform currentMapTooltipReference { get; }
-
-    /// <summary>
-    /// Transform used to positionate the builder section tooltips.
-    /// </summary>
-
-    /// <summary>
-    /// Transform used to positionate the quest section tooltips.
-    /// </summary>
-    RectTransform currentQuestTooltipReference { get; }
-
-    /// <summary>
-    /// Transform used to positionate the settings section tooltips.
-    /// </summary>
-    RectTransform currentSettingsTooltipReference { get; }
-
-    /// <summary>
-    /// Transform used to positionate the profile section tooltips.
-    /// </summary>
-    RectTransform currentProfileCardTooltipReference { get; }
-    /// <summary>
-    /// It will be triggered when the close button is clicked.
-    /// </summary>
-    event Action<bool> OnCloseButtonPressed;
-
-    /// <summary>
-    /// It will be triggered when a section is open.
-    /// </summary>
-    event Action<ExploreSection> OnSectionOpen;
-
-    /// <summary>
-    /// It will be triggered after the show animation has finished.
-    /// </summary>
-    event Action OnAfterShowAnimation;
-
-    /// <summary>
-    /// Shows/Hides the game object of the explore menu.
-    /// </summary>
-    /// <param name="isActive">True to show it.</param>
-    void SetVisible(bool isActive);
-
-    /// <summary>
-    /// Open a section.
-    /// </summary>
-    /// <param name="section">Section to go.</param>
-    void GoToSection(ExploreSection section);
-
-    /// <summary>
-    /// Activates/Deactivates a section in the selector.
-    /// </summary>
-    /// <param name="section">Section to activate/deactivate.</param>
-    /// <param name="isActive">True for activating.</param>
-    void SetSectionActive(ExploreSection section, bool isActive);
-
-    /// <summary>
-    /// Check if a section is actived or not.
-    /// </summary>
-    /// <param name="section">Section to check.</param>
-    /// <returns></returns>
-    bool IsSectionActive(ExploreSection section);
-
-    /// <summary>
-    /// Configures a encapsulated section.
-    /// </summary>
-    /// <param name="sectionId">Section to configure.</param>
-    /// <param name="featureConfiguratorFlag">Flag used to configurates the feature.</param>
-    void ConfigureEncapsulatedSection(ExploreSection sectionId, BaseVariable<Transform> featureConfiguratorFlag);
-
-    /// <summary>
-    /// Shows the Realm Selector modal.
-    /// </summary>
-    void ShowRealmSelectorModal();
-}
 
 public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuComponentView
 {
@@ -150,47 +34,14 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
     private Dictionary<ExploreSection, FeatureEncapsulatorComponentView> exploreSectionsById;
     private HUDCanvasCameraModeController hudCanvasCameraModeController;
 
-    private RectTransform profileCardRectTranform;
+    private RectTransform profileCardRectTransform;
     private RealmSelectorComponentView realmSelectorModal;
-
-    public override void Awake()
-    {
-        base.Awake();
-        showHideAnimator.OnWillFinishStart += OnAfterShowAnimationCompleted;
-
-        profileCardRectTranform = profileCard.GetComponent<RectTransform>();
-        realmSelectorModal = ConfigureRealmSelectorModal();
-        hudCanvasCameraModeController = new HUDCanvasCameraModeController(GetComponent<Canvas>(), DataStore.i.camera.hudsCamera);
-
-        exploreSectionsById = new Dictionary<ExploreSection, FeatureEncapsulatorComponentView>()
-        {
-            { ExploreSection.Explore, null },
-            { ExploreSection.Backpack, backpackSection },
-            { ExploreSection.Map, mapSection },
-            { ExploreSection.Quest, questSection },
-            { ExploreSection.Settings, settingsSection },
-        };
-    }
-
-    public override void Start()
-    {
-        DataStore.i.exploreV2.isInitialized.OnChange += IsInitialized_OnChange;
-        IsInitialized_OnChange(DataStore.i.exploreV2.isInitialized.Get(), false);
-
-        ConfigureCloseButton();
-    }
-
-    public override void Update() =>
-        CheckIfProfileCardShouldBeClosed();
-
-    public void OnDestroy() =>
-        hudCanvasCameraModeController?.Dispose();
 
     public IRealmViewerComponentView currentRealmViewer => realmViewer;
     public IRealmSelectorComponentView currentRealmSelectorModal => realmSelectorModal;
     public IProfileCardComponentView currentProfileCard => profileCard;
     public IPlacesAndEventsSectionComponentView currentPlacesAndEventsSection => placesAndEventsSection;
-    public RectTransform currentTopMenuTooltipReference => sectionSelector.GetSection((int) ExploreSection.Explore).pivot;
+    public RectTransform currentTopMenuTooltipReference => sectionSelector.GetSection((int)ExploreSection.Explore).pivot;
     public RectTransform currentPlacesAndEventsTooltipReference => sectionSelector.GetSection((int)ExploreSection.Explore).pivot;
     public RectTransform currentBackpackTooltipReference => sectionSelector.GetSection((int)ExploreSection.Backpack).pivot;
     public RectTransform currentMapTooltipReference => sectionSelector.GetSection((int)ExploreSection.Map).pivot;
@@ -216,113 +67,38 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
             realmSelectorModal.Dispose();
     }
 
-    public void SetVisible(bool isActive)
+    public override void Awake()
     {
-        if (isActive)
+        base.Awake();
+        showHideAnimator.OnWillFinishStart += OnAfterShowAnimationCompleted;
+
+        profileCardRectTransform = profileCard.GetComponent<RectTransform>();
+        realmSelectorModal = ConfigureRealmSelectorModal();
+        hudCanvasCameraModeController = new HUDCanvasCameraModeController(GetComponent<Canvas>(), DataStore.i.camera.hudsCamera);
+
+        exploreSectionsById = new Dictionary<ExploreSection, FeatureEncapsulatorComponentView>
         {
-            DataStore.i.exploreV2.isInShowAnimationTransiton.Set(true);
-            Show();
-
-            ISectionToggle sectionToGo = sectionSelector.GetSection(DataStore.i.exploreV2.currentSectionIndex.Get());
-
-            if (sectionToGo != null && sectionToGo.IsActive())
-            {
-                GoToSection((ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get());
-            }
-            else
-            {
-                List<ISectionToggle> allSections = sectionSelector.GetAllSections();
-                foreach (ISectionToggle section in allSections)
-                {
-                    if (section != null && section.IsActive())
-                    {
-                        section.SelectToggle(reselectIfAlreadyOn: true);
-                        break;
-                    }
-                }
-            }
-        }
-        else
-        {
-            Hide();
-            AudioScriptableObjects.dialogClose.Play(true);
-        }
+            { ExploreSection.Explore, null },
+            { ExploreSection.Backpack, backpackSection },
+            { ExploreSection.Map, mapSection },
+            { ExploreSection.Quest, questSection },
+            { ExploreSection.Settings, settingsSection },
+        };
     }
 
-    public void GoToSection(ExploreSection section)
+    public override void Start()
     {
-        sectionSelector.GetSection((int)section)?.SelectToggle(reselectIfAlreadyOn: true);
+        DataStore.i.exploreV2.isInitialized.OnChange += IsInitialized_OnChange;
+        IsInitialized_OnChange(DataStore.i.exploreV2.isInitialized.Get(), false);
 
-        AudioScriptableObjects.dialogOpen.Play(true);
-        AudioScriptableObjects.listItemAppear.ResetPitch();
+        ConfigureCloseButton();
     }
 
-    public void OnAfterShowAnimationCompleted(ShowHideAnimator _)
-    {
-        if (!DataStore.i.exploreV2.isOpen.Get())
-            return;
+    public override void Update() =>
+        CheckIfProfileCardShouldBeClosed();
 
-        DataStore.i.exploreV2.isInShowAnimationTransiton.Set(false);
-        OnAfterShowAnimation?.Invoke();
-    }
-
-    public void SetSectionActive(ExploreSection section, bool isActive) =>
-        sectionSelector.GetSection((int)section).SetActive(isActive);
-
-    public bool IsSectionActive(ExploreSection section) =>
-        sectionSelector.GetSection((int)section).IsActive();
-
-    public void ConfigureEncapsulatedSection(ExploreSection sectionId, BaseVariable<Transform> featureConfiguratorFlag) =>
-        exploreSectionsById[sectionId]?.EncapsulateFeature(featureConfiguratorFlag);
-
-    public void ShowRealmSelectorModal() =>
-        realmSelectorModal.Show();
-
-    public override void RefreshControl()
-    {
-        placesAndEventsSection.RefreshControl();
-
-        foreach (var section in exploreSectionsById.Keys)
-            exploreSectionsById[section]?.RefreshControl();
-    }
-
-    internal void RemoveSectionSelectorMappings()
-    {
-        foreach (int sectionId in Enum.GetValues(typeof(ExploreSection)))
-            sectionSelector.GetSection(sectionId)?.onSelect.RemoveAllListeners();
-    }
-
-    internal void ConfigureCloseButton()
-    {
-        closeMenuButton.onClick.AddListener(() => OnCloseButtonPressed?.Invoke(false));
-        closeAction.OnTriggered += OnCloseActionTriggered;
-        DataStore.i.exploreV2.isSomeModalOpen.OnChange += IsSomeModalOpen_OnChange;
-    }
-
-    /// <summary>
-    /// Instantiates (if does not already exists) a realm selector modal from the given prefab.
-    /// </summary>
-    /// <returns>An instance of a realm modal modal.</returns>
-    internal RealmSelectorComponentView ConfigureRealmSelectorModal()
-    {
-        RealmSelectorComponentView realmSelectorModal = null;
-
-        GameObject existingModal = GameObject.Find(REALM_SELECTOR_MODAL_ID);
-
-        if (existingModal != null)
-        {
-            realmSelectorModal = existingModal.GetComponent<RealmSelectorComponentView>();
-        }
-        else
-        {
-            realmSelectorModal = GameObject.Instantiate(realmSelectorModalPrefab);
-            realmSelectorModal.name = REALM_SELECTOR_MODAL_ID;
-        }
-
-        realmSelectorModal.Hide(true);
-
-        return realmSelectorModal;
-    }
+    public void OnDestroy() =>
+        hudCanvasCameraModeController?.Dispose();
 
     internal static ExploreV2MenuComponentView Create()
     {
@@ -351,7 +127,7 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
     {
         foreach (ExploreSection sectionId in Enum.GetValues(typeof(ExploreSection)))
             sectionSelector.GetSection((int)sectionId)
-                           ?.onSelect.AddListener(OnSectionSelected(sectionId));
+                          ?.onSelect.AddListener(OnSectionSelected(sectionId));
     }
 
     private UnityAction<bool> OnSectionSelected(ExploreSection sectionId) =>
@@ -375,6 +151,102 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
             }
         };
 
+    public void SetVisible(bool isActive)
+    {
+        if (isActive)
+        {
+            DataStore.i.exploreV2.isInShowAnimationTransiton.Set(true);
+            Show();
+
+            ISectionToggle sectionToGo = sectionSelector.GetSection(DataStore.i.exploreV2.currentSectionIndex.Get());
+
+            if (sectionToGo != null && sectionToGo.IsActive())
+                GoToSection((ExploreSection)DataStore.i.exploreV2.currentSectionIndex.Get());
+            else
+            {
+                List<ISectionToggle> allSections = sectionSelector.GetAllSections();
+
+                foreach (ISectionToggle section in allSections)
+                    if (section != null && section.IsActive())
+                    {
+                        section.SelectToggle(reselectIfAlreadyOn: true);
+                        break;
+                    }
+            }
+        }
+        else
+        {
+            Hide();
+            AudioScriptableObjects.dialogClose.Play(true);
+        }
+    }
+
+    public void GoToSection(ExploreSection section)
+    {
+        sectionSelector.GetSection((int)section)?.SelectToggle(reselectIfAlreadyOn: true);
+
+        AudioScriptableObjects.dialogOpen.Play(true);
+        AudioScriptableObjects.listItemAppear.ResetPitch();
+    }
+
+    public void SetSectionActive(ExploreSection section, bool isActive) =>
+        sectionSelector.GetSection((int)section).SetActive(isActive);
+
+    public bool IsSectionActive(ExploreSection section) =>
+        sectionSelector.GetSection((int)section).IsActive();
+
+    private void OnAfterShowAnimationCompleted(ShowHideAnimator _)
+    {
+        if (!DataStore.i.exploreV2.isOpen.Get())
+            return;
+
+        DataStore.i.exploreV2.isInShowAnimationTransiton.Set(false);
+        OnAfterShowAnimation?.Invoke();
+    }
+
+    public void ConfigureEncapsulatedSection(ExploreSection sectionId, BaseVariable<Transform> featureConfiguratorFlag) =>
+        exploreSectionsById[sectionId]?.EncapsulateFeature(featureConfiguratorFlag);
+
+    public override void RefreshControl()
+    {
+        placesAndEventsSection.RefreshControl();
+
+        foreach (ExploreSection section in exploreSectionsById.Keys)
+            exploreSectionsById[section]?.RefreshControl();
+    }
+
+    internal void RemoveSectionSelectorMappings()
+    {
+        foreach (int sectionId in Enum.GetValues(typeof(ExploreSection)))
+            sectionSelector.GetSection(sectionId)?.onSelect.RemoveAllListeners();
+    }
+
+    public void ShowRealmSelectorModal() =>
+        realmSelectorModal.Show();
+
+    /// <summary>
+    /// Instantiates (if does not already exists) a realm selector modal from the given prefab.
+    /// </summary>
+    /// <returns>An instance of a realm modal modal.</returns>
+    internal RealmSelectorComponentView ConfigureRealmSelectorModal()
+    {
+        RealmSelectorComponentView realmSelectorView;
+
+        var existingModal = GameObject.Find(REALM_SELECTOR_MODAL_ID);
+
+        if (existingModal != null)
+            realmSelectorView = existingModal.GetComponent<RealmSelectorComponentView>();
+        else
+        {
+            realmSelectorView = Instantiate(realmSelectorModalPrefab);
+            realmSelectorView.name = REALM_SELECTOR_MODAL_ID;
+        }
+
+        realmSelectorView.Hide(true);
+
+        return realmSelectorView;
+    }
+
     private void IsSomeModalOpen_OnChange(bool current, bool previous)
     {
         closeAction.OnTriggered -= OnCloseActionTriggered;
@@ -382,8 +254,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
         if (!current)
             closeAction.OnTriggered += OnCloseActionTriggered;
     }
-
-    private void OnCloseActionTriggered(DCLAction_Trigger action) => OnCloseButtonPressed?.Invoke(true);
 
     private void CheckIfProfileCardShouldBeClosed()
     {
@@ -393,10 +263,18 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
         cameraDataStore ??= DataStore.i.camera;
 
         if (Input.GetMouseButton(0) &&
-            !RectTransformUtility.RectangleContainsScreenPoint(profileCardRectTranform, Input.mousePosition, cameraDataStore.hudsCamera.Get()) &&
+            !RectTransformUtility.RectangleContainsScreenPoint(profileCardRectTransform, Input.mousePosition, cameraDataStore.hudsCamera.Get()) &&
             !RectTransformUtility.RectangleContainsScreenPoint(HUDController.i.profileHud.view.ExpandedMenu, Input.mousePosition, cameraDataStore.hudsCamera.Get()))
-        {
             DataStore.i.exploreV2.profileCardIsOpen.Set(false);
-        }
     }
+
+    internal void ConfigureCloseButton()
+    {
+        closeMenuButton.onClick.AddListener(() => OnCloseButtonPressed?.Invoke(false));
+        closeAction.OnTriggered += OnCloseActionTriggered;
+        DataStore.i.exploreV2.isSomeModalOpen.OnChange += IsSomeModalOpen_OnChange;
+    }
+
+    private void OnCloseActionTriggered(DCLAction_Trigger action) =>
+        OnCloseButtonPressed?.Invoke(true);
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -197,7 +197,6 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
     public void GoToSection(ExploreSection section)
     {
-        Debug.Log($"Go to {section}");
         sectionSelector.GetSection((int)section)?.SelectToggle(reselectIfAlreadyOn: true);
 
         AudioScriptableObjects.dialogOpen.Play(true);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -151,13 +151,10 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
                     sectionView.Show();
 
                 OnSectionOpen?.Invoke(sectionId);
-
-                Debug.Log($"VV: OnSectionOpened SHOW {sectionId}");
             }
             else if (sectionView != null) // If not an explorer Section, because we do not Show/Hide it
             {
                 sectionView.Hide();
-                Debug.Log($"VV: OnSectionOpened HIDE {sectionId}");
             }
         };
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/ExploreV2MenuComponentView.cs
@@ -39,8 +39,10 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
 
     public IRealmViewerComponentView currentRealmViewer => realmViewer;
     public IRealmSelectorComponentView currentRealmSelectorModal => realmSelectorModal;
+
     public IProfileCardComponentView currentProfileCard => profileCard;
     public IPlacesAndEventsSectionComponentView currentPlacesAndEventsSection => placesAndEventsSection;
+
     public RectTransform currentTopMenuTooltipReference => sectionSelector.GetSection((int)ExploreSection.Explore).pivot;
     public RectTransform currentPlacesAndEventsTooltipReference => sectionSelector.GetSection((int)ExploreSection.Explore).pivot;
     public RectTransform currentBackpackTooltipReference => sectionSelector.GetSection((int)ExploreSection.Backpack).pivot;
@@ -151,9 +153,9 @@ public class ExploreV2MenuComponentView : BaseComponentView, IExploreV2MenuCompo
             }
         };
 
-    public void SetVisible(bool isActive)
+    public void SetVisible(bool visible)
     {
-        if (isActive)
+        if (visible)
         {
             DataStore.i.exploreV2.isInShowAnimationTransiton.Set(true);
             Show();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/IExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/IExploreV2MenuComponentView.cs
@@ -1,0 +1,117 @@
+using System;
+using UnityEngine;
+
+public interface IExploreV2MenuComponentView : IDisposable
+{
+
+    /// <summary>
+    /// Real viewer component.
+    /// </summary>
+    IRealmViewerComponentView currentRealmViewer { get; }
+
+    /// <summary>
+    /// Realm Selector component.
+    /// </summary>
+    IRealmSelectorComponentView currentRealmSelectorModal { get; }
+
+    /// <summary>
+    /// Profile card component.
+    /// </summary>
+    IProfileCardComponentView currentProfileCard { get; }
+
+    /// <summary>
+    /// Places and Events section component.
+    /// </summary>
+    IPlacesAndEventsSectionComponentView currentPlacesAndEventsSection { get; }
+
+    /// <summary>
+    /// Transform used to position the top menu tooltips.
+    /// </summary>
+    RectTransform currentTopMenuTooltipReference { get; }
+
+    /// <summary>
+    /// Transform used to position the places and events section tooltips.
+    /// </summary>
+    RectTransform currentPlacesAndEventsTooltipReference { get; }
+
+    /// <summary>
+    /// Transform used to position the backpack section tooltips.
+    /// </summary>
+    RectTransform currentBackpackTooltipReference { get; }
+
+    /// <summary>
+    /// Transform used to position the map section tooltips.
+    /// </summary>
+    RectTransform currentMapTooltipReference { get; }
+
+    /// <summary>
+    /// Transform used to position the builder section tooltips.
+    /// </summary>
+
+    /// <summary>
+    /// Transform used to position the quest section tooltips.
+    /// </summary>
+    RectTransform currentQuestTooltipReference { get; }
+
+    /// <summary>
+    /// Transform used to position the settings section tooltips.
+    /// </summary>
+    RectTransform currentSettingsTooltipReference { get; }
+
+    /// <summary>
+    /// Transform used to position the profile section tooltips.
+    /// </summary>
+    RectTransform currentProfileCardTooltipReference { get; }
+    /// <summary>
+    /// It will be triggered when the close button is clicked.
+    /// </summary>
+    event Action<bool> OnCloseButtonPressed;
+
+    /// <summary>
+    /// It will be triggered when a section is open.
+    /// </summary>
+    event Action<ExploreSection> OnSectionOpen;
+
+    /// <summary>
+    /// It will be triggered after the show animation has finished.
+    /// </summary>
+    event Action OnAfterShowAnimation;
+
+    /// <summary>
+    /// Shows/Hides the game object of the explore menu.
+    /// </summary>
+    /// <param name="isActive">True to show it.</param>
+    void SetVisible(bool isActive);
+
+    /// <summary>
+    /// Open a section.
+    /// </summary>
+    /// <param name="section">Section to go.</param>
+    void GoToSection(ExploreSection section);
+
+    /// <summary>
+    /// Activates/Deactivates a section in the selector.
+    /// </summary>
+    /// <param name="section">Section to activate/deactivate.</param>
+    /// <param name="isActive">True for activating.</param>
+    void SetSectionActive(ExploreSection section, bool isActive);
+
+    /// <summary>
+    /// Check if a section is activated or not.
+    /// </summary>
+    /// <param name="section">Section to check.</param>
+    /// <returns></returns>
+    bool IsSectionActive(ExploreSection section);
+
+    /// <summary>
+    /// Configures a encapsulated section.
+    /// </summary>
+    /// <param name="sectionId">Section to configure.</param>
+    /// <param name="featureConfiguratorFlag">Flag used to configure the feature.</param>
+    void ConfigureEncapsulatedSection(ExploreSection sectionId, BaseVariable<Transform> featureConfiguratorFlag);
+
+    /// <summary>
+    /// Shows the Realm Selector modal.
+    /// </summary>
+    void ShowRealmSelectorModal();
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/IExploreV2MenuComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/IExploreV2MenuComponentView.cs
@@ -80,8 +80,8 @@ public interface IExploreV2MenuComponentView : IDisposable
     /// <summary>
     /// Shows/Hides the game object of the explore menu.
     /// </summary>
-    /// <param name="isActive">True to show it.</param>
-    void SetVisible(bool isActive);
+    /// <param name="visible">True to show it.</param>
+    void SetVisible(bool visible);
 
     /// <summary>
     /// Open a section.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/IExploreV2MenuComponentView.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/ExploreV2Menu/IExploreV2MenuComponentView.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 096db08049a34509b137a094e383b4d8
+timeCreated: 1672830264

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -129,145 +129,69 @@ public class ExploreV2MenuComponentControllerTests
         exploreV2MenuView.Received().SetVisible(isVisible);
     }
 
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaisePlacesAndEventsVisibleChangedCorrectly(bool isVisible)
+    [TestCase(ExploreSection.Explore,true)]
+    [TestCase(ExploreSection.Explore, false)]
+    [TestCase(ExploreSection.Map, true)]
+    [TestCase(ExploreSection.Map,false)]
+    [TestCase(ExploreSection.Backpack, true)]
+    [TestCase(ExploreSection.Backpack,false)]
+    [TestCase(ExploreSection.Quest, true)]
+    [TestCase(ExploreSection.Quest,false)]
+    [TestCase(ExploreSection.Settings, true)]
+    [TestCase(ExploreSection.Settings,false)]
+    public void RaiseSectionVisibleChangedCorrectly(ExploreSection section, bool isVisible)
     {
         // Arrange
-        exploreV2MenuController.isInitialized.Set(true);
-        exploreV2MenuController.currentOpenSection = ExploreSection.Explore;
+        switch (section)
+        {
+            case ExploreSection.Explore:
+                exploreV2MenuController.isInitialized.Set(true);
+                break;
+            case ExploreSection.Map:
+                exploreV2MenuController.isNavmapInitialized.Set(true);
+                break;
+            case ExploreSection.Quest:
+                exploreV2MenuController.isQuestInitialized.Set(true);
+                break;
+            case ExploreSection.Settings:
+                exploreV2MenuController.isSettingsPanelInitialized.Set(true);
+                break;
+            case ExploreSection.Backpack:
+                exploreV2MenuController.isAvatarEditorInitialized.Set(true);
+                DataStore.i.common.isSignUpFlow.Set(false);
+                break;
+        }
+
+        exploreV2MenuController.currentOpenSection = section;
 
         // Act
-        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Explore, isVisible);
+        exploreV2MenuController.SetMenuTargetVisibility(section, isVisible);
 
         // Assert
+        exploreV2MenuView.Received().SetVisible(isVisible);
+
         if (isVisible)
-            exploreV2MenuView.Received().GoToSection(ExploreSection.Explore);
+            Assert.That(exploreV2MenuController.currentSectionIndex.Get(), Is.EqualTo((int)section));
 
         Assert.AreEqual(isVisible, DataStore.i.exploreV2.isOpen.Get());
-        exploreV2Analytics.Received().SendStartMenuSectionVisibility(ExploreSection.Explore, isVisible);
+        exploreV2Analytics.Received().SendStartMenuSectionVisibility(section, isVisible);
     }
 
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaiseIsAvatarEditorInitializedChangedCorrectly(bool isVisible)
+    [TestCase(ExploreSection.Quest, true)]
+    [TestCase(ExploreSection.Quest,false)]
+    [TestCase(ExploreSection.Map, true)]
+    [TestCase(ExploreSection.Map,false)]
+    [TestCase(ExploreSection.Backpack, true)]
+    [TestCase(ExploreSection.Backpack,false)]
+    [TestCase(ExploreSection.Settings, true)]
+    [TestCase(ExploreSection.Settings,false)]
+    public void RaiseIsSectionInitializedChangedCorrectly(ExploreSection section, bool isVisible)
     {
         // Act
-        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Backpack, isVisible);
+        exploreV2MenuController.SectionInitializedChanged(section, isVisible);
 
         // Assert
-        exploreV2MenuView.Received().SetSectionActive(ExploreSection.Backpack, isVisible);
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaiseAvatarEditorVisibleChangedCorrectly(bool isVisible)
-    {
-        // Arrange
-        exploreV2MenuController.isAvatarEditorInitialized.Set(true);
-        DataStore.i.common.isSignUpFlow.Set(false);
-        exploreV2MenuController.currentOpenSection = ExploreSection.Backpack;
-
-        // Act
-        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Backpack, isVisible);
-        ;
-
-        // Assert
-        if (isVisible)
-            exploreV2MenuView.Received().GoToSection(ExploreSection.Backpack);
-
-        Assert.AreEqual(isVisible, DataStore.i.exploreV2.isOpen.Get());
-        exploreV2Analytics.Received().SendStartMenuSectionVisibility(ExploreSection.Backpack, isVisible);
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaiseIsNavMapInitializedChangedCorrectly(bool isVisible)
-    {
-        // Act
-        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Map, isVisible);
-
-        // Assert
-        exploreV2MenuView.Received().SetSectionActive(ExploreSection.Map, isVisible);
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaiseNavmapVisibleChangedCorrectly(bool isVisible)
-    {
-        // Arrange
-        exploreV2MenuController.isNavmapInitialized.Set(true);
-        exploreV2MenuController.currentOpenSection = ExploreSection.Map;
-
-        // Act
-        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Map, isVisible);
-
-        // Assert
-        if (isVisible)
-            exploreV2MenuView.Received().GoToSection(ExploreSection.Map);
-
-        Assert.AreEqual(isVisible, DataStore.i.exploreV2.isOpen.Get());
-        exploreV2Analytics.Received().SendStartMenuSectionVisibility(ExploreSection.Map, isVisible);
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaiseIsQuestInitializedChangedCorrectly(bool isVisible)
-    {
-        // Act
-        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Quest, isVisible);
-
-        // Assert
-        exploreV2MenuView.Received().SetSectionActive(ExploreSection.Quest, isVisible);
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaiseQuestVisibleChangedCorrectly(bool isVisible)
-    {
-        // Arrange
-        exploreV2MenuController.isQuestInitialized.Set(true);
-        exploreV2MenuController.currentOpenSection = ExploreSection.Quest;
-
-        // Act
-        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Quest, isVisible);
-
-        // Assert
-        if (isVisible)
-            exploreV2MenuView.Received().GoToSection(ExploreSection.Quest);
-
-        Assert.AreEqual(isVisible, DataStore.i.exploreV2.isOpen.Get());
-        exploreV2Analytics.Received().SendStartMenuSectionVisibility(ExploreSection.Quest, isVisible);
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaiseIsSettingsPanelInitializedChangedCorrectly(bool isVisible)
-    {
-        // Act
-        exploreV2MenuController.SectionInitializedChanged(ExploreSection.Settings, isVisible);
-
-        // Assert
-        exploreV2MenuView.Received().SetSectionActive(ExploreSection.Settings, isVisible);
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public void RaiseSettingsVisibleChangedCorrectly(bool isVisible)
-    {
-        // Arrange
-        exploreV2MenuController.isSettingsPanelInitialized.Set(true);
-        exploreV2MenuController.currentOpenSection = ExploreSection.Settings;
-
-        // Act
-        exploreV2MenuController.SetMenuTargetVisibility(ExploreSection.Settings, isVisible);
-
-        // Assert
-        if (isVisible)
-            exploreV2MenuView.Received().GoToSection(ExploreSection.Settings);
-
-        Assert.AreEqual(isVisible, DataStore.i.exploreV2.isOpen.Get());
-        exploreV2Analytics.Received().SendStartMenuSectionVisibility(ExploreSection.Settings, isVisible);
+        exploreV2MenuView.Received().SetSectionActive(section, isVisible);
     }
 
     [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -297,7 +297,7 @@ public class ExploreV2MenuComponentControllerTests
     [TestCase(ExploreSection.Settings)]
     public void GoToSectionCorrectly(ExploreSection section)
     {
-        // Arrange 
+        // Arrange
         if (section == ExploreSection.Backpack)
             DataStore.i.exploreV2.currentSectionIndex.Set((int)ExploreSection.Backpack);
 
@@ -325,7 +325,7 @@ public class ExploreV2MenuComponentControllerTests
         // Assert
         Assert.AreEqual(sectionId, exploreV2MenuController.currentOpenSection);
 
-        foreach (KeyValuePair<BaseVariable<bool>, ExploreSection> sectionVisiblityVar in exploreV2MenuController.sectionsByVisiblityVar)
+        foreach (KeyValuePair<BaseVariable<bool>, ExploreSection> sectionVisiblityVar in exploreV2MenuController.sectionsByVisibilityVar)
             Assert.IsTrue(sectionVisiblityVar.Key.Get() == (sectionId == sectionVisiblityVar.Value));
 
         // would be nice to implement: exploreV2MenuView.ReceivedWithAnyArgs(1).GoToSection(default); exploreV2MenuView.Received(1).GoToSection(sectionId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2MenuComponentControllerTests.cs
@@ -335,36 +335,42 @@ public class ExploreV2MenuComponentControllerTests
     public void UpdateRealmInfoCorrectly()
     {
         // Arrange
-        string testRealmName = "TestName";
+        ExploreV2ComponentRealmsController realmsController = new ExploreV2ComponentRealmsController(DataStore.i.realm, exploreV2MenuView);
+
+        const string TEST_REALM_NAME = "TestName";
         DataStore.i.realm.playerRealm.Set(new CurrentRealmModel
         {
-            serverName = testRealmName,
-            layer = null
+            serverName = TEST_REALM_NAME,
+            layer = null,
         });
 
-        List<RealmModel> testRealmList = new List<RealmModel>();
-        int testUsersCount = 100;
-        testRealmList.Add(new RealmModel
+        const int TEST_USERS_COUNT = 100;
+        List<RealmModel> testRealmList = new List<RealmModel>
         {
-            serverName = testRealmName,
-            layer = null,
-            usersCount = testUsersCount
-        });
+            new()
+            {
+                serverName = TEST_REALM_NAME,
+                layer = null,
+                usersCount = TEST_USERS_COUNT,
+            },
+        };
         DataStore.i.realm.realmsInfo.Set(testRealmList.ToArray());
 
         // Act
-        exploreV2MenuController.UpdateRealmInfo(testRealmName);
+        realmsController.UpdateRealmInfo(TEST_REALM_NAME);
 
         // Assert
-        exploreV2MenuView.currentRealmViewer.Received().SetRealm(testRealmName);
-        exploreV2MenuView.currentRealmSelectorModal.Received().SetCurrentRealm(testRealmName);
-        exploreV2MenuView.currentRealmViewer.Received().SetNumberOfUsers(testUsersCount);
+        exploreV2MenuView.currentRealmViewer.Received().SetRealm(TEST_REALM_NAME);
+        exploreV2MenuView.currentRealmSelectorModal.Received().SetCurrentRealm(TEST_REALM_NAME);
+        exploreV2MenuView.currentRealmViewer.Received().SetNumberOfUsers(TEST_USERS_COUNT);
     }
 
     [Test]
     public void UpdateAvailableRealmsInfoCorrectly()
     {
         // Arrange
+        ExploreV2ComponentRealmsController realmsController = new ExploreV2ComponentRealmsController(DataStore.i.realm, exploreV2MenuView);
+
         RealmModel[] testRealms =
         {
             new RealmModel
@@ -385,11 +391,11 @@ public class ExploreV2MenuComponentControllerTests
         };
 
         // Act
-        exploreV2MenuController.UpdateAvailableRealmsInfo(testRealms);
+        realmsController.UpdateAvailableRealmsInfo(testRealms);
 
         // Assert
-        Assert.AreEqual(3, exploreV2MenuController.currentAvailableRealms.Count);
-        exploreV2MenuView.currentRealmSelectorModal.Received().SetAvailableRealms(exploreV2MenuController.currentAvailableRealms);
+        Assert.AreEqual(3, realmsController.currentAvailableRealms.Count);
+        exploreV2MenuView.currentRealmSelectorModal.Received().SetAvailableRealms(realmsController.currentAvailableRealms);
     }
 
     [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ThumbnailsManager/ThumbnailsManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ThumbnailsManager/ThumbnailsManager.cs
@@ -88,13 +88,13 @@ public static class ThumbnailsManager
             {
                 promise.OnSuccessEvent += OnComplete;
             }
-            
+
             return;
         }
-        
+
         var newPromise = new AssetPromise_Texture(url);
         promiseCache.Add(url, newPromise);
-        
+
         AddToQueue(new EnqueuedThumbnail(newPromise, OnComplete));
         CheckQueue();
     }
@@ -109,7 +109,7 @@ public static class ThumbnailsManager
                 progressList.RemoveAt(i);
             }
         }
-        
+
         if (availableSlots > 0)
         {
             var availableDownloads = Mathf.Min(availableSlots, promiseQueue.Count);
@@ -120,7 +120,7 @@ public static class ThumbnailsManager
                 {
                     if (promiseQueue.Count == 0)
                         break;
-                    
+
                     var promise = promiseQueue.Dequeue();
                     AssetPromise_Texture assetPromiseTexture = promise.Promise;
                     BeginDownload(assetPromiseTexture, promise.OnComplete);
@@ -146,19 +146,20 @@ public static class ThumbnailsManager
         promise.OnFailEvent += (x, error) =>
         {
             progressList.Remove(promise);
-            Debug.Log($"Error downloading: {promise.url}, Exception: {error}"); 
+            Debug.Log($"Error downloading: {promise.url}, Exception: {error}");
             CheckQueue();
         };
-        
+
         AssetPromiseKeeper_Texture.i.Keep(promise);
     }
-    
+
     public static Sprite GetOrCreateSpriteFromTexture(Texture2D texture, out bool wasCreated)
     {
         wasCreated = false;
         if (!spriteCache.ContainsKey(texture))
         {
-            spriteCache[texture] = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), Vector2.zero);
+            spriteCache[texture] =
+                Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), Vector2.zero, 100, 0, SpriteMeshType.FullRect, Vector4.one, false);
             wasCreated = true;
         }
         return spriteCache[texture];

--- a/unity-renderer/Assets/UIComponents/Scripts/Components/SectionSelector/SectionToggle.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/SectionSelector/SectionToggle.cs
@@ -153,7 +153,8 @@ public class SectionToggle : MonoBehaviour, ISectionToggle, IPointerDownHandler
         if (reselectIfAlreadyOn)
             toggle.isOn = false;
 
-        toggle.isOn = true;
+        if(!toggle.isOn)
+            toggle.isOn = true;
     }
 
     public void SetSelectedVisuals()

--- a/unity-renderer/unity-renderer.sln.DotSettings
+++ b/unity-renderer/unity-renderer.sln.DotSettings
@@ -156,5 +156,6 @@
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">Built-in: Reformat &amp; Apply Syntax Style</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">Reformat Code DCL</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Interactibility/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Navmap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=onboarding/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
 	

--- a/unity-renderer/unity-renderer.sln.DotSettings
+++ b/unity-renderer/unity-renderer.sln.DotSettings
@@ -22,8 +22,8 @@
     &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="HTML"&amp;gt;&#xD;
-    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
     &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
     &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="HTTP Request"&amp;gt;&#xD;
@@ -42,8 +42,8 @@
     &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="JavaScript"&amp;gt;&#xD;
-    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
     &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
     &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="Markdown"&amp;gt;&#xD;
@@ -59,14 +59,14 @@
     &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="XML"&amp;gt;&#xD;
-    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
     &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
     &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
   &amp;lt;Language id="yaml"&amp;gt;&#xD;
     &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
-&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;CSCodeStyleAttributes ArrangeNamespaces="True" ArrangeDefaultValue="True" ArrangeObjectCreation="True" ArrangeTrailingCommas="True" ArrangeCodeBodyStyle="True" ArrangeAttributes="True" ArrangeBraces="True" AddMissingParentheses="True" RemoveRedundantParentheses="True" SortModifiers="True" ArrangeTypeMemberAccessModifier="True" ArrangeTypeAccessModifier="True" ArrangeVarStyle="True" /&gt;&lt;CppCodeStyleCleanupDescriptor /&gt;&lt;CppClangTidyCleanupDescriptor /&gt;&lt;XAMLCollapseEmptyTags&gt;False&lt;/XAMLCollapseEmptyTags&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;/Profile&gt;</s:String>
+&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;CSCodeStyleAttributes ArrangeNamespaces="True" ArrangeDefaultValue="True" ArrangeObjectCreation="True" ArrangeTrailingCommas="True" ArrangeCodeBodyStyle="True" ArrangeAttributes="True" AddMissingParentheses="True" RemoveRedundantParentheses="True" SortModifiers="True" ArrangeTypeMemberAccessModifier="True" ArrangeTypeAccessModifier="True" ArrangeVarStyle="True" /&gt;&lt;CppCodeStyleCleanupDescriptor /&gt;&lt;CppClangTidyCleanupDescriptor /&gt;&lt;XAMLCollapseEmptyTags&gt;False&lt;/XAMLCollapseEmptyTags&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;/Profile&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=FileLayout/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="FileLayout"&gt;&lt;XAMLCollapseEmptyTags&gt;False&lt;/XAMLCollapseEmptyTags&gt;&lt;CSOptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;IDEA_SETTINGS&gt;&amp;lt;profile version="1.0"&amp;gt;&#xD;
   &amp;lt;option name="myName" value="FileLayout" /&amp;gt;&#xD;
   &amp;lt;inspection_tool class="ES6ShorthandObjectProperty" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;


### PR DESCRIPTION
## What does this PR change?
Closes #3030 

### Problem Description
Opening or switching **ExploreV2Menu** sections from UI toggle or via keyboard shortcut was triggering `OnSectionOpen` event of `ExploreV2MenuComponentView` several times in one frame. Real problem is the chain calls between View and Controller for opening section task. That should be treated separately as a task of bigger refactoring of this pair (with more clear separation of responsibilities).

### Solution
- To eliminate event to be called several time per frame I added a simple lock variable `isOpeningSectionThisFrame `(line 39 in `ExploreV2MenuComponentView`) and a coroutine `ResetSectionOpenLock()` (line 164) which updates it in one frame after a call (they used inside a logic of `OnSectionSelected` function).
- Add checks of variables change to apply it only if values changes - for visibility vars inside View's `ChangeVisibilityVarForSwitchedSections` (line 255), and for `SectionToggle.SelectToggle` (line 156)


### Additional changes
- Applied code style to both Controller and View and rearranged the code
- extracted Realm logic to a separate `ExploreV2ComponentRealmsController` class
- DRY refactored related Tests via applying [TestCases]

## How to test the changes?
Not meant for qa. Devs only

1. Checkout the branch
2. Go to the one commit before the [removed debugs](https://github.com/decentraland/unity-renderer/pull/3896/commits/cde3e80e5983206ae90713f8444fd7f77cc82d48)
3. Run from Editor. 
4. Open Explorer - via UI and via keyboard
5. Observe only 1 SHOW logs printed in the console
6. Switch between tabs - and observe as well 1 SHOW logs printed for the event

if want to see 3 SHOW logs - switch to some earlier commits on the branch

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
