### PR TITLE
chore: set a new reviewers group for tech leads

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -5,15 +5,16 @@ addReviewers: true
 numberOfReviewers: 1
 useReviewGroups: true
 reviewGroups:
-  devs:
+  techleads:
     - AjimenezDCL
-    - sandrade-dcl
     - Kinerius
+    - mikhail-dcl
+  devs:    
+    - sandrade-dcl    
     - lorux0
     - davidejensen
     - dalkia
-    - popuz
-    - mikhail-dcl
+    - popuz    
   qa:
     - kwssbocian
     - kwspgoliasz


### PR DESCRIPTION
Update the autoassign tool to have a new tech-leads reviewers