### PR TITLE
Remove FindGameObjectsOfType in Culling Controller

### DIFF
--- a/unity-renderer/Assets/Rendering/Culling/CullingController.cs
+++ b/unity-renderer/Assets/Rendering/Culling/CullingController.cs
@@ -129,7 +129,7 @@ namespace DCL.Rendering
 
         public void AddRenderers(ICollection<Renderer> renderers)
         {
-            objectsTracker.Add(renderers);
+            objectsTracker.AddRenderers(renderers);
         }
 
         /// <summary>

--- a/unity-renderer/Assets/Rendering/Culling/CullingController.cs
+++ b/unity-renderer/Assets/Rendering/Culling/CullingController.cs
@@ -127,6 +127,11 @@ namespace DCL.Rendering
             updateCoroutine = null;
         }
 
+        public void AddRenderers(ICollection<Renderer> renderers)
+        {
+            objectsTracker.Add(renderers);
+        }
+
         /// <summary>
         /// Process all sceneObject renderers with the parameters set by the given profile.
         /// </summary>

--- a/unity-renderer/Assets/Rendering/Culling/CullingController.cs
+++ b/unity-renderer/Assets/Rendering/Culling/CullingController.cs
@@ -127,11 +127,6 @@ namespace DCL.Rendering
             updateCoroutine = null;
         }
 
-        public void AddRenderers(ICollection<Renderer> renderers)
-        {
-            objectsTracker.AddRenderers(renderers);
-        }
-
         /// <summary>
         /// Process all sceneObject renderers with the parameters set by the given profile.
         /// </summary>

--- a/unity-renderer/Assets/Rendering/Culling/CullingObjectsTracker.cs
+++ b/unity-renderer/Assets/Rendering/Culling/CullingObjectsTracker.cs
@@ -13,9 +13,11 @@ namespace DCL.Rendering
     /// </summary>
     public class CullingObjectsTracker : ICullingObjectsTracker
     {
-        private ICollection<Renderer> renderers;
-        private ICollection<SkinnedMeshRenderer> skinnedRenderers;
-        private Animation[] animations;
+        private ICollection<Renderer> detectedRenderers = new List<Renderer>();
+        private ICollection<Renderer> usingRenderers;
+        private ICollection<SkinnedMeshRenderer> detectedSkinnedRenderers;
+        private ICollection<SkinnedMeshRenderer> usingSkinnedRenderers;
+        private Animation[] usingAnimations;
 
         private int ignoredLayersMask;
         private bool dirty = true;
@@ -27,6 +29,15 @@ namespace DCL.Rendering
             PoolManager.i.OnGet += MarkDirty;
         }
 
+        public void AddRenderers(ICollection<Renderer> inRenderers)
+        {
+            foreach (Renderer renderer in inRenderers)
+            {
+                if (renderer is not SkinnedMeshRenderer and not ParticleSystemRenderer)
+                    detectedRenderers.Add(renderer);
+            }
+        }
+
         /// <summary>
         /// If the dirty flag is true, this coroutine will re-populate all the tracked objects.
         /// </summary>
@@ -35,44 +46,15 @@ namespace DCL.Rendering
             if (!dirty)
                 yield break;
 
-            List<Renderer> renderersList = new List<Renderer>();
-            List<SkinnedMeshRenderer> skinnedRenderersList = new List<SkinnedMeshRenderer>();
-            Renderer[] allRenderers = Object.FindObjectsOfType<Renderer>();
-
-            // TODO new task, avoid FindGameObjectsOfType and use:
-            // SceneManager.GetActiveScene().GetRootGameObjects(), calculate from there.
-
+            detectedSkinnedRenderers = Object.FindObjectsOfType<SkinnedMeshRenderer>();
             yield return null;
-
-            int amount = 0;
-            foreach (Renderer renderer in allRenderers)
-            {
-                if (renderer == null)
-                    continue;
-
-                if (amount >= CullingControllerSettings.MAX_POPULATING_ELEMENTS_PER_FRAME)
-                {
-                    yield return null;
-                    amount = 0;
-                }
-                amount++;
-
-                if ((((1 << renderer.gameObject.layer) & ignoredLayersMask) == 0)
-                    && !(renderer is ParticleSystemRenderer))
-                {
-                    if (renderer is SkinnedMeshRenderer)
-                        skinnedRenderersList.Add((SkinnedMeshRenderer)renderer);
-                    else
-                        renderersList.Add(renderer);
-                }
-            }
-            renderers = renderersList;
-            skinnedRenderers = skinnedRenderersList;
-
+            yield return CalculateRenderers();
             yield return null;
-
-            animations = Object.FindObjectsOfType<Animation>();
-
+            yield return CalculateSkinnedRenderers();
+            yield return null;
+            usingAnimations = Object.FindObjectsOfType<Animation>();
+            yield return null;
+            
             dirty = false;
         }
 
