### PR TITLE
fix: chat not opening from notification when the friend was not previously loaded

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUD.asmdef
@@ -49,7 +49,8 @@
         "GUID:86283d9d82e051a498e66b0305d327b1",
         "GUID:d7ed7add69e3b49179bf6bb5e5336dd1",
         "GUID:bb3eef89092f71f44aa2449a9cf7879c",
-        "GUID:3c7b57a14671040bd8c549056adc04f5"
+        "GUID:3c7b57a14671040bd8c549056adc04f5",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?

Fixes clicking on chat notifications not opening the chat window with that user.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=fix/open-dm-from-noti
2. Take two friend users, both in different locations in the world, far away from each other
3. Do not open any friends window with user A
4. Write a private message from user B to user A
5. User A should receive a DM notification
6. Click the notification
7. The chat window should be opened as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
