### PR TITLE
fix: Offline friends sometimes don't load

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
@@ -14,7 +14,6 @@ namespace DCL.Social.Friends
         private readonly Dictionary<string, FriendRequest> friendRequests = new ();
         private readonly Dictionary<string, UserStatus> friends = new ();
 
-        public event Action<int> OnTotalFriendsUpdated;
         public int AllocatedFriendCount => friends.Count(f => f.Value.friendshipStatus == FriendshipStatus.FRIEND);
         public bool IsInitialized { get; private set; }
 
@@ -45,7 +44,6 @@ namespace DCL.Social.Friends
             this.apiBridge = apiBridge;
             apiBridge.OnInitialized += Initialize;
             apiBridge.OnFriendNotFound += FriendNotFound;
-            apiBridge.OnFriendsAdded += AddFriends;
             apiBridge.OnFriendWithDirectMessagesAdded += AddFriendsWithDirectMessages;
             apiBridge.OnUserPresenceUpdated += UpdateUserPresence;
             apiBridge.OnFriendshipStatusUpdated += HandleUpdateFriendshipStatus;
@@ -146,11 +144,23 @@ namespace DCL.Social.Friends
         public void RemoveFriend(string friendId) =>
             apiBridge.RemoveFriend(friendId);
 
-        public void GetFriends(int limit, int skip) =>
-            apiBridge.GetFriends(limit, skip);
+        public async UniTask<string[]> GetFriendsAsync(int limit, int skip)
+        {
+            var payload = await apiBridge.GetFriendsAsync(limit, skip);
+            TotalFriendCount = payload.totalFriends;
+            AddFriends(payload.friends);
 
-        public void GetFriends(string usernameOrId, int limit) =>
-            apiBridge.GetFriends(usernameOrId, limit);
+            return payload.friends;
+        }
+
+        public async UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit)
+        {
+            var payload= await apiBridge.GetFriendsAsync(usernameOrId, limit);
+            TotalFriendCount = payload.totalFriends;
+            AddFriends(payload.friends);
+
+            return payload.friends;
+        }
 
         // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version
         public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) =>
@@ -281,17 +291,17 @@ namespace DCL.Social.Friends
         private void FriendNotFound(string name) =>
             OnFriendNotFound?.Invoke(name);
 
-        private void AddFriends(AddFriendsPayload msg)
-        {
-            TotalFriendCount = msg.totalFriends;
-            OnTotalFriendsUpdated?.Invoke(TotalFriendCount);
-            AddFriends(msg.friends);
-        }
-
         private void AddFriendsWithDirectMessages(AddFriendsWithDirectMessagesPayload friendsWithDMs)
         {
             TotalFriendsWithDirectMessagesCount = friendsWithDMs.totalFriendsWithDirectMessages;
-            AddFriends(friendsWithDMs.currentFriendsWithDirectMessages.Select(messages => messages.userId));
+
+            var friendIds = friendsWithDMs.currentFriendsWithDirectMessages.Select(messages => messages.userId);
+            foreach (var friendId in friendIds)
+            {
+                UpdateFriendshipStatus(new FriendshipUpdateStatusMessage
+                { action = FriendshipAction.APPROVED, userId = friendId });
+            }
+
             OnAddFriendsWithDirectMessages?.Invoke(friendsWithDMs.currentFriendsWithDirectMessages.ToList());
         }
 
@@ -314,7 +324,6 @@ namespace DCL.Social.Friends
         private void UpdateTotalFriends(UpdateTotalFriendsPayload msg)
         {
             TotalFriendCount = msg.totalFriends;
-            OnTotalFriendsUpdated?.Invoke(TotalFriendCount);
         }
 
         private void UpdateUserStatus(UserStatus newUserStatus)
