### PR TITLE
chore: remove @decentraland/explorer-team as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 
 
 # explorer
-unity-renderer/**/*               @decentraland/explorer-team
+# unity-renderer/**/*               @decentraland/explorer-team
 
 # comms
 browser-interface/packages/shared/comms/logic/rfc-4-room-connection.ts   @decentraland/platform


### PR DESCRIPTION
Signed-off-by: Mateo Miccino <mateomiccino@gmail.com>

## What does this PR change?

Due to issues with the notifications, the code-owners will work in a different way for explorer-team 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
