### PR TITLE
feat: implemented a color scheme for avatar name tags

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Interface/IPlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Interface/IPlayerName.cs
@@ -13,8 +13,8 @@ public interface IPlayerName
     /// </summary>
     /// <param name="constraint"></param>
     void RemoveVisibilityConstaint(string constraint);
-    
-    void SetName(string name);
+
+    void SetName(string name, bool isClaimed, bool isGuest);
     void Show(bool instant = false);
     void Hide(bool instant = false);
     void SetForceShow(bool forceShow);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -12,8 +12,8 @@ public class PlayerName : MonoBehaviour, IPlayerName
     internal const int DEFAULT_CANVAS_SORTING_ORDER = 0;
     internal const int FORCE_CANVAS_SORTING_ORDER = 40;
     internal static readonly int TALKING_ANIMATOR_BOOL = Animator.StringToHash("Talking");
-    internal const float MINIMUM_ALPHA_TO_SHOW =  1f / 32f;
-    internal const float ALPHA_TRANSITION_STEP_PER_SECOND =  1f / 0.25f;
+    internal const float MINIMUM_ALPHA_TO_SHOW = 1f / 32f;
+    internal const float ALPHA_TRANSITION_STEP_PER_SECOND = 1f / 0.25f;
     internal const float ALPHA_STEPS = 32f;
     internal const float TARGET_ALPHA_SHOW = 1;
     internal const float TARGET_ALPHA_HIDE = 0;
@@ -26,29 +26,32 @@ public class PlayerName : MonoBehaviour, IPlayerName
     [SerializeField] internal Image background;
     [SerializeField] internal Transform pivot;
     [SerializeField] internal Animator talkingAnimator;
-    
     [SerializeField] internal List<CanvasRenderer> canvasRenderers;
 
     internal BaseVariable<float> namesOpacity => DataStore.i.HUDs.avatarNamesOpacity;
     internal BaseVariable<bool> namesVisible => DataStore.i.HUDs.avatarNamesVisible;
     internal BaseVariable<bool> profanityFilterEnabled;
 
-    internal bool forceShow = false;
+    internal bool forceShow;
     internal Color backgroundOriginalColor;
-    internal List<string> hideConstraints = new List<string>();
+    internal List<string> hideConstraints = new ();
     internal string currentName = "";
 
     private float alpha;
     private float targetAlpha;
     private bool renderersVisible;
+    private bool isNameClaimed;
+    private bool isUserGuest;
 