@@ -406,8 +415,10 @@ namespace DCL.Social.Friends
         {
             foreach (var friendId in friendIds)
             {
-                UpdateFriendshipStatus(new FriendshipUpdateStatusMessage
-                    { action = FriendshipAction.APPROVED, userId = friendId });
+                if (!friends.ContainsKey(friendId))
+                    friends.Add(friendId, new UserStatus { userId = friendId });
+
+                friends[friendId].friendshipStatus = ToFriendshipStatus(FriendshipAction.APPROVED);
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
@@ -3,6 +3,7 @@ using DCl.Social.Friends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace DCL.Social.Friends
 {
@@ -144,18 +145,18 @@ namespace DCL.Social.Friends
         public void RemoveFriend(string friendId) =>
             apiBridge.RemoveFriend(friendId);
 
-        public async UniTask<string[]> GetFriendsAsync(int limit, int skip)
+        public async UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken ct)
         {
-            var payload = await apiBridge.GetFriendsAsync(limit, skip);
+            var payload = await apiBridge.GetFriendsAsync(limit, skip, ct);
             TotalFriendCount = payload.totalFriends;
             AddFriends(payload.friends);
 
             return payload.friends;
         }
 
-        public async UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit)
+        public async UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct)
         {
-            var payload= await apiBridge.GetFriendsAsync(usernameOrId, limit);
+            var payload= await apiBridge.GetFriendsAsync(usernameOrId, limit, ct);
             TotalFriendCount = payload.totalFriends;
             AddFriends(payload.friends);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/FriendsController.cs
@@ -145,18 +145,22 @@ namespace DCL.Social.Friends
         public void RemoveFriend(string friendId) =>
             apiBridge.RemoveFriend(friendId);
 
-        public async UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken ct)
+        public async UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken cancellationToken = default)
         {
-            var payload = await apiBridge.GetFriendsAsync(limit, skip, ct);
+            var payload = await apiBridge.GetFriendsAsync(limit, skip, cancellationToken);
+            await UniTask.SwitchToMainThread();
+
             TotalFriendCount = payload.totalFriends;
             AddFriends(payload.friends);
 
             return payload.friends;
         }
 
-        public async UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct)
+        public async UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken cancellationToken = default)
         {
-            var payload= await apiBridge.GetFriendsAsync(usernameOrId, limit, ct);
+            var payload = await apiBridge.GetFriendsAsync(usernameOrId, limit, cancellationToken);
+            await UniTask.SwitchToMainThread();
+
             TotalFriendCount = payload.totalFriends;
             AddFriends(payload.friends);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsApiBridge.cs
@@ -8,7 +8,6 @@ namespace DCl.Social.Friends
     {
         event Action<FriendshipInitializationMessage> OnInitialized;
         event Action<string> OnFriendNotFound;
-        event Action<AddFriendsPayload> OnFriendsAdded;
         [Obsolete("Old API. Use GetFriendRequestsAsync instead")]
         event Action<AddFriendRequestsPayload> OnFriendRequestsAdded;
         event Action<AddFriendsWithDirectMessagesPayload> OnFriendWithDirectMessagesAdded;
@@ -22,8 +21,8 @@ namespace DCl.Social.Friends
         void RejectFriendship(string userId);
         UniTask<RejectFriendshipPayload> RejectFriendshipAsync(string friendRequestId);
         void RemoveFriend(string userId);
-        void GetFriends(int limit, int skip);
-        void GetFriends(string usernameOrId, int limit);
+        UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip);
+        UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit);
         [Obsolete("Old API. Use GetFriendRequestsV2(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) instead")]
         void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip); // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version
         UniTask<AddFriendRequestsV2Payload> GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsApiBridge.cs
@@ -22,8 +22,8 @@ namespace DCl.Social.Friends
         void RejectFriendship(string userId);
         UniTask<RejectFriendshipPayload> RejectFriendshipAsync(string friendRequestId);
         void RemoveFriend(string userId);
-        UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken ct);
-        UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct);
+        UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken cancellationToken = default);
+        UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken cancellationToken = default);
         [Obsolete("Old API. Use GetFriendRequestsV2(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) instead")]
         void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip); // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version
         UniTask<AddFriendRequestsV2Payload> GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsApiBridge.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.Social.Friends;
 using System;
+using System.Threading;
 
 namespace DCl.Social.Friends
 {
@@ -21,8 +22,8 @@ namespace DCl.Social.Friends
         void RejectFriendship(string userId);
         UniTask<RejectFriendshipPayload> RejectFriendshipAsync(string friendRequestId);
         void RemoveFriend(string userId);
-        UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip);
-        UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit);
+        UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken ct);
+        UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct);
         [Obsolete("Old API. Use GetFriendRequestsV2(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) instead")]
         void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip); // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version
         UniTask<AddFriendRequestsV2Payload> GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsController.cs
