### PR TITLE
feat: use hostnames as realmname

### DIFF
--- a/browser-interface/packages/shared/realm/resolver.ts
+++ b/browser-interface/packages/shared/realm/resolver.ts
@@ -79,10 +79,6 @@ function dclWorldUrl(dclName: string) {
 export function realmToConnectionString(realm: IRealmAdapter) {
   const realmName = realm.about.configurations?.realmName
 
-  if ((realm.about.comms?.protocol === 'v2' || realm.about.comms?.protocol === 'v3') && realmName?.match(/^[a-z]+$/i)) {
-    return realmName
-  }
-
   if (isDclEns(realmName) && realm.baseUrl === dclWorldUrl(realmName)) {
     return realmName
   }


### PR DESCRIPTION
<img width="1014" alt="Screenshot 2023-02-28 at 11 28 56" src="https://user-images.githubusercontent.com/260114/221884794-58b56c93-5897-4650-a1b2-c1622decc442.png">

Replaces the realm name for its hostname or url
- To foster transparency and to provide meaningful information about where you are connected to
- To reduce issues caused by repeated realm names (unresolvable)
- To enable reload of the explorer keeping the previous connection. Repro steps:
   1. Load play.decentraland.org
   2. `/changerealm https://sdk-test-scenes.decentraland.zone/` (now the url says `realm=LocalPreview`)
   3. Reload the explorer
   4. It won't get reconnected, this PR fixes it