### PR TITLE
fix: The backpack breaks when the owned wearables request fails

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
@@ -65,7 +65,7 @@ public class CatalogController : MonoBehaviour
         pendingRequestsToSend.Clear();
     }
 
-    //This temporary until the emotes are in the content server
+    // TODO: when emotes get published to the content server, remove this
     public void EmbedWearables(IEnumerable<WearableItem> wearables)
     {
         foreach (WearableItem wearableItem in wearables)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
@@ -30,7 +30,7 @@ public class CatalogController : MonoBehaviour
     private static Dictionary<string, float> pendingWearablesByContextRequestedTimes = new Dictionary<string, float>();
     private static List<string> pendingRequestsToSend = new List<string>();
     private float timeSinceLastUnusedWearablesCheck = 0f;
-    
+
     public BaseDictionary<string, WearableItem> Wearables => DataStore.i.common.wearables;
 
     public void Awake() { i = this; }
@@ -65,7 +65,7 @@ public class CatalogController : MonoBehaviour
         pendingRequestsToSend.Clear();
     }
 
-    //This temporary until the emotes are in the content server 
+    //This temporary until the emotes are in the content server
     public void EmbedWearables(IEnumerable<WearableItem> wearables)
     {
         foreach (WearableItem wearableItem in wearables)
@@ -130,6 +130,9 @@ public class CatalogController : MonoBehaviour
     public void WearablesRequestFailed(string payload)
     {
         WearablesRequestFailed requestFailedResponse = JsonUtility.FromJson<WearablesRequestFailed>(payload);
+		
+		if (requestFailedResponse?.context == null)
+            return;
 
         if (requestFailedResponse.context == BASE_WEARABLES_CONTEXT ||
             requestFailedResponse.context.Contains(THIRD_PARTY_WEARABLES_CONTEXT) ||

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -217,6 +217,7 @@ public class AvatarEditorHUDController : IHUD
                              }
                              else
                              {
+                                 LoadUserProfile(userProfile, true);
                                  NotificationsController.i.ShowNotification(new Model
                                  {
                                      message = LOADING_OWNED_WEARABLES_ERROR_MESSAGE,


### PR DESCRIPTION
## What does this PR change?
Fix #4167 

Solves 2 things:

- A NullRef that we were not managing correctly in the `CatalogController.WearablesRequestFailed` method.
- A wrong behavior of the backpack which caused it to stuck when the request of the owned wearables failed.

![image](https://user-images.githubusercontent.com/64659061/215596557-8bc41295-36b5-4b5d-82f1-7296f5543dac.png)

## How to test the changes?
1. Switch your metamask to GOERLI.
2. Go to: https://play.decentraland.zone/?explorer-branch=fix/null-wearable-is-added-to-inventory&BUILDER_SERVER_URL=https://builder-api.decentraland.zone/v1&NETWORK=goerli&DEBUG_MODE=true&WITH_COLLECTIONS=9c4d923f-3e19-4abc-a012-33397f1e10ea
3. Open the backpack.
4. Notice that, even if the owned wearables failed when they were requested, the rest of the backpack (avatar preview and all the rest of wearables) loads correctly.
5. Close the backpack.
6. Notice the user's flow doesn't break.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md