-
-    internal float Alpha 
+    // TODO: remove this property, is only used on tests
+    internal float Alpha
     {
         get => alpha;
+
         set
         {
             alpha = Mathf.Clamp01(value);
+
             if (alpha < 0.01f)
             {
                 UpdateVisuals(0);
@@ -61,12 +64,12 @@ public class PlayerName : MonoBehaviour, IPlayerName
         }
     }
 
+    // TODO: remove this property, is only used on tests
     internal float TargetAlpha
     {
         get => targetAlpha;
         set => targetAlpha = Mathf.Clamp01(value);
     }
-
 
     private void Awake()
     {
@@ -76,41 +79,127 @@ public class PlayerName : MonoBehaviour, IPlayerName
         namesVisible.OnChange += OnNamesVisibleChanged;
         namesOpacity.OnChange += OnNamesOpacityChanged;
         profanityFilterEnabled.OnChange += OnProfanityFilterChanged;
-        
+
         OnNamesVisibleChanged(namesVisible.Get(), true);
         OnNamesOpacityChanged(namesOpacity.Get(), 1);
         Show(true);
     }
-    internal void OnNamesOpacityChanged(float current, float previous) { background.color = new Color(backgroundOriginalColor.r, backgroundOriginalColor.g, backgroundOriginalColor.b, current); }
 
-    internal void OnNamesVisibleChanged(bool current, bool previous) { canvas.enabled = current || forceShow; }
-    private void OnProfanityFilterChanged(bool current, bool previous) { SetName(currentName); }
-    public void SetName(string name) { AsyncSetName(name).Forget(); }
-    private async UniTaskVoid AsyncSetName(string name)
+    private void OnDestroy()
+    {
+        namesVisible.OnChange -= OnNamesVisibleChanged;
+        namesOpacity.OnChange -= OnNamesOpacityChanged;
+        profanityFilterEnabled.OnChange -= OnProfanityFilterChanged;
+    }
+
+    public void SetName(string name, bool isClaimed, bool isGuest) =>
+        AsyncSetName(name, isClaimed, isGuest).Forget();
+
+    public void Show(bool instant = false)
+    {
+        targetAlpha = TARGET_ALPHA_SHOW;
+        SetRenderersVisible(true);
+
+        if (instant)
+            alpha = TARGET_ALPHA_SHOW;
+    }
+
+    public void Hide(bool instant = false)
+    {
+        targetAlpha = TARGET_ALPHA_HIDE;
+
+        if (instant && !forceShow)
+        {
+            alpha = TARGET_ALPHA_HIDE;
+            SetRenderersVisible(false);
+        }
+    }
+
+    // Note: Ideally we should separate the LODController logic from this one so we don't have to add constraints
+    public void AddVisibilityConstaint(string constraint)
+    {
+        hideConstraints.Add(constraint);
+    }
+
+    public void RemoveVisibilityConstaint(string constraint)
+    {
+        hideConstraints.Remove(constraint);
+    }
+
+    public void SetForceShow(bool forceShow)
+    {
+        canvas.enabled = forceShow || namesVisible.Get();
+        canvas.sortingOrder = forceShow ? FORCE_CANVAS_SORTING_ORDER : DEFAULT_CANVAS_SORTING_ORDER;
+        background.color = new Color(backgroundOriginalColor.r, backgroundOriginalColor.g, backgroundOriginalColor.b, forceShow ? 1 : namesOpacity.Get());
+        this.forceShow = forceShow;
+
+        if (this.forceShow)
+            SetRenderersVisible(true);
+    }
+
+    public void SetIsTalking(bool talking)
+    {
+        talkingAnimator.SetBool(TALKING_ANIMATOR_BOOL, talking);
+    }
+
+    public void SetYOffset(float yOffset)
+    {
+        transform.localPosition = Vector3.up * yOffset;
+    }
+
+    public Rect ScreenSpaceRect(Camera mainCamera)
+    {
+        Vector3 origin = mainCamera.WorldToScreenPoint(background.transform.position);
+        Vector2 size = background.rectTransform.sizeDelta;
+        return new Rect(origin.x, Screen.height - origin.y, size.x, size.y);
+    }
+
+    public Vector3 ScreenSpacePos(Camera mainCamera)
+    {
+        return mainCamera.WorldToScreenPoint(background.transform.position);
+    }
+
+    internal void OnNamesOpacityChanged(float current, float previous)
+    {
+        background.color = new Color(backgroundOriginalColor.r, backgroundOriginalColor.g, backgroundOriginalColor.b, current);
+    }
+
+    internal void OnNamesVisibleChanged(bool current, bool previous)
+    {
+        canvas.enabled = current || forceShow;
+    }
+
+    private void OnProfanityFilterChanged(bool current, bool previous)
+    {
+        SetName(currentName, isNameClaimed, isUserGuest);
+    }
+
+    private async UniTaskVoid AsyncSetName(string name, bool isClaimed, bool isGuest)
     {
         currentName = name;
+        isNameClaimed = isClaimed;
+        isUserGuest = isGuest;
         name = await FilterName(currentName);
-        nameText.text = name;
+        nameText.text = GetNameWithColorCodes(isClaimed, isGuest, name);
         background.rectTransform.sizeDelta = new Vector2(nameText.GetPreferredValues().x + BACKGROUND_EXTRA_WIDTH, BACKGROUND_HEIGHT);
     }
 
-    private async UniTask<string> FilterName(string name)
-    {
-        return IsProfanityFilteringEnabled()
+    private async UniTask<string> FilterName(string name) =>
+        IsProfanityFilteringEnabled()
             ? await ProfanityFilterSharedInstances.regexFilter.Filter(name)
             : name;
-    }
 
-    private bool IsProfanityFilteringEnabled()
+    private bool IsProfanityFilteringEnabled() =>
+        DataStore.i.settings.profanityChatFilteringEnabled.Get();
+
+    private void Update()
     {
-        return DataStore.i.settings.profanityChatFilteringEnabled.Get();
+        Update(Time.deltaTime);
     }
-
-    private void Update() { Update(Time.deltaTime); }
 
     private void SetRenderersVisible(bool value)
     {
-        if (renderersVisible == value) 
+        if (renderersVisible == value)
             return;
 
         canvasRenderers.ForEach(c => c.SetAlpha(value ? 1f : 0f));
@@ -127,6 +216,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
 
         float finalTargetAlpha = forceShow ? TARGET_ALPHA_SHOW : targetAlpha;
         alpha = Mathf.MoveTowards(alpha, finalTargetAlpha, ALPHA_TRANSITION_STEP_PER_SECOND * deltaTime);
+
         if (CheckAndUpdateVisibility(alpha))
             return;
 
@@ -144,6 +234,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
         pivot.transform.localPosition = Vector3.up * GetPivotYOffsetByDistance(distanceToCamera);
 
         float resolvedAlpha = forceShow ? TARGET_ALPHA_SHOW : ResolveAlphaByDistance(alpha, distanceToCamera, forceShow);
+
         if (CheckAndUpdateVisibility(resolvedAlpha))
             return;
 
@@ -151,24 +242,18 @@ public class PlayerName : MonoBehaviour, IPlayerName
         float resolvedAlphaStep = GetNearestAlphaStep(resolvedAlpha);
         float canvasAlphaStep = GetNearestAlphaStep(canvasGroup.alpha);
 
-        if (resolvedAlphaStep != canvasAlphaStep)
+        if (Math.Abs(resolvedAlphaStep - canvasAlphaStep) > Mathf.Epsilon)
             UpdateVisuals(resolvedAlpha);
 
-
-        // Local Methods
         bool CheckAndUpdateVisibility(float checkAlpha)
         {
-            if (checkAlpha < MINIMUM_ALPHA_TO_SHOW)
-            {
-                if (renderersVisible)
-                {
-                    UpdateVisuals(0);
-                    SetRenderersVisible(false);
-                }
-                return true;
-            }
+            if (checkAlpha >= MINIMUM_ALPHA_TO_SHOW) return false;
+            if (!renderersVisible) return true;
 
-            return false;
+            UpdateVisuals(0);
+            SetRenderersVisible(false);
+
+            return true;
         }
     }
 
@@ -183,58 +268,13 @@ public class PlayerName : MonoBehaviour, IPlayerName
         cachedTransform.localEulerAngles = finalEulerAngle;
     }
 
