### PR TITLE
fix: removed default friendship status when updating user presence

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
@@ -298,9 +298,6 @@ namespace DCL.Social.Friends
         private void UpdateUserPresence(UserStatus newUserStatus)
         {
             if (!friends.ContainsKey(newUserStatus.userId)) return;
-
-            // Kernel doesn't send the friendship status on this call, we have to keep it or it gets defaulted
-            newUserStatus.friendshipStatus = friends[newUserStatus.userId].friendshipStatus;
             UpdateUserStatus(newUserStatus);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsApiBridge.cs
@@ -12,6 +12,7 @@ namespace DCl.Social.Friends
         [Obsolete("Old API. Use GetFriendRequestsAsync instead")]
         event Action<AddFriendRequestsPayload> OnFriendRequestsAdded;
         event Action<AddFriendsWithDirectMessagesPayload> OnFriendWithDirectMessagesAdded;
+        // TODO: friendship status should not be in the user presence. Make a different payload instead
         event Action<UserStatus> OnUserPresenceUpdated;
         event Action<FriendshipUpdateStatusMessage> OnFriendshipStatusUpdated;
         event Action<UpdateTotalFriendRequestsPayload> OnTotalFriendRequestCountUpdated;


### PR DESCRIPTION
## What does this PR change?

Kernel now sends the friendship status when updating the user presence.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/presence-friendship-status&kernel-branch=fix/add-friendship-status
2. Add and remove friendships with a user
3. Let the other user disconnect and reconnect changing its online status
4. The user should be always represented in the correct friendships in the friend list/friend request list

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