@@ -82,62 +64,150 @@ namespace DCL.Rendering
         /// <param name="includeInactives">True for add inactive objects to the tracked list.</param>
         public void ForcePopulateRenderersList(bool includeInactives)
         {
-            List<Renderer> renderersList = new List<Renderer>();
-            List<SkinnedMeshRenderer> skinnedRenderersList = new List<SkinnedMeshRenderer>();
-            Renderer[] allRenderers = Object.FindObjectsOfType<Renderer>(includeInactives);
+            detectedSkinnedRenderers = Object.FindObjectsOfType<SkinnedMeshRenderer>();
 
-            foreach (Renderer renderer in allRenderers)
-            {
-                if ((((1 << renderer.gameObject.layer) & ignoredLayersMask) == 0)
-                    && !(renderer is ParticleSystemRenderer))
-                {
-                    if (renderer is SkinnedMeshRenderer)
-                        skinnedRenderersList.Add((SkinnedMeshRenderer)renderer);
-                    else
-                        renderersList.Add(renderer);
-                }
-            }
-            renderers = renderersList;
-            skinnedRenderers = skinnedRenderersList;
+            ForceCalculateRenderers();
+            ForceCalculateSkinnedRenderers();
+            usingAnimations = Object.FindObjectsOfType<Animation>();
+            
+            dirty = false;
         }
+
+
+        private IEnumerator CalculateRenderers()
+        {
+            int amount = 0;
+            List<Renderer> renderersToRemove = new List<Renderer>();
+            List<Renderer> checkingRenderers = new List<Renderer>(detectedRenderers);
+            usingRenderers.Clear();
+            foreach (Renderer renderer in checkingRenderers)
+            {
+                if (renderer == null)
+                {
+                    renderersToRemove.Add(renderer);
+                    continue;
+                }
+
+                if (amount >= CullingControllerSettings.MAX_POPULATING_ELEMENTS_PER_FRAME)
+                {
+                    yield return null;
+                    amount = 0;
+                }
+                amount++;
+
+                if (((1 << renderer.gameObject.layer) & ignoredLayersMask) == 0)
+                    usingRenderers.Add(renderer);
+            }
+            for (int i = renderersToRemove.Count - 1; i >= 0; i--)
+                renderersToRemove.Remove(renderersToRemove[i]);
+        }
+
+        private IEnumerator CalculateSkinnedRenderers()
+        {
+            int amount = 0;
+            List<SkinnedMeshRenderer> skinnedRenderersToRemove = new List<SkinnedMeshRenderer>();
+            List<SkinnedMeshRenderer> checkingSkinnedRenderers = new List<SkinnedMeshRenderer>(skinnedRenderersToRemove);
+            usingSkinnedRenderers.Clear();
+            foreach (SkinnedMeshRenderer skinnedRenderer in checkingSkinnedRenderers)
+            {
+                if (skinnedRenderer == null)
+                {
+                    skinnedRenderersToRemove.Add(skinnedRenderer);
+                    continue;
+                }
+
+                if (amount >= CullingControllerSettings.MAX_POPULATING_ELEMENTS_PER_FRAME)
+                {
+                    yield return null;
+                    amount = 0;
+                }
+                amount++;
+
+                if (((1 << skinnedRenderer.gameObject.layer) & ignoredLayersMask) == 0)
+                    usingSkinnedRenderers.Add(skinnedRenderer);
+            }
+            for (int i = skinnedRenderersToRemove.Count - 1; i >= 0; i--)
+                skinnedRenderersToRemove.Remove(skinnedRenderersToRemove[i]);
+        }
+
+        private void ForceCalculateRenderers()
+        {
+            List<Renderer> renderersToRemove = new List<Renderer>();
+            usingRenderers.Clear();
+            foreach (Renderer renderer in detectedRenderers)
+            {
+                if (renderer == null)
+                {
+                    renderersToRemove.Add(renderer);
+                    continue;
+                }
+
+                if (((1 << renderer.gameObject.layer) & ignoredLayersMask) == 0)
+                    usingRenderers.Add(renderer);
+            }
+            for (int i = renderersToRemove.Count - 1; i >= 0; i--)
+                renderersToRemove.Remove(renderersToRemove[i]);
+        }
+
+        private void ForceCalculateSkinnedRenderers()
+        {
+            List<SkinnedMeshRenderer> skinnedRenderersToRemove = new List<SkinnedMeshRenderer>();
+            usingSkinnedRenderers.Clear();
+            foreach (SkinnedMeshRenderer skinnedRenderer in detectedSkinnedRenderers)
+            {
+                if (skinnedRenderer == null)
+                {
+                    skinnedRenderersToRemove.Add(skinnedRenderer);
+                    continue;
+                }
+
+                if (((1 << skinnedRenderer.gameObject.layer) & ignoredLayersMask) == 0)
+                    usingSkinnedRenderers.Add(skinnedRenderer);
+            }
+            for (int i = skinnedRenderersToRemove.Count - 1; i >= 0; i--)
+                skinnedRenderersToRemove.Remove(skinnedRenderersToRemove[i]);
+        }
+
 
         public void SetIgnoredLayersMask(int ignoredLayersMask) { this.ignoredLayersMask = ignoredLayersMask; }
 
         /// <summary>
         /// Sets the dirty flag to true to make PopulateRenderersList retrieve all the scene objects on its next call.
         /// </summary>
