### PR TITLE
fix: collider setup in sdk7 not working with gltfast

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerHandler.cs
@@ -16,6 +16,7 @@ namespace DCL.ECSComponents
     {
         private const string POINTER_COLLIDER_NAME = "OnPointerEventCollider";
         private const string FEATURE_GLTFAST = "gltfast";
+        private const StringComparison IGNORE_CASE = StringComparison.CurrentCultureIgnoreCase;
 
         internal RendereableAssetLoadHelper gltfLoader;
         internal GameObject gameObject;
@@ -167,14 +168,9 @@ namespace DCL.ECSComponents
         }
 
         // Compatibility layer for old GLTF importer and GLTFast
-        private static bool IsCollider(MeshFilter meshFilter)
-        {
-            string ownName = meshFilter.name.ToLower();
-            if (ownName.Contains("_collider")) return true;
-
-            string parentName = meshFilter.transform.parent.name.ToLower();
-            return parentName.Contains("_collider");
-        }
+        private static bool IsCollider(MeshFilter meshFilter) =>
+            meshFilter.name.Contains("_collider", IGNORE_CASE)
+            || meshFilter.transform.parent.name.Contains("_collider", IGNORE_CASE);
 
         private static (List<Collider>, List<Renderer>) SetUpPointerCollidersAndRenderers(HashSet<Renderer> renderers)
         {

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerHandler.cs
@@ -152,7 +152,7 @@ namespace DCL.ECSComponents
                     continue;
                 }
 
-                if (!meshFilters[i].transform.parent.name.ToLower().Contains("_collider"))
+                if (!IsCollider(meshFilters[i]))
                     continue;
 
                 MeshCollider collider = meshFilters[i].gameObject.AddComponent<MeshCollider>();
@@ -164,6 +164,16 @@ namespace DCL.ECSComponents
             }
 
             return physicColliders;
+        }
+
+        // Compatibility layer for old GLTF importer and GLTFast
+        private static bool IsCollider(MeshFilter meshFilter)
+        {
+            string ownName = meshFilter.name.ToLower();
+            if (ownName.Contains("_collider")) return true;
+
+            string parentName = meshFilter.transform.parent.name.ToLower();
+            return parentName.Contains("_collider");
         }
 
         private static (List<Collider>, List<Renderer>) SetUpPointerCollidersAndRenderers(HashSet<Renderer> renderers)
@@ -196,7 +206,10 @@ namespace DCL.ECSComponents
                 GameObject colliderGo = new GameObject(POINTER_COLLIDER_NAME);
                 colliderGo.layer = PhysicsLayers.onPointerEventLayer;
                 MeshCollider collider = colliderGo.AddComponent<MeshCollider>();
-                collider.sharedMesh = renderer.GetComponent<MeshFilter>().sharedMesh;
+                MeshFilter meshFilter = renderer.GetComponent<MeshFilter>();
+                if (meshFilter == null) continue;
+
+                collider.sharedMesh = meshFilter.sharedMesh;
                 colliderGo.transform.SetParent(renderer.transform);
                 colliderGo.transform.ResetLocalTRS();
                 pointerColliders.Add(collider);


### PR DESCRIPTION
## What does this PR change?

Fixes some features not working because of the hierarchy change of gltfast 

## How to test the changes?

Clone https://github.com/decentraland-scenes/sdk7-goerli-plaza.git
Run `avatar-swap` with `dcl start`
Add `&renderer-branch=fix/gltfast-sdk7&ENABLE_GLTFAST` to the URL

The character should animate correctly.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
