### PR TITLE
Added fix for GLTF Fast and Parametrized tags for AB Detection tool

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ABDetectorPlugin/ABDetectorMaterialsHolder.cs
+++ b/unity-renderer/Assets/DCLPlugins/ABDetectorPlugin/ABDetectorMaterialsHolder.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace DCL
 {
@@ -6,8 +6,10 @@ namespace DCL
     {
         [SerializeField] private Material abMaterial;
         [SerializeField] private Material gltfMaterial;
+        [SerializeField] private Material parametrizedShapeMaterial;
 
         public Material ABMaterial => abMaterial;
         public Material GLTFMaterial => gltfMaterial;
+        public Material ParametrizedShapeMaterial => parametrizedShapeMaterial;
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/ABDetectorPlugin/ABDetectorPrefabs/Resources/AbDetectorMaterials.prefab
+++ b/unity-renderer/Assets/DCLPlugins/ABDetectorPlugin/ABDetectorPrefabs/Resources/AbDetectorMaterials.prefab
@@ -27,6 +27,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -45,3 +46,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   abMaterial: {fileID: 2100000, guid: ac31696862e17db48b7a7b61a9e766e4, type: 2}
   gltfMaterial: {fileID: 2100000, guid: 60ff5e133651a5e488ff7440b0addaf6, type: 2}
+  parametrizedShapeMaterial: {fileID: 2100000, guid: 3263e6363f3336a4dbe79bd632b72c2e,
+    type: 2}

--- a/unity-renderer/Assets/DCLPlugins/ABDetectorPlugin/ABDetectorTracker.cs
+++ b/unity-renderer/Assets/DCLPlugins/ABDetectorPlugin/ABDetectorTracker.cs
@@ -9,116 +9,108 @@ namespace DCL
     {
         private const string FROM_ASSET_BUNDLE_TAG = "FromAssetBundle";
         private const string FROM_RAW_GLTF_TAG = "FromRawGLTF";
+        private const string PARAMETRIZED_SHAPE_TAG = "FromParametrized";
         private const string AB_DETECTOR_MATERIALS_PREFAB_NAME = "AbDetectorMaterials";
-        
+
         private readonly DebugConfig debugConfig;
         private readonly DataStore_Player player;
 
-        private readonly Dictionary<Renderer, Material[]> rendererDict  = 
-            new Dictionary<Renderer, Material[]>();
-        private readonly Multimap<IParcelScene, Renderer> parcelToRendererMultimap = 
-            new Multimap<IParcelScene, Renderer>();
+        private readonly Dictionary<Renderer, Material[]> rendererDict = new Dictionary<Renderer, Material[]>();
+        private readonly Multimap<IParcelScene, Renderer> parcelToRendererMultimap = new Multimap<IParcelScene, Renderer>();
 
         private ABDetectorMaterialsHolder abDetectorMaterialsHolder;
         private readonly IWorldState worldState;
 
+        
         public ABDetectorTracker(DebugConfig debugConfig, DataStore_Player player, IWorldState worldState)
         {
             this.debugConfig = debugConfig;
             this.player = player;
             this.worldState = worldState;
-            
+
             debugConfig.showGlobalABDetectionLayer.OnChange += OnGlobalABDetectionChanged;
             debugConfig.showSceneABDetectionLayer.OnChange += OnSceneABDetectionChanged;
         }
-        
+
         public void Dispose()
         {
             debugConfig.showGlobalABDetectionLayer.OnChange -= OnGlobalABDetectionChanged;
             debugConfig.showSceneABDetectionLayer.OnChange -= OnSceneABDetectionChanged;
         }
         
+
         private IParcelScene FindSceneForPlayer()
         {
-            var currentPos = player.playerGridPosition.Get();
-            if (worldState.TryGetScene(worldState.GetSceneNumberByCoords(currentPos), 
-                    out IParcelScene resultScene))
-                return resultScene;
-
-            return null;
+            Vector2Int currentPos = player.playerGridPosition.Get();
+            return worldState.TryGetScene(worldState.GetSceneNumberByCoords(currentPos), out IParcelScene resultScene)
+                ? resultScene
+                : null;
         }
 
         private void LoadMaterialsIfNeeded()
         {
             if (abDetectorMaterialsHolder == null)
             {
-                abDetectorMaterialsHolder = Resources.Load<GameObject>
-                        (AB_DETECTOR_MATERIALS_PREFAB_NAME)
-                    .GetComponent<ABDetectorMaterialsHolder>();
+                abDetectorMaterialsHolder = Resources.Load<GameObject>(AB_DETECTOR_MATERIALS_PREFAB_NAME).
+                    GetComponent<ABDetectorMaterialsHolder>();
             }
         }
 
         private void OnGlobalABDetectionChanged(bool current, bool previous)
         {
             LoadMaterialsIfNeeded();
-            
+
             if (current)
             {
                 RemoveGlobalABDetectionPainting();
                 ApplyGlobalABDetectionPainting();
             }
             else
-            {
                 RemoveGlobalABDetectionPainting();
-            }
         }
 
         private void OnSceneABDetectionChanged(bool current, bool previous)
         {
             LoadMaterialsIfNeeded();
-            
+
             if (current)
             {
                 RemoveGlobalABDetectionPainting();
                 ApplyABDetectionPaintingForCurrentScene();
             }
             else
-            {
                 RemoveABDetectionPaintingForCurrentScene();
-            }
         }
 
         private void ApplyGlobalABDetectionPainting()
         {
-            var gameObjects = GameObject.FindObjectsOfType(typeof(GameObject));
+            UnityEngine.Object[] gameObjects = UnityEngine.Object.FindObjectsOfType(typeof(GameObject));
             foreach (var gameObject in gameObjects)
             {
-                var converted = (GameObject) gameObject;
+                var converted = (GameObject)gameObject;
                 if (converted.transform.parent == null)
-                {
                     ApplyMaterials(converted.transform);
-                }
             }
         }
 
         private void RemoveGlobalABDetectionPainting()
         {
-            foreach (KeyValuePair<Renderer,Material[]> keyValuePair in rendererDict)
+            foreach (KeyValuePair<Renderer, Material[]> keyValuePair in rendererDict)
             {
                 if (keyValuePair.Key != null)
                     keyValuePair.Key.materials = keyValuePair.Value;
             }
-        
+
             rendererDict.Clear();
             parcelToRendererMultimap.Clear();
         }
-        
+
         private void ApplyABDetectionPaintingForCurrentScene()
         {
             var currentScene = FindSceneForPlayer();
             ApplyMaterials(currentScene.GetSceneTransform(), currentScene);
         }
-        
+
         private void RemoveABDetectionPaintingForCurrentScene()
         {
             var currentScene = FindSceneForPlayer();
@@ -127,16 +119,13 @@ namespace DCL
                 foreach (var renderer in parcelToRendererMultimap.GetValues(currentScene))
                 {
                     if (rendererDict.TryGetValue(renderer, out var materials))
-                    {
                         renderer.materials = materials;
-                    }
 
                     rendererDict.Remove(renderer);
                 }
-                
+
                 parcelToRendererMultimap.Remove(currentScene);
             }
-            
         }
 
         private void ApplyMaterials(Transform someTransform, IParcelScene optionalParcelScene = null)
@@ -145,29 +134,24 @@ namespace DCL
             {
                 for (int i = 0; i < someTransform.childCount; i++)
                 {
-                    var childTransform = someTransform.GetChild(i).transform;
-                    var renderers = childTransform.
-                        GetComponents<Renderer>();
-                  
+                    Transform childTransform = someTransform.GetChild(i).transform;
+                    Renderer[] renderers = childTransform.GetComponents<Renderer>();
+
                     foreach (Renderer renderer in renderers)
                     {
                         rendererDict[renderer] = renderer.materials;
 
                         if (optionalParcelScene != null)
-                        {
                             parcelToRendererMultimap.Add(optionalParcelScene, renderer);
-                        }
 
-                        if (renderer.tag.Equals(FROM_ASSET_BUNDLE_TAG))
-                        {
+                        if (renderer.CompareTag(FROM_ASSET_BUNDLE_TAG))
                             renderer.material = abDetectorMaterialsHolder.ABMaterial;
-                        }
-                        else if(renderer.tag.Equals(FROM_RAW_GLTF_TAG))
-                        {
+                        else if (renderer.CompareTag(FROM_RAW_GLTF_TAG))
                             renderer.material = abDetectorMaterialsHolder.GLTFMaterial;
-                        }
+                        else if (renderer.CompareTag(PARAMETRIZED_SHAPE_TAG))
+                            renderer.material = abDetectorMaterialsHolder.ParametrizedShapeMaterial;
                     }
-                    
+
                     ApplyMaterials(childTransform, optionalParcelScene);
                 }
             }

--- a/unity-renderer/Assets/Materials/ParametrizedShapeMaterial.mat
+++ b/unity-renderer/Assets/Materials/ParametrizedShapeMaterial.mat
@@ -1,0 +1,126 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ParametrizedShapeMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2000
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0, g: 0.48754692, b: 1, a: 1}
+    - _Color: {r: 0, g: 0.48754692, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &7835713675338735837
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5

--- a/unity-renderer/Assets/Materials/ParametrizedShapeMaterial.mat.meta
+++ b/unity-renderer/Assets/Materials/ParametrizedShapeMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3263e6363f3336a4dbe79bd632b72c2e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/ParametrizedShapes/ParametrizedShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/ParametrizedShapes/ParametrizedShape.cs
@@ -1,4 +1,4 @@
-﻿using DCL.Helpers;
+using DCL.Helpers;
 using DCL.Models;
 using System.Collections;
 using System.Collections.Generic;
@@ -10,6 +10,8 @@ namespace DCL.Components
     public abstract class ParametrizedShape<T> : BaseShape
         where T : BaseShape.Model, new()
     {
+        private const string PARAMETRIZED_SHAPE_TAG = "FromParametrized";
+
         public Dictionary<IDCLEntity, Rendereable> attachedRendereables = new Dictionary<IDCLEntity, Rendereable>();
         bool visibilityDirty = false;
         bool collisionsDirty = false;
@@ -69,8 +71,8 @@ namespace DCL.Components
             {
                 entity.meshesInfo.UpdateExistingMeshAtIndex(currentMesh, 0);
             }
-         
-            DCL.Environment.i.world.sceneBoundsChecker?.AddEntityToBeChecked(entity);
+
+            Environment.i.world.sceneBoundsChecker?.AddEntityToBeChecked(entity);
         }
 
         void OnShapeAttached(IDCLEntity entity)
@@ -95,6 +97,7 @@ namespace DCL.Components
             entity.meshesInfo.currentShape = this;
 
             meshFilter.sharedMesh = currentMesh;
+            meshFilter.gameObject.tag = PARAMETRIZED_SHAPE_TAG;
 
             if (Configuration.ParcelSettings.VISUAL_LOADING_ENABLED)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -195,7 +195,8 @@ namespace DCL.Components
                     meshDataSize = x.meshDataSize
                 };
 
-                foreach (var someRenderer in r.renderers) { someRenderer.tag = FROM_ASSET_BUNDLE_TAG; }
+                foreach (var someRenderer in r.renderers)
+                    someRenderer.tag = FROM_ASSET_BUNDLE_TAG;
 
                 OnSuccessWrapper(r, OnSuccess);
             };
