### PR TITLE
chore: set rollout to .org to 0%

### DIFF
--- a/.github/workflows/set-rollout.yml
+++ b/.github/workflows/set-rollout.yml
@@ -62,4 +62,4 @@ jobs:
           # Rollout information
           deploymentDomain: "play.decentraland.org"
           deploymentName: "@dcl/explorer"
-          percentage: 100
+          percentage: 0


### PR DESCRIPTION
Temporal fix, because the release process is publishing incorrect artifacts. We're going to check those artifacts before releasing.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
