### PR TITLE
feat: disabled friends ui by a feature flag

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentController.cs
@@ -23,6 +23,7 @@ namespace DCL.Social.Passports
         private UserProfile ownUserProfile => userProfileBridge.GetOwn();
         private string name;
         private bool isNewFriendRequestsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("new_friend_requests");
+        private bool isFriendsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("friends_enabled");
         public event Action OnClosePassport;
         private CancellationTokenSource cancellationTokenSource;
 
@@ -129,6 +130,7 @@ namespace DCL.Social.Passports
                     isBlocked = ownUserProfile.IsBlocked(userProfile.userId),
                     hasBlocked = userProfile.IsBlocked(ownUserProfile.userId),
                     friendshipStatus = await friendsController.GetFriendshipStatus(userProfile.userId),
+                    isFriendshipVisible = isFriendsEnabled,
                 };
             }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentView.cs
@@ -1,15 +1,14 @@
 using Cysharp.Threading.Tasks;
 using DCL.Helpers;
-using System;
-using System.Collections;
-using UnityEngine;
-using TMPro;
-using SocialFeaturesAnalytics;
 using DCL.Social.Friends;
+using SocialFeaturesAnalytics;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using TMPro;
 using UIComponents.Scripts.Components;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace DCL.Social.Passports
@@ -31,6 +30,7 @@ namespace DCL.Social.Passports
         [SerializeField] private ButtonComponentView cancelFriendRequestButton;
         [SerializeField] private ButtonComponentView acceptFriendButton;
         [SerializeField] private ButtonComponentView blockedFriendButton;
+        [SerializeField] private GameObject friendshipContainer;
         [SerializeField] private Button whisperButton;
         [SerializeField] private TooltipComponentView whisperNonFriendsPopup;
         [SerializeField] private GameObject onlineStatus;
@@ -69,12 +69,12 @@ namespace DCL.Social.Passports
         {
             walletCopyButton.onClick.AddListener(CopyWalletToClipboard);
             usernameCopyButton.onClick.AddListener(CopyUsernameToClipboard);
-            addFriendButton.onClick.AddListener(()=>OnAddFriend?.Invoke());
-            alreadyFriendsButton.onClick.AddListener(()=>OnRemoveFriend?.Invoke());
-            cancelFriendRequestButton.onClick.AddListener(()=>OnCancelFriendRequest?.Invoke());
-            acceptFriendButton.onClick.AddListener(()=>OnAcceptFriendRequest?.Invoke());
+            addFriendButton.onClick.AddListener(() => OnAddFriend?.Invoke());
+            alreadyFriendsButton.onClick.AddListener(() => OnRemoveFriend?.Invoke());
+            cancelFriendRequestButton.onClick.AddListener(() => OnCancelFriendRequest?.Invoke());
+            acceptFriendButton.onClick.AddListener(() => OnAcceptFriendRequest?.Invoke());
             userContextMenu.OnBlock += OnBlock;
-            blockedFriendButton.onClick.AddListener(()=>OnUnblockUser?.Invoke());
+            blockedFriendButton.onClick.AddListener(() => OnUnblockUser?.Invoke());
             userContextMenu.OnReport += OnReport;
             whisperButton.onClick.AddListener(WhisperActionFlow);
             optionsButton.onClick.AddListener(OpenOptions);
@@ -83,10 +83,10 @@ namespace DCL.Social.Passports
 
             friendStatusButtonsMapping = new Dictionary<FriendshipStatus, GameObject>()
             {
-                {FriendshipStatus.NOT_FRIEND, addFriendButton.gameObject},
-                {FriendshipStatus.FRIEND, alreadyFriendsButton.gameObject},
-                {FriendshipStatus.REQUESTED_FROM, acceptFriendButton.gameObject},
-                {FriendshipStatus.REQUESTED_TO, cancelFriendRequestButton.gameObject}
+                { FriendshipStatus.NOT_FRIEND, addFriendButton.gameObject },
+                { FriendshipStatus.FRIEND, alreadyFriendsButton.gameObject },
+                { FriendshipStatus.REQUESTED_FROM, acceptFriendButton.gameObject },
+                { FriendshipStatus.REQUESTED_TO, cancelFriendRequestButton.gameObject }
             };
         }
 
@@ -113,6 +113,7 @@ namespace DCL.Social.Passports
             SetIsBlocked(model.isBlocked);
             SetHasBlockedOwnUser(model.hasBlocked);
             SetFriendStatus(model.friendshipStatus);
+            SetFriendshipVisibility(model.isFriendshipVisible);
         }
 
         public override void Dispose()
@@ -139,23 +140,23 @@ namespace DCL.Social.Passports
                 jumpInButton.gameObject.SetActive(true);
                 jumpInButton.Initialize(friendsController, userId, socialAnalytics);
             }
-            else
-            {
-                jumpInButton.gameObject.SetActive(false);
-            }
+            else { jumpInButton.gameObject.SetActive(false); }
         }
 
         public void SetFriendStatus(FriendshipStatus friendStatus)
         {
             areFriends = friendStatus == FriendshipStatus.FRIEND;
 
-            if(isBlocked)
+            if (isBlocked)
                 return;
 
             DisableAllFriendFlowButtons();
             friendStatusButtonsMapping[friendStatus].SetActive(true);
             whisperNonFriendsPopup.Hide(true);
         }
+
+        private void SetFriendshipVisibility(bool visible) =>
+            friendshipContainer.SetActive(visible);
 
         private void RemoveFriendsFocused(bool isFocused)
         {
@@ -168,6 +169,7 @@ namespace DCL.Social.Passports
             string[] splitName = name.Split('#');
             this.name.SetText(splitName[0]);
             address.SetText($"{(splitName.Length == 2 ? "#" + splitName[1] : "")}");
+
             //We are forced to use this due to the UI not being correctly responsive with the placing of the copy icon
             //without the force rebuild it's not setting the elements as dirty and not replacing them correctly
             Utils.ForceRebuildLayoutImmediate(usernameRect);
@@ -180,7 +182,7 @@ namespace DCL.Social.Passports
                 return;
 
             fullWalletAddress = wallet;
-            this.wallet.text = $"{wallet.Substring(0,5)}...{wallet.Substring(wallet.Length - 5)}";
+            this.wallet.text = $"{wallet.Substring(0, 5)}...{wallet.Substring(wallet.Length - 5)}";
         }
 
         public void SetIsBlocked(bool isBlocked)
@@ -189,17 +191,15 @@ namespace DCL.Social.Passports
             DisableAllFriendFlowButtons();
             blockedFriendButton.gameObject.SetActive(isBlocked);
 
-            if (!isBlocked)
-            {
-                SetFriendStatus(model.friendshipStatus);
-            }
+            if (!isBlocked) { SetFriendStatus(model.friendshipStatus); }
         }
 
-        public void SetActionsActive(bool isActive) => actionsContainer.SetActive(isActive);
+        public void SetActionsActive(bool isActive) =>
+            actionsContainer.SetActive(isActive);
 
         private void SetPresence(PresenceStatus status)
         {
-            if(status == PresenceStatus.ONLINE)
+            if (status == PresenceStatus.ONLINE)
             {
                 onlineStatus.SetActive(true);
                 offlineStatus.SetActive(false);
@@ -232,7 +232,7 @@ namespace DCL.Social.Passports
 
         private void CopyWalletToClipboard()
         {
-            if(fullWalletAddress == null)
+            if (fullWalletAddress == null)
                 return;
 
             OnWalletCopy?.Invoke(fullWalletAddress);
@@ -243,7 +243,7 @@ namespace DCL.Social.Passports
 
         private void CopyUsernameToClipboard()
         {
-            if(string.IsNullOrEmpty(model.name))
+            if (string.IsNullOrEmpty(model.name))
                 return;
 
             OnUsernameCopy?.Invoke(model.name);
@@ -254,10 +254,7 @@ namespace DCL.Social.Passports
 
         private async UniTaskVoid ShowCopyToast(ShowHideAnimator toast, CancellationToken ct)
         {
-            if (!toast.gameObject.activeSelf)
-            {
-                toast.gameObject.SetActive(true);
-            }
+            if (!toast.gameObject.activeSelf) { toast.gameObject.SetActive(true); }
 
             toast.Show();
             await Task.Delay(COPY_TOAST_VISIBLE_TIME, ct);
@@ -273,20 +270,11 @@ namespace DCL.Social.Passports
 
         private void WhisperActionFlow()
         {
-            if (areFriends)
-            {
-                OnWhisperUser?.Invoke(model.userId);
-            }
+            if (areFriends) { OnWhisperUser?.Invoke(model.userId); }
             else
             {
-                if (areFriends)
-                {
-                    whisperNonFriendsPopup.Hide();
-                }
-                else
-                {
-                    whisperNonFriendsPopup.Show();
-                }
+                if (areFriends) { whisperNonFriendsPopup.Hide(); }
+                else { whisperNonFriendsPopup.Show(); }
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportModel.cs
@@ -11,4 +11,5 @@ public record PlayerPassportModel
     public bool isBlocked;
     public bool hasBlocked;
     public FriendshipStatus friendshipStatus;
+    public bool isFriendshipVisible;
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Resources/PlayerPassport.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Resources/PlayerPassport.prefab
@@ -9339,6 +9339,7 @@ MonoBehaviour:
     isBlocked: 0
     hasBlocked: 0
     friendshipStatus: 0
+    isFriendshipVisible: 0
   name: {fileID: 1750995632636747991}
   address: {fileID: 3431385152357898269}
   nameInOptionsPanel: {fileID: 2313361900714903975}
@@ -9352,6 +9353,7 @@ MonoBehaviour:
   cancelFriendRequestButton: {fileID: 3539354935361854780}
   acceptFriendButton: {fileID: 1556928558984779415}
   blockedFriendButton: {fileID: 6329467860429900791}
+  friendshipContainer: {fileID: 3257621660973361290}
   whisperButton: {fileID: 3884232551266363028}
   whisperNonFriendsPopup: {fileID: 2036723919353643394}
   onlineStatus: {fileID: 5036442527997073431}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
@@ -1,12 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using DCL;
 using DCL.Helpers;
 using DCL.Social.Friends;
+using System;
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
-using UnityEngine.Assertions;
 using UnityEngine.Events;
 using UnityEngine.UI;
 
@@ -119,7 +117,7 @@ public class PlayerInfoCardHUDView : MonoBehaviour
 
         if (SceneReferences.i != null)
         {
-            var mouseCatcher = DCL.SceneReferences.i.mouseCatcher;
+            var mouseCatcher = SceneReferences.i.mouseCatcher;
 
             if (mouseCatcher != null)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Tests/PlayerInfoCardHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Tests/PlayerInfoCardHUDControllerShould.cs
@@ -45,6 +45,7 @@ public class PlayerInfoCardHUDControllerShould : IntegrationTestSuite_Legacy
         GivenWearableCatalog();
 
         dataStore = new DataStore();
+        dataStore.featureFlags.flags.Set(new FeatureFlag { flags = { ["friends_enabled"] = true } });
         GivenProfanityFiltering();
         GivenProfanityFilteringAvailability(true);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Tests/PlayerInfoCardHUDTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Tests/PlayerInfoCardHUDTests.asmdef
@@ -24,7 +24,8 @@
         "GUID:0663fad624d836944b40ae27c3414652",
         "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
         "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca",
-        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:2995626b54c60644988f134a69a77450"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -35,12 +35,13 @@ public class TaskbarHUDController : IHUD
     private Transform experiencesViewerTransform;
     private Transform notificationViewerTransform;
     private Transform topNotificationViewerTransform;
-    private IHUD chatToggleTargetWindow;
     private IHUD chatInputTargetWindow;
     private IHUD chatBackWindow;
     private SearchChannelsWindowController searchChannelsHud;
     private CreateChannelWindowController channelCreationWindow;
     private LeaveChannelConfirmationWindowController channelLeaveWindow;
+
+    private bool isFriendsFeatureEnabled => DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("friends_enabled");
 
     public event Action OnAnyTaskbarButtonClicked;
 
@@ -219,6 +220,7 @@ public class TaskbarHUDController : IHUD
     private void ToggleFriendsTrigger_OnTriggered(DCLAction_Trigger action)
     {
         if (friendsHud == null) return;
+        if (!isFriendsFeatureEnabled) return;
 
         bool anyInputFieldIsSelected = EventSystem.current != null &&
                                        EventSystem.current.currentSelectedGameObject != null &&
@@ -269,7 +271,6 @@ public class TaskbarHUDController : IHUD
         {
             publicChatWindow.SetVisibility(false);
             worldChatWindowHud.SetVisibility(true);
-            chatToggleTargetWindow = worldChatWindowHud;
             chatInputTargetWindow = publicChatWindow;
         }
         else
@@ -385,7 +386,6 @@ public class TaskbarHUDController : IHUD
         privateChatWindow.Setup(userId);
         privateChatWindow.SetVisibility(true);
         view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
-        chatToggleTargetWindow = worldChatWindowHud;
         chatInputTargetWindow = privateChatWindow;
     }
 
@@ -466,7 +466,6 @@ public class TaskbarHUDController : IHUD
 
         view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
 
-        chatToggleTargetWindow = worldChatWindowHud;
         chatInputTargetWindow = channelChatWindow;
     }
 
@@ -486,7 +485,6 @@ public class TaskbarHUDController : IHUD
 
         view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
 
-        chatToggleTargetWindow = worldChatWindowHud;
         chatInputTargetWindow = publicChatWindow;
     }
 
@@ -502,8 +500,6 @@ public class TaskbarHUDController : IHUD
         voiceChatHud?.SetVisibility(false);
         worldChatWindowHud.SetVisibility(true);
         view.ToggleOn(TaskbarHUDView.TaskbarButtonType.Chat);
-
-        chatToggleTargetWindow = worldChatWindowHud;
     }
 
     private void CloseChatList()
@@ -622,7 +618,11 @@ public class TaskbarHUDController : IHUD
         experiencesViewerTransform?.SetAsLastSibling();
 
         friendsHud = controller;
-        view.ShowFriendsButton();
+
+        if (isFriendsFeatureEnabled)
+            view.ShowFriendsButton();
+        else
+            view.HideFriendsButton();
 
         friendsHud.OnViewClosed += () =>
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDView.cs
@@ -132,20 +132,20 @@ public class TaskbarHUDView : MonoBehaviour
     public void ToggleOn(TaskbarButtonType buttonType) => ToggleOn(buttonsByType[buttonType], false);
 
     public void ToggleOff(TaskbarButtonType buttonType) => ToggleOff(buttonsByType[buttonType], false);
-    
+
     private void ToggleOn(TaskbarButton obj) => ToggleOn(obj, true);
 
     private void ToggleOn(TaskbarButton obj, bool useCallback)
     {
         var wasToggled = lastToggledOnButton == obj;
         lastToggledOnButton = obj;
-        
+
         foreach (var btn in buttonsByType.Values)
             btn.SetToggleState(btn == obj, useCallback);
 
         if (!useCallback) return;
         if (wasToggled) return;
-        
+
         if (obj == friendsButton)
             OnFriendsToggle?.Invoke(true);
         if (obj == emotesButton)
@@ -163,15 +163,15 @@ public class TaskbarHUDView : MonoBehaviour
     private void ToggleOff(TaskbarButton obj, bool useCallback)
     {
         var wasToggled = lastToggledOnButton == obj;
-        
+
         if (wasToggled)
             lastToggledOnButton = null;
-        
+
         obj.SetToggleState(false, useCallback);
 
         if (!useCallback) return;
         if (!wasToggled) return;
-        
+
         if (obj == friendsButton)
             OnFriendsToggle?.Invoke(false);
         if (obj == emotesButton)
@@ -194,6 +194,11 @@ public class TaskbarHUDView : MonoBehaviour
     internal void ShowFriendsButton()
     {
         friendsButton.transform.parent.gameObject.SetActive(true);
+    }
+
+    internal void HideFriendsButton()
+    {
+        friendsButton.transform.parent.gameObject.SetActive(false);
     }
 
     internal void ShowEmotesButton()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
@@ -350,8 +350,8 @@ public class UserContextMenu : MonoBehaviour
 
     private void SetupFriendship(FriendshipStatus friendshipStatus)
     {
-        bool friendshipEnabled = (currentConfigFlags & MenuConfigFlags.Friendship) != 0;
-        bool messageEnabled = (currentConfigFlags & MenuConfigFlags.Message) != 0;
+        bool friendshipEnabled = (currentConfigFlags & MenuConfigFlags.Friendship) != 0 && isFriendsEnabled;
+        bool messageEnabled = (currentConfigFlags & MenuConfigFlags.Message) != 0 && isFriendsEnabled;
 
         if (friendshipStatus == FriendshipStatus.FRIEND)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
@@ -86,6 +86,7 @@ public class UserContextMenu : MonoBehaviour
     private MenuConfigFlags currentConfigFlags;
     private IConfirmationDialog currentConfirmationDialog;
     private bool isNewFriendRequestsEnabled => DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("new_friend_requests");
+    private bool isFriendsEnabled => DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("friends_enabled");
     internal ISocialAnalytics socialAnalytics;
 
     /// <summary>
@@ -304,8 +305,8 @@ public class UserContextMenu : MonoBehaviour
     {
         headerContainer.SetActive((flags & headerFlags) != 0);
         userName.gameObject.SetActive((flags & MenuConfigFlags.Name) != 0);
-        friendshipContainer.SetActive((flags & MenuConfigFlags.Friendship) != 0);
-        deleteFriendButton.gameObject.SetActive((flags & MenuConfigFlags.Friendship) != 0);
+        friendshipContainer.SetActive((flags & MenuConfigFlags.Friendship) != 0 && isFriendsEnabled);
+        deleteFriendButton.gameObject.SetActive((flags & MenuConfigFlags.Friendship) != 0 && isFriendsEnabled);
         passportButton.gameObject.SetActive((flags & MenuConfigFlags.Passport) != 0);
         blockButton.gameObject.SetActive((flags & MenuConfigFlags.Block) != 0);
         reportButton.gameObject.SetActive((flags & MenuConfigFlags.Report) != 0);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Tests/UserContextMenuShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Tests/UserContextMenuShould.cs
@@ -1,3 +1,4 @@
+using DCL;
 using NUnit.Framework;
 using System;
 using System.Collections;
@@ -31,6 +32,8 @@ public class UserContextMenuShould
             name = TEST_USER_ID,
             userId = TEST_USER_ID
         });
+
+        DataStore.i.featureFlags.flags.Set(new FeatureFlag { flags = { ["friends_enabled"] = true } });
 
         yield break;
     }
@@ -156,7 +159,7 @@ public class UserContextMenuShould
         Assert.IsFalse(contextMenu.friendRequestedContainer.activeSelf,
             "friendRequestedContainer should not be active");
         Assert.IsTrue(contextMenu.deleteFriendButton.gameObject.activeSelf, "deleteFriendButton should be active");
-        
+
         WhenFriendshipStatusUpdates(new FriendshipUpdateStatusMessage
         {
             userId = TEST_USER_ID,
@@ -184,7 +187,7 @@ public class UserContextMenuShould
         });
 
         Assert.IsFalse(contextMenu.messageButton.gameObject.activeSelf, "messageButton should not be active");
-        
+
         WhenFriendshipStatusUpdates(new FriendshipUpdateStatusMessage
         {
             userId = TEST_USER_ID,
@@ -192,7 +195,7 @@ public class UserContextMenuShould
         });
 
         Assert.IsTrue(contextMenu.messageButton.gameObject.activeSelf, "messageButton should be active");
-        
+
         WhenFriendshipStatusUpdates(new FriendshipUpdateStatusMessage
         {
             userId = TEST_USER_ID,
@@ -201,7 +204,7 @@ public class UserContextMenuShould
 
         Assert.IsFalse(contextMenu.messageButton.gameObject.activeSelf, "messageButton should not be active");
     }
-    
+
     private void WhenFriendshipStatusUpdates(FriendshipUpdateStatusMessage status)
     {
         friendsApiBridge.OnFriendshipStatusUpdated += Raise.Event<Action<FriendshipUpdateStatusMessage>>(

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Tests/UserContextMenuTest.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Tests/UserContextMenuTest.asmdef
@@ -9,7 +9,10 @@
         "GUID:ef84d7ce90ba34f07be26ace428e9bc8",
         "GUID:1de3566cccb280f4a982c59ad0d08c96",
         "GUID:ba9b721ce33233c4da7ff4ef30d25b59",
-        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca"
+        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca",
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:2995626b54c60644988f134a69a77450",
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?

`Fixes #3914 `

Enables or disables the friends UI depending on a feature flag: `explorer-friends_enabled`.

## How to test the changes?

1. Go to: https://play.decentraland.zone/?renderer-branch=feat/friends-feature-flag
2. None of the UI should be referring to the friends feature
3. Go to: https://play.decentraland.org/?renderer-branch=feat/friends-feature-flag
4. The friends UI should be enabled as usual

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