@@ -45,8 +45,8 @@ namespace DCL.Social.Friends
         UniTask<SocialFriendRequest> RejectFriendshipAsync(string friendRequestId);
         bool IsFriend(string userId);
         void RemoveFriend(string friendId);
-        UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken ct);
-        UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct);
+        UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken cancellationToken = default);
+        UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken cancellationToken = default);
         [Obsolete("Old API. Use GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) instead")]
         void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip); // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version
         UniTask<List<SocialFriendRequest>> GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsController.cs
@@ -2,6 +2,7 @@ using Cysharp.Threading.Tasks;
 using DCl.Social.Friends;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using SocialFriendRequest = DCL.Social.Friends.FriendRequest;
 
 namespace DCL.Social.Friends
@@ -44,8 +45,8 @@ namespace DCL.Social.Friends
         UniTask<SocialFriendRequest> RejectFriendshipAsync(string friendRequestId);
         bool IsFriend(string userId);
         void RemoveFriend(string friendId);
-        UniTask<string[]> GetFriendsAsync(int limit, int skip);
-        UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit);
+        UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken ct);
+        UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct);
         [Obsolete("Old API. Use GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) instead")]
         void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip); // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version
         UniTask<List<SocialFriendRequest>> GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/IFriendsController.cs
@@ -14,7 +14,6 @@ namespace DCL.Social.Friends
         event Action<string> OnFriendNotFound;
         event Action<List<FriendWithDirectMessages>> OnAddFriendsWithDirectMessages;
         event Action<int, int> OnTotalFriendRequestUpdated;
-        event Action<int> OnTotalFriendsUpdated;
         event Action<SocialFriendRequest> OnFriendRequestReceived;
         event Action<SocialFriendRequest> OnSentFriendRequestApproved;
 
@@ -45,8 +44,8 @@ namespace DCL.Social.Friends
         UniTask<SocialFriendRequest> RejectFriendshipAsync(string friendRequestId);
         bool IsFriend(string userId);
         void RemoveFriend(string friendId);
-        void GetFriends(int limit, int skip);
-        void GetFriends(string usernameOrId, int limit);
+        UniTask<string[]> GetFriendsAsync(int limit, int skip);
+        UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit);
         [Obsolete("Old API. Use GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) instead")]
         void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip); // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version
         UniTask<List<SocialFriendRequest>> GetFriendRequestsAsync(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/RPCFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/RPCFriendsApiBridge.cs
@@ -43,12 +43,6 @@ namespace DCl.Social.Friends
             remove => fallbackApiBridge.OnFriendNotFound -= value;
         }
 
-        public event Action<AddFriendsPayload> OnFriendsAdded
-        {
-            add => fallbackApiBridge.OnFriendsAdded += value;
-            remove => fallbackApiBridge.OnFriendsAdded -= value;
-        }
-
         public event Action<AddFriendRequestsPayload> OnFriendRequestsAdded
         {
             add => fallbackApiBridge.OnFriendRequestsAdded += value;
@@ -122,11 +116,11 @@ namespace DCl.Social.Friends
         public void RemoveFriend(string userId) =>
             fallbackApiBridge.RemoveFriend(userId);
 
-        public void GetFriends(int limit, int skip) =>
-            fallbackApiBridge.GetFriends(limit, skip);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip) =>
+            fallbackApiBridge.GetFriendsAsync(limit, skip);
 