-    public void Show(bool instant = false)
-    {
-        targetAlpha = TARGET_ALPHA_SHOW;
-        SetRenderersVisible(true);
-        if (instant)
-            alpha = TARGET_ALPHA_SHOW;
-    }
-
-    public void Hide(bool instant = false)
-    {
-        targetAlpha = TARGET_ALPHA_HIDE;
-        if (instant && !forceShow)
-        {
-            alpha = TARGET_ALPHA_HIDE;
-            SetRenderersVisible(false);
-        }
-    }
-
-    // Note: Ideally we should separate the LODController logic from this one so we don't have to add constraints
-    public void AddVisibilityConstaint(string constraint) { hideConstraints.Add(constraint); }
-    
-    public void RemoveVisibilityConstaint(string constraint) { hideConstraints.Remove(constraint); }
-
-    public void SetForceShow(bool forceShow)
-    {
-        canvas.enabled = forceShow || namesVisible.Get();
-        canvas.sortingOrder = forceShow ? FORCE_CANVAS_SORTING_ORDER : DEFAULT_CANVAS_SORTING_ORDER;
-        background.color = new Color(backgroundOriginalColor.r, backgroundOriginalColor.g, backgroundOriginalColor.b, forceShow ? 1 : namesOpacity.Get());
-        this.forceShow = forceShow;
-        if (this.forceShow)
-            SetRenderersVisible(true);
-    }
-
-    public void SetIsTalking(bool talking) { talkingAnimator.SetBool(TALKING_ANIMATOR_BOOL, talking); }
-
-    public void SetYOffset(float yOffset) { transform.localPosition = Vector3.up * yOffset; }
-
-    public Rect ScreenSpaceRect(Camera mainCamera)
-    {
-        Vector3 origin = mainCamera.WorldToScreenPoint(background.transform.position);
-        Vector2 size = background.rectTransform.sizeDelta;
-        return new Rect(origin.x, Screen.height - origin.y, size.x, size.y);
-    }
-
-    public Vector3 ScreenSpacePos(Camera mainCamera) { return mainCamera.WorldToScreenPoint(background.transform.position); }
-
     internal static float ResolveAlphaByDistance(float alphaValue, float distanceToCamera, bool forceShow)
     {
         if (forceShow)
             return alphaValue;
 
         const float MIN_DISTANCE = 5;
+
         if (distanceToCamera < MIN_DISTANCE)
             return alphaValue;
 
@@ -246,28 +286,52 @@ public class PlayerName : MonoBehaviour, IPlayerName
         canvasGroup.alpha = resolvedAlpha;
     }
 
