### PR TITLE
hotfix: names & lands repetitive requests when the passport is opened

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/AvatarEditorHUDViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/AvatarEditorHUDViewShould.cs
@@ -108,7 +108,7 @@ namespace AvatarEditorHUD_Tests
 
             Assert.IsTrue(controller.myView.selectorsByCategory.ContainsKey(category));
             var selector = controller.myView.selectorsByCategory[category];
-            
+
             Assert.IsTrue(selector.currentItemToggles.ContainsKey(wearableId));
             Assert.IsTrue(selector.totalWearables.ContainsKey(wearableId));
         }
@@ -131,7 +131,7 @@ namespace AvatarEditorHUD_Tests
             userProfile.UpdateData(new UserProfileModel()
             {
                 name = "name",
-                email = "mail",
+                email = "email",
                 avatar = new AvatarModel()
                 {
                     bodyShape = WearableLiterals.BodyShapes.FEMALE,
@@ -261,7 +261,7 @@ namespace AvatarEditorHUD_Tests
 
             Assert.IsTrue( itemToggleObject.smartItemBadge.activeSelf);
         }
-        
+
         [Test]
         public void HideSmartIconWhenIsNormalNFT()
         {
@@ -272,7 +272,7 @@ namespace AvatarEditorHUD_Tests
 
             Assert.IsFalse( itemToggleObject.smartItemBadge.activeSelf);
         }
-        
+
         [Test]
         public void ShowWarningWhenNoLinkedWearableAvailable()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
@@ -36,8 +36,8 @@ public class AvatarModel : BaseModel
             return false;
 
         //wearables are the same
-        if (!(wearables.Count == other.wearables.Count 
-              && wearables.All(other.wearables.Contains) 
+        if (!(wearables.Count == other.wearables.Count
+              && wearables.All(other.wearables.Contains)
               && other.wearables.All(wearables.Contains)))
             return false;
 
@@ -74,8 +74,10 @@ public class AvatarModel : BaseModel
 
     public bool Equals(AvatarModel other)
     {
-        bool wearablesAreEqual = wearables.All(other.wearables.Contains) 
-                                 && other.wearables.All(wearables.Contains) 
+        if (other == null) return false;
+
+        bool wearablesAreEqual = wearables.All(other.wearables.Contains)
+                                 && other.wearables.All(wearables.Contains)
                                  && wearables.Count == other.wearables.Count;
 
         return id == other.id &&
@@ -110,5 +112,5 @@ public class AvatarModel : BaseModel
     }
 
     public override BaseModel GetDataFromJSON(string json) { return Utils.SafeFromJson<AvatarModel>(json); }
-    
+
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 [System.Serializable]
 public class UserProfileModel
@@ -8,6 +9,14 @@ public class UserProfileModel
     {
         public string face256;
         public string body;
+
+        public bool Equals(Snapshots snapshots)
+        {
+            if (snapshots == null) return false;
+            if (snapshots.face256 != face256) return false;
+            if (snapshots.body != body) return false;
+            return true;
+        }
     }
 
     [System.Serializable]
@@ -22,6 +31,15 @@ public class UserProfileModel
         {
             OWNER = 0,
             OPERATOR = 1
+        }
+
+        public bool Equals(ParcelsWithAccess parcelsWithAccess)
+        {
+            if (parcelsWithAccess == null) return false;
+            if (parcelsWithAccess.x != x) return false;
+            if (parcelsWithAccess.y != y) return false;
+            if (parcelsWithAccess.landRole != landRole) return false;
+            return true;
         }
     }
 
@@ -47,6 +65,53 @@ public class UserProfileModel
     public int tutorialStep;
     public bool hasClaimedName = false;
 
+    public bool Equals(UserProfileModel model)
+    {
+        if (model == null) return false;
+        if (model.userId != userId) return false;
+        if (model.ethAddress != ethAddress) return false;
+        if (model.name != name) return false;
+        if (model.email != email) return false;
+        if (model.description != description) return false;
+        if (model.baseUrl != baseUrl) return false;
+        if (model.created_at != created_at) return false;
+        if (model.updated_at != updated_at) return false;
+        if (model.version != version) return false;
+        if (!model.avatar.Equals(avatar)) return false;
+
+        if (model.parcelsWithAccess != null)
+        {
+            if (!model.parcelsWithAccess.Equals(parcelsWithAccess))
+                return false;
+        }
+        else if (parcelsWithAccess != null)
+            return false;
+
+        if (model.hasConnectedWeb3 != hasConnectedWeb3) return false;
+        if (model.tutorialFlagsMask != tutorialFlagsMask) return false;
+        if (model.tutorialFlagsMask != tutorialFlagsMask) return false;
+
+        if (model.blocked != null && blocked != null)
+        {
+            if (!model.blocked.All(blocked.Contains) || model.blocked.Count != blocked.Count)
+                return false;
+        }
+        else if (model.blocked != null || blocked != null)
+            return false;
+
+        if (model.muted != null && muted != null)
+        {
+            if (!model.muted.All(muted.Contains) || model.muted.Count != muted.Count)
+                return false;
+        }
+        else if (model.muted != null || muted != null)
+            return false;
+
+        if (model.tutorialStep != tutorialStep) return false;
+        if (model.hasClaimedName != hasClaimedName) return false;
+
+        return true;
+    }
 
     public string ComposeCorrectUrl(string url)
     {


### PR DESCRIPTION
## What does this PR change?

The profile updating event is only triggered when the profile equality check fails. This fixes:
- many pagination buttons over the names section in the passport
- many GET requests for lands and names while the passport is opened
- passport being reloaded for no reason

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/names-lands-repetitive-requests
2. Go to a crowded place (ideally 10+ users around)
3. Open the http requests tab in the developer console
4. The friends and names request should be triggered only once. Example: `/lambdas/nfts/names/:id` or `/lambdas/nfts/lands`
5. Let the user to change a wearable, name, anything in the profile. A request should be triggered again.
6. Go to the names section, the pagination "dots" should be displayed correctly
7. Open your backpack, start making changes in the wearables, check that you can apply all the changes
8. Open your profile menu, change your name, description, etc. Check that all changes are applied

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
