### PR TITLE
feat: PoC use mouse up to open other player's passport.

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOnPointerDown.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarOnPointerDown/AvatarOnPointerDown.cs
@@ -119,7 +119,7 @@ namespace DCL.Components
 
         public PointerInputEventType GetEventType()
         {
-            return PointerInputEventType.DOWN;
+            return PointerInputEventType.UP;
         }
 
         void ReEnableOnInfoCardClosed(bool newState, bool prevState)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.asmdef
@@ -8,7 +8,9 @@
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:98bf3bf29030cbf4092d89a7cc28b7fb",
         "GUID:555c1f3c6d18648df910b7a1de75b424",
-        "GUID:bb3eef89092f71f44aa2449a9cf7879c"
+        "GUID:bb3eef89092f71f44aa2449a9cf7879c",
+        "GUID:cc6bfabbfe87b7949aa248893f89ce37",
+        "GUID:1c69d8bb67ff1244b8de3b17766ccbef"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
@@ -2,7 +2,9 @@
 #define WEB_PLATFORM
 #endif
 
+using DCL.Configuration;
 using DCL.Helpers;
+using DCLPlugins.UUIDEventComponentsPlugin.UUIDComponent.Interfaces;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -66,8 +68,27 @@ namespace DCL
 #endif
         }
 
+        private Camera charCamera;
+
+        void RetrieveCamera()
+        {
+            if (charCamera == null) { charCamera = Camera.main; }
+        }
+
         public void OnPointerDown(PointerEventData eventData)
         {
+            RetrieveCamera();
+
+            if (charCamera != null)
+            {
+                Ray ray = charCamera.ScreenPointToRay(Input.mousePosition);
+
+                if (Physics.Raycast(ray, out var hitInfo, Mathf.Infinity, PhysicsLayers.physicsCastLayerMaskWithoutCharacter))
+                    if (hitInfo.collider.gameObject.GetComponentInChildren<IAvatarOnPointerDown>() != null)
+                        return;
+            }
+
+
             if (eventData.button == PointerEventData.InputButton.Right)
             {
                 LockCursor();


### PR DESCRIPTION
## What does this PR change?

NOTE: THIS IS A PoC, if we want to apply this changes in production we would need a refactor of the mouse interaction, this has been solved in an hacky way just to test it

...

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=feat/mouse-up-poc
2. Interact with the world
3. Verify that the passports are opened only with the "mouse up" interaction

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