-    internal float GetNearestAlphaStep(float alpha)
-    {
-        return Mathf.Floor(alpha * ALPHA_STEPS);
-    }
+    internal float GetNearestAlphaStep(float alpha) =>
+        Mathf.Floor(alpha * ALPHA_STEPS);
 
-    internal void ScalePivotByDistance(float distanceToCamera) { pivot.transform.localScale = Vector3.one * 0.15f * distanceToCamera; }
+    internal void ScalePivotByDistance(float distanceToCamera)
+    {
+        pivot.transform.localScale = Vector3.one * 0.15f * distanceToCamera;
+    }
 
     internal float GetPivotYOffsetByDistance(float distanceToCamera)
     {
         const float NEAR_Y_OFFSET = 0f;
         const float FAR_Y_OFFSET = 0.1f;
         const float MAX_DISTANCE = 5;
+
         if (distanceToCamera >= MAX_DISTANCE)
             return FAR_Y_OFFSET;
 
         return Mathf.Lerp(NEAR_Y_OFFSET, FAR_Y_OFFSET, distanceToCamera / MAX_DISTANCE);
     }
 
-    private void OnDestroy()
+    private string GetNameWithColorCodes(bool isClaimed, bool isGuest, string name)
     {
-        namesVisible.OnChange -= OnNamesVisibleChanged;
-        namesOpacity.OnChange -= OnNamesOpacityChanged;
-        profanityFilterEnabled.OnChange -= OnProfanityFilterChanged;
+        string text = name;
+
+        if (isClaimed)
+            text = $"<color=#FFFFFF>{name}</color>";
+        else
+        {
+            if (isGuest)
+            {
+                string[] split = name.Split('#', StringSplitOptions.RemoveEmptyEntries);
+
+                text = split.Length > 1
+                    ? $"<color=#A09BA8>{split[0]}</color><color=#716B7C>#{split[1]}</color>"
+                    : $"<color=#A09BA8>{name}</color>";
+            }
+            else
+            {
+                string[] split = name.Split('#');
+
+                text = split.Length > 1
+                    ? $"<color=#CFCDD4>{split[0]}</color><color=#A09BA8>#{split[1]}</color>"
+                    : $"<color=#CFCDD4>{name}</color>";
+            }
+        }
+
+        return text;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Resources/PlayerName.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Resources/PlayerName.prefab
@@ -28,6 +28,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8580222438754567058}
   m_RootOrder: 2
@@ -103,6 +104,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.007, y: 0.007, z: 0.007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6225888458169134410}
   - {fileID: 8559866741916390979}
@@ -173,6 +175,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8202583866629784727}
   m_Father: {fileID: 7315286666275099008}
@@ -206,6 +209,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8580222438754567058}
   m_RootOrder: 0
@@ -280,6 +284,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 2.8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2017979172353991747}
   m_Father: {fileID: 0}
@@ -339,6 +344,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2907026683050443899}
   - {fileID: 4966696433824734485}
@@ -361,7 +367,7 @@ CanvasRenderer:
   m_CullTransparentMesh: 0
 --- !u!95 &4757240879941231793
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -374,6 +380,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -426,6 +433,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8580222438754567058}
   m_Father: {fileID: 8202583866629784727}
@@ -457,7 +465,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -503,6 +511,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8202583866629784727}
   m_RootOrder: 1