@@ -243,7 +244,8 @@ namespace DCL.Components
                     animationClips = x.animationClips
                 };
 
-                foreach (var someRenderer in r.renderers) { someRenderer.tag = FROM_RAW_GLTF_TAG; }
+                foreach (var someRenderer in r.renderers)
+                    someRenderer.tag = FROM_RAW_GLTF_TAG;
 
                 OnSuccessWrapper(r, OnSuccess);
             };
@@ -277,6 +279,8 @@ namespace DCL.Components
                 x.container.name = GLTFAST_GO_NAME_PREFIX + x.container.name;
 #endif
                 Rendereable r = x.ToRendereable();
+                foreach (var someRenderer in r.renderers)
+                    someRenderer.tag = FROM_RAW_GLTF_TAG;
 
                 OnSuccessWrapper(r, OnSuccess);
             };


### PR DESCRIPTION
fixes #3783 

## PR
This task was about investigating why some parcels where not being drawn correctly when using the AB detection tool.
The two issues were:
- Some scenes did not lit up when /detectabs was introduced
- Some scenes were not loaded

## QA
- using /detectabs on the scenes that were not lit previously should now lit them (In color blue) - Test coord (-82,-107)
- The non loaded scenes should see no changes as this tool was discarded as the root issue for that problem, (No changes applied then)