### PR TITLE
fix: avatar shape with null user id failing to load

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PlayerName/PlayerName.cs
@@ -182,6 +182,9 @@ public class PlayerName : MonoBehaviour, IPlayerName
         currentName = name;
         isNameClaimed = isClaimed;
         isUserGuest = isGuest;
+
+        if (name == null) return;
+
         name = await FilterName(currentName);
         nameText.text = GetNameWithColorCodes(isClaimed, isGuest, name);
         background.rectTransform.sizeDelta = new Vector2(nameText.GetPreferredValues().x + BACKGROUND_EXTRA_WIDTH, BACKGROUND_HEIGHT);
@@ -215,7 +218,7 @@ public class PlayerName : MonoBehaviour, IPlayerName
 
     internal void Update(float deltaTime)
     {
-        if (hideConstraints.Count > 0)
+        if (hideConstraints.Count > 0 || currentName == null)
         {
             UpdateVisuals(0);
             return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileWebInterfaceBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileWebInterfaceBridge.cs
@@ -22,6 +22,7 @@ public class UserProfileWebInterfaceBridge : IUserProfileBridge
 
     public UserProfile Get(string userId)
     {
+        if (userId == null) return null;
         return UserProfileController.userProfilesCatalog.Get(userId);
     }
 


### PR DESCRIPTION
## What does this PR change?

Fixed a few null reference exceptions caused by the userId being null when loading avatar shapes.

Also fixed the nameplate background being visible when the player name is null. 

## How to test the changes?

https://play.decentraland.zone/?renderer-branch=fix/avatar-shape-name&realm=redeemer.dcl.eth

The avatar in the mirror should be visible and the nameplate of those avatars should be invisible.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
