### PR TITLE
fix: loading when `decoupled_loading_screen` feature flag is disabled

### DIFF
--- a/browser-interface/packages/shared/loadingScreen/sagas.ts
+++ b/browser-interface/packages/shared/loadingScreen/sagas.ts
@@ -13,6 +13,7 @@ import { TELEPORT_TRIGGERED } from '../loading/types'
 import { SET_REALM_ADAPTER } from '../realm/actions'
 import { POSITION_SETTLED, POSITION_UNSETTLED, SET_SCENE_LOADER } from '../scene-loader/actions'
 import { RENDERING_ACTIVATED, RENDERING_BACKGROUND, RENDERING_DEACTIVATED, RENDERING_FOREGROUND } from './types'
+import { getFeatureFlagEnabled } from 'shared/meta/selectors'
 
 // The following actions may change the status of the loginVisible
 // Reaction on them will be ported to Renderer
@@ -52,7 +53,17 @@ export function* loadingScreenSaga() {
  * @deprecated #3642 Loading Screen Visualisation will be moved to Renderer
  */
 function* updateLoadingScreenInternal() {
+  function shouldWaitMetaConfiguration(state: RootState) {
+    return !state.meta.initialized
+  }
+
   yield call(waitForRendererInstance)
+
+  while (yield select(shouldWaitMetaConfiguration)) {}
+
+  const isDecoupledLoadingScreen = yield select(getFeatureFlagEnabled, 'decoupled_loading_screen')
+
+  if (isDecoupledLoadingScreen) return
 
   const isVisible = yield select(isLoadingScreenVisible)
 

--- a/browser-interface/packages/shared/meta/types.ts
+++ b/browser-interface/packages/shared/meta/types.ts
@@ -48,6 +48,7 @@ export type FeatureFlagsName =
   | 'use-social-server-friendships' // get friendships from social service v1 API
   | 'new_tutorial_variant'
   | 'enable_legacy_comms_v2'
+  | 'decoupled_loading_screen'
 
 export type BannedUsers = Record<string, Ban[]>
 

--- a/browser-interface/packages/shared/store/rootSaga.ts
+++ b/browser-interface/packages/shared/store/rootSaga.ts
@@ -20,6 +20,7 @@ import { sceneEventsSaga } from 'shared/sceneEvents/sagas'
 import { sceneLoaderSaga } from 'shared/scene-loader/sagas'
 import { worldSagas } from 'shared/world/sagas'
 import { bffSaga } from 'shared/realm/sagas'
+import { loadingScreenSaga } from 'shared/loadingScreen/sagas'
 
 export function createRootSaga() {
   return function* rootSaga() {
@@ -44,5 +45,9 @@ export function createRootSaga() {
     yield fork(wearablesPortableExperienceSaga)
     yield fork(sceneLoaderSaga)
     yield fork(worldSagas)
+
+    // Deprecated `loadingScreenSaga` needs to be added until `DECOUPLED_LOADING_SCREEN`
+    // feature flag is removed and set as the default loading screen flow
+    yield fork(loadingScreenSaga)
   }
 }


### PR DESCRIPTION
fix explorer not loading when feature flag `decoupled_loading_screen` is not enabled