### PR TITLE
chore: update githubactions with new branch name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           message: |
             After the CI passes:
 
-            - This branch can be previewed at https://play.decentraland.zone/?renderer-branch=${{ github.head_ref }}
+            - This branch can be previewed at https://play.decentraland.zone/?explorer-branch=${{ github.head_ref }}
             - Code coverage report: [https://renderer-artifacts.decentraland.org/branch-coverage/${{ github.head_ref }}](https://renderer-artifacts.decentraland.org/branch-coverage/${{ github.head_ref }})
             - Benchmark report: [https://renderer-artifacts.decentraland.org/branch-benchmark/${{ github.head_ref }}/index.html](https://renderer-artifacts.decentraland.org/branch-benchmark/${{ github.head_ref }}/index.html)
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Then, on the Unity editor, click on `Assets > Reimport All`
 
 To test against a build made on this repository, you can use a link with this format:
 
-    https://play.decentraland.zone/?renderer-branch=<branch-name>
+    https://play.decentraland.zone/?explorer-branch=<branch-name>
 
 Note that using this approach, the Unity builds will run against kernel `master` HEAD.
 
 If you want to test your Unity branch against a specific kernel branch, you'll have to use the `renderer` url param like this:
 
-    https://play.decentraland.zone/?renderer-branch=<branch-name>&kernel-branch=<kernel-branch-name>
+    https://play.decentraland.zone/?explorer-branch=<branch-name>&kernel-branch=<kernel-branch-name>
 
 If the CI for both branches succeeds, you can browse to the generated link and test your changes. Bear in mind that any push will kick the CI. There's no need to create a pull request.
 


### PR DESCRIPTION
Signed-off-by: Juan Ignacio Molteni <juanignaciomolteni@gmail.com>

## What does this PR change?

Updates the github action so it shows the correct branch name after kernel merger

## How to test the changes?



## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
