### PR TITLE
hotfix: Fix interactivity of the scenes input texts

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIInputText/Resources/UIInputText.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/UI/UIInputText/Resources/UIInputText.prefab
@@ -365,7 +365,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:


### PR DESCRIPTION
## What does this PR change?
The users cannot put the focus on any input text of any scene.

![image](https://user-images.githubusercontent.com/64659061/216080637-4dad7d83-61d1-4ffd-8bd1-f59ee1167821.png)
![image](https://user-images.githubusercontent.com/64659061/216080695-8aaef83f-dd4e-415c-bdea-353059222747.png)

## Problem
The problem was that the `UIInputText.prefab` had the `RaycastTarget` deactivated in its text component:

![image](https://user-images.githubusercontent.com/64659061/216081780-7885bfe2-fc38-4f3e-80a9-96e1677d049a.png)

## How to test the changes?
1. Go to: https://play.decentraland.org/?explorer-branch=hotfix/missing-raycast-target-on-scenes-ui-input-text
2. Go to GolfCraft scene.
3. Open one of the input text of the scene.
4. Check that you can click on the input box and write.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md