### PR TITLE
fix: Avoid duplication of POIs in Map

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using DCL.Helpers;
 using KernelConfigurationTypes;
 using TMPro;
+using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -96,7 +97,11 @@ namespace DCL
                 parcelHighlightImage.gameObject.SetActive(parcelHighlightEnabledValue);
                 MapVisibilityChanged?.Invoke(value);
             }
-            get { return parcelHighlightEnabledValue; }
+
+            get
+            {
+                return parcelHighlightEnabledValue;
+            }
         }
 
         private BaseDictionary<string, Player> otherPlayers => DataStore.i.player.otherPlayers;
@@ -125,7 +130,10 @@ namespace DCL
             UpdateParcelHold();
         }
 
-        public void OnDestroy() { Cleanup(); }
+        public void OnDestroy()
+        {
+            Cleanup();
+        }
 
         [HideInInspector]
         public event System.Action<float, float> OnMovedParcelCursor;
@@ -164,7 +172,10 @@ namespace DCL
             KernelConfig.i.OnChange += OnKernelConfigChanged;
         }
 
-        private void MoveHomePointIcon(Vector2Int current, Vector2Int previous) { homePointIcon.anchoredPosition = MapUtils.CoordsToPosition(new Vector3(current.x, current.y, 0)); }
+        private void MoveHomePointIcon(Vector2Int current, Vector2Int previous)
+        {
+            homePointIcon.anchoredPosition = MapUtils.CoordsToPosition(new Vector3(current.x, current.y, 0));
+        }
 
         private void InitializeHomePointIcon()
         {
@@ -193,25 +204,31 @@ namespace DCL
             }
         }
 
-        public void SetParcelHighlightActive(bool isAtive) => parcelHighlightImage.enabled = isAtive;
+        public void SetParcelHighlightActive(bool isAtive) =>
+            parcelHighlightImage.enabled = isAtive;
 
-        public Vector3 GetParcelHighlightTransform() => parcelHighlightImage.transform.position;
+        public Vector3 GetParcelHighlightTransform() =>
+            parcelHighlightImage.transform.position;
 
         public void SetOtherPlayersIconActive(bool isActive)
         {
             otherPlayersIconsEnabled = isActive;
 
-            foreach (PoolableObject poolableObject in usersInfoMarkers.Values)
-            {
-                poolableObject.gameObject.SetActive(isActive);
-            }
+            foreach (PoolableObject poolableObject in usersInfoMarkers.Values) { poolableObject.gameObject.SetActive(isActive); }
         }
 
-        public void SetPlayerIconActive(bool isActive) => playerPositionIcon.gameObject.SetActive(isActive);
+        public void SetPlayerIconActive(bool isActive) =>
+            playerPositionIcon.gameObject.SetActive(isActive);
 
-        public void SetHighlighSize(Vector2Int size) { highlight.ChangeHighlighSize(size); }
+        public void SetHighlighSize(Vector2Int size)
+        {
+            highlight.ChangeHighlighSize(size);
+        }
 
