### PR TITLE
fix: exceptions caused avatars to never end loading or never show up

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationsTracker.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationsTracker.cs
@@ -103,18 +103,18 @@ namespace DCL.Emotes
             try
             {
                 var emote = await(emotesCatalogService.RequestEmoteAsync(emoteId, ct));
-                
+
                 IEmoteAnimationLoader animationLoader = emoteAnimationLoaderFactory.Get();
                 loaders.Add((bodyShapeId, emoteId), animationLoader);
                 await animationLoader.LoadEmote(animationsModelsContainer, emote, bodyShapeId, ct);
-                
+
                 EmoteClipData emoteClipData;
                 if(emote is EmoteItem newEmoteItem)
                     emoteClipData = new EmoteClipData(animationLoader.loadedAnimationClip, newEmoteItem.data.loop);
                 else
                     emoteClipData = new EmoteClipData(animationLoader.loadedAnimationClip, emote.emoteDataV0);
 
-                dataStore.animations.Add((bodyShapeId, emoteId), emoteClipData);
+                dataStore.animations[(bodyShapeId, emoteId)] = emoteClipData;
 
                 if (animationLoader.loadedAnimationClip == null)
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
@@ -55,7 +55,7 @@ namespace AvatarSystem
 
         public static void CopyBones(Transform rootBone, Transform[] bones, SkinnedMeshRenderer skinnedMeshRenderer)
         {
-            if (rootBone == null || bones == null)
+            if (rootBone == null || bones == null || skinnedMeshRenderer == null)
                 return;
 
             skinnedMeshRenderer.rootBone = rootBone;


### PR DESCRIPTION
## What does this PR change?

Closes #3933

It was reported that we could highlight hidden avatars but the actual issue was that the avatar was not visible.
This PR fixes 2 common exceptions that occur when loading avatars on certain conditions, thus failing and getting the whole avatar revealing system stuck. 

## How to test the changes?

https://play.decentraland.zone/?renderer-branch=fix/invisible-avatars&ENABLE_AVATAR_OUTLINER

It should be from very hard to near impossible to find invisible avatars that can be highlighted, if it happens, please post the exception. 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
