### PR TITLE
fix: locked mouse on scene timeout

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Rendering/RenderingController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Rendering/RenderingController.cs
@@ -31,9 +31,9 @@ public class RenderingController : MonoBehaviour
 
     private void DecoupleLoadingScreenVisibilityChange(bool visible, bool _)
     {
-        if (visible)
-            DeactivateRendering_Internal();
-        else
+        //Removed the Deactive rendering logic. This was not being called by kernel, and started calling it from the decoupled loading screen brought unexpected behaviour.
+        //This requires a further refactor and analysis on how the CommonScriptableObjects.renderState is used
+        if(!visible)
             //Coming-from-kernel condition. If we are on signup flow, then we must force the ActivateRendering
             ActivateRendering_Internal(isSignUpFlow);
     }


### PR DESCRIPTION
## What does this PR change?

Kernel was not using the DeactivateRendering method at all. 

With the new decoupled loading screen, the usage was reintroduced, but involved unexpected behaviour, like the locked mouse on scene timeout.

This PR stops using the DeactivateRendering method, so as to copy the current behaviour. Its not ideal, but it should be corrected while we take out responsibilities from kernel; as well as rethinking how the RenderingController class is used.

## How to test the changes?

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
