### PR TITLE
chore: clean up use_gpu_only_meshes feature flag

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -17,7 +17,6 @@ namespace DCL
 
         private BaseVariable<FeatureFlag> featureFlags => DataStore.i.featureFlags.flags;
         private const string AB_LOAD_ANIMATION = "ab_load_animation";
-        private const string GPU_ONLY_MESHES = "use_gpu_only_meshes_variant:enabled";
         private bool doTransitionAnimation;
 
         public AssetPromise_AB_GameObject(string contentUrl, string hash) : base(contentUrl, hash)
@@ -189,8 +188,6 @@ namespace DCL
 
         private void UploadMeshesToGPU(HashSet<Mesh> meshesList)
         {
-            var uploadToGPU = featureFlags.Get().IsFeatureEnabled(GPU_ONLY_MESHES);
-
             foreach ( Mesh mesh in meshesList )
             {
                 if ( !mesh.isReadable )
@@ -199,11 +196,8 @@ namespace DCL
                 asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
                 asset.meshes.Add(mesh);
 
-                if (uploadToGPU)
-                {
-                    Physics.BakeMesh(mesh.GetInstanceID(), false);
-                    mesh.UploadMeshData(true);
-                }
+                Physics.BakeMesh(mesh.GetInstanceID(), false);
+                mesh.UploadMeshData(true);
             }
         }
 

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -102,9 +102,6 @@ namespace UnityGLTF
         private  CancellationTokenSource ctokenSource;
         private bool scheduledToCleanUp;
 
-        private const string GPU_ONLY_MESHES = "use_gpu_only_meshes_variant:enabled";
-
-
         public Action OnSuccess { get { return OnFinishedLoadingAsset; } set { OnFinishedLoadingAsset = value; } }
 
         public Action<Exception> OnFail { get { return OnFailedLoadingAsset; } set { OnFailedLoadingAsset = value; } }
@@ -352,7 +349,7 @@ namespace UnityGLTF
             sceneImporter.initialVisibility = initialVisibility;
             sceneImporter.addMaterialsToPersistentCaching = addMaterialsToPersistentCaching;
 
-            sceneImporter.forceGPUOnlyMesh = settings.forceGPUOnlyMesh && DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(GPU_ONLY_MESHES);
+            sceneImporter.forceGPUOnlyMesh = settings.forceGPUOnlyMesh;
 
             sceneImporter.OnMeshCreated += meshCreatedCallback;
             sceneImporter.OnRendererCreated += rendererCreatedCallback;


### PR DESCRIPTION
## What does this PR change?

This pull request removes the feature flag `explorer-use_gpu_only_meshes_variant` for the A/B test that was implemented to test any performance impact for uploading mesh data to gpu.
The test results have shown a slight performance gain, so this PR is setting this behaviour as default.

Group A display results with the feature disabled, and group B with the feature on.
![image](https://user-images.githubusercontent.com/7305682/214048759-07829f31-6e89-4e2b-8f4d-4e4ee5f388de.png)


## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=chore/clean-up-use-gpu-only-meshes-ab-test
2. No change should be visible with 3d models.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