-        public void GetFriends(string usernameOrId, int limit) =>
-            fallbackApiBridge.GetFriends(usernameOrId, limit);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit) =>
+            fallbackApiBridge.GetFriendsAsync(usernameOrId, limit);
 
         public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) =>
             fallbackApiBridge.GetFriendRequests(sentLimit, sentSkip, receivedLimit, receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/RPCFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/RPCFriendsApiBridge.cs
@@ -116,11 +116,11 @@ namespace DCl.Social.Friends
         public void RemoveFriend(string userId) =>
             fallbackApiBridge.RemoveFriend(userId);
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip) =>
-            fallbackApiBridge.GetFriendsAsync(limit, skip);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken ct) =>
+            fallbackApiBridge.GetFriendsAsync(limit, skip, ct);
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit) =>
-            fallbackApiBridge.GetFriendsAsync(usernameOrId, limit);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct) =>
+            fallbackApiBridge.GetFriendsAsync(usernameOrId, limit, ct);
 
         public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) =>
             fallbackApiBridge.GetFriendRequests(sentLimit, sentSkip, receivedLimit, receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/RPCFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/RPCFriendsApiBridge.cs
@@ -116,11 +116,11 @@ namespace DCl.Social.Friends
         public void RemoveFriend(string userId) =>
             fallbackApiBridge.RemoveFriend(userId);
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken ct) =>
-            fallbackApiBridge.GetFriendsAsync(limit, skip, ct);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken cancellationToken = default) =>
+            fallbackApiBridge.GetFriendsAsync(limit, skip, cancellationToken);
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct) =>
-            fallbackApiBridge.GetFriendsAsync(usernameOrId, limit, ct);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken cancellationToken = default) =>
+            fallbackApiBridge.GetFriendsAsync(usernameOrId, limit, cancellationToken);
 
         public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) =>
             fallbackApiBridge.GetFriendRequests(sentLimit, sentSkip, receivedLimit, receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/FriendsControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/FriendsControllerShould.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
+using System.Threading;
 
 namespace DCL.Social.Friends
 {
@@ -41,13 +42,13 @@ namespace DCL.Social.Friends
         [Test]
         public void AddFriends()
         {
-            _ = apiBridge.GetFriendsAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(UniTask.FromResult(
+            _ = apiBridge.GetFriendsAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(UniTask.FromResult(
                 new AddFriendsPayload
                 {
                     totalFriends = 2,
                     friends = new[] {"woah", "bleh"}
                 }));
-            controller.GetFriendsAsync(0, 0).Forget();
+            controller.GetFriendsAsync(0, 0, new CancellationToken()).Forget();
 
             Assert.AreEqual(2, controller.TotalFriendCount);
             var updatedFriends = controller.GetAllocatedFriends();
@@ -185,13 +186,13 @@ namespace DCL.Social.Friends
             var updatedFriends = new Dictionary<string, UserStatus>();
             controller.OnUpdateUserStatus += (s, status) => updatedFriends[s] = status;
 
-            _ = apiBridge.GetFriendsAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(UniTask.FromResult(
+            _ = apiBridge.GetFriendsAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(UniTask.FromResult(
                 new AddFriendsPayload
                 {
                     totalFriends = 7,
                     friends = new[] {"usr1"}
                 }));
-            controller.GetFriendsAsync(0, 0).Forget();
+            controller.GetFriendsAsync(0, 0, new CancellationToken()).Forget();
 
             apiBridge.OnUserPresenceUpdated += Raise.Event<Action<UserStatus>>(new UserStatus
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/Helpers/FriendsController_Mock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/Helpers/FriendsController_Mock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCl.Social.Friends;
 using DCL.Social.Friends;
@@ -55,10 +56,10 @@ public class FriendsController_Mock : IFriendsController
         OnUpdateFriendship?.Invoke(friendId, FriendshipAction.DELETED);
     }
 
-    public UniTask<string[]> GetFriendsAsync(int limit, int skip) =>
+    public UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken ct) =>
         UniTask.FromResult(new string[0]);
 
-    public UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit) =>
+    public UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct) =>
         UniTask.FromResult(new string[0]);
 
     public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/Helpers/FriendsController_Mock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/Helpers/FriendsController_Mock.cs
@@ -55,13 +55,11 @@ public class FriendsController_Mock : IFriendsController
         OnUpdateFriendship?.Invoke(friendId, FriendshipAction.DELETED);
     }
 
-    public void GetFriends(int limit, int skip)
-    {
-    }
+    public UniTask<string[]> GetFriendsAsync(int limit, int skip) =>
+        UniTask.FromResult(new string[0]);
 
-    public void GetFriends(string usernameOrId, int limit)
-    {
-    }
+    public UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit) =>
+        UniTask.FromResult(new string[0]);
 
     public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/Helpers/FriendsController_Mock.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/Tests/Helpers/FriendsController_Mock.cs
@@ -56,10 +56,10 @@ public class FriendsController_Mock : IFriendsController
         OnUpdateFriendship?.Invoke(friendId, FriendshipAction.DELETED);
     }
 
-    public UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken ct) =>
+    public UniTask<string[]> GetFriendsAsync(int limit, int skip, CancellationToken cancellationToken = default) =>
         UniTask.FromResult(new string[0]);
 
