### PR TITLE
chore: remove LINQ from AvatarsLODController

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarsLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarsLODController.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using DCL.CameraTool;
 using UnityEngine;
 
@@ -25,7 +24,7 @@ namespace DCL
         internal readonly Dictionary<string, IAvatarLODController> lodControllers = new Dictionary<string, IAvatarLODController>();
         private UnityEngine.Camera mainCamera;
 
-        public AvatarsLODController ()
+        public AvatarsLODController()
         {
             gpuSkinningThrottlingCurve = Resources.Load<GPUSkinningThrottlingCurveSO>("GPUSkinningThrottlingCurve");
         }
@@ -33,18 +32,12 @@ namespace DCL
         public void Initialize()
         {
             Environment.i.platform.updateEventHandler.AddListener(IUpdateEventHandler.EventType.Update, Update);
-            
-            foreach (IAvatarLODController lodController in lodControllers.Values)
-            {
-                lodController.Dispose();
-            }
+
+            foreach (IAvatarLODController lodController in lodControllers.Values) { lodController.Dispose(); }
 
             lodControllers.Clear();
 
-            foreach (var keyValuePair in otherPlayers.Get())
-            {
-                RegisterAvatar(keyValuePair.Key, keyValuePair.Value);
-            }
+            foreach (var keyValuePair in otherPlayers.Get()) { RegisterAvatar(keyValuePair.Key, keyValuePair.Value); }
 
             otherPlayers.OnAdded += RegisterAvatar;
             otherPlayers.OnRemoved += UnregisterAvatar;
@@ -58,7 +51,8 @@ namespace DCL
             lodControllers.Add(id, CreateLodController(player));
         }
 
-        protected internal virtual IAvatarLODController CreateLodController(Player player) => new AvatarLODController(player);
+        protected internal virtual IAvatarLODController CreateLodController(Player player) =>
+            new AvatarLODController(player);
 
         public void UnregisterAvatar(string id, Player player)
         {
@@ -81,19 +75,21 @@ namespace DCL
         {
             if (mainCamera == null)
                 mainCamera = UnityEngine.Camera.main;
-            int avatarsCount = 0; //Full Avatar + Simple Avatar
-            int impostorCount = 0; //Impostor
+
+            var avatarsCount = 0; //Full Avatar + Simple Avatar
+            var impostorCount = 0; //Impostor
 
             float simpleAvatarDistance = this.simpleAvatarDistance.Get();
             Vector3 ownPlayerPosition = CommonScriptableObjects.playerUnityPosition.Get();
 
             overlappingTracker.Reset();
 
-            (IAvatarLODController lodController, float distance)[] lodControllersByDistance = ComposeLODControllersSortedByDistance(lodControllers.Values, ownPlayerPosition);
+            (IAvatarLODController lodController, float distance)[] lodControllersByDistance =
+                ComposeLODControllersSortedByDistance(lodControllers.Values, ownPlayerPosition);
 
-            for (int index = 0; index < lodControllersByDistance.Length; index++)
+            foreach (var controllerDistancePair in lodControllersByDistance)
             {
-                (IAvatarLODController lodController, float distance) = lodControllersByDistance[index];
+                (IAvatarLODController lodController, float distance) = controllerDistancePair;
 
                 if (IsInInvisibleDistance(distance))
                 {
@@ -105,21 +101,21 @@ namespace DCL
                 if (avatarsCount < maxAvatars)
                 {
                     lodController.SetAnimationThrottling((int)gpuSkinningThrottlingCurve.curve.Evaluate(distance));
+
                     if (distance < simpleAvatarDistance)
                         lodController.SetLOD0();
                     else
                         lodController.SetLOD1();
+
                     avatarsCount++;
 
-                    if (mainCamera == null)
-                        lodController.SetNameVisible(true);
-                    else
-                        lodController.SetNameVisible(overlappingTracker.RegisterPosition(lodController.player.playerName.ScreenSpacePos(mainCamera)));
+                    lodController.SetNameVisible(mainCamera == null || overlappingTracker.RegisterPosition(lodController.player.playerName.ScreenSpacePos(mainCamera)));
 
                     continue;
                 }
 
                 lodController.SetNameVisible(false);
+
                 if (impostorCount < maxImpostors)
                 {
                     lodController.SetLOD2();
@@ -139,11 +135,23 @@ namespace DCL
             return firstPersonCamera ? distance < AVATARS_INVISIBILITY_DISTANCE : distance < 0f; // < 0 is behind camera
         }
 
-        private (IAvatarLODController lodController, float distance)[] ComposeLODControllersSortedByDistance(IEnumerable<IAvatarLODController> lodControllers, Vector3 ownPlayerPosition)
+        private (IAvatarLODController lodController, float distance)[] ComposeLODControllersSortedByDistance(Dictionary<string, IAvatarLODController>.ValueCollection lodControllers, Vector3 ownPlayerPosition)
         {
-            (IAvatarLODController lodController, float distance)[] lodControllersWithDistance = lodControllers.Select(x => (x, DistanceToOwnPlayer(x.player, ownPlayerPosition))).ToArray();
-            Array.Sort(lodControllersWithDistance, (x, y) => x.distance.CompareTo(y.distance));
+            (IAvatarLODController lodController, float distance)[] lodControllersWithDistance = new (IAvatarLODController x, float)[lodControllers.Count];
+
+            var i = 0;
+            foreach (IAvatarLODController x in lodControllers)
+            {
+                lodControllersWithDistance[i] = (x, DistanceToOwnPlayer(x.player, ownPlayerPosition));
+                i++;
+            }
+
+            Array.Sort(lodControllersWithDistance, CompareByDistance());
+
             return lodControllersWithDistance;
+
+            Comparison<(IAvatarLODController lodController, float distance)> CompareByDistance() =>
+                (x, y) => x.distance.CompareTo(y.distance);
         }
 
         /// <summary>
@@ -159,14 +167,14 @@ namespace DCL
             return Vector3.Distance(ownPlayerPosition, player.worldPosition);
         }
 
-        private bool IsInFrontOfCamera(Vector3 position) { return Vector3.Dot(cameraForward, (position - cameraPosition).normalized) >= RENDERED_DOT_PRODUCT_ANGLE; }
+        private bool IsInFrontOfCamera(Vector3 position)
+        {
+            return Vector3.Dot(cameraForward, (position - cameraPosition).normalized) >= RENDERED_DOT_PRODUCT_ANGLE;
+        }
 
         public void Dispose()
         {
-            foreach (IAvatarLODController lodController in lodControllers.Values)
-            {
-                lodController.Dispose();
-            }
+            foreach (IAvatarLODController lodController in lodControllers.Values) { lodController.Dispose(); }
 
             otherPlayers.OnAdded -= RegisterAvatar;
             otherPlayers.OnRemoved -= UnregisterAvatar;


### PR DESCRIPTION
## What does this PR change?
Closes #3876, that was extracted from #3385 (where you can find more info about the issue)

Method `ComposeLODControllersSortedByDistance` was using LINQ. I reverted it to a normal array.

## How to test the changes?

1. Run in editor scene with 80+ avatars
2. Observe in Profiler no allocation from AvatarsLODController

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