-        public void MarkDirty() { dirty = true; }
+        public void MarkDirty() => dirty = true;
 
         /// <summary>
         /// Returns true if dirty.
         /// </summary>
         /// <returns>True if dirty.</returns>
-        public bool IsDirty() { return dirty; }
+        public bool IsDirty() => dirty;
 
         /// <summary>
         /// Returns the renderers list.
         /// </summary>
         /// <returns>An ICollection with all the tracked renderers.</returns>
-        public ICollection<Renderer> GetRenderers() { return renderers; }
+        public ICollection<Renderer> GetRenderers() => usingRenderers;
 
         /// <summary>
         /// Returns the skinned renderers list.
         /// </summary>
         /// <returns>An ICollection with all the tracked skinned renderers.</returns>
-        public ICollection<SkinnedMeshRenderer> GetSkinnedRenderers() { return skinnedRenderers; }
+        public ICollection<SkinnedMeshRenderer> GetSkinnedRenderers() => usingSkinnedRenderers;
 
         /// <summary>
         /// Returns the animations list.
         /// </summary>
         /// <returns>An array with all the tracked animations.</returns>
-        public Animation[] GetAnimations() { return animations; }
+        public Animation[] GetAnimations() => usingAnimations;
 
         public void Dispose()
         {
             dirty = true;
-            renderers = null;
-            animations = null;
-            skinnedRenderers = null;
+            usingRenderers = null;
+            detectedRenderers = null;
+            usingSkinnedRenderers = null;
+            detectedSkinnedRenderers = null;
+            usingAnimations = null;
             PoolManager.i.OnGet -= MarkDirty;
         }
     }

--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/CullingControllerInterfaces.asmdef
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/CullingControllerInterfaces.asmdef
@@ -1,16 +1,16 @@
 {
-  "name": "CullingControllerInterfaces",
-  "rootNamespace": "",
-  "references": [
-    "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "CullingControllerInterfaces",
+    "rootNamespace": "",
+    "references": [
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingController.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingController.cs
@@ -8,7 +8,6 @@ namespace DCL.Rendering
     {
         void Start();
         void Stop();
-        void AddRenderers(ICollection<Renderer> inRenderers);
         void MarkDirty();
         void SetSettings(CullingControllerSettings settings);
         CullingControllerSettings GetSettingsCopy();

--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingController.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingController.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace DCL.Rendering
 {
@@ -6,6 +8,7 @@ namespace DCL.Rendering
     {
         void Start();
         void Stop();
+        void AddRenderers(ICollection<Renderer> inRenderers);
         void MarkDirty();
         void SetSettings(CullingControllerSettings settings);
         CullingControllerSettings GetSettingsCopy();

--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingObjectsTracker.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingObjectsTracker.cs
@@ -7,7 +7,6 @@ namespace DCL.Rendering
 {
     public interface ICullingObjectsTracker : IDisposable
     {
-        void AddRenderers(ICollection<Renderer> inRenderers);
         void SetIgnoredLayersMask(int ignoredLayersMask);
         void MarkDirty();
         bool IsDirty();

--- a/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingObjectsTracker.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Interfaces/ICullingObjectsTracker.cs
@@ -7,6 +7,7 @@ namespace DCL.Rendering
 {
     public interface ICullingObjectsTracker : IDisposable
     {
+        void AddRenderers(ICollection<Renderer> inRenderers);
         void SetIgnoredLayersMask(int ignoredLayersMask);
         void MarkDirty();
         bool IsDirty();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
@@ -78,7 +78,6 @@ namespace DCL.Components
             rendereable = Rendereable.CreateFromGameObject(entity.meshRootGameObject);
             rendereable.ownerId = entity.entityId;
             DataStore.i.sceneWorldObjects.AddRendereable(entity.scene.sceneData.sceneNumber, rendereable);
-            Environment.i.platform.cullingController.AddRenderers(rendereable.renderers);
 
             entity.OnShapeUpdated?.Invoke(entity);
             entity.OnShapeLoaded?.Invoke(entity);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
@@ -78,6 +78,7 @@ namespace DCL.Components
             rendereable = Rendereable.CreateFromGameObject(entity.meshRootGameObject);
             rendereable.ownerId = entity.entityId;
             DataStore.i.sceneWorldObjects.AddRendereable(entity.scene.sceneData.sceneNumber, rendereable);
+            Environment.i.platform.cullingController.AddRenderers(rendereable.renderers);
 
             entity.OnShapeUpdated?.Invoke(entity);
             entity.OnShapeLoaded?.Invoke(entity);


### PR DESCRIPTION
fixes #3297 

## What does this PR do?

This PR aims to resolve a spike created by the CullingController Tracker when getting all Renderers by using a FindGameObjectsOfType.
In order to doso, now, Rendereables are added as soon as they are created to a list and the received Renderers come from that list.


## QA

- No changes should be observable
- If something changes should be detected when scenes that with one system are shown, are not in the other


## Other possible improvements

- Having the Rendereables detected can allow us to disable those scenes outside camera frustrum, I recommend testing if there is performance to be gained using that technique