### PR TITLE
fix: race condition on signup flow

### DIFF
--- a/browser-interface/packages/shared/scene-loader/sagas.ts
+++ b/browser-interface/packages/shared/scene-loader/sagas.ts
@@ -165,9 +165,13 @@ function* teleportHandler(action: TeleportToAction) {
   }
 }
 
+const waitForUserAuthenticated = waitFor(isLoginCompleted, CHANGE_LOGIN_STAGE)
+
 function* rendererPositionSettler() {
   // wait for renderer
   yield call(waitForRendererInstance)
+  // wait for signup to be finished (teleporting interferes with the signup logic on the renderer)
+  yield call(waitForUserAuthenticated)
 
   while (true) {
     const isSettled: boolean = yield select(isPositionSettled)
@@ -265,8 +269,6 @@ function* positionSettler() {
     }
   }
 }
-
-const waitForUserAuthenticated = waitFor(isLoginCompleted, CHANGE_LOGIN_STAGE)
 
 // This saga reacts to every parcel position change and signals the scene loader
 // about it


### PR DESCRIPTION
Steps to test:

Current bug:
- Clear local storage
- Log in as a guest
- Ensure the signup flow isn't broken by a teleporting logo

Potentially affected flows:
- Sign up as new user, with wallet
- Login as existing guest
- Login as existing wallet user (with and without localstorage session)
- Teleporting
- Starting not on genesis plaza