### PR TITLE
Chore: adjust quality settings presets

### DIFF
--- a/unity-renderer/Assets/Rendering/Common/UniversalRenderPipelineAsset.asset
+++ b/unity-renderer/Assets/Rendering/Common/UniversalRenderPipelineAsset.asset
@@ -34,7 +34,7 @@ MonoBehaviour:
   m_MainLightRenderingMode: 1
   m_MainLightShadowsSupported: 1
   m_MainLightShadowmapResolution: 4096
-  m_AdditionalLightsRenderingMode: 2
+  m_AdditionalLightsRenderingMode: 0
   m_AdditionalLightsPerObjectLimit: 4
   m_AdditionalLightShadowsSupported: 0
   m_AdditionalLightsShadowmapResolution: 512

--- a/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
@@ -34,7 +34,7 @@ MonoBehaviour:
   - displayName: Medium
     baseResolution: 0
     antiAliasing: 1
-    renderScale: 0.86
+    renderScale: 1
     shadows: 1
     softShadows: 1
     shadowResolution: 1024
@@ -47,11 +47,11 @@ MonoBehaviour:
     ssaoQuality: 1
     maxHQAvatars: 40
     reflectionResolution: 1
-    shaderQuality: 1
+    shaderQuality: 0
   - displayName: High
-    baseResolution: 0
+    baseResolution: 1
     antiAliasing: 2
-    renderScale: 1
+    renderScale: 0.75
     shadows: 1
     softShadows: 1
     shadowResolution: 2048
@@ -64,11 +64,11 @@ MonoBehaviour:
     ssaoQuality: 2
     maxHQAvatars: 60
     reflectionResolution: 2
-    shaderQuality: 2
+    shaderQuality: 1
   - displayName: Ultra
-    baseResolution: 0
+    baseResolution: 1
     antiAliasing: 8
-    renderScale: 1
+    renderScale: 0.86
     shadows: 1
     softShadows: 1
     shadowResolution: 4096

--- a/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
@@ -27,30 +27,30 @@ MonoBehaviour:
     shadowDistance: 45
     enableDetailObjectCulling: 1
     detailObjectCullingLimit: 85
-    ssaoQuality: 1
+    ssaoQuality: 0
     maxHQAvatars: 25
     reflectionResolution: 0
     shaderQuality: 0
   - displayName: Medium
-    baseResolution: 1
+    baseResolution: 0
     antiAliasing: 1
-    renderScale: 1
+    renderScale: 0.86
     shadows: 1
     softShadows: 1
     shadowResolution: 1024
     cameraDrawDistance: 150
     bloom: 1
     fpsCap: 1
-    shadowDistance: 60
+    shadowDistance: 50
     enableDetailObjectCulling: 1
     detailObjectCullingLimit: 50
-    ssaoQuality: 2
+    ssaoQuality: 1
     maxHQAvatars: 40
     reflectionResolution: 1
     shaderQuality: 1
   - displayName: High
-    baseResolution: 1
-    antiAliasing: 4
+    baseResolution: 0
+    antiAliasing: 2
     renderScale: 1
     shadows: 1
     softShadows: 1
@@ -66,7 +66,7 @@ MonoBehaviour:
     reflectionResolution: 2
     shaderQuality: 2
   - displayName: Ultra
-    baseResolution: 1
+    baseResolution: 0
     antiAliasing: 8
     renderScale: 1
     shadows: 1

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/RenderingScaleControlConfiguration.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/RenderingScaleControlConfiguration.asset
@@ -18,7 +18,11 @@ MonoBehaviour:
   controlController: {fileID: 11400000, guid: 0abb8a86a6f04be4b98f64245bc532e5, type: 2}
   flagsThatDisableMe: []
   flagsThatDeactivateMe: []
+  flagsThatOverrideMe: []
   isBeta: 0