-        public void SetHighlightStyle(MapParcelHighlight.HighlighStyle style) { highlight.SetStyle(style); }
+        public void SetHighlightStyle(MapParcelHighlight.HighlighStyle style)
+        {
+            highlight.SetStyle(style);
+        }
 
         public void Cleanup()
         {
@@ -246,21 +263,18 @@ namespace DCL
 
         public void CleanLandsHighlights()
         {
-            foreach (KeyValuePair<Vector2Int, Image> kvp in highlightedLands)
-            {
-                Destroy(kvp.Value.gameObject);
-            }
+            foreach (KeyValuePair<Vector2Int, Image> kvp in highlightedLands) { Destroy(kvp.Value.gameObject); }
 
-            highlightedLands.Clear (); //To Clear out the dictionary
+            highlightedLands.Clear(); //To Clear out the dictionary
         }
 
         public void ClearLandHighlightsInfo()
         {
-            ownedLandsWithContent.Clear (); //To Clear out the content lands
-            ownedEmptyLands.Clear (); //To Clear out the empty content 
+            ownedLandsWithContent.Clear(); //To Clear out the content lands
+            ownedEmptyLands.Clear(); //To Clear out the empty content
         }
 
-        public void SelectLand(Vector2Int coordsToSelect, Vector2Int size )
+        public void SelectLand(Vector2Int coordsToSelect, Vector2Int size)
         {
             if (highlightedLands.ContainsKey(lastSelectedLand))
             {
@@ -299,6 +313,7 @@ namespace DCL
 
                 if (!ownedLandsWithContent.Contains(coords))
                     ownedLandsWithContent.Add(coords);
+
                 CreateHighlightParcel(parcelHighlighWithContentImagePrefab, coords, Vector2Int.one);
             }
 
@@ -353,10 +368,7 @@ namespace DCL
             parcelHighlightImage.rectTransform.anchoredPosition = MapUtils.CoordsToPosition(cursorMapCoords);
             highlightedParcelText.text = showCursorCoords ? $"{cursorMapCoords.x}, {cursorMapCoords.y}" : string.Empty;
 
-            if (highlightedParcelText.text != previousText && !Input.GetMouseButton(0))
-            {
-                OnMovedParcelCursor?.Invoke(cursorMapCoords.x, cursorMapCoords.y);
-            }
+            if (highlightedParcelText.text != previousText && !Input.GetMouseButton(0)) { OnMovedParcelCursor?.Invoke(cursorMapCoords.x, cursorMapCoords.y); }
 
             // ----------------------------------------------------
             // TODO: Use sceneInfo to highlight whole scene parcels and populate scenes hover info on navmap once we can access all the scenes info
@@ -365,80 +377,83 @@ namespace DCL
 
         void UpdateParcelHold()
         {
-            if (Vector2.Distance(lastClickedCursorMapCoords, cursorMapCoords) > MAX_CURSOR_PARCEL_DISTANCE / (scaleFactor * 2.5f))
-            {
-                OnCursorFarFromParcel?.Invoke();
-            }
+            if (Vector2.Distance(lastClickedCursorMapCoords, cursorMapCoords) > MAX_CURSOR_PARCEL_DISTANCE / (scaleFactor * 2.5f)) { OnCursorFarFromParcel?.Invoke(); }
         }
 
-        private void OnKernelConfigChanged(KernelConfigModel current, KernelConfigModel previous) { validWorldRanges = current.validWorldRanges; }
+        private void OnKernelConfigChanged(KernelConfigModel current, KernelConfigModel previous)
+        {
+            validWorldRanges = current.validWorldRanges;
+        }
 
         bool CoordinatesAreInsideTheWorld(int xCoord, int yCoord)
         {
             foreach (WorldRange worldRange in validWorldRanges)
             {
-                if (worldRange.Contains(xCoord, yCoord))
-                {
-                    return true;
-                }
+                if (worldRange.Contains(xCoord, yCoord)) { return true; }
             }
+
             return false;
         }
 
+        static readonly ProfilerMarker s_PreparePerfMarker = new ("Vitaly.Contains");
+
         private void MapRenderer_OnSceneInfoUpdated(MinimapMetadata.MinimapSceneInfo sceneInfo)
         {
-            if (!sceneInfo.isPOI)
-                return;
+                Debug.Log($"VV: {Time.frameCount} CALL = {scenesOfInterest.Contains(sceneInfo)}");
 
-            if (scenesOfInterest.Contains(sceneInfo))
-                return;
+                using (s_PreparePerfMarker.Auto())
 
-            if (IsEmptyParcel(sceneInfo))
-                return;
-
-            scenesOfInterest.Add(sceneInfo);
-
-            GameObject go = Object.Instantiate(scenesOfInterestIconPrefab.gameObject, overlayContainer.transform);
-
-            Vector2 centerTile = Vector2.zero;
-
-            foreach (var parcel in sceneInfo.parcels)
-            {
-                centerTile += parcel;
-            }
-
-            centerTile /= (float)sceneInfo.parcels.Count;
-            float distance = float.PositiveInfinity;
-            Vector2 centerParcel = Vector2.zero;
-            foreach (var parcel in sceneInfo.parcels)
-            {
-                if (Vector2.Distance(centerTile, parcel) < distance)
                 {
-                    distance = Vector2.Distance(centerParcel, parcel);
-                    centerParcel = parcel;
+                    if (!sceneInfo.isPOI)
+                        return;
+
+                    if (scenesOfInterest.Contains(sceneInfo))
+                        return;
+
+                    if (IsEmptyParcel(sceneInfo))
+                        return;
+
+                    scenesOfInterest.Add(sceneInfo);
+
+                    GameObject go = Instantiate(scenesOfInterestIconPrefab.gameObject, overlayContainer.transform);
+
+                    Vector2 centerTile = Vector2.zero;
+
+                    foreach (var parcel in sceneInfo.parcels) { centerTile += parcel; }
+
+                    centerTile /= (float)sceneInfo.parcels.Count;
+                    float distance = float.PositiveInfinity;
+                    Vector2 centerParcel = Vector2.zero;
+
+                    foreach (var parcel in sceneInfo.parcels)
+                    {
+                        if (Vector2.Distance(centerTile, parcel) < distance)
+                        {
+                            distance = Vector2.Distance(centerParcel, parcel);
+                            centerParcel = parcel;
+                        }
+                    }
+
+                    (go.transform as RectTransform).anchoredPosition = MapUtils.CoordsToPosition(centerParcel);
+
+                    MapSceneIcon icon = go.GetComponent<MapSceneIcon>();
+
+                    if (icon.title != null)
+                        icon.title.text = sceneInfo.name.Length > MAX_SCENE_CHARACTER_TITLE ? sceneInfo.name.Substring(0, MAX_SCENE_CHARACTER_TITLE - 1) : sceneInfo.name;
+
+                    scenesOfInterestMarkers.Add(sceneInfo, go);
                 }
-
-            }
-
-            (go.transform as RectTransform).anchoredPosition = MapUtils.CoordsToPosition(centerParcel);
-
-            MapSceneIcon icon = go.GetComponent<MapSceneIcon>();
-
-            if (icon.title != null)
-                icon.title.text = sceneInfo.name.Length > MAX_SCENE_CHARACTER_TITLE ? sceneInfo.name.Substring(0, MAX_SCENE_CHARACTER_TITLE - 1) : sceneInfo.name;
-
-            scenesOfInterestMarkers.Add(sceneInfo, go);
         }
 
         public void SetPointOfInterestActive(bool areActive)
         {
-            foreach (GameObject pointOfInterestGameObject in scenesOfInterestMarkers.Values)
-            {
-                pointOfInterestGameObject.SetActive(areActive);
-            }
+            foreach (GameObject pointOfInterestGameObject in scenesOfInterestMarkers.Values) { pointOfInterestGameObject.SetActive(areActive); }
         }
 
-        private bool IsEmptyParcel(MinimapMetadata.MinimapSceneInfo sceneInfo) { return (sceneInfo.name != null && sceneInfo.name.Equals(EMPTY_PARCEL_NAME)); }
+        private bool IsEmptyParcel(MinimapMetadata.MinimapSceneInfo sceneInfo)
+        {
+            return (sceneInfo.name != null && sceneInfo.name.Equals(EMPTY_PARCEL_NAME));
+        }
 
         private void OnOtherPlayersAdded(string userId, Player player)
         {
@@ -454,10 +469,7 @@ namespace DCL
 
         private void OnOtherPlayerRemoved(string userId, Player player)
         {
-            if (!usersInfoMarkers.TryGetValue(userId, out PoolableObject go))
-            {
-                return;
-            }
+            if (!usersInfoMarkers.TryGetValue(userId, out PoolableObject go)) { return; }
 
             usersInfoPool.Release(go);
             usersInfoMarkers.Remove(userId);
@@ -469,7 +481,10 @@ namespace DCL
             iconGO.transform.localPosition = MapUtils.CoordsToPosition(Vector2Int.RoundToInt(gridPosition));
         }
 
-        private void OnCharacterRotate(Vector3 current, Vector3 previous) { UpdateRendering(Utils.WorldToGridPositionUnclamped(playerWorldPosition.Get())); }
+        private void OnCharacterRotate(Vector3 current, Vector3 previous)
+        {
+            UpdateRendering(Utils.WorldToGridPositionUnclamped(playerWorldPosition.Get()));
+        }
 
         public void OnCharacterSetPosition(Vector2Int newCoords, Vector2Int oldCoords)
         {
@@ -486,7 +501,10 @@ namespace DCL
             UpdateOverlayLayer();
         }
 
-        void UpdateBackgroundLayer(Vector2 newCoords) { atlas.CenterToTile(newCoords); }
+        void UpdateBackgroundLayer(Vector2 newCoords)
+        {
+            atlas.CenterToTile(newCoords);
+        }
 
         void UpdateSelectionLayer()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MapRenderer.cs
@@ -395,8 +395,6 @@ namespace DCL
 
         private void MapRenderer_OnSceneInfoUpdated(MinimapMetadata.MinimapSceneInfo sceneInfo)
         {
-            Debug.Log($"VV: {Time.frameCount} CALL = {scenesOfInterest.Contains(sceneInfo)}");
-
             if (!sceneInfo.isPOI)
                 return;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
@@ -94,10 +94,15 @@ public class MinimapMetadata : ScriptableObject
         public override int GetHashCode()
         {
             if (hashCode == -1)
-                hashCode = name.GetHashCode() + type.GetHashCode() + isPOI.GetHashCode() + owner.GetHashCode() + description.GetHashCode() + previewImageUrl.GetHashCode()
-                           + parcels.GetHashCode() + parcels.Count + (parcels.Count > 0 ? parcels[0].x + parcels[0].y * 600 : 0);
+                hashCode = name.GetHashCode() + type.GetHashCode() + GenerateParcelHashCode() + isPOI.GetHashCode() + GenerateOwnerInfo();
 
             return hashCode;
+
+            int GenerateOwnerInfo() =>
+                owner == null ? 0 : owner.GetHashCode() + description.GetHashCode() + previewImageUrl.GetHashCode();
+
+            int GenerateParcelHashCode() =>
+                parcels.GetHashCode() + parcels.Count + (parcels.Count > 0 ? parcels[0].x + (parcels[0].y * 600) : 0);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
@@ -34,6 +34,18 @@ public class MinimapMetadata : ScriptableObject
         public string owner;
         public string description;
         public string previewImageUrl;
+
+        public override bool Equals(object obj)
+        {
+            if (obj is not MinimapSceneInfo) return false;
+            return Equals(obj as MinimapSceneInfo);
+        }
+
+        private bool Equals(MinimapSceneInfo other) =>
+            name.Equals(other.name) && owner.Equals(other.owner) && description.Equals(other.description);
+
+        public override int GetHashCode() =>
+            (name+owner+description).GetHashCode();
     }
 
     public event Action<MinimapSceneInfo> OnSceneInfoUpdated;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Unity.Profiling;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "MinimapMetadata", menuName = "MinimapMetadata")]
@@ -78,8 +77,6 @@ public class MinimapMetadata : ScriptableObject
     [Serializable]
     public class MinimapSceneInfo
     {
-        static readonly ProfilerMarker s_PreparePerfMarker = new ("Vitaly.Equals");
-
         public string name;
         public TileType type;
         public List<Vector2Int> parcels;
@@ -92,22 +89,15 @@ public class MinimapMetadata : ScriptableObject
         [NonSerialized]
         private int hashCode = -1;
 
-        public override bool Equals(object obj)
-        {
-            using (s_PreparePerfMarker.Auto())
-                return obj is MinimapSceneInfo info && Equals(info);
-        }
-
-        private bool Equals(MinimapSceneInfo other) =>
-            this.GetHashCode() == other.GetHashCode();
+        public override bool Equals(object obj) =>
+            obj != null && obj.GetHashCode() == GetHashCode();
 
         public override int GetHashCode()
         {
-            if(hashCode == -1)
+            if (hashCode == -1)
                 hashCode = (name + type + parcels + isPOI + owner + description + previewImageUrl).GetHashCode();
 
             return hashCode;
         }
-
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
@@ -1,4 +1,3 @@
-using Castle.Components.DictionaryAdapter.Xml;
 using System;
 using System.Collections.Generic;
 using UnityEngine;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
@@ -98,7 +98,7 @@ public class MinimapMetadata : ScriptableObject
             return hashCode;
 
             int GenerateOwnerInfo() =>
-                owner == null ? 0 : owner.GetHashCode() + description.GetHashCode() + previewImageUrl.GetHashCode();
+                owner == null ? 0 : owner.GetHashCode() + description.GetHashCode();
 
             int GenerateParcelHashCode() =>
                 parcels.GetHashCode() + parcels.Count + (parcels.Count > 0 ? parcels[0].x + (parcels[0].y * 600) : 0);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/MinimapMetadata.cs
@@ -1,3 +1,4 @@
+using Castle.Components.DictionaryAdapter.Xml;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -46,10 +47,8 @@ public class MinimapMetadata : ScriptableObject
         {
             if (sceneInfoMap.ContainsKey(sceneInfo.parcels[i]))
 
-                //NOTE(Brian): I intended at first to just return; here. But turns out kernel is sending
-                //             overlapping coordinates, sending first gigantic 'Estate' and 'Roads' scenes to
-                //             send the proper scenes later. This will be fixed when we implement the content v3 data
-                //             plumbing.
+                // NOTE: This removes outdated information for a particular parcel. Subsequent calls to update the
+                // information for a parcel must override previously submitted information.
                 sceneInfoMap.Remove(sceneInfo.parcels[i]);
 
             sceneInfoMap.Add(sceneInfo.parcels[i], sceneInfo);
@@ -95,7 +94,8 @@ public class MinimapMetadata : ScriptableObject
         public override int GetHashCode()
         {
             if (hashCode == -1)
-                hashCode = (name + type + parcels + isPOI + owner + description + previewImageUrl).GetHashCode();
+                hashCode = name.GetHashCode() + type.GetHashCode() + isPOI.GetHashCode() + owner.GetHashCode() + description.GetHashCode() + previewImageUrl.GetHashCode()
+                           + parcels.GetHashCode() + parcels.Count + (parcels.Count > 0 ? parcels[0].x + parcels[0].y * 600 : 0);
 
             return hashCode;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Tests/MapRendererShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Tests/MapRendererShould.cs
@@ -118,7 +118,7 @@ namespace Tests
         public void DisplayParcelOfInterestIconsProperly2()
         {
             var sceneInfo = new MinimapMetadata.MinimapSceneInfo();
-            sceneInfo.name = "important scene";
+            sceneInfo.name = "important scene 2";
             sceneInfo.isPOI = true;
             sceneInfo.parcels = new List<Vector2Int>()
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Tests/MapRendererShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/Tests/MapRendererShould.cs
@@ -118,7 +118,7 @@ namespace Tests
         public void DisplayParcelOfInterestIconsProperly2()
         {
             var sceneInfo = new MinimapMetadata.MinimapSceneInfo();
-            sceneInfo.name = "important scene 2";
+            sceneInfo.name = "important scene";
             sceneInfo.isPOI = true;
             sceneInfo.parcels = new List<Vector2Int>()
             {


### PR DESCRIPTION
## What does this PR change?

Avoids duplication of POIs by adding a correct comparison of `MinimapMetada.cs`. Issue described further in [here](https://app.zenhub.com/workspaces/workstream-core-experience-63aaac346e1c8d00104586e8/issues/gh/decentraland/unity-renderer/4244) and [here](https://app.zenhub.com/workspaces/workstream-core-experience-63aaac346e1c8d00104586e8/issues/gh/decentraland/unity-renderer/4294) 


## How to test the changes?


Using this [video ](https://decentralandteam.slack.com/archives/C01QVR7TJK1/p1675259138800659) as reference

1. Go to: -84,-135. Move your camera around and check the fps
2. Wait 10 minutes
3. Move your camera around and check the fps. Performance degradation shouldnt be as bad as in the video
4. Check that the POIs in the map are the same as in `prd`
5. Test that the POIs thumbnails are showing the correct information

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
