### PR TITLE
fix: Remove LINQ usage in PassModifierKeys

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -5,6 +5,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using DCL.Configuration;
+using UnityEngine.Profiling;
 using UnityEngine.UIElements;
 
 /// <summary>
@@ -620,6 +621,7 @@ public static class InputProcessor
     /// <returns></returns>
     public static Boolean PassModifierKeys(KeyCode[] modifierKeys)
     {
+        Profiler.BeginSample("PassModifierKeys");
         for (var i = 0; i < MODIFIER_KEYS.Length; i++)
         {
             var keyCode = MODIFIER_KEYS[i];
@@ -631,10 +633,20 @@ public static class InputProcessor
             }
             else
             {
-                if (modifierKeys.Contains(keyCode) != pressed)
+                // Very confusing function, but this should avoid allocations and LINQ
+                var contains = false;
+                foreach (KeyCode kc in modifierKeys)
+                {
+                    if (kc == keyCode)
+                    {
+                        contains = true;
+                    }
+                }
+                if (contains != pressed)
                     return false;
             }
         }
+        Profiler.EndSample();
 
         return true;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -621,7 +621,6 @@ public static class InputProcessor
     /// <returns></returns>
     public static Boolean PassModifierKeys(KeyCode[] modifierKeys)
     {
-        Profiler.BeginSample("PassModifierKeys");
         for (var i = 0; i < MODIFIER_KEYS.Length; i++)
         {
             var keyCode = MODIFIER_KEYS[i];
@@ -646,7 +645,6 @@ public static class InputProcessor
                     return false;
             }
         }
-        Profiler.EndSample();
 
         return true;
     }


### PR DESCRIPTION
Before:
![Before_PassModifierKeys_No_Linq2](https://user-images.githubusercontent.com/296469/216556563-dcb458a9-5d89-479a-a161-e18a77d9edd3.PNG)

After:
![After_PassModifierKeys_No_Linq](https://user-images.githubusercontent.com/296469/216556557-68b02788-65ac-4c21-a605-bcb1620d23e3.PNG)

### Testing
- [ ] Ensure input modifier keys still work as expected