+  infoButtonEnabled: 1
+  infoTooltipMessage: Try to lower this setting before switching to lower quality
+    preset.
   sliderMinValue: 0.5
   sliderMaxValue: 1
   storeValueAsNormalized: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/RenderingScaleControlConfiguration.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/RenderingScaleControlConfiguration.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   flagsThatOverrideMe: []
   isBeta: 0
   infoButtonEnabled: 1
-  infoTooltipMessage: Try to lower this setting before switching to lower quality
+  infoTooltipMessage: Try lowering this setting before switching to a lower quality
     preset.
   sliderMinValue: 0.5
   sliderMaxValue: 1

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SettingsControlModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SettingsControlModel.cs
@@ -43,5 +43,8 @@ namespace DCL.SettingsPanelHUD.Controls
         public List<BooleanVariable> flagsThatOverrideMe;
 
         public bool isBeta;
+
+        public bool infoButtonEnabled;
+        public string infoTooltipMessage;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SettingsControlView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SettingsControlView.cs
@@ -28,7 +28,6 @@ namespace DCL.SettingsPanelHUD.Controls
         [SerializeField] private GameObject betaIndicator;
         [SerializeField] private ButtonComponentView infoButton;
         [SerializeField] private TooltipComponentView tooltip;
-        [SerializeField] private TooltipComponentModel model;
 
         [Space]
         [SerializeField] private List<TextMeshProUGUI> valueLabels;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SettingsControlView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SettingsControlView.cs
@@ -28,6 +28,7 @@ namespace DCL.SettingsPanelHUD.Controls
         [SerializeField] private GameObject betaIndicator;
         [SerializeField] private ButtonComponentView infoButton;
         [SerializeField] private TooltipComponentView tooltip;
+        [SerializeField] private TooltipComponentModel model;
 
         [Space]
         [SerializeField] private List<TextMeshProUGUI> valueLabels;
@@ -57,9 +58,11 @@ namespace DCL.SettingsPanelHUD.Controls
 
             betaIndicator.SetActive(model.isBeta);
 
-            tooltip.SetModel(new TooltipComponentModel("This setting is being controlled \n by the creator"));
+            string tooltipMessage = !string.IsNullOrEmpty(model.infoTooltipMessage) ? model.infoTooltipMessage : "This setting is being controlled \n by the creator";
+            tooltip.SetModel(new TooltipComponentModel(tooltipMessage));
+
             infoButton.onClick.AddListener(OnInfoButtonClicked);
-            infoButton.gameObject.SetActive(false);
+            infoButton.gameObject.SetActive(model.infoButtonEnabled);
 
             title.text = model.title;
             originalTitleColor = title.color;
@@ -69,7 +72,9 @@ namespace DCL.SettingsPanelHUD.Controls
 
             SwitchInteractibility(isInteractable: model.flagsThatDisableMe.All(flag => flag.Get() == false));
             SwitchVisibility(isVisible: model.flagsThatDeactivateMe.All(flag => flag.Get() == false));
-            SetOverriden(@override: model.flagsThatOverrideMe.Any(flag => flag.Get()));
+
+            if(!model.infoButtonEnabled)
+                SetOverriden(@override: model.flagsThatOverrideMe.Any(flag => flag.Get()));
 
             RefreshControl();
 


### PR DESCRIPTION
## What does this PR change?
Closes #4342 

Common changes are:
- disable additional lights in general Quality settings 

Changes per Quality Preset
### LOW:
- disabled Ambient Occlusion
### MEDIUM:
- drop Resolution to Normal from MatchScreen
- drop Ambient Occlusion to Low
- drop Shader Quality to Low
### HIGH:
- drop Resolution Scale to 0.75
- drop Anti-Aliasing to 2
- drop Shader Quality to Medium
### ULTRA
- drop Resolution Scale to 0.86

## How to test the changes?

1. Go to: https://play.decentraland.zone/?explorer-branch={branch_name}&{desired_url_params}
2. Go to Settings->Quality and choose these 4 presets - Low, Medium, High, Ultra
3. Observe quality changed accordingly to the description above for LOW-MEDIUM-HIGH☝️
4. Check that performance is better (use `/debug` window)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
