### PR TITLE
Fix: Remove Hologram from PassportHUD

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/CharacterPreview/ICharacterPreviewController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/CharacterPreview/ICharacterPreviewController.cs
@@ -10,11 +10,11 @@ namespace MainScripts.DCL.Controllers.HUD.CharacterPreview
 
         UniTask TryUpdateModelAsync(AvatarModel newModel, CancellationToken cancellationToken = default);
 
-        void SetFocus(global::MainScripts.DCL.Controllers.HUD.CharacterPreview.CharacterPreviewController.CameraFocus focus, bool useTransition = true);
+        void SetFocus(CharacterPreviewController.CameraFocus focus, bool useTransition = true);
 
         void SetEnabled(bool enabled);
 
-        void TakeSnapshots(global::MainScripts.DCL.Controllers.HUD.CharacterPreview.CharacterPreviewController.OnSnapshotsReady onSuccess, Action onFailed);
+        void TakeSnapshots(CharacterPreviewController.OnSnapshotsReady onSuccess, Action onFailed);
 
         void Rotate(float rotationVelocity);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPreview/PassportPlayerPreviewComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPreview/PassportPlayerPreviewComponentController.cs
@@ -22,7 +22,7 @@ namespace DCL.Social.Passports
             view.PreviewCameraRotation.OnHorizontalRotation += RotateCharacterPreview;
             cancellationTokenSource = new CancellationTokenSource();
 
-            previewController = characterPreviewFactory.Ref.Create(CharacterPreviewMode.WithHologram,
+            previewController = characterPreviewFactory.Ref.Create(CharacterPreviewMode.WithoutHologram,
                 view.CharacterPreviewTexture, true, CharacterPreviewController.CameraFocus.Preview);
 
             view.SetModel(new (TutorialEnabled));


### PR DESCRIPTION
Closes #4046

```
await baseAvatar.FadeOut(loader.combinedRenderer.GetComponent<MeshRenderer>(), visibility.IsMainRenderVisible(), linkedCt);
```
FadeOut is awaited but 
```
public void SetAsLoading(bool isLoading)
        {
            loadingSpinner.SetActive(isLoading);
            CharacterPreviewImage.gameObject.SetActive(!isLoading);
        }
```
disables the Image it is being rendered to so it makes no sense.
Solution: don't use hologram as it is redundant

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?explorer-branch={branch_name}&{desired_url_params}
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
