### PR TITLE
fix: Decoupled loading screen rotated image in desktop

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Resources/_LoadingScreen.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Resources/_LoadingScreen.prefab
@@ -226,7 +226,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0.00012207031, y: 13.000061}
+  m_AnchoredPosition: {x: 0.00024414062, y: 13.000061}
   m_SizeDelta: {x: 0, y: 20}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &1548540707
@@ -733,7 +733,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &653450988801228817
 RectTransform:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenController.cs
@@ -126,7 +126,7 @@ namespace DCL.LoadingScreen
             bool realmChangeRequiresLoadingScreen;
 
             if (commonDataStore.isWorld.Get())
-                realmChangeRequiresLoadingScreen = !currentRealm.Equals(realmDataStore.playerRealmAboutConfiguration.Get().RealmName);
+                realmChangeRequiresLoadingScreen = string.IsNullOrEmpty(currentRealm) || !currentRealm.Equals(realmDataStore.playerRealmAboutConfiguration.Get().RealmName);
             else
                 realmChangeRequiresLoadingScreen = currentRealmIsWorld;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenView.cs
@@ -30,7 +30,6 @@ namespace DCL.LoadingScreen
             betaTag.SetActive(!Application.isEditor && Application.platform != RuntimePlatform.WebGLPlayer);
 
             SetupBlitTexture();
-            rawImage.gameObject.SetActive(false);
             FadeIn(true, false);
         }
 
@@ -87,7 +86,7 @@ namespace DCL.LoadingScreen
             //Blit null works differently in WebGL than in desktop platform. We have to deal with it and rotate the resultant image accordingly
             if (Application.isEditor || Application.platform != RuntimePlatform.WebGLPlayer)
                 rawImage.GetComponent<RectTransform>().eulerAngles = new Vector3(180, 0, 0);
-            
+
             if (renderTexture) renderTexture.Release();
             renderTexture = new RenderTexture(Screen.width, Screen.height, 0);
             rawImage.texture = renderTexture;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenView.cs
@@ -28,7 +28,7 @@ namespace DCL.LoadingScreen
             showHideAnimator.OnWillFinishStart += FadeInFinish;
 
             betaTag.SetActive(!Application.isEditor && Application.platform != RuntimePlatform.WebGLPlayer);
-            
+
             SetupBlitTexture();
             rawImage.gameObject.SetActive(false);
             FadeIn(true, false);
@@ -84,6 +84,10 @@ namespace DCL.LoadingScreen
 
         private void SetupBlitTexture()
         {
+            //Blit null works differently in WebGL than in desktop platform. We have to deal with it and rotate the resultant image accordingly
+            if (Application.isEditor || Application.platform != RuntimePlatform.WebGLPlayer)
+                rawImage.GetComponent<RectTransform>().eulerAngles = new Vector3(180, 0, 0);
+            
             if (renderTexture) renderTexture.Release();
             renderTexture = new RenderTexture(Screen.width, Screen.height, 0);
             rawImage.texture = renderTexture;


### PR DESCRIPTION
## What does this PR change?

Maintaince task for decoupled loading screen.

In desktop, the null blit texture appears rotated 180 degrees. This PR adds a check to rotate the image accordingly.

Also, it turns off by default the blit texture in the prefab, since it was generating a white flash in that platform.

## How to test the changes?

All of these is testable in desktop. To test that nothing broke in renderer,

1. https://play.decentraland.zone/?renderer-branch=fix/decoupled-loading-screen-rotated-image-in-desktop&ENABLE_DECOUPLED_LOADING_SCREEN
2. Teleport around. No issues should be visible

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
