### PR TITLE
fix: Clicking on BUY on NFTs in the Profile does not open the right link

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/IPassportApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/IPassportApiBridge.cs
@@ -6,6 +6,8 @@ namespace DCL.Social.Passports
     public interface IPassportApiBridge
     {
         UniTask<List<Nft>> QueryNftCollectionsEthereum(string userId);
+        UniTask<Nft> QueryNftCollectionEthereum(string userId, string urn);
         UniTask<List<Nft>> QueryNftCollectionsMatic(string userId);
+        UniTask<Nft> QueryNftCollectionMatic(string userId, string urn);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/IPassportApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/IPassportApiBridge.cs
@@ -6,9 +6,7 @@ namespace DCL.Social.Passports
 {
     public interface IPassportApiBridge
     {
-        UniTask<List<Nft>> QueryNftCollectionsEthereumAsync(string userId, CancellationToken ct);
-        UniTask<Nft> QueryNftCollectionEthereumAsync(string userId, string urn, CancellationToken ct);
-        UniTask<List<Nft>> QueryNftCollectionsMaticAsync(string userId, CancellationToken ct);
-        UniTask<Nft> QueryNftCollectionMaticAsync(string userId, string urn, CancellationToken ct);
+        UniTask<List<Nft>> QueryNftCollectionsAsync(string userId, NftCollectionsLayer layer, CancellationToken ct);
+        UniTask<Nft> QueryNftCollectionAsync(string userId, string urn, NftCollectionsLayer layer, CancellationToken ct);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/IPassportApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/IPassportApiBridge.cs
@@ -1,13 +1,14 @@
 using Cysharp.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace DCL.Social.Passports
 {
     public interface IPassportApiBridge
     {
-        UniTask<List<Nft>> QueryNftCollectionsEthereum(string userId);
-        UniTask<Nft> QueryNftCollectionEthereum(string userId, string urn);
-        UniTask<List<Nft>> QueryNftCollectionsMatic(string userId);
-        UniTask<Nft> QueryNftCollectionMatic(string userId, string urn);
+        UniTask<List<Nft>> QueryNftCollectionsEthereumAsync(string userId, CancellationToken ct);
+        UniTask<Nft> QueryNftCollectionEthereumAsync(string userId, string urn, CancellationToken ct);
+        UniTask<List<Nft>> QueryNftCollectionsMaticAsync(string userId, CancellationToken ct);
+        UniTask<Nft> QueryNftCollectionMaticAsync(string userId, string urn, CancellationToken ct);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
@@ -161,18 +161,18 @@ namespace DCL.Social.Passports
             if (string.IsNullOrEmpty(userId))
                 return;
 
-            ownedNftCollectionsL1 = await passportApiBridge.QueryNftCollectionsEthereumAsync(userId, cts.Token);
-            ownedNftCollectionsL2 = await passportApiBridge.QueryNftCollectionsMaticAsync(userId, cts.Token);
+            ownedNftCollectionsL1 = await passportApiBridge.QueryNftCollectionsAsync(userId, NftCollectionsLayer.ETHEREUM, cts.Token);
+            ownedNftCollectionsL2 = await passportApiBridge.QueryNftCollectionsAsync(userId, NftCollectionsLayer.MATIC, cts.Token);
         }
 
         private void ClickedBuyNft(string id, string wearableType)
         {
             async UniTaskVoid QueryNftCollectionByUrnAsync(string urn)
             {
-                var nft = await passportApiBridge.QueryNftCollectionMaticAsync(currentUserProfile.userId, urn, cts.Token);
+                var nft = await passportApiBridge.QueryNftCollectionAsync(currentUserProfile.userId, urn, NftCollectionsLayer.MATIC, cts.Token);
 
                 if (nft == null)
-                    nft = await passportApiBridge.QueryNftCollectionEthereumAsync(currentUserProfile.userId, urn, cts.Token);
+                    nft = await passportApiBridge.QueryNftCollectionAsync(currentUserProfile.userId, urn, NftCollectionsLayer.ETHEREUM, cts.Token);
 
                 if (nft != null)
                     OpenNftMarketUrl(nft);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
@@ -3,6 +3,7 @@ using DCL.Interface;
 using SocialFeaturesAnalytics;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using UnityEngine;
 
 namespace DCL.Social.Passports
@@ -29,6 +30,7 @@ namespace DCL.Social.Passports
         private List<Nft> ownedNftCollectionsL1 = new ();
         private List<Nft> ownedNftCollectionsL2 = new ();
         private double passportOpenStartTime;
+        private CancellationTokenSource cts = new CancellationTokenSource();
 
         public PlayerPassportHUDController(
             IPlayerPassportHUDView view,
@@ -99,6 +101,10 @@ namespace DCL.Social.Passports
 
         public void Dispose()
         {
+            cts?.Cancel();
+            cts?.Dispose();
+            cts = null;
+
             closeWindowTrigger.OnTriggered -= OnCloseButtonPressed;
             currentPlayerId.OnChange -= OnCurrentPlayerIdChanged;
             playerInfoController.OnClosePassport -= ClosePassport;
@@ -161,6 +167,27 @@ namespace DCL.Social.Passports
 
         private void ClickedBuyNft(string id, string wearableType)
         {
+            async UniTaskVoid QueryNftCollectionByUrnAsync(string urn)
+            {
+                var ct = cts.Token;
+
+                var nft = await passportApiBridge
+                    .QueryNftCollectionMatic(currentUserProfile.userId, urn)
+                    .AttachExternalCancellation(ct);
+
+                if (nft == null)
+                {
+                    nft = await passportApiBridge
+                        .QueryNftCollectionEthereum(currentUserProfile.userId, urn)
+                        .AttachExternalCancellation(ct);
+                }
+
+                if (nft != null)
+                    OpenNftMarketUrl(nft);
+                else
+                    WebInterface.OpenURL(URL_COLLECTIBLE_GENERIC);
+            }
+
             if (wearableType is "name" or "parcel" or "estate")
             {
                 WebInterface.OpenURL((wearableType is "name" ? URL_COLLECTIBLE_NAME : URL_COLLECTIBLE_LAND).Replace("{userId}", id));
@@ -173,15 +200,24 @@ namespace DCL.Social.Passports
                 ownedCollectible = ownedNftCollectionsL2.FirstOrDefault(nft => nft.urn == id);
 
             if (ownedCollectible != null)
-            {
-                WebInterface.OpenURL(URL_BUY_SPECIFIC_COLLECTIBLE.Replace("{collectionId}", ownedCollectible.collectionId).Replace("{tokenId}", ownedCollectible.tokenId));
-                //TODO: integrate ItemType itemType once new lambdas are active
-                socialAnalytics.SendNftBuy(PlayerActionSource.Passport);
-            }
+                OpenNftMarketUrl(ownedCollectible);
             else
             {
-                WebInterface.OpenURL(URL_COLLECTIBLE_GENERIC);
+                cts?.Cancel();
+                cts?.Dispose();
+                cts = new CancellationTokenSource();
+
+                // In case the NFT's information is not found neither on ownedNftCollectionsL1 nor or ownedNftCollectionsL2 (it could happen due
+                // to the TheGraph queries only return a maximum of 100 entries by default), we request the information of this specific NFT.
+                QueryNftCollectionByUrnAsync(id).Forget();
             }
+        }
+
+        private void OpenNftMarketUrl(Nft nft)
+        {
+            WebInterface.OpenURL(URL_BUY_SPECIFIC_COLLECTIBLE.Replace("{collectionId}", nft.collectionId).Replace("{tokenId}", nft.tokenId));
+            //TODO: integrate ItemType itemType once new lambdas are active
+            socialAnalytics.SendNftBuy(PlayerActionSource.Passport);
         }
 
         private void ClickedCollectibles()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
@@ -161,26 +161,18 @@ namespace DCL.Social.Passports
             if (string.IsNullOrEmpty(userId))
                 return;
 
-            ownedNftCollectionsL1 = await passportApiBridge.QueryNftCollectionsEthereum(userId);
-            ownedNftCollectionsL2 = await passportApiBridge.QueryNftCollectionsMatic(userId);
+            ownedNftCollectionsL1 = await passportApiBridge.QueryNftCollectionsEthereumAsync(userId, cts.Token);
+            ownedNftCollectionsL2 = await passportApiBridge.QueryNftCollectionsMaticAsync(userId, cts.Token);
         }
 
         private void ClickedBuyNft(string id, string wearableType)
         {
             async UniTaskVoid QueryNftCollectionByUrnAsync(string urn)
             {
-                var ct = cts.Token;
-
-                var nft = await passportApiBridge
-                    .QueryNftCollectionMatic(currentUserProfile.userId, urn)
-                    .AttachExternalCancellation(ct);
+                var nft = await passportApiBridge.QueryNftCollectionMaticAsync(currentUserProfile.userId, urn, cts.Token);
 
                 if (nft == null)
-                {
-                    nft = await passportApiBridge
-                        .QueryNftCollectionEthereum(currentUserProfile.userId, urn)
-                        .AttachExternalCancellation(ct);
-                }
+                    nft = await passportApiBridge.QueryNftCollectionEthereumAsync(currentUserProfile.userId, urn, cts.Token);
 
                 if (nft != null)
                     OpenNftMarketUrl(nft);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/WebInterfacePassportApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/WebInterfacePassportApiBridge.cs
@@ -12,7 +12,7 @@ namespace DCl.Social.Passports
 
         public async UniTask<List<Nft>> QueryNftCollectionsEthereum(string userId)
         {
-            List<Nft> nftList = new List<Nft>();
+            List<Nft> nftList = null;
             await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, NftCollectionsLayer.ETHEREUM)
                      .Then((nfts) => nftList = nfts);
 
@@ -21,16 +21,16 @@ namespace DCl.Social.Passports
 
         public async UniTask<Nft> QueryNftCollectionEthereum(string userId, string urn)
         {
-            List<Nft> nftList = new List<Nft>();
+            List<Nft> nftList = null;
             await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.ETHEREUM)
                      .Then((nfts) => nftList = nfts);
 
-            return nftList.Count > 0 ? nftList[0] : null;
+            return nftList?.Count > 0 ? nftList[0] : null;
         }
 
         public async UniTask<List<Nft>> QueryNftCollectionsMatic(string userId)
         {
-            List<Nft> nftList = new List<Nft>();
+            List<Nft> nftList = null;
             await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, NftCollectionsLayer.MATIC)
                      .Then((nfts) => nftList = nfts);
 
@@ -39,11 +39,11 @@ namespace DCl.Social.Passports
 
         public async UniTask<Nft> QueryNftCollectionMatic(string userId, string urn)
         {
-            List<Nft> nftList = new List<Nft>();
+            List<Nft> nftList = null;
             await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.MATIC)
                      .Then((nfts) => nftList = nfts);
 
-            return nftList.Count > 0 ? nftList[0] : null;
+            return nftList?.Count > 0 ? nftList[0] : null;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/WebInterfacePassportApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/WebInterfacePassportApiBridge.cs
@@ -1,8 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.Social.Passports;
-using System;
 using System.Collections.Generic;
-using UnityEngine;
 
 namespace DCl.Social.Passports
 {
@@ -21,6 +19,15 @@ namespace DCl.Social.Passports
             return nftList;
         }
 
+        public async UniTask<Nft> QueryNftCollectionEthereum(string userId, string urn)
+        {
+            List<Nft> nftList = new List<Nft>();
+            await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.ETHEREUM)
+                     .Then((nfts) => nftList = nfts);
+
+            return nftList.Count > 0 ? nftList[0] : null;
+        }
+
         public async UniTask<List<Nft>> QueryNftCollectionsMatic(string userId)
         {
             List<Nft> nftList = new List<Nft>();
@@ -28,6 +35,15 @@ namespace DCl.Social.Passports
                      .Then((nfts) => nftList = nfts);
 
             return nftList;
+        }
+
+        public async UniTask<Nft> QueryNftCollectionMatic(string userId, string urn)
+        {
+            List<Nft> nftList = new List<Nft>();
+            await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.MATIC)
+                     .Then((nfts) => nftList = nfts);
+
+            return nftList.Count > 0 ? nftList[0] : null;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/WebInterfacePassportApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/WebInterfacePassportApiBridge.cs
@@ -13,14 +13,14 @@ namespace DCl.Social.Passports
 
         public WebInterfacePassportApiBridge() { }
 
-        public async UniTask<List<Nft>> QueryNftCollectionsEthereumAsync(string userId, CancellationToken ct)
+        public async UniTask<List<Nft>> QueryNftCollectionsAsync(string userId, NftCollectionsLayer layer, CancellationToken ct)
         {
             List<Nft> nftList = null;
             Promise<List<Nft>> promise = null;
 
             try
             {
-                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, NftCollectionsLayer.ETHEREUM)
+                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, layer)
                     .Then((nfts) => nftList = nfts);
 
                 await promise.WithCancellation(ct);
@@ -33,55 +33,15 @@ namespace DCl.Social.Passports
             return nftList;
         }
 
-        public async UniTask<Nft> QueryNftCollectionEthereumAsync(string userId, string urn, CancellationToken ct)
+        public async UniTask<Nft> QueryNftCollectionAsync(string userId, string urn, NftCollectionsLayer layer, CancellationToken ct)
         {
             List<Nft> nftList = null;
             Promise<List<Nft>> promise = null;
 
             try
             {
-                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.ETHEREUM)
+                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, layer)
                     .Then((nfts) => nftList = nfts);
-
-                await promise.WithCancellation(ct);
-            }
-            catch (OperationCanceledException e)
-            {
-                promise?.Reject("Canceled");
-            }
-
-            return nftList?.Count > 0 ? nftList[0] : null;
-        }
-
-        public async UniTask<List<Nft>> QueryNftCollectionsMaticAsync(string userId, CancellationToken ct)
-        {
-            List<Nft> nftList = null;
-            Promise<List<Nft>> promise = null;
-
-            try
-            {
-                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, NftCollectionsLayer.MATIC)
-                         .Then((nfts) => nftList = nfts);
-
-                await promise.WithCancellation(ct);
-            }
-            catch (OperationCanceledException e)
-            {
-                promise?.Reject("Canceled");
-            }
-
-            return nftList;
-        }
-
-        public async UniTask<Nft> QueryNftCollectionMaticAsync(string userId, string urn, CancellationToken ct)
-        {
-            List<Nft> nftList = null;
-            Promise<List<Nft>> promise = null;
-
-            try
-            {
-                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.MATIC)
-                         .Then((nfts) => nftList = nfts);
 
                 await promise.WithCancellation(ct);
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/WebInterfacePassportApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/WebInterfacePassportApiBridge.cs
@@ -1,6 +1,9 @@
 using Cysharp.Threading.Tasks;
+using DCL.Helpers;
 using DCL.Social.Passports;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace DCl.Social.Passports
 {
@@ -10,38 +13,82 @@ namespace DCl.Social.Passports
 
         public WebInterfacePassportApiBridge() { }
 
-        public async UniTask<List<Nft>> QueryNftCollectionsEthereum(string userId)
+        public async UniTask<List<Nft>> QueryNftCollectionsEthereumAsync(string userId, CancellationToken ct)
         {
             List<Nft> nftList = null;
-            await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, NftCollectionsLayer.ETHEREUM)
-                     .Then((nfts) => nftList = nfts);
+            Promise<List<Nft>> promise = null;
+
+            try
+            {
+                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, NftCollectionsLayer.ETHEREUM)
+                    .Then((nfts) => nftList = nfts);
+
+                await promise.WithCancellation(ct);
+            }
+            catch (OperationCanceledException e)
+            {
+                promise?.Reject("Canceled");
+            }
 
             return nftList;
         }
 
-        public async UniTask<Nft> QueryNftCollectionEthereum(string userId, string urn)
+        public async UniTask<Nft> QueryNftCollectionEthereumAsync(string userId, string urn, CancellationToken ct)
         {
             List<Nft> nftList = null;
-            await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.ETHEREUM)
-                     .Then((nfts) => nftList = nfts);
+            Promise<List<Nft>> promise = null;
+
+            try
+            {
+                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.ETHEREUM)
+                    .Then((nfts) => nftList = nfts);
+
+                await promise.WithCancellation(ct);
+            }
+            catch (OperationCanceledException e)
+            {
+                promise?.Reject("Canceled");
+            }
 
             return nftList?.Count > 0 ? nftList[0] : null;
         }
 
-        public async UniTask<List<Nft>> QueryNftCollectionsMatic(string userId)
+        public async UniTask<List<Nft>> QueryNftCollectionsMaticAsync(string userId, CancellationToken ct)
         {
             List<Nft> nftList = null;
-            await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, NftCollectionsLayer.MATIC)
-                     .Then((nfts) => nftList = nfts);
+            Promise<List<Nft>> promise = null;
+
+            try
+            {
+                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollections(userId, NftCollectionsLayer.MATIC)
+                         .Then((nfts) => nftList = nfts);
+
+                await promise.WithCancellation(ct);
+            }
+            catch (OperationCanceledException e)
+            {
+                promise?.Reject("Canceled");
+            }
 
             return nftList;
         }
 
-        public async UniTask<Nft> QueryNftCollectionMatic(string userId, string urn)
+        public async UniTask<Nft> QueryNftCollectionMaticAsync(string userId, string urn, CancellationToken ct)
         {
             List<Nft> nftList = null;
-            await DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.MATIC)
-                     .Then((nfts) => nftList = nfts);
+            Promise<List<Nft>> promise = null;
+
+            try
+            {
+                promise = DCL.Environment.i.platform.serviceProviders.theGraph.QueryNftCollectionsByUrn(userId, urn, NftCollectionsLayer.MATIC)
+                         .Then((nfts) => nftList = nfts);
+
+                await promise.WithCancellation(ct);
+            }
+            catch (OperationCanceledException e)
+            {
+                promise?.Reject("Canceled");
+            }
 
             return nftList?.Count > 0 ? nftList[0] : null;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/Interfaces/ITheGraph.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/Interfaces/ITheGraph.cs
@@ -15,5 +15,21 @@ public interface ITheGraph : IDisposable
     Promise<List<Land>> QueryLands(string network, string address);
     Promise<List<Land>> QueryLands(string network, string address, float cacheMaxAgeSeconds);
     Promise<double> QueryPolygonMana(string address);
+
+    /// <summary>
+    /// Get the list of NFTs owned by an user.
+    /// </summary>
+    /// <param name="address">User Id</param>
+    /// <param name="layer">ETHEREUM or MATIC</param>
+    /// <returns>A list of NFTs (limited to 100).</returns>
     Promise<List<Nft>> QueryNftCollections(string address, NftCollectionsLayer layer);
+
+    /// <summary>
+    /// Get the list of NFTs owned by an user and filtered by urn.
+    /// </summary>
+    /// <param name="address">User Id</param>
+    /// <param name="urn">NFT's urn</param>
+    /// <param name="layer">ETHEREUM or MATIC</param>
+    /// <returns>A list of NFTs (limited to 100).</returns>
+    Promise<List<Nft>> QueryNftCollectionsByUrn(string address, string urn, NftCollectionsLayer layer);
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/Interfaces/VariablesTypes.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/Interfaces/VariablesTypes.cs
@@ -8,3 +8,10 @@ public class AddressVariable : QueryVariablesBase
 {
     public string address;
 }
+
+[Serializable]
+public class AddressAndUrnVariable : QueryVariablesBase
+{
+    public string address;
+    public string urn;
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraph.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraph.cs
@@ -124,16 +124,7 @@ public class TheGraph : ITheGraph
     {
         Promise<List<Nft>> promise = new Promise<List<Nft>>();
 
-        string url = "";
-        switch (layer)
-        {
-            case NftCollectionsLayer.ETHEREUM:
-                url = NFT_COLLECTIONS_SUBGRAPH_URL_ETHEREUM;
-                break;
-            case NftCollectionsLayer.MATIC:
-                url = NFT_COLLECTIONS_SUBGRAPH_URL_MATIC;
-                break;
-        }
+        string url = GetSubGraphUrl(layer);
 
         Query(url, TheGraphQueries.getNftCollectionsQuery, new AddressVariable() { address = address.ToLower() })
             .Then(resultJson =>
@@ -145,7 +136,39 @@ public class TheGraph : ITheGraph
         return promise;
     }
 
+    public Promise<List<Nft>> QueryNftCollectionsByUrn(string address, string urn, NftCollectionsLayer layer)
+    {
+        Promise<List<Nft>> promise = new Promise<List<Nft>>();
+
+        string url = GetSubGraphUrl(layer);
+
+        Query(url, TheGraphQueries.getNftCollectionByUserAndUrnQuery, new AddressAndUrnVariable() { address = address.ToLower(), urn = urn.ToLower() })
+            .Then(resultJson =>
+            {
+                ProcessReceivedNftData(promise, resultJson);
+            })
+            .Catch(error => promise.Reject(error));
+
+        return promise;
+    }
+
     public void Dispose() { landQueryCache.Dispose(); }
+
+    private string GetSubGraphUrl(NftCollectionsLayer layer)
+    {
+        string url = "";
+        switch (layer)
+        {
+            case NftCollectionsLayer.ETHEREUM:
+                url = NFT_COLLECTIONS_SUBGRAPH_URL_ETHEREUM;
+                break;
+            case NftCollectionsLayer.MATIC:
+                url = NFT_COLLECTIONS_SUBGRAPH_URL_MATIC;
+                break;
+        }
+
+        return url;
+    }
 
     private void ProcessReceivedLandsData(Promise<List<Land>> landPromise, string jsonValue, string lowerCaseAddress, bool cache)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraphQueries.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraphQueries.cs
@@ -85,4 +85,16 @@ public static class TheGraphQueries
         }
     }
 ";
+
+    public static readonly string getNftCollectionByUserAndUrnQuery = @"
+    query WearablesCollectionsByUrn($address: ID, $urn: ID){
+        nfts(where: { owner: $address, urn: $urn}) {
+            urn,
+            collection {
+                id
+            }
+            tokenId
+        }
+    }
+";
 }


