### PR TITLE
feat: hardcode catalyst selection

### DIFF
--- a/browser-interface/packages/config/index.ts
+++ b/browser-interface/packages/config/index.ts
@@ -86,6 +86,7 @@ export const DEBUG_DISABLE_LOADING = qs.has('DEBUG_DISABLE_LOADING')
 
 export const RESET_TUTORIAL = location.search.includes('RESET_TUTORIAL')
 
+export const HARDCODED_CATALYST_LIST = true
 export const ENGINE_DEBUG_PANEL = location.search.includes('ENGINE_DEBUG_PANEL')
 export const SCENE_DEBUG_PANEL = location.search.includes('SCENE_DEBUG_PANEL') && !ENGINE_DEBUG_PANEL
 export const SHOW_FPS_COUNTER = location.search.includes('SHOW_FPS_COUNTER') || location.search.includes('DEBUG_MODE')

--- a/browser-interface/packages/config/index.ts
+++ b/browser-interface/packages/config/index.ts
@@ -86,7 +86,7 @@ export const DEBUG_DISABLE_LOADING = qs.has('DEBUG_DISABLE_LOADING')
 
 export const RESET_TUTORIAL = location.search.includes('RESET_TUTORIAL')
 
-export const HARDCODED_CATALYST_LIST = true
+export const CATALYSTS_FROM_DAO_CONTRACT = location.search.includes('CATALYSTS_FROM_DAO_CONTRACT')
 export const ENGINE_DEBUG_PANEL = location.search.includes('ENGINE_DEBUG_PANEL')
 export const SCENE_DEBUG_PANEL = location.search.includes('SCENE_DEBUG_PANEL') && !ENGINE_DEBUG_PANEL
 export const SHOW_FPS_COUNTER = location.search.includes('SHOW_FPS_COUNTER') || location.search.includes('DEBUG_MODE')

--- a/browser-interface/packages/shared/web3.ts
+++ b/browser-interface/packages/shared/web3.ts
@@ -1,9 +1,9 @@
-import { ETHEREUM_NETWORK, ethereumConfigurations } from 'config'
-import { defaultLogger } from 'lib/logger'
-import { CatalystNode, GraphResponse } from './types'
+import { ethereumConfigurations, ETHEREUM_NETWORK, HARDCODED_CATALYST_LIST } from 'config'
+import { bytesToHex, ContractFactory } from 'eth-connect'
 import { retry } from 'lib/javascript/retry'
+import { defaultLogger } from 'lib/logger'
 import { requestManager } from './ethereum/provider'
-import { ContractFactory, bytesToHex } from 'eth-connect'
+import { CatalystNode, GraphResponse } from './types'
 
 declare let window: Window & {
   ethereum: any
@@ -280,12 +280,41 @@ const catalystABI = [
   }
 ]
 
+/**
+ * The HARDCODED_CATALYST_LIST exists because this function was taking ~8s fetching all the data from the contract (at
+ * least through metamask)
+ */
 export async function fetchCatalystNodesFromDAO(): Promise<CatalystNode[]> {
   if (!requestManager.provider) {
     throw new Error('requestManager.provider not set')
   }
 
   const net = await getAppNetwork()
+
+  if (HARDCODED_CATALYST_LIST) {
+    if (net === ETHEREUM_NETWORK.MAINNET) {
+      return [
+        { domain: 'https://peer-wc1.decentraland.org' },
+        { domain: 'https://interconnected.online' },
+        { domain: 'https://peer-ec2.decentraland.org' },
+        { domain: 'https://peer-ec1.decentraland.org' },
+        { domain: 'https://peer.dclnodes.io' },
+        { domain: 'https://peer-eu1.decentraland.org' },
+        { domain: 'https://peer-ap1.decentraland.org' },
+        { domain: 'https://peer.decentral.io' },
+        { domain: 'https://peer.uadevops.com' },
+        { domain: 'https://peer.kyllian.me' },
+        { domain: 'https://peer.melonwave.com' }
+      ]
+    } else if (net === ETHEREUM_NETWORK.GOERLI) {
+      return [
+        { domain: 'https://peer.decentraland.zone' },
+        { domain: 'https://peer-ap1.decentraland.zone' },
+        { domain: 'https://peer-ue-2.decentraland.zone' },
+        { domain: 'https://peer-ue-2.decentraland.zone' }
+      ]
+    }
+  }
 
   const contract2: {
     catalystCount(): Promise<string>

--- a/browser-interface/packages/shared/web3.ts
+++ b/browser-interface/packages/shared/web3.ts
@@ -1,4 +1,4 @@
-import { ethereumConfigurations, ETHEREUM_NETWORK, HARDCODED_CATALYST_LIST } from 'config'
+import { CATALYSTS_FROM_DAO_CONTRACT, ethereumConfigurations, ETHEREUM_NETWORK } from 'config'
 import { bytesToHex, ContractFactory } from 'eth-connect'
 import { retry } from 'lib/javascript/retry'
 import { defaultLogger } from 'lib/logger'
@@ -291,7 +291,7 @@ export async function fetchCatalystNodesFromDAO(): Promise<CatalystNode[]> {
 
   const net = await getAppNetwork()
 
-  if (HARDCODED_CATALYST_LIST) {
+  if (!CATALYSTS_FROM_DAO_CONTRACT) {
     if (net === ETHEREUM_NETWORK.MAINNET) {
       return [
         { domain: 'https://peer-wc1.decentraland.org' },


### PR DESCRIPTION
Because `eth` contract calls are pretty slow (particularly over metamask), the function to get the list of catalysts from the DAO contract was taking ~10 seconds out of every boot. This hard-codes the values into the code for a faster boot, without removing the logic to actually fetch the catalysts' list from the DAO contract.