### PR TITLE
fix: sdk7 exception while removing parent entity

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -99,6 +99,7 @@ namespace DCL.ECSComponents
                 {
                     parent.childrenId.Remove(entity.entityId);
                 }
+                ECSTransformUtils.TrySetParent(scene, entity, SpecialEntityId.SCENE_ROOT_ENTITY);
             }
 
             entity.parentId = parentId;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformParentingSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Tests/ECSTransformParentingSystemShould.cs
@@ -65,5 +65,24 @@ namespace Tests
             Assert.IsFalse(ECSTransformUtils.orphanEntities.ContainsKey(entity));
             Assert.AreEqual(scene.GetSceneTransform(), entity.gameObject.transform.parent);
         }
+
+        [Test]
+        public void RemoveEntityWithChildren()
+        {
+            var childEntity = scene.CreateEntity(43);
+
+            handler.OnComponentCreated(scene, entity);
+            handler.OnComponentCreated(scene, childEntity);
+
+            handler.OnComponentModelUpdated(scene, entity, new ECSTransform());
+            handler.OnComponentModelUpdated(scene, childEntity, new ECSTransform() { parentId = entity.entityId });
+
+            ECSTransformParentingSystem.Update();
+
+            handler.OnComponentModelUpdated(scene, childEntity, new ECSTransform() { parentId = 0 });
+            handler.OnComponentRemoved(scene, entity);
+            scene.RemoveEntity(entity.entityId, true);
+            ECSTransformParentingSystem.Update();
+        }
     }
 }


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/520
removing a parent entity while setting it child's `parent` property was raising an exception due to child transform was still child of the removed entity transform 