### PR TITLE
fix: disable `CallGetCurrentStateWithStoredState` flaky test

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/SceneControllerService/Tests/SceneControllerServiceShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/SceneControllerService/Tests/SceneControllerServiceShould.cs
@@ -296,6 +296,8 @@ namespace Tests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("Flakytest, issue to fix it: https://github.com/decentraland/unity-renderer/issues/4222")]
+        [Category("Explicit")]
         public IEnumerator CallGetCurrentStateWithStoredState()
         {
             yield return UniTask.ToCoroutine(async () =>


### PR DESCRIPTION
Related to https://github.com/decentraland/unity-renderer/issues/4222

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
