### PR TITLE
fix: disable `CallGetCurrentStateWithoutStoredState` flaky test

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/SceneControllerService/Tests/SceneControllerServiceShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/SceneControllerService/Tests/SceneControllerServiceShould.cs
@@ -247,6 +247,8 @@ namespace Tests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("Flakytest, issue to fix it: https://github.com/decentraland/unity-renderer/issues/4222")]
+        [Category("Explicit")]
         public IEnumerator CallGetCurrentStateWithoutStoredState()
         {
             yield return UniTask.ToCoroutine(async () =>


### PR DESCRIPTION
Issue to fix the flaky test: https://github.com/decentraland/unity-renderer/issues/4222

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
