### PR TITLE
refactor: single select to increase efficiency of profiles

### DIFF
--- a/browser-interface/packages/shared/comms/selectors.ts
+++ b/browser-interface/packages/shared/comms/selectors.ts
@@ -8,7 +8,7 @@ import { RoomConnection } from './interface'
 import { RootCommsState } from './types'
 
 export const getCommsIsland = (store: RootCommsState): string | undefined => store.comms.island
-export const getCommsRoom = (state: RootCommsState): RoomConnection | undefined => state.comms?.context
+export const getCommsRoom = (state: RootCommsState): RoomConnection | undefined => state.comms.context
 
 export function reconnectionState(state: RootState): {
   commsConnection: RoomConnection | undefined

--- a/browser-interface/packages/shared/comms/selectors.ts
+++ b/browser-interface/packages/shared/comms/selectors.ts
@@ -8,7 +8,7 @@ import { RoomConnection } from './interface'
 import { RootCommsState } from './types'
 
 export const getCommsIsland = (store: RootCommsState): string | undefined => store.comms.island
-export const getCommsRoom = (state: RootCommsState): RoomConnection | undefined => state.comms.context
+export const getCommsRoom = (state: RootCommsState): RoomConnection | undefined => state.comms?.context
 
 export function reconnectionState(state: RootState): {
   commsConnection: RoomConnection | undefined

--- a/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
@@ -1,29 +1,30 @@
 import type { Avatar } from '@dcl/schemas'
+import { FETCH_REMOTE_PROFILE_RETRIES } from 'config'
+import { generateRandomUserProfile } from 'lib/decentraland/profiles/generateRandomUserProfile'
+import { ensureAvatarCompatibilityFormat } from 'lib/decentraland/profiles/transformations/profileToServerFormat'
 import { call, put, select } from 'redux-saga/effects'
 import { trackEvent } from 'shared/analytics'
 import type { RoomConnection } from 'shared/comms/interface'
 import { getCommsRoom } from 'shared/comms/selectors'
 import type { ProfileRequestAction } from 'shared/profiles/actions'
 import { profileFailure, profileSuccess } from 'shared/profiles/actions'
-import { generateRandomUserProfile } from 'lib/decentraland/profiles/generateRandomUserProfile'
-import { isCurrentUserId, isGuestLogin } from 'shared/session/selectors'
+import { isCurrentUserId, isGuestLogin as isGuestLoginSelector } from 'shared/session/selectors'
+import type { RootState } from 'shared/store/rootTypes'
 import { getProfileStatusAndData } from '../../selectors'
-import { ensureAvatarCompatibilityFormat } from '../../../../lib/decentraland/profiles/transformations/profileToServerFormat'
 import type { ProfileStatus } from '../../types'
 import { fetchPeerProfile } from '../comms'
 import { fetchCatalystProfile } from '../content'
-import { FETCH_REMOTE_PROFILE_RETRIES } from 'config'
 
 export function* fetchProfile(action: ProfileRequestAction): any {
   const { userId, minimumVersion } = action.payload
-
-  const roomConnection: RoomConnection | undefined = yield select(getCommsRoom)
-  const hasRoomConnection = !!roomConnection
-  const loadingCurrentUser: boolean = yield select(isCurrentUserId, userId)
-
-  const [_, existingProfile]: [ProfileStatus?, Avatar?] = yield select(getProfileStatusAndData, userId)
-  const existingProfileWithCorrectVersion =
-    existingProfile && (!minimumVersion || existingProfile.version >= minimumVersion)
+  const {
+    roomConnection,
+    loadingCurrentUser,
+    hasRoomConnection,
+    existingProfile,
+    isGuestLogin,
+    existingProfileWithCorrectVersion
+  } = yield select(getInformationToFetchProfileFromStore, action)
 
   if (existingProfileWithCorrectVersion) {
     yield put(profileSuccess(existingProfile))
@@ -31,7 +32,7 @@ export function* fetchProfile(action: ProfileRequestAction): any {
   }
 
   try {
-    const isCurrentUserGuest = loadingCurrentUser && (yield select(isGuestLogin))
+    const isCurrentUserGuest = loadingCurrentUser && isGuestLogin
 
     const canFetchFromComms = !loadingCurrentUser && hasRoomConnection
     const canFetchFromCatalyst = !isCurrentUserGuest
@@ -89,4 +90,24 @@ function* fetchWithBestStrategy(
     }
   }
   return generateRandomUserProfile(userId)
+}
+
+export function getInformationToFetchProfileFromStore(state: RootState, action: ProfileRequestAction) {
+  const { userId, minimumVersion } = action.payload
+  const roomConnection: RoomConnection | undefined = getCommsRoom(state)
+  const hasRoomConnection = !!roomConnection
+  const loadingCurrentUser: boolean = isCurrentUserId(state, userId)
+  const isGuestLogin = isGuestLoginSelector(state)
+
+  const [_, existingProfile]: [ProfileStatus?, Avatar?] = getProfileStatusAndData(state, userId)
+  const existingProfileWithCorrectVersion =
+    existingProfile && (!minimumVersion || existingProfile.version >= minimumVersion)
+  return {
+    roomConnection,
+    loadingCurrentUser,
+    hasRoomConnection,
+    existingProfile,
+    isGuestLogin,
+    existingProfileWithCorrectVersion
+  }
 }


### PR DESCRIPTION
The `fetchProfile` function makes 5 calls to `yield select`. This makes the fetching of profiles more efficient by only issuing one `select` effect.