### PR TITLE
fix: names opacity default value set to 1

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/DefaultSettingsFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/DefaultSettingsFactory.cs
@@ -20,7 +20,7 @@ namespace DCL.SettingsCommon
             maxNonLODAvatars = DataStore_AvatarsLOD.DEFAULT_MAX_AVATAR,
             voiceChatVolume = 1,
             voiceChatAllow = GeneralSettings.VoiceChatAllow.ALL_USERS,
-            namesOpacity = 0.5f,
+            namesOpacity = 1f,
             profanityChatFiltering = true,
             nightMode = false,
             hideUI = false,


### PR DESCRIPTION
## What does this PR change?

Since the color scheme of name tags has been changed, the opacity should be defaulted to 1 in the configuration.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/name-default-opacity
2. Clear cookies so you get a fresh start
3. Go to the settings
4. The names opacity value should be set to 1

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
