### PR TITLE
feat: spawn in middle of scene by default

### DIFF
--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -107,10 +107,13 @@ function pickSpawnpoint(land: Scene): InstancedSpawnPoint {
     spawnPoints = [{
       position: {
         x: [1, 15],
-        y: [1, 15],
+        y: [0, 0],
         z: [1, 15]
       },
     }]
+  }
+  if (!spawnPoints) {
+    throw new Error(`Invalid spawnpoint definition`)
   }
 
   // 1 - default spawn points

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -103,7 +103,7 @@ export function pickWorldSpawnpoint(land: Scene): InstancedSpawnPoint {
 
 function pickSpawnpoint(land: Scene): InstancedSpawnPoint {
   let spawnPoints = land.spawnPoints
-  if (!spawnPoints || spawnPoints.length === 0) {
+  if (!Array.isArray(spawnPoints) || spawnPoints.length === 0) {
     spawnPoints = [{
       position: {
         x: [1, 15],

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -84,9 +84,7 @@ export function getInitialPositionFromUrl(): ReadOnlyVector2 | undefined {
  * @param land Scene on which the player is spawning
  */
 export function pickWorldSpawnpoint(land: Scene): InstancedSpawnPoint {
-  const pick = pickSpawnpoint(land)
-
-  const spawnpoint = pick || { position: { x: 0, y: 0, z: 0 } }
+  const spawnpoint = pickSpawnpoint(land)
 
   const baseParcel = land.scene.base
   const [bx, by] = baseParcel.split(',')
@@ -103,16 +101,23 @@ export function pickWorldSpawnpoint(land: Scene): InstancedSpawnPoint {
   }
 }
 
-function pickSpawnpoint(land: Scene): InstancedSpawnPoint | undefined {
-  if (!land || !land.spawnPoints || land.spawnPoints.length === 0) {
-    return undefined
+function pickSpawnpoint(land: Scene): InstancedSpawnPoint {
+  let spawnPoints = land.spawnPoints
+  if (!spawnPoints || spawnPoints.length === 0) {
+    spawnPoints = [{
+      position: {
+        x: [1, 15],
+        y: [1, 15],
+        z: [1, 15]
+      },
+    }]
   }
 
   // 1 - default spawn points
-  const defaults = land.spawnPoints.filter(($) => $.default)
+  const defaults = spawnPoints.filter(($) => $.default)
 
   // 2 - if no default spawn points => all existing spawn points
-  const eligiblePoints = defaults.length === 0 ? land.spawnPoints : defaults
+  const eligiblePoints = defaults.length === 0 ? spawnPoints : defaults
 
   // 3 - pick randomly between spawn points
   const { position, cameraTarget } = eligiblePoints[Math.floor(Math.random() * eligiblePoints.length)]
@@ -138,8 +143,8 @@ function pickSpawnpoint(land: Scene): InstancedSpawnPoint | undefined {
     }
 
     if (!isWorldPositionInsideParcels(land.scene.parcels, finalWorldPosition)) {
-      finalPosition.x = 0
-      finalPosition.z = 0
+      finalPosition.x = 8
+      finalPosition.z = 8
     }
   }
 

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -97,12 +97,12 @@ describe('pickWorldSpawnPoint unit tests', function () {
 
     const pick = pickWorldSpawnpoint(land)
 
-    expect(JSON.stringify(pick)).to.deep.equal(
-      JSON.stringify({
-        position: basePosition,
-        cameraTarget: undefined
-      })
-    )
+    expect(pick.position.x).to.be.at.least(160) 
+    expect(pick.position.x).to.be.below(176) 
+    expect(pick.position.y).to.equal(0)
+    expect(pick.position.z).to.be.at.least(160) 
+    expect(pick.position.z).to.be.below(176) 
+    expect(pick.cameraTarget).to.equal(undefined)
   })
 })
 


### PR DESCRIPTION
This prevents awkward interactions with greenblockers if scenes around have not been loaded. Scene owners are free to fix their spawn point to this position anyways!

Test plan:
- Enter a scene with a defined start position (for example, genesis plaza). Ensure that scene defined spawn point is used
- Enter a scene with no spawn position defined (for example, 46,74). Ensure that you spawn in the middle of the scene, and not strictly in the edge of a corner (a relative 0,0 of the scene)
- Enter a scene with a 0,0 spawn position defined (for example, aetheria at 110,100). Ensure that you spawn strictly in the corner