-    public UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct) =>
+    public UniTask<string[]> GetFriendsAsync(string usernameOrId, int limit, CancellationToken cancellationToken = default) =>
         UniTask.FromResult(new string[0]);
 
     public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridge.cs
@@ -11,6 +11,8 @@ namespace DCL.Social.Friends
 {
     public partial class WebInterfaceFriendsApiBridge : MonoBehaviour, IFriendsApiBridge
     {
+        private const string GET_FRIENDS_REQUEST_MESSAGE_ID = "GetFriendsRequest";
+
         private readonly Dictionary<string, IUniTaskSource> pendingRequests = new ();
         private readonly Dictionary<string, UniTaskCompletionSource<FriendshipUpdateStatusMessage>> updatedFriendshipPendingRequests = new ();
 
@@ -36,7 +38,7 @@ namespace DCL.Social.Friends
         public void AddFriends(string json)
         {
             var payload = JsonUtility.FromJson<AddFriendsPayload>(json);
-            string messageId = "GetFriendsRequest";
+            string messageId = GET_FRIENDS_REQUEST_MESSAGE_ID;
             if (!pendingRequests.ContainsKey(messageId))
                 return;
 
@@ -167,24 +169,28 @@ namespace DCL.Social.Friends
             });
         }
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken ct)
+        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var task = new UniTaskCompletionSource<AddFriendsPayload>();
 
-            pendingRequests["GetFriendsRequest"] = task;
+            pendingRequests[GET_FRIENDS_REQUEST_MESSAGE_ID] = task;
             WebInterface.GetFriends(limit, skip);
 
-            return task.Task.AttachExternalCancellation(ct);
+            return task.Task.AttachExternalCancellation(cancellationToken);
         }
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct)
+        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var task = new UniTaskCompletionSource<AddFriendsPayload>();
 
-            pendingRequests["GetFriendsRequest"] = task;
+            pendingRequests[GET_FRIENDS_REQUEST_MESSAGE_ID] = task;
             WebInterface.GetFriends(usernameOrId, limit);
 
-            return task.Task.AttachExternalCancellation(ct);
+            return task.Task.AttachExternalCancellation(cancellationToken);
         }
 
         // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridge.cs
@@ -5,6 +5,7 @@ using DCL.Interface;
 using DCl.Social.Friends;
 using JetBrains.Annotations;
 using UnityEngine;
+using System.Threading;
 
 namespace DCL.Social.Friends
 {
@@ -166,24 +167,24 @@ namespace DCL.Social.Friends
             });
         }
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip)
+        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken ct)
         {
             var task = new UniTaskCompletionSource<AddFriendsPayload>();
 
             pendingRequests["GetFriendsRequest"] = task;
             WebInterface.GetFriends(limit, skip);
 
-            return task.Task;
+            return task.Task.AttachExternalCancellation(ct);
         }
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit)
+        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct)
         {
             var task = new UniTaskCompletionSource<AddFriendsPayload>();
 
             pendingRequests["GetFriendsRequest"] = task;
             WebInterface.GetFriends(usernameOrId, limit);
 
-            return task.Task;
+            return task.Task.AttachExternalCancellation(ct);
         }
 
         // TODO (NEW FRIEND REQUESTS): remove when we don't need to keep the retro-compatibility with the old version

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridgeProxy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridgeProxy.cs
@@ -71,11 +71,11 @@ namespace DCL.Social.Friends
         public void RemoveFriend(string userId) =>
             apiBridgeInUse.RemoveFriend(userId);
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken ct) =>
-            apiBridgeInUse.GetFriendsAsync(limit, skip, ct);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken cancellationToken = default) =>
+            apiBridgeInUse.GetFriendsAsync(limit, skip, cancellationToken);
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct) =>
-            apiBridgeInUse.GetFriendsAsync(usernameOrId, limit, ct);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken cancellationToken = default) =>
+            apiBridgeInUse.GetFriendsAsync(usernameOrId, limit, cancellationToken);
 
         public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) =>
             apiBridgeInUse.GetFriendRequests(sentLimit, sentSkip, receivedLimit, receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridgeProxy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridgeProxy.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCl.Social.Friends;
 using System;
+using System.Threading;
 
 namespace DCL.Social.Friends
 {
@@ -70,11 +71,11 @@ namespace DCL.Social.Friends
         public void RemoveFriend(string userId) =>
             apiBridgeInUse.RemoveFriend(userId);
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip) =>
-            apiBridgeInUse.GetFriendsAsync(limit, skip);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip, CancellationToken ct) =>
+            apiBridgeInUse.GetFriendsAsync(limit, skip, ct);
 
