### PR TITLE
fix: close connect wallet modal when pressing ESC

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
@@ -96,6 +96,9 @@ namespace DCL.Social.Passports
 
             isOpen = false;
 
+            if (userProfileBridge.GetOwn().isGuest)
+                dataStore.HUDs.connectWalletModalVisible.Set(false);
+
             passportNavigationController.CloseAllNFTItemInfos();
             passportNavigationController.SetViewInitialPage();
             playerInfoController.ClosePassport();


### PR DESCRIPTION
Steps to reproduce:

* Log in as guest, without wallet
* Click on a user
* You should see a "Connect your wallet" modal blocking the passport view
* Press Escape

What should happen with this fix:
* Both the Passport and the "Connect Wallet" modals get hidden

Error happening in production:
* The Passport is closed, but the "Connect Wallet" modal is still open