### PR TITLE
fix: scene bounds checker and animations 

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestEntity.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestEntity.cs
@@ -15,6 +15,7 @@ public class ECS7TestEntity : IDCLEntity
     public long entityId { get; set; }
     public long parentId { get; set; }
     public IList<long> childrenId { get; internal set; }
+
     public Action<IDCLEntity> OnRemoved { get; set; }
 
     internal ECS7TestEntity() { }
@@ -24,47 +25,138 @@ public class ECS7TestEntity : IDCLEntity
         OnRemoved?.Invoke(this);
     }
 
-// FOLLOWING NOT SUPPORTED
+    // FOLLOWING NOT SUPPORTED
     void ICleanable.Cleanup()
     {
         throw new NotImplementedException();
     }
-    Action<ICleanableEventDispatcher> ICleanableEventDispatcher.OnCleanupEvent { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-    MeshesInfo IDCLEntity.meshesInfo { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    Action<ICleanableEventDispatcher> ICleanableEventDispatcher.OnCleanupEvent
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    MeshesInfo IDCLEntity.meshesInfo
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
     GameObject IDCLEntity.meshRootGameObject => throw new NotImplementedException();
     Renderer[] IDCLEntity.renderers => throw new NotImplementedException();
+
     void IDCLEntity.SetParent(IDCLEntity entity)
     {
         throw new NotImplementedException();
     }
+
     void IDCLEntity.AddChild(IDCLEntity entity)
     {
         throw new NotImplementedException();
     }
+
     void IDCLEntity.RemoveChild(IDCLEntity entity)
     {
         throw new NotImplementedException();
     }
+
     void IDCLEntity.EnsureMeshGameObject(string gameObjectName)
     {
         throw new NotImplementedException();
     }
+
     void IDCLEntity.ResetRelease()
     {
         throw new NotImplementedException();
     }
-    IParcelScene IDCLEntity.scene { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    bool IDCLEntity.markedForCleanup { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    bool IDCLEntity.isInsideSceneOuterBoundaries { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    bool IDCLEntity.isInsideSceneBoundaries { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    IParcelScene IDCLEntity.scene
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    bool IDCLEntity.markedForCleanup
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    bool IDCLEntity.isInsideSceneOuterBoundaries
+    {
+        get => throw new NotImplementedException();
+    }
+
+    bool IDCLEntity.isInsideSceneBoundaries
+    {
+        get => throw new NotImplementedException();
+    }
+
     Dictionary<long, IDCLEntity> IDCLEntity.children => throw new NotImplementedException();
     IDCLEntity IDCLEntity.parent => throw new NotImplementedException();
-    Action<IDCLEntity> IDCLEntity.OnShapeUpdated { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    Action<IDCLEntity> IDCLEntity.OnShapeLoaded { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    Action<IDCLEntity> IDCLEntity.OnMeshesInfoUpdated { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    Action<IDCLEntity> IDCLEntity.OnMeshesInfoCleaned { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    Action<CLASS_ID_COMPONENT, IDCLEntity> IDCLEntity.OnBaseComponentAdded { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    Action<object> IDCLEntity.OnNameChange { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-    Action<object> IDCLEntity.OnTransformChange { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    Action<IDCLEntity> IDCLEntity.OnShapeUpdated
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    Action<IDCLEntity> IDCLEntity.OnShapeLoaded
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    Action<IDCLEntity> IDCLEntity.OnMeshesInfoUpdated
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    Action<IDCLEntity> IDCLEntity.OnMeshesInfoCleaned
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    Action<CLASS_ID_COMPONENT, IDCLEntity> IDCLEntity.OnBaseComponentAdded
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    Action<object> IDCLEntity.OnNameChange
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    Action<object> IDCLEntity.OnTransformChange
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public Action<bool> OnOuterBoundariesChanged
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public Action<bool> OnInsideBoundariesChanged
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public void UpdateInsideBoundariesStatus(bool isInsideBoundaries)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void UpdateOuterBoundariesStatus(bool isInsideOuterBoundaries)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DecentralandEntity.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DecentralandEntity.cs
@@ -13,8 +13,8 @@ namespace DCL.Models
         public bool markedForCleanup { get; set; } = false;
 
         // We let the SceneBoundsChecker update these values later
-        public bool isInsideSceneOuterBoundaries { get; set; } = true;
-        public bool isInsideSceneBoundaries { get; set; } = true;
+        public bool isInsideSceneOuterBoundaries { get; private set; } = true;
+        public bool isInsideSceneBoundaries { get; private set; } = true;
 
         public Dictionary<long, IDCLEntity> children { get; private set; } = new Dictionary<long, IDCLEntity>();
         public IDCLEntity parent { get; private set; }
@@ -24,7 +24,7 @@ namespace DCL.Models
         public GameObject meshRootGameObject => meshesInfo.meshRootGameObject;
         public Renderer[] renderers => meshesInfo.renderers;
 
-        
+
         public Action<IDCLEntity> OnShapeUpdated { get; set; }
         public Action<IDCLEntity> OnShapeLoaded { get; set; }
         public Action<object> OnNameChange { get; set; }
@@ -33,11 +33,13 @@ namespace DCL.Models
         public Action<IDCLEntity> OnMeshesInfoUpdated { get; set; }
         public Action<IDCLEntity> OnMeshesInfoCleaned { get; set; }
         public Action<CLASS_ID_COMPONENT, IDCLEntity> OnBaseComponentAdded { get; set; }
+        public Action<bool> OnInsideBoundariesChanged { get; set; }
+        public Action<bool> OnOuterBoundariesChanged { get; set; }
 
         public Action<ICleanableEventDispatcher> OnCleanupEvent { get; set; }
 
         public long parentId { get; set; }
-        public IList<long> childrenId { get; } = new List<long>(); 
+        public IList<long> childrenId { get; } = new List<long>();
 
         const string MESH_GAMEOBJECT_NAME = "Mesh";
 
@@ -50,29 +52,20 @@ namespace DCL.Models
             meshesInfo.OnUpdated += () => OnMeshesInfoUpdated?.Invoke(this);
             meshesInfo.OnCleanup += () => OnMeshesInfoCleaned?.Invoke(this);
         }
-        
+
         public void AddChild(IDCLEntity entity)
         {
-            if (!children.ContainsKey(entity.entityId))
-            {
-                children.Add(entity.entityId, entity);
-            }
+            if (!children.ContainsKey(entity.entityId)) { children.Add(entity.entityId, entity); }
         }
 
         public void RemoveChild(IDCLEntity entity)
         {
-            if (children.ContainsKey(entity.entityId))
-            {
-                children.Remove(entity.entityId);
-            }
+            if (children.ContainsKey(entity.entityId)) { children.Remove(entity.entityId); }
         }
 
         public void SetParent(IDCLEntity entity)
         {
-            if (parent != null)
-            {
-                parent.RemoveChild(this);
-            }
+            if (parent != null) { parent.RemoveChild(this); }
 
             if (entity != null)
             {
@@ -82,10 +75,7 @@ namespace DCL.Models
                 if (entity.gameObject && gameObject)
                     gameObject.transform.SetParent(entity.gameObject.transform, false);
             }
-            else if (gameObject)
-            {
-                gameObject.transform.SetParent(null, false);
-            }
+            else if (gameObject) { gameObject.transform.SetParent(null, false); }
 
             parent = entity;
         }
@@ -101,7 +91,10 @@ namespace DCL.Models
             }
         }
 
-        public void ResetRelease() { isReleased = false; }
+        public void ResetRelease()
+        {
+            isReleased = false;
+        }
 
         public void Cleanup()
         {
@@ -127,10 +120,7 @@ namespace DCL.Models
                 int childCount = gameObject.transform.childCount;
 
                 // Destroy any other children
-                for (int i = 0; i < childCount; i++)
-                {
-                    Utils.SafeDestroy(gameObject.transform.GetChild(i).gameObject);
-                }
+                for (int i = 0; i < childCount; i++) { Utils.SafeDestroy(gameObject.transform.GetChild(i).gameObject); }
 
                 //NOTE(Brian): This will prevent any component from storing/querying invalid gameObject references.
                 gameObject = null;
@@ -138,6 +128,18 @@ namespace DCL.Models
 
             OnTransformChange = null;
             isReleased = true;
+        }
+
+        public void UpdateInsideBoundariesStatus(bool isInsideBoundaries)
+        {
+            isInsideSceneBoundaries = isInsideBoundaries;
+            OnInsideBoundariesChanged?.Invoke(isInsideSceneBoundaries);
+        }
+
+        public void UpdateOuterBoundariesStatus(bool isInsideOuterBoundaries)
+        {
+            isInsideSceneOuterBoundaries = isInsideOuterBoundaries;
+            OnOuterBoundariesChanged?.Invoke(isInsideSceneOuterBoundaries);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IDCLEntity.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IDCLEntity.cs
@@ -19,8 +19,8 @@ namespace DCL.Models
         void ResetRelease();
         IParcelScene scene { get; set; }
         bool markedForCleanup { get; set; }
-        bool isInsideSceneOuterBoundaries { get; set; }
-        bool isInsideSceneBoundaries { get; set; }
+        bool isInsideSceneOuterBoundaries { get; }
+        bool isInsideSceneBoundaries { get; }
         Dictionary<long, IDCLEntity> children { get; }
         IDCLEntity parent { get; }
         Action<IDCLEntity> OnShapeUpdated { get; set; }
@@ -32,7 +32,13 @@ namespace DCL.Models
 
         Action<object> OnNameChange { get; set; }
         Action<object> OnTransformChange { get; set; }
+        Action<bool> OnInsideBoundariesChanged { get; set; }
+        Action<bool> OnOuterBoundariesChanged { get; set; }
         long parentId { get; set; }
         IList<long> childrenId { get; }
+
+        void UpdateInsideBoundariesStatus(bool isInsideBoundaries);
+
+        void UpdateOuterBoundariesStatus(bool isInsideOuterBoundaries);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -228,7 +228,8 @@ namespace DCL.Controllers
             if (loadWrapper != null && !loadWrapper.alreadyLoaded)
                 return;
 
-            entity.isInsideSceneOuterBoundaries = entity.scene.IsInsideSceneOuterBoundaries(entity.meshesInfo.mergedBounds);
+            entity.UpdateOuterBoundariesStatus(entity.scene.IsInsideSceneOuterBoundaries(entity.meshesInfo.mergedBounds));
+
 
             if (!entity.isInsideSceneOuterBoundaries)
                 SetMeshesAndComponentsInsideBoundariesState(entity, false);
@@ -242,7 +243,7 @@ namespace DCL.Controllers
         private void EvaluateEntityPosition(IDCLEntity entity, bool onlyOuterBoundsCheck = false)
         {
             Vector3 entityGOPosition = entity.gameObject.transform.position;
-            entity.isInsideSceneOuterBoundaries = entity.scene.IsInsideSceneOuterBoundaries(entityGOPosition);
+            entity.UpdateOuterBoundariesStatus(entity.scene.IsInsideSceneOuterBoundaries(entityGOPosition));
 
             if (!entity.isInsideSceneOuterBoundaries)
             {
@@ -268,7 +269,7 @@ namespace DCL.Controllers
             avatarBounds.center = entityGOPosition;
             avatarBounds.size = entity.gameObject.transform.lossyScale;
 
-            entity.isInsideSceneOuterBoundaries = entity.scene.IsInsideSceneOuterBoundaries(avatarBounds);
+            entity.UpdateOuterBoundariesStatus(entity.scene.IsInsideSceneOuterBoundaries(avatarBounds));
 
             if (!entity.isInsideSceneOuterBoundaries)
             {
@@ -289,7 +290,7 @@ namespace DCL.Controllers
             if (entity.isInsideSceneBoundaries == isInsideBoundaries)
                 return;
 
-            entity.isInsideSceneBoundaries = isInsideBoundaries;
+            entity.UpdateInsideBoundariesStatus(isInsideBoundaries);
             OnEntityBoundsCheckerStatusChanged?.Invoke(entity, isInsideBoundaries);
         }
 


### PR DESCRIPTION
## What does this PR change?

When Loadable Shapes are loaded out of bounds, their animations get disabled forever. 

Added an event to re-check their visibility status so we can re-enable the animations.

## How to test the changes?

Go to Dragon City, animations should work.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