-        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit) =>
-            apiBridgeInUse.GetFriendsAsync(usernameOrId, limit);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit, CancellationToken ct) =>
+            apiBridgeInUse.GetFriendsAsync(usernameOrId, limit, ct);
 
         public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) =>
             apiBridgeInUse.GetFriendRequests(sentLimit, sentSkip, receivedLimit, receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridgeProxy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/FriendsController/WebInterfaceFriendsApiBridgeProxy.cs
@@ -39,9 +39,6 @@ namespace DCL.Social.Friends
             this.fallbackApiBridge.OnFriendNotFound += x => OnFriendNotFound?.Invoke(x);
             this.newFriendsApiBridge.OnFriendNotFound += x => OnFriendNotFound?.Invoke(x);
 
-            this.fallbackApiBridge.OnFriendsAdded += x => OnFriendsAdded?.Invoke(x);
-            this.newFriendsApiBridge.OnFriendsAdded += x => OnFriendsAdded?.Invoke(x);
-
             this.fallbackApiBridge.OnFriendWithDirectMessagesAdded += x => OnFriendWithDirectMessagesAdded?.Invoke(x);
             this.newFriendsApiBridge.OnFriendWithDirectMessagesAdded += x => OnFriendWithDirectMessagesAdded?.Invoke(x);
 
@@ -73,11 +70,11 @@ namespace DCL.Social.Friends
         public void RemoveFriend(string userId) =>
             apiBridgeInUse.RemoveFriend(userId);
 
-        public void GetFriends(int limit, int skip) =>
-            apiBridgeInUse.GetFriends(limit, skip);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(int limit, int skip) =>
+            apiBridgeInUse.GetFriendsAsync(limit, skip);
 
-        public void GetFriends(string usernameOrId, int limit) =>
-            apiBridgeInUse.GetFriends(usernameOrId, limit);
+        public UniTask<AddFriendsPayload> GetFriendsAsync(string usernameOrId, int limit) =>
+            apiBridgeInUse.GetFriendsAsync(usernameOrId, limit);
 
         public void GetFriendRequests(int sentLimit, int sentSkip, int receivedLimit, int receivedSkip) =>
             apiBridgeInUse.GetFriendRequests(sentLimit, sentSkip, receivedLimit, receivedSkip);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/FriendsHUDController.cs
@@ -40,7 +40,7 @@ namespace DCL.Social.Friends
         public event Action OnClosed;
         public event Action OnViewClosed;
 
-        private CancellationTokenSource cts = new CancellationTokenSource();
+        private CancellationTokenSource friendOperationsCancellationTokenSource = new CancellationTokenSource();
 
         public FriendsHUDController(DataStore dataStore,
             IFriendsController friendsController,
@@ -118,9 +118,9 @@ namespace DCL.Social.Friends
 
         public void Dispose()
         {
-            cts?.Cancel();
-            cts?.Dispose();
-            cts = null;
+            friendOperationsCancellationTokenSource?.Cancel();
+            friendOperationsCancellationTokenSource?.Dispose();
+            friendOperationsCancellationTokenSource = null;
 
             if (friendsController != null)
             {
@@ -618,9 +618,9 @@ namespace DCL.Social.Friends
 
         private void DisplayMoreFriends()
         {
-            cts?.Cancel();
-            cts?.Dispose();
-            cts = null;
+            friendOperationsCancellationTokenSource?.Cancel();
+            friendOperationsCancellationTokenSource?.Dispose();
+            friendOperationsCancellationTokenSource = null;
 
             DisplayMoreFriendsAsync().Forget();
         }
@@ -629,10 +629,10 @@ namespace DCL.Social.Friends
         {
             if (!friendsController.IsInitialized) return;
 
-            cts = new CancellationTokenSource();
+            friendOperationsCancellationTokenSource = new CancellationTokenSource();
 
             var friendsToAdd = await friendsController
-                .GetFriendsAsync(LOAD_FRIENDS_ON_DEMAND_COUNT, lastSkipForFriends, cts.Token)
+                .GetFriendsAsync(LOAD_FRIENDS_ON_DEMAND_COUNT, lastSkipForFriends, friendOperationsCancellationTokenSource.Token)
                 .Timeout(TimeSpan.FromSeconds(GET_FRIENDS_TIMEOUT));
 
             for (int i = 0; i < friendsToAdd.Length; i++)
@@ -745,9 +745,9 @@ namespace DCL.Social.Friends
 
         private void SearchFriends(string search)
         {
-            cts?.Cancel();
-            cts?.Dispose();
-            cts = null;
+            friendOperationsCancellationTokenSource?.Cancel();
+            friendOperationsCancellationTokenSource?.Dispose();
+            friendOperationsCancellationTokenSource = null;
 
             SearchFriendsAsync(search).Forget();
         }
@@ -762,10 +762,10 @@ namespace DCL.Social.Friends
                 return;
             }
 
-            cts = new CancellationTokenSource();
+            friendOperationsCancellationTokenSource = new CancellationTokenSource();
 
             var friendsToAdd = await friendsController
-                .GetFriendsAsync(search, MAX_SEARCHED_FRIENDS, cts.Token)
+                .GetFriendsAsync(search, MAX_SEARCHED_FRIENDS, friendOperationsCancellationTokenSource.Token)
                 .Timeout(TimeSpan.FromSeconds(GET_FRIENDS_TIMEOUT));
 
             for (int i = 0; i < friendsToAdd.Length; i++)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendsHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendsHUDControllerShould.cs
@@ -43,6 +43,8 @@ namespace DCl.Social.Friends
             userProfileBridge.GetOwn().Returns(ownProfile);
             friendsController = Substitute.For<IFriendsController>();
             friendsController.AllocatedFriendCount.Returns(FRIENDS_COUNT);
+            friendsController.GetFriendsAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(UniTask.FromResult(new string[0]));
+            friendsController.GetFriendsAsync(Arg.Any<string>(), Arg.Any<int>()).Returns(UniTask.FromResult(new string[0]));
             dataStore = new DataStore();
             controller = new FriendsHUDController(dataStore,
                 friendsController,
@@ -362,7 +364,7 @@ namespace DCl.Social.Friends
 
             controller.SetVisibility(true);
 
-            friendsController.Received(1).GetFriends(30, 0);
+            friendsController.Received(1).GetFriendsAsync(30, 0);
         }
 
         [Test]
@@ -372,7 +374,7 @@ namespace DCl.Social.Friends
 
             view.OnFriendListDisplayed += Raise.Event<Action>();
 
-            friendsController.Received(1).GetFriends(30, 0);
+            friendsController.Received(1).GetFriendsAsync(30, 0);
         }
 
         [Test]
@@ -457,7 +459,7 @@ namespace DCl.Social.Friends
             friendsController.IsInitialized.Returns(true);
             view.OnRequireMoreFriends += Raise.Event<Action>();
 
-            friendsController.GetFriends(30, 0);
+            friendsController.Received(1).GetFriendsAsync(30, 0);
         }
 
         [Test]
@@ -469,7 +471,7 @@ namespace DCl.Social.Friends
 
             view.OnRequireMoreFriends += Raise.Event<Action>();
 
-            friendsController.Received(1).GetFriends(30, 30);
+            friendsController.Received(1).GetFriendsAsync(30, 30);
         }
 
         [Test]
@@ -504,7 +506,7 @@ namespace DCl.Social.Friends
 
             view.OnSearchFriendsRequested += Raise.Event<Action<string>>(searchText);
 
-            friendsController.Received(1).GetFriends(searchText, 100);
+            friendsController.Received(1).GetFriendsAsync(searchText, 100);
             view.Received(1).EnableSearchMode();
         }
 
