### PR TITLE
fix: settings should not be cleared when user logs out

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUD.asmdef
@@ -30,7 +30,8 @@
         "GUID:320f1c61ad4373b4f9ffa3075e1f3d48",
         "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
         "GUID:bb3eef89092f71f44aa2449a9cf7879c",
-        "GUID:81f3218b29e049144b175dad2ebbac1b"
+        "GUID:81f3218b29e049144b175dad2ebbac1b",
+        "GUID:301149363e31a4bdaa1943465a825c8e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDController.cs
@@ -56,12 +56,8 @@ public class ProfileHUDController : IHUD
         view.SetDescriptionIsEditing(false);
 
         view.LogedOutPressed += OnLoggedOut;
-
-        // (object sender, EventArgs args) => WebInterface.LogOut();
-
         view.SignedUpPressed += OnSignedUp;
 
-        // (object sender, EventArgs args) => WebInterface.RedirectToSignUp();
         view.ClaimNamePressed += (object sender, EventArgs args) => WebInterface.OpenURL(URL_CLAIM_NAME);
 
         view.Opened += (object sender, EventArgs args) =>
@@ -143,6 +139,9 @@ public class ProfileHUDController : IHUD
 
     public void Dispose()
     {
+        view.LogedOutPressed -= OnLoggedOut;
+        view.SignedUpPressed -= OnSignedUp;
+
         if (fetchManaIntervalRoutine != null)
         {
             CoroutineStarter.Stop(fetchManaIntervalRoutine);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDController.cs
@@ -38,9 +38,7 @@ public class ProfileHUDController : IHUD
 
     private Regex nameRegex = null;
 
-
     public RectTransform TutorialTooltipReference => view.TutorialReference;
-
 
     public ProfileHUDController(IUserProfileBridge userProfileBridge)
     {
@@ -57,8 +55,13 @@ public class ProfileHUDController : IHUD
         view.SetNonWalletSectionEnabled(false);
         view.SetDescriptionIsEditing(false);
 
-        view.LogedOutPressed += (object sender, EventArgs args) => WebInterface.LogOut();
-        view.SignedUpPressed += (object sender, EventArgs args) => WebInterface.RedirectToSignUp();
+        view.LogedOutPressed += OnLoggedOut;
+
+        // (object sender, EventArgs args) => WebInterface.LogOut();
+
+        view.SignedUpPressed += OnSignedUp;
+
+        // (object sender, EventArgs args) => WebInterface.RedirectToSignUp();
         view.ClaimNamePressed += (object sender, EventArgs args) => WebInterface.OpenURL(URL_CLAIM_NAME);
 
         view.Opened += (object sender, EventArgs args) =>
@@ -66,6 +69,7 @@ public class ProfileHUDController : IHUD
             WebInterface.RequestOwnProfileUpdate();
             OnOpen?.Invoke();
         };
+
         view.Closed += (object sender, EventArgs args) => OnClose?.Invoke();
         view.NameSubmitted += (object sender, string name) => UpdateProfileName(name);
         view.DescriptionSubmitted += (object sender, string description) => UpdateProfileDescription(description);
@@ -91,17 +95,32 @@ public class ProfileHUDController : IHUD
         ExploreV2Changed(DataStore.i.exploreV2.isInitialized.Get(), false);
     }
 
+    private void OnSignedUp(object sender, EventArgs e)
+    {
+        DCL.SettingsCommon.Settings.i.SaveSettings();
+        WebInterface.RedirectToSignUp();
+    }
+
+    private void OnLoggedOut(object sender, EventArgs e)
+    {
+        DCL.SettingsCommon.Settings.i.SaveSettings();
+        WebInterface.LogOut();
+    }
+
     private void SetProfileCardExtended(bool isOpenCurrent, bool previous)
     {
         OnOpen?.Invoke();
         view.ShowExpanded(isOpenCurrent);
     }
 
-    public void ChangeVisibilityForBuilderInWorld(bool current, bool previus) => view.GameObject.SetActive(current);
+    public void ChangeVisibilityForBuilderInWorld(bool current, bool previus) =>
+        view.GameObject.SetActive(current);
 
-    public void SetManaBalance(string balance) => view?.SetManaBalance(balance);
+    public void SetManaBalance(string balance) =>
+        view?.SetManaBalance(balance);
 
-    public void SetPolygonManaBalance(double balance) => view?.SetPolygonBalance(balance);
+    public void SetPolygonManaBalance(double balance) =>
+        view?.SetPolygonBalance(balance);
 
     public void SetVisibility(bool visible)
     {
@@ -142,16 +161,16 @@ public class ProfileHUDController : IHUD
         DataStore.i.exploreV2.isInitialized.OnChange -= ExploreV2Changed;
     }
 
-
     protected virtual GameObject GetViewPrefab()
     {
         return Resources.Load<GameObject>(DataStore.i.HUDs.enableNewPassport.Get() ? "ProfileHUD_V2" : "ProfileHUD");
     }
 
+    private void OnProfileUpdated(UserProfile profile) =>
+        view?.SetProfile(profile);
 
-    private void OnProfileUpdated(UserProfile profile) => view?.SetProfile(profile);
-
-    private void ExploreV2Changed(bool current, bool previous) => view.SetStartMenuButtonActive(current);
+    private void ExploreV2Changed(bool current, bool previous) =>
+        view.SetStartMenuButtonActive(current);
 
     private void OnKernelConfigChanged(KernelConfigModel current, KernelConfigModel previous) =>
         nameRegex = new Regex(current.profiles.nameValidRegex);
@@ -176,7 +195,6 @@ public class ProfileHUDController : IHUD
     {
         view.ShowProfileIcon(!currentIsFullScreenMenuMode);
     }
-
 
     private IEnumerator ManaIntervalRoutine()
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -41,6 +41,7 @@ namespace DCL
                 InitializeSceneDependencies();
 
             Settings.CreateSharedInstance(new DefaultSettingsFactory());
+
             // TODO: migrate chat controller singleton into a service in the service locator
             ChatController.CreateSharedInstance(GetComponent<WebInterfaceChatBridge>(), DataStore.i);
 
@@ -51,11 +52,11 @@ namespace DCL
 
                 dataStoreLoadingScreen.Ref.loadingHUD.visible.OnChange += OnLoadingScreenVisibleStateChange;
                 dataStoreLoadingScreen.Ref.decoupledLoadingHUD.visible.OnChange += OnLoadingScreenVisibleStateChange;
-
             }
 
             // TODO (NEW FRIEND REQUESTS): remove when the kernel bridge is production ready
             WebInterfaceFriendsApiBridge webInterfaceFriendsApiBridge = GetComponent<WebInterfaceFriendsApiBridge>();
