### PR TITLE
chore: add "No QA Needed" label to exclussion list in auto assign tool

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -23,3 +23,4 @@ filterLabels:
   exclude:
     - no_reviewers
     - "Not QA Needed"
+    - "No QA Needed"


### PR DESCRIPTION
Added "No QA Needed" to exclussion list, since the previous one was modified.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
