### PR TITLE
(WIP - do not review) feat: fix loading screen for guests

### DIFF
--- a/browser-interface/packages/shared/loadingScreen/sagas.ts
+++ b/browser-interface/packages/shared/loadingScreen/sagas.ts
@@ -1,19 +1,10 @@
-﻿import { call, put, select, takeLatest } from 'redux-saga/effects'
-import { UPDATE_LOADING_SCREEN, updateLoadingScreen } from './actions'
-import { waitForRendererInstance } from '../renderer/sagas-helper'
-import { getParcelLoadingStarted, isLoadingScreenVisible } from './selectors'
-import { LoadingState } from '../loading/reducer'
-import { getLoadingState } from '../loading/selectors'
-import { RootState } from '../store/rootTypes'
-import { getUnityInstance } from 'unity-interface/IUnityInterface'
-import { AUTHENTICATE, CHANGE_LOGIN_STAGE, SIGNUP_SET_IS_SIGNUP } from '../session/actions'
-import { PARCEL_LOADING_STARTED, RENDERER_INITIALIZED_CORRECTLY } from '../renderer/types'
-import { PENDING_SCENES, SCENE_FAIL, SCENE_LOAD, SCENE_UNLOAD, UPDATE_STATUS_MESSAGE } from '../loading/actions'
+﻿import { PENDING_SCENES, SCENE_FAIL, SCENE_LOAD, SCENE_UNLOAD, UPDATE_STATUS_MESSAGE } from '../loading/actions'
 import { TELEPORT_TRIGGERED } from '../loading/types'
 import { SET_REALM_ADAPTER } from '../realm/actions'
+import { PARCEL_LOADING_STARTED, RENDERER_INITIALIZED_CORRECTLY } from '../renderer/types'
 import { POSITION_SETTLED, POSITION_UNSETTLED, SET_SCENE_LOADER } from '../scene-loader/actions'
+import { AUTHENTICATE, CHANGE_LOGIN_STAGE, SIGNUP_SET_IS_SIGNUP } from '../session/actions'
 import { RENDERING_ACTIVATED, RENDERING_BACKGROUND, RENDERING_DEACTIVATED, RENDERING_FOREGROUND } from './types'
-import { getFeatureFlagEnabled } from 'shared/meta/selectors'
 
 // The following actions may change the status of the loginVisible
 // Reaction on them will be ported to Renderer

--- a/browser-interface/packages/shared/loadingScreen/sagas.ts
+++ b/browser-interface/packages/shared/loadingScreen/sagas.ts
@@ -39,52 +39,5 @@ export const ACTIONS_FOR_LOADING = [
   SCENE_UNLOAD
 ]
 
-/** @deprecated #3642 */
 export function* loadingScreenSaga() {
-  yield takeLatest(UPDATE_LOADING_SCREEN, updateLoadingScreenInternal)
-
-  yield takeLatest(ACTIONS_FOR_LOADING, function* () {
-    yield put(updateLoadingScreen())
-  })
-}
-
-/**
- * This saga hides, show and update the loading screen
- * @deprecated #3642 Loading Screen Visualisation will be moved to Renderer
- */
-function* updateLoadingScreenInternal() {
-  function shouldWaitMetaConfiguration(state: RootState) {
-    return !state.meta.initialized
-  }
-
-  yield call(waitForRendererInstance)
-
-  while (yield select(shouldWaitMetaConfiguration)) {}
-
-  const isDecoupledLoadingScreen = yield select(getFeatureFlagEnabled, 'decoupled_loading_screen')
-
-  if (isDecoupledLoadingScreen) return
-
-  const isVisible = yield select(isLoadingScreenVisible)
-
-  const parcelLoadingStarted = yield select(getParcelLoadingStarted)
-  const loadingState: LoadingState = yield select(getLoadingState)
-  const loadingMessage: string | undefined = yield select((state: RootState): string | undefined => {
-    const msgs: string[] = []
-    if (!state.realm.realmAdapter) msgs.push('Picking realm...')
-    else if (!state.sceneLoader) msgs.push('Initializing world loader...')
-    else if (!parcelLoadingStarted) msgs.push('Fetching initial parcels...')
-
-    if (!state.comms.context) msgs.push('Connecting to comms...')
-
-    msgs.push(loadingState.message)
-    return msgs.join('\n')
-  })
-
-  const loadingScreen = {
-    isVisible,
-    message: loadingMessage || loadingState.message || '',
-    showTips: loadingState.initialLoad || !parcelLoadingStarted
-  }
-  getUnityInstance().SetLoadingScreen(loadingScreen)
 }


### PR DESCRIPTION
Currently new guests are seeing a strange behavior. This PR attempts to fix that.

Test:
- Clear browser storage
- Log in as guest
- Wait until avatar creation shows up
- Hold on for a few seconds
- Make sure you can customize your avatar
- Continue with the login flow. Genesis plaza should be loaded at the end.