### PR TITLE
chore: suppress warning on hiding deprecated "animation" field

### DIFF
--- a/unity-renderer/Assets/Scripts/CodeStyleExample.cs
+++ b/unity-renderer/Assets/Scripts/CodeStyleExample.cs
@@ -53,7 +53,7 @@ namespace DCL.UIComponents
 
         protected float cooldown;
         
-        private Animation animation;
+        private new Animation animation;
         private Interaction<int> interactionsBuffer;
 
         //----------------------------------------------------------------------------------------  Properties group


### PR DESCRIPTION
chore: suppress warning on hiding deprecated "animation" field

As suggested by the C# compiler:

```
Assets\Scripts\CodeStyleExample.cs(56,27): warning CS0108: 'CodeStyleExample.animation' hides inherited member 'Component.animation'. Use the new keyword if hiding was intended.
```