### PR DESCRIPTION
## What does this PR change?
Fixes #3991

When we clicked on the BUY button of some NFTs inside the Profile, it sometimes takes us to the Marketplace front page instead of the specific item.

### Problem
- In order to get the necessary information to build the marketplace's url for an NFT (basically we need the collectionId + the tokenId of the NFT), when the passport opens, we send a query to TheGraph (to both networks ETHEREUM and POLYGON) to obtain the list of owned NFTs belonging to the user that we're loading in the passport. As result we always have these 2 pre-loaded lists with the TheGraph information: `ownedNftCollectionsL1`  and `ownedNftCollectionsL2`.
- When we click on the BUY button of any NFT item loaded in the passport, we try to find that NFT in the pre-loaded lists mentioned above. If we find it, we get the the collectionId + the tokenId from there and we build the url to redirect to the correct page in the marketplace.
- The problem is that these pre-loaded lists only can have a maximum of 100 entries because the queries to TheGraph have this maximum as default, so we can find cases where an user can own more than 100 NFTs and if we click on the BUY button of one of them and it is not found in none of the pre-loaded lists, we cannot build the correct url because we don't have the collectionId + the tokenId. In these cases we are redirectioning to the landing page of the marketplace.

### Solution
In the cases where we click on the BUY button of a NFT whose information we do not have in the pre-loaded TheGraph lists, we will send another query to TheGraph to obtain the information of that specific NFT and to be able to build the correct marketplace's url.

### Important
In the future, when we use the new lambdas to obtain the wearables/emotes info (as we are already doing with the names/lands information), we will be able to obtain the collectionId + the tokenId directly in our `WearableItem` model, in the same request, and we won't have to use a paralel request to TheGraph to obtain extra information of the NFTs.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/buy-in-profile-does-not-open-the-right-link
2. Open the passport for several users.
3. Check that the BUY buttons of all wearable and emote items redirect to the correct marketplace url.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md