@@ -652,6 +661,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8580222438754567058}
   m_RootOrder: 1

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Tests/PlayerNameShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Tests/PlayerNameShould.cs
@@ -60,7 +60,7 @@ public class PlayerNameShould : MonoBehaviour
     public void SetNameCorrectly(string name)
     {
         playerName.SetName(name, false, false);
-        Assert.AreEqual(name, playerName.nameText.text);
+        Assert.AreEqual($"<color=#CFCDD4>{name}</color>", playerName.nameText.text);
         Assert.AreEqual(new Vector2(playerName.nameText.GetPreferredValues().x + PlayerName.BACKGROUND_EXTRA_WIDTH, PlayerName.BACKGROUND_HEIGHT), playerName.background.rectTransform.sizeDelta);
     }
 
@@ -120,9 +120,29 @@ public class PlayerNameShould : MonoBehaviour
     public void ApplyProfanityFilteringToOffensiveNames(string originalName, string displayedName)
     {
         DataStore.i.settings.profanityChatFilteringEnabled.Set(true);
-        var defaultName = playerName.nameText.text;
         playerName.SetName(originalName, false, false);
-        Assert.IsTrue(displayedName.Equals(playerName.nameText.text) || defaultName.Equals(playerName.nameText.text));
+        Assert.AreEqual($"<color=#CFCDD4>{displayedName}</color>", playerName.nameText.text);
+    }
+
+    [Test]
+    public void SetGuestColor()
+    {
+        playerName.SetName("hey#83df", false, true);
+        Assert.AreEqual("<color=#A09BA8>hey</color><color=#716B7C>#83df</color>", playerName.nameText.text);
+    }
+
+    [Test]
+    public void SetWeb3Color()
+    {
+        playerName.SetName("hey#83df", false, false);
+        Assert.AreEqual("<color=#CFCDD4>hey</color><color=#A09BA8>#83df</color>", playerName.nameText.text);
+    }
+
+    [Test]
+    public void SetClaimedColor()
+    {
+        playerName.SetName("hey", true, false);
+        Assert.AreEqual("<color=#FFFFFF>hey</color>", playerName.nameText.text);
     }
 
     [TearDown]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Tests/PlayerNameShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/Tests/PlayerNameShould.cs
@@ -59,7 +59,7 @@ public class PlayerNameShould : MonoBehaviour
     [TestCase("VeryLongName")]
     public void SetNameCorrectly(string name)
     {
-        playerName.SetName(name);
+        playerName.SetName(name, false, false);
         Assert.AreEqual(name, playerName.nameText.text);
         Assert.AreEqual(new Vector2(playerName.nameText.GetPreferredValues().x + PlayerName.BACKGROUND_EXTRA_WIDTH, PlayerName.BACKGROUND_HEIGHT), playerName.background.rectTransform.sizeDelta);
     }
@@ -72,9 +72,9 @@ public class PlayerNameShould : MonoBehaviour
         playerName.Update(float.MaxValue);
 
         var canvasRenderers = playerName.canvasRenderers;
-        Assert.IsTrue(canvasRenderers != null 
+        Assert.IsTrue(canvasRenderers != null
                       && canvasRenderers.
-                          TrueForAll(r => 
+                          TrueForAll(r =>
                               r.GetAlpha() < 0.01f));
     }
 
@@ -121,7 +121,7 @@ public class PlayerNameShould : MonoBehaviour
     {
         DataStore.i.settings.profanityChatFilteringEnabled.Set(true);
         var defaultName = playerName.nameText.text;
-        playerName.SetName(originalName);
+        playerName.SetName(originalName, false, false);
         Assert.IsTrue(displayedName.Equals(playerName.nameText.text) || defaultName.Equals(playerName.nameText.text));
     }
 


### PR DESCRIPTION
## What does this PR change?

`Closes #3627`
Adds a new color scheme for avatar name tags depending if they are guests, web3 or claimed.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?renderer-branch=feat/avatar-name-colors
2. Go to a crowded place
3. Spot users as guests, names should be greyed out
4. Spot users with connected wallets, names should be lighter
5. Spot users with claimed names, should be white

<img width="537" alt="Screen Shot 2023-01-09 at 16 23 54" src="https://user-images.githubusercontent.com/56365551/211396711-4137e5bf-9a10-4133-a826-7fde68931d6a.png">
 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