+
             FriendsController.CreateSharedInstance(new WebInterfaceFriendsApiBridgeProxy(
                 webInterfaceFriendsApiBridge,
                 RPCFriendsApiBridge.CreateSharedInstance(Environment.i.serviceLocator.Get<IRPC>(), webInterfaceFriendsApiBridge),
@@ -84,12 +85,10 @@ namespace DCL
 
             kernelCommunication = new NativeBridgeCommunication(Environment.i.world.sceneController);
 #else
+
             // TODO(Brian): Remove this branching once we finish migrating all tests out of the
             //              IntegrationTestSuite_Legacy base class.
-            if (!EnvironmentSettings.RUNNING_TESTS)
-            {
-                kernelCommunication = new WebSocketCommunication(DebugConfigComponent.i.webSocketSSL);
-            }
+            if (!EnvironmentSettings.RUNNING_TESTS) { kernelCommunication = new WebSocketCommunication(DebugConfigComponent.i.webSocketSSL); }
 #endif
         }
 
@@ -137,6 +136,7 @@ namespace DCL
         {
             Application.wantsToQuit += ApplicationWantsToQuit;
         }
+
         private static bool ApplicationWantsToQuit()
         {
             if (i != null)
@@ -150,8 +150,8 @@ namespace DCL
             dataStoreLoadingScreen.Ref.loadingHUD.visible.OnChange -= OnLoadingScreenVisibleStateChange;
             dataStoreLoadingScreen.Ref.decoupledLoadingHUD.visible.OnChange -= OnLoadingScreenVisibleStateChange;
 
-
             DataStore.i.common.isApplicationQuitting.Set(true);
+            Settings.i.SaveSettings();
 
             pluginSystem?.Dispose();
 
@@ -186,6 +186,7 @@ namespace DCL
             MainSceneFactory.CreateEventSystem();
         }
 
-        protected virtual void CreateEnvironment() => MainSceneFactory.CreateEnvironment();
+        protected virtual void CreateEnvironment() =>
+            MainSceneFactory.CreateEnvironment();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
@@ -17,9 +17,7 @@ namespace DCL.SettingsCommon
         public const string INVERT_Y_AXIS = "InvertYAxis";
         public const string SKYBOX_TIME = "skyboxTime";
         public const string FIRST_PERSON_CAMERA_FOV = "firstPersonCameraFOV";
-
         public const string SHOW_AVATAR_NAMES = "showAvatarNames";
-        public const string HIDE_UI = "hideUI";
         public const string CAMERA_MOVEMENT_MODE = "cameraMovementMode";
 
         private readonly IPlayerPrefsSettingsByKey settingsByKey;
@@ -61,7 +59,6 @@ namespace DCL.SettingsCommon
             settingsByKey.SetBool(INVERT_Y_AXIS, currentSettings.invertYAxis);
             settingsByKey.SetFloat(SKYBOX_TIME, currentSettings.skyboxTime);
             settingsByKey.SetFloat(FIRST_PERSON_CAMERA_FOV, currentSettings.firstPersonCameraFOV);
-            settingsByKey.SetBool(HIDE_UI, currentSettings.hideUI);
             settingsByKey.SetBool(SHOW_AVATAR_NAMES, currentSettings.showAvatarNames);
             settingsByKey.SetBool(CAMERA_MOVEMENT_MODE, currentSettings.leftMouseButtonCursorLock);
         }
