### PR TITLE
fix: disabling skybox camera when fullscreen ui is visible

### DIFF
--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxCamera.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxCamera.cs
@@ -1,11 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering.Universal;
 
 namespace DCL.Skybox
 {
-
     public class SkyboxCamera
     {
         private GameObject skyboxCameraGO;
@@ -56,6 +53,11 @@ namespace DCL.Skybox
             }
 
             camBehavior.AssignCamera(mainCamComponent, skyboxCamera);
+        }
+
+        public void SetCameraEnabledState(bool enabled)
+        {
+            skyboxCamera.enabled = enabled;
         }
     }
 }

--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxController.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxController.cs
@@ -3,10 +3,8 @@ using DCL.Providers;
 using System;
 using System.Linq;
 using UnityEngine;
-using DCL.ServerTime;
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace DCL.Skybox
 {
@@ -79,6 +77,9 @@ namespace DCL.Skybox
                 directionalLight.type = LightType.Directional;
             }
 
+            CommonScriptableObjects.isFullscreenHUDOpen.OnChange += OnFullscreenUIVisibilityChange;
+            CommonScriptableObjects.isLoadingHUDOpen.OnChange += OnFullscreenUIVisibilityChange;
+
             DoAsyncInitializations();
         }
 
@@ -150,6 +151,14 @@ namespace DCL.Skybox
         {
             skyboxCam.AssignTargetCamera(currentTransform);
             skyboxElements.AssignCameraInstance(currentTransform);
+        }
+
+        private void OnFullscreenUIVisibilityChange(bool visibleState, bool prevVisibleState)
+        {
+            if (visibleState == prevVisibleState)
+                return;
+
+            skyboxCam.SetCameraEnabledState(!visibleState && CommonScriptableObjects.rendererState.Get());
         }
 
         private void FixedTime_OnChange(float current, float _ = 0)
@@ -529,6 +538,9 @@ namespace DCL.Skybox
             DataStore.i.skyboxConfig.fixedTime.OnChange -= FixedTime_OnChange;
             DataStore.i.skyboxConfig.reflectionResolution.OnChange -= ReflectionResolution_OnChange;
             DataStore.i.camera.transform.OnChange -= AssignCameraReferences;
+
+            CommonScriptableObjects.isLoadingHUDOpen.OnChange -= OnFullscreenUIVisibilityChange;
+            CommonScriptableObjects.isFullscreenHUDOpen.OnChange -= OnFullscreenUIVisibilityChange;
 
             timeReporter.Dispose();
             DisposeCT();


### PR DESCRIPTION
## What does this PR change?

When showing fullscreen UI there is not point in rendering anything under. We already disable main camera, but skybox was still rendering

## How to test the changes?

Open and close main menu. There should not be any visible change, skybox should be visible.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
