### PR TITLE
Null check before delegate unregister

### DIFF
--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxController.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxController.cs
@@ -476,7 +476,7 @@ namespace DCL.Skybox
             DataStore.i.skyboxConfig.objectUpdated.OnChange -= UpdateConfig;
 
             DataStore.i.worldTimer.OnTimeChanged -= GetTimeFromTheServer;
-            configuration.OnTimelineEvent -= Configuration_OnTimelineEvent;
+            if(configuration != null) configuration.OnTimelineEvent -= Configuration_OnTimelineEvent;
             KernelConfig.i.OnChange -= KernelConfig_OnChange;
             Environment.i.platform.updateEventHandler.RemoveListener(IUpdateEventHandler.EventType.Update, Update);
             DataStore.i.skyboxConfig.mode.OnChange -= UseDynamicSkybox_OnChange;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavMapLoadingLogo.cs
@@ -25,7 +25,7 @@ namespace DCL
             DataStore.i.HUDs.navmapVisible.OnChange -= OnOpeningNavMap;
             DataStore.i.exploreV2.isOpen.OnChange -= OnExploreUiVisibilityChange;
 
-            MapRenderer.i.MapVisibilityChanged -= OnNavMapLoaded;
+            if (MapRenderer.i != null) { MapRenderer.i.MapVisibilityChanged -= OnNavMapLoaded; }
         }
 
         private void SubscribeToMapRenderer(bool current, bool previous)


### PR DESCRIPTION
We have many access violation errors on destroy when disposing, these fix two that I found for now. I imagine the common singleton pattern that we are using can cause this quite often if the singleton is destroyed first before any registered delegate attempts to unregister itself from the object.