@@ -87,7 +84,6 @@ namespace DCL.SettingsCommon
                 settings.invertYAxis = settingsByKey.GetBool(INVERT_Y_AXIS, defaultSettings.invertYAxis);
                 settings.skyboxTime = settingsByKey.GetFloat(SKYBOX_TIME, defaultSettings.skyboxTime);
                 settings.firstPersonCameraFOV = settingsByKey.GetFloat(FIRST_PERSON_CAMERA_FOV, defaultSettings.firstPersonCameraFOV);
-                settings.hideUI = settingsByKey.GetBool(HIDE_UI, defaultSettings.hideUI);
                 settings.showAvatarNames = settingsByKey.GetBool(SHOW_AVATAR_NAMES, defaultSettings.showAvatarNames);
                 settings.leftMouseButtonCursorLock = settingsByKey.GetBool(CAMERA_MOVEMENT_MODE, defaultSettings.leftMouseButtonCursorLock);
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/PlayerPrefsGeneralSettingsRepository.cs
@@ -18,15 +18,17 @@ namespace DCL.SettingsCommon
         public const string SKYBOX_TIME = "skyboxTime";
         public const string FIRST_PERSON_CAMERA_FOV = "firstPersonCameraFOV";
 
+        public const string SHOW_AVATAR_NAMES = "showAvatarNames";
+        public const string HIDE_UI = "hideUI";
+        public const string CAMERA_MOVEMENT_MODE = "cameraMovementMode";
+
         private readonly IPlayerPrefsSettingsByKey settingsByKey;
         private readonly GeneralSettings defaultSettings;
         private GeneralSettings currentSettings;
 
         public event Action<GeneralSettings> OnChanged;
 
-        public PlayerPrefsGeneralSettingsRepository(
-            IPlayerPrefsSettingsByKey settingsByKey,
-            GeneralSettings defaultSettings)
+        public PlayerPrefsGeneralSettingsRepository(IPlayerPrefsSettingsByKey settingsByKey, GeneralSettings defaultSettings)
         {
             this.settingsByKey = settingsByKey;
             this.defaultSettings = defaultSettings;
@@ -59,6 +61,9 @@ namespace DCL.SettingsCommon
             settingsByKey.SetBool(INVERT_Y_AXIS, currentSettings.invertYAxis);
             settingsByKey.SetFloat(SKYBOX_TIME, currentSettings.skyboxTime);
             settingsByKey.SetFloat(FIRST_PERSON_CAMERA_FOV, currentSettings.firstPersonCameraFOV);
+            settingsByKey.SetBool(HIDE_UI, currentSettings.hideUI);
+            settingsByKey.SetBool(SHOW_AVATAR_NAMES, currentSettings.showAvatarNames);
+            settingsByKey.SetBool(CAMERA_MOVEMENT_MODE, currentSettings.leftMouseButtonCursorLock);
         }
 
         public bool HasAnyData() => !Data.Equals(defaultSettings);
