### PR TITLE
Fix decoupled loading screen enabled when the AB test is off

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/LoadingScreenPlugin/LoadingScreenPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/LoadingScreenPlugin/LoadingScreenPlugin.cs
@@ -13,6 +13,7 @@ namespace DCLPlugins.LoadingScreenPlugin
 
         public LoadingScreenPlugin()
         {
+            dataStoreLoadingScreen.Ref.decoupledLoadingHUD.visible.Set(true);
             loadingScreenController = new LoadingScreenController(LoadingScreenView.Create(), Environment.i.world.sceneController, Environment.i.world.state, NotificationsController.i,DataStore.i.player,
                 DataStore.i.common, dataStoreLoadingScreen.Ref, DataStore.i.realm);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_LoadingScreen.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_LoadingScreen.cs
@@ -18,6 +18,6 @@ public class DataStore_LoadingScreen
 
     public class DecoupledLoadingScreen
     {
-        public readonly BaseVariable<bool> visible = new (true);
+        public readonly BaseVariable<bool> visible = new (false);
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fix dataStoreLoadingScreen.visible when the AB-test is disabled
...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?renderer-branch={branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
