### PR TITLE
fix: gltfast texture re-size for different platforms

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
@@ -35,6 +35,7 @@ namespace DCL.GLTFast.Wrappers
 #if UNITY_WEBGL
                 texture2D.Compress(false);
 #endif
+                texture2D = TextureHelpers.ClampSize(texture2D, DataStore.i.textureConfig.gltfMaxSize.Get(), true);
 
                 return texture2D;
             }


### PR DESCRIPTION
## What does this PR change?

While importing textures with gltfast we were not resizing textures for platform-specific settings. 
This should reduce the memory usage for WebGL

## How to test the changes?

The platform should be more stable and crash less when roaming around the world and teleporting to different places using only GLTFAST and disabling asset bundles

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
