### PR TITLE
fix: Sentry script busting the cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,9 @@ commands:
       - run: &HASH_UNITY_FILES
           name: Get the hash of source files
           command: ./scripts/hash-unity-files.sh
+      - store_artifacts:
+          path: /tmp/workspace/.unitysources-checksum
+          destination: unitysources-checksum.txt
       - run: &STORE_TARGET
           name: Save target to file
           command: |

--- a/scripts/hash-unity-files.sh
+++ b/scripts/hash-unity-files.sh
@@ -7,6 +7,7 @@ find ./unity-renderer -type f \
     \( -not -path '*Library*' \) \
     \( -not -path '*browser-interface*' \) \
     \( -not -path '*node_modules*' \) \
+    \( -not -path '*Sentry/SentryOptions.asset' \) \
     \( -iname \*.unity \
     -o -iname \*.sh \
     -o -iname \*.cs \


### PR DESCRIPTION
[Offending code](https://github.com/decentraland/unity-renderer/blob/1632eb12d26eb5c7454690c2453b0430190ee217/scripts/src/inject-sentry-params.ts#L53)

Also, leaving the `.txt` with checksums as circleci artifacts for easier debugging of these kind of issues later