@@ -82,6 +87,9 @@ namespace DCL.SettingsCommon
                 settings.invertYAxis = settingsByKey.GetBool(INVERT_Y_AXIS, defaultSettings.invertYAxis);
                 settings.skyboxTime = settingsByKey.GetFloat(SKYBOX_TIME, defaultSettings.skyboxTime);
                 settings.firstPersonCameraFOV = settingsByKey.GetFloat(FIRST_PERSON_CAMERA_FOV, defaultSettings.firstPersonCameraFOV);
+                settings.hideUI = settingsByKey.GetBool(HIDE_UI, defaultSettings.hideUI);
+                settings.showAvatarNames = settingsByKey.GetBool(SHOW_AVATAR_NAMES, defaultSettings.showAvatarNames);
+                settings.leftMouseButtonCursorLock = settingsByKey.GetBool(CAMERA_MOVEMENT_MODE, defaultSettings.leftMouseButtonCursorLock);
             }
             catch (Exception e)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/HideUIControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/HideUIControlController.cs
@@ -9,27 +9,24 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
         public override void Initialize()
         {
             base.Initialize();
-
             CommonScriptableObjects.allUIHidden.OnChange += AllUIHiddenChanged;
-            AllUIHiddenChanged(CommonScriptableObjects.allUIHidden.Get(), false);
-        }
 
-        public override object GetStoredValue() { return currentGeneralSettings.hideUI; }
-
-        public override void UpdateSetting(object newValue)
-        {
-            currentGeneralSettings.hideUI = (bool)newValue;
-            CommonScriptableObjects.allUIHidden.Set(currentGeneralSettings.hideUI);
+            AllUIHiddenChanged(currentGeneralSettings.hideUI);
         }
 
         public override void OnDestroy()
         {
             base.OnDestroy();
-
             CommonScriptableObjects.allUIHidden.OnChange -= AllUIHiddenChanged;
         }
 
-        private void AllUIHiddenChanged(bool current, bool previous)
+        public override object GetStoredValue() =>
+            currentGeneralSettings.hideUI;
+
+        public override void UpdateSetting(object newValue) =>
+            CommonScriptableObjects.allUIHidden.Set((bool)newValue);
+
+        private void AllUIHiddenChanged(bool current, bool _ = false)
         {
             currentGeneralSettings.hideUI = current;
             ApplySettings();

--- a/unity-renderer/unity-renderer.sln.DotSettings
+++ b/unity-renderer/unity-renderer.sln.DotSettings
@@ -155,9 +155,12 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=test/@EntryIndexRemoved">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">Built-in: Reformat &amp; Apply Syntax Style</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">Reformat Code DCL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SFX/@EntryIndexedValue">SFX</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UISFX/@EntryIndexedValue">UISFX</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Decentraland/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Interactibility/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Navmap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=onboarding/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reloader/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reloader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=UISFX/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
 	


### PR DESCRIPTION
## What does this PR change?
Closes #3999 

### Problem 1
Settings were saved only when closing the UI. So it wasn't saved in case if user pressed sign-in (Guest) or log-out (Wallet) button before closing settings UI.

**Solution:**
- Since I didn't found any exit-point for the WebGL application to put the saving logic there, I directly subscribed to the SingIn and LogOut events to solve just this particular cases - it is inside `ProfileHUDController.cs` constructor and `Dispose` methods.
- I also added `Settings.Save(`) to `Main.ApplicationWantsToQuit()`, method, but it will work only in Standalone client.


### Problem 2
 `HideUI`, `ShowAvatarNames` and `CameraControl` userSettings were not saved in any scenario.

**Solution:** added respective logic in `PlayerPrefsGeneralSettingsRepository` and adjusted `HideUIControlController`

## How to test the changes?

### WALLET scenario
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/save-user-setttings-on-logout
2. Load into the platform with a wallet.
3. Open the Settings menu ('P').
4. Change any of the settings.
5. Log out using the "Logout" button on the avatar's menu (top right), before closing the UI
6. Log into the platform again with the same wallet
7. Access the Settings menu
8. See settings being saved

### GUEST scenario
same as previous, but in step 5 press "Sing-in" button instead.

### Alternative journeys to test: 
- Wallet, then Guest; 
- Guest, then Wallet; 
Note: settings are shared between Wallets and Guests on the same PC.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
