### PR TITLE
fix: remove cases where the character forward was set to 0,0,0.

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
@@ -183,6 +183,9 @@ namespace DCL.Camera
                 var horizontalAxisLookAt = payload.y - cameraTarget.y;
                 verticalAxisLookAt = new Vector3(cameraTarget.x - payload.x, 0, cameraTarget.z - payload.z);
 
+                if (verticalAxisLookAt.sqrMagnitude == 0)
+                    verticalAxisLookAt = Vector3.forward;
+
                 eulerDir.y = Vector3.SignedAngle(Vector3.forward, verticalAxisLookAt, Vector3.up);
                 eulerDir.x = Mathf.Atan2(horizontalAxisLookAt, verticalAxisLookAt.magnitude) * Mathf.Rad2Deg;
             }
@@ -192,8 +195,8 @@ namespace DCL.Camera
             //value range 0 to 1, being 0 the bottom orbit and 1 the top orbit
             var yValue = Mathf.InverseLerp(-90, 90, eulerDir.x);
             defaultVirtualCameraAsFreeLook.m_YAxis.Value = yValue;
-            
-            characterForward.Set(verticalAxisLookAt); 
+
+            characterForward.Set(verticalAxisLookAt);
         }
 
         public override void OnBlock(bool blocked)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraStateTPS.cs
@@ -183,7 +183,7 @@ namespace DCL.Camera
                 var horizontalAxisLookAt = payload.y - cameraTarget.y;
                 verticalAxisLookAt = new Vector3(cameraTarget.x - payload.x, 0, cameraTarget.z - payload.z);
 
-                if (verticalAxisLookAt.sqrMagnitude == 0)
+                if (verticalAxisLookAt is { x: 0, y: 0, z: 0 })
                     verticalAxisLookAt = Vector3.forward;
 
                 eulerDir.y = Vector3.SignedAngle(Vector3.forward, verticalAxisLookAt, Vector3.up);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -430,7 +430,7 @@ public class DCLCharacterController : MonoBehaviour
             //               if we dont do this, the character wont rotate when moving, only when the platform rotates
             var newForward = newCharacterForward + lastFrameDifference;
 
-            if (newForward.sqrMagnitude == 0)
+            if (newForward is { x: 0, y: 0, z: 0 })
                 newForward = Vector3.forward;
 
             CommonScriptableObjects.characterForward.Set(newForward);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -23,7 +23,7 @@ public class DCLCharacterController : MonoBehaviour
 
     [Header("Collisions")]
     public LayerMask groundLayers;
-    
+
     [Header("Additional Camera Layers")]
     public LayerMask cameraLayers;
 
@@ -103,7 +103,7 @@ public class DCLCharacterController : MonoBehaviour
     public event System.Action OnJump;
     public event System.Action OnHitGround;
     public event System.Action<float> OnMoved;
-    
+
     void Awake()
     {
         if (i != null)
@@ -228,7 +228,7 @@ public class DCLCharacterController : MonoBehaviour
         var payload = Utils.FromJsonWithNulls<Vector3>(teleportPayload);
         dataStorePlayer.lastTeleportPosition.Set(payload, notifyEvent: true);
     }
-    
+
     private void Teleport(Vector3 newPosition, Vector3 prevPosition)
     {
         ResetGround();
@@ -428,7 +428,12 @@ public class DCLCharacterController : MonoBehaviour
 
             //NOTE(Kinerius) CameraStateTPS rotates the character between frames so we add the difference.
             //               if we dont do this, the character wont rotate when moving, only when the platform rotates
-            CommonScriptableObjects.characterForward.Set(newCharacterForward + lastFrameDifference);
+            var newForward = newCharacterForward + lastFrameDifference;
+
+            if (newForward.sqrMagnitude == 0)
+                newForward = Vector3.forward;
+
+            CommonScriptableObjects.characterForward.Set(newForward);
         }
 
         Transform transformHit = CastGroundCheckingRays();


### PR DESCRIPTION
Fixes #4107 

## Test
Go to 119,-12, there shouldnt be a `Look rotation viewing vector is zero` error anymore