@@ -526,7 +528,7 @@ namespace DCl.Social.Friends
             controller.SetVisibility(false);
             controller.SetVisibility(true);
 
-            friendsController.Received(2).GetFriends(30, 0);
+            friendsController.Received(2).GetFriendsAsync(30, 0);
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendsHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendsHUDControllerShould.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL;
 using DCL.Helpers;
@@ -43,8 +44,8 @@ namespace DCl.Social.Friends
             userProfileBridge.GetOwn().Returns(ownProfile);
             friendsController = Substitute.For<IFriendsController>();
             friendsController.AllocatedFriendCount.Returns(FRIENDS_COUNT);
-            friendsController.GetFriendsAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(UniTask.FromResult(new string[0]));
-            friendsController.GetFriendsAsync(Arg.Any<string>(), Arg.Any<int>()).Returns(UniTask.FromResult(new string[0]));
+            friendsController.GetFriendsAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(UniTask.FromResult(new string[0]));
+            friendsController.GetFriendsAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(UniTask.FromResult(new string[0]));
             dataStore = new DataStore();
             controller = new FriendsHUDController(dataStore,
                 friendsController,
@@ -364,7 +365,7 @@ namespace DCl.Social.Friends
 
             controller.SetVisibility(true);
 
-            friendsController.Received(1).GetFriendsAsync(30, 0);
+            friendsController.Received(1).GetFriendsAsync(30, 0, Arg.Any<CancellationToken>());
         }
 
         [Test]
@@ -374,7 +375,7 @@ namespace DCl.Social.Friends
 
             view.OnFriendListDisplayed += Raise.Event<Action>();
 
-            friendsController.Received(1).GetFriendsAsync(30, 0);
+            friendsController.Received(1).GetFriendsAsync(30, 0, Arg.Any<CancellationToken>());
         }
 
         [Test]
@@ -459,7 +460,7 @@ namespace DCl.Social.Friends
             friendsController.IsInitialized.Returns(true);
             view.OnRequireMoreFriends += Raise.Event<Action>();
 
-            friendsController.Received(1).GetFriendsAsync(30, 0);
+            friendsController.Received(1).GetFriendsAsync(30, 0, Arg.Any<CancellationToken>());
         }
 
         [Test]
@@ -471,7 +472,7 @@ namespace DCl.Social.Friends
 
             view.OnRequireMoreFriends += Raise.Event<Action>();
 
-            friendsController.Received(1).GetFriendsAsync(30, 30);
+            friendsController.Received(1).GetFriendsAsync(30, 30, Arg.Any<CancellationToken>());
         }
 
         [Test]
@@ -506,7 +507,7 @@ namespace DCl.Social.Friends
 
             view.OnSearchFriendsRequested += Raise.Event<Action<string>>(searchText);
 
-            friendsController.Received(1).GetFriendsAsync(searchText, 100);
+            friendsController.Received(1).GetFriendsAsync(searchText, 100, Arg.Any<CancellationToken>());
             view.Received(1).EnableSearchMode();
         }
 
@@ -528,7 +529,7 @@ namespace DCl.Social.Friends
             controller.SetVisibility(false);
             controller.SetVisibility(true);
 
-            friendsController.Received(2).GetFriendsAsync(30, 0);
+            friendsController.Received(2).GetFriendsAsync(30, 0, Arg.Any<CancellationToken>());
         }
 
         [Test]


### PR DESCRIPTION
## What does this PR change?
Fix #4023 (Point 2 of this issue: `Friends who are offline are not being displayed`)

## Problem
From the second time on we opened the friends window, the offline list was always loading empty.
The problem was that, after re-opening the HUD from a second time and clean its lists, when we received the new list of friends from the backend, when the flow reached the `UpdateFriendshipStatus()` function, we had this condition:
```
if (friends.ContainsKey(userId) && friends[userId].friendshipStatus == friendshipStatus)
    return;
``` 

In this case, as the new friends received already were loaded in our internal dictionary `friends`, the flow was being always canceled and never added the data into the HUD.

The main problem here is that we were using the `UpdateFriendshipStatus()` for managing the request of friends, when this function should be used only to keep updated the status of the already loaded friends.

## Solution
In order to not depend on the `UpdateFriendshipStatus()` flow for getting the list of friends, we have made the `GetFriends()` function in the `FriendsController` as async (`GetFriends()` -> `GetFriendsAsync()`), then the consumer (`FriendsHUDController`) can call it and wait for the response to directly fill the list in the UI.

## How to test the changes?
1. Go to: https://play.decentraland.zone/?renderer-branch=fix/offline-friends-are-not-being-displayed
2. Open the friends list by first time.
3. Check the friends list is loaded correctly.
4. Close the friends list.
5. Open it again.
6. Check the friends list is loaded correctly.
7. Repeat this process several times and check that the lists are being loaded correctly.
8. Check the friends feature is working as expected.

## Important
This has been the quicker solution in order to add the fix in the next release and let the users load their offline friends list correctly, but as a second step we should synchronize with dService team in order to create a new RPC function for the current `GetFriends` approach. With these changes, it should be something very easy to adapt.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md