### PR TITLE
fix: emotes performance degradation

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationLoader.cs
+++ b/unity-renderer/Assets/DCLPlugins/EmoteAnimations/EmoteAnimationLoader.cs
@@ -11,7 +11,10 @@ namespace DCL.Emotes
         private readonly IWearableRetriever retriever;
         public AnimationClip loadedAnimationClip { get; internal set; }
 
-        public EmoteAnimationLoader(IWearableRetriever retriever) { this.retriever = retriever; }
+        public EmoteAnimationLoader(IWearableRetriever retriever)
+        {
+            this.retriever = retriever;
+        }
 
         public async UniTask LoadEmote(GameObject container, WearableItem emote, string bodyShapeId, CancellationToken ct = default)
         {
@@ -27,22 +30,23 @@ namespace DCL.Emotes
             ct.ThrowIfCancellationRequested();
 
             WearableItem.Representation representation = emote.GetRepresentation(bodyShapeId);
-            if (representation == null)
-            {
-                throw new Exception($"No representation for {bodyShapeId} of emote: {emote.id}");
-            }
+
+            if (representation == null) { throw new Exception($"No representation for {bodyShapeId} of emote: {emote.id}"); }
 
             Rendereable rendereable = await retriever.Retrieve(container, emote.GetContentProvider(bodyShapeId), emote.baseUrlBundles, representation.mainFile, ct);
 
             var animation = rendereable.container.GetComponentInChildren<Animation>();
-            if (animation == null)            
+
+            if (animation == null)
             {
                 Debug.LogError("Animation component not found in the container for emote " + emote.id);
                 return;
             }
-             
+
+            animation.enabled = false;
             var animationClip = animation.clip;
-            if(animationClip == null)
+
+            if (animationClip == null)
             {
                 Debug.LogError("AnimationClip not found in the container for emote " + emote.id);
                 return;
@@ -53,6 +57,9 @@ namespace DCL.Emotes
             animationClip.name = emote.id;
         }
 
-        public void Dispose() { retriever?.Dispose(); }
+        public void Dispose()
+        {
+            retriever?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Disabled the Animation component of loaded emotes to avoid the processing overhead

## Benchmark

Performance increase scales with the amount of NFT emotes that were loaded
In the next example there's a great amount of them and the overhead can be greatly reduced. 

### Prod
![image](https://user-images.githubusercontent.com/7646450/215588389-67031739-7ccb-4c26-b4cf-ff967122e7b1.png)

### This branch
![image](https://user-images.githubusercontent.com/7646450/215589814-9fb29d6d-e959-43c0-aed0-233c590258ab.png)


## How to test the changes?

- Check that base emotes and NFT emotes work correctly.
- Check that you can see another avatar rather than yourself being animated correctly while their use an emote.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
