### PR TITLE
Fix: hide notification area when no notifications are present

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs
@@ -259,6 +259,9 @@ namespace DCL.Chat.Notifications
 
         private void TogglePanelBackground(bool isInFocus)
         {
+            if (mainChatNotificationView.GetNotificationsCount() == 0)
+                return;
+
             if (isInFocus)
                 mainChatNotificationView.ShowPanel();
             else

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/IMainChatNotificationsComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/IMainChatNotificationsComponentView.cs
@@ -22,5 +22,6 @@ namespace DCL.Chat.Notifications
         void HideNotifications();
         void ShowPanel();
         void HidePanel();
+        int GetNotificationsCount();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs
@@ -92,6 +92,9 @@ namespace DCL.Chat.Notifications
             scrollbarAnimator?.Hide();
         }
 
+        public int GetNotificationsCount() =>
+            notificationQueue.Count;
+
         public void ShowNotifications()
         {
             foreach (BaseComponentView notification in notificationQueue)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/Tests/ChatNotificationControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/Tests/ChatNotificationControllerShould.cs
@@ -465,6 +465,26 @@ namespace DCL.Chat.Notifications
             Assert.AreEqual("fr", dataStore.HUDs.openReceivedFriendRequestDetail.Get());
         }
 
+        [Test]
+        public void DoNotShowNotificationPanelWhenTheNotificationQueueIsEmpty()
+        {
+            mainNotificationsView.GetNotificationsCount().Returns(0);
+
+            mainNotificationsView.OnPanelFocus += Raise.Event<Action<bool>>(true);
+
+            mainNotificationsView.DidNotReceive().ShowPanel();
+        }
+
+        [Test]
+        public void ShowNotificationPanelWhenAnyNotificationIsAdded()
+        {
+            mainNotificationsView.GetNotificationsCount().Returns(1);
+
+            mainNotificationsView.OnPanelFocus += Raise.Event<Action<bool>>(true);
+
+            mainNotificationsView.Received().ShowPanel();
+        }
+
         private void GivenProfile(string userId, string userName)
         {
             var senderUserProfile = ScriptableObject.CreateInstance<UserProfile>();


### PR DESCRIPTION
## What does this PR change?

Fix #4427
Hides notification area when no notifications are present

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://play.decentraland.zone/?explorer-branch=fix/hide-notifications
2. Verify that notifications tab doesn't appear when overing if there are no notifications
3. Get notifications
4. Check the notification panel appears correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
