### PR TITLE
fix: ensure user profiles in social features

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUD.asmdef
@@ -27,7 +27,8 @@
         "GUID:8aa60ff897c74401cb96cdbc583fed0d",
         "GUID:81f3218b29e049144b175dad2ebbac1b",
         "GUID:82873c2d9c9cbe94391e6b33e5153865",
-        "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
+        "GUID:4d3366a36e77f41cfb7436340334e236"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -173,7 +173,7 @@ public class ChatHUDControllerShould
                 bodyText = "test"
             };
 
-            controller.AddChatMessage(msg);
+            await controller.AddChatMessage(msg);
 
             view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.senderName.Equals(filteredName)));
         });

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendRequestHUD/ReceivedFriendRequestHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendRequestHUD/ReceivedFriendRequestHUDController.cs
@@ -19,6 +19,7 @@ namespace DCL.Social.Friends
         private readonly StringVariable openPassportVariable;
         private readonly ISocialAnalytics socialAnalytics;
 
+        private CancellationTokenSource showCancellationToken = new ();
         private CancellationTokenSource friendOperationsCancellationToken = new ();
         private string friendRequestId;
 
@@ -50,6 +51,7 @@ namespace DCL.Social.Friends
         public void Dispose()
         {
             friendOperationsCancellationToken.SafeCancelAndDispose();
+            showCancellationToken.SafeCancelAndDispose();
             dataStore.HUDs.openReceivedFriendRequestDetail.OnChange -= ShowOrHide;
             friendRequestHUDController.Dispose();
         }
@@ -64,33 +66,44 @@ namespace DCL.Social.Friends
 
         private void Show(string friendRequestId)
         {
-            this.friendRequestId = friendRequestId;
-
-            FriendRequest friendRequest = friendsController.GetAllocatedFriendRequest(this.friendRequestId);
-
-            if (friendRequest == null)
+            async UniTaskVoid ShowAsync(string friendRequestId, CancellationToken cancellationToken)
             {
-                Debug.LogError($"Cannot display friend request {friendRequestId}, is not allocated");
-                return;
-            }
+                this.friendRequestId = friendRequestId;
 
-            view.SetBodyMessage(friendRequest.MessageBody);
-            view.SetTimestamp(DateTimeOffset.FromUnixTimeMilliseconds(friendRequest.Timestamp).DateTime);
+                FriendRequest friendRequest = friendsController.GetAllocatedFriendRequest(this.friendRequestId);
 
-            var recipientProfile = userProfileBridge.Get(friendRequest.From);
+                if (friendRequest == null)
+                {
+                    Debug.LogError($"Cannot display friend request {friendRequestId}, is not allocated");
+                    return;
+                }
 
-            if (recipientProfile != null)
-            {
+                view.SetBodyMessage(friendRequest.MessageBody);
+                view.SetTimestamp(DateTimeOffset.FromUnixTimeMilliseconds(friendRequest.Timestamp).DateTime);
+
+                UserProfile recipientProfile = userProfileBridge.Get(friendRequest.From);
+
+                try
+                {
+                    recipientProfile ??= await userProfileBridge.RequestFullUserProfileAsync(friendRequest.From);
+                }
+                catch (Exception e) when (e is not OperationCanceledException)
+                {
+                    view.SetSenderName(friendRequest.From);
+                    throw;
+                }
+
                 view.SetSenderName(recipientProfile.userName);
                 view.SetSenderProfilePicture(recipientProfile.face256SnapshotURL);
-            }
-            else
-                Debug.LogError($"Cannot display user profile {friendRequest.From}, is not allocated");
 
-            var ownProfile = userProfileBridge.GetOwn();
-            view.SetRecipientProfilePicture(ownProfile.face256SnapshotURL);
-            view.SetSortingOrder(dataStore.HUDs.currentPassportSortingOrder.Get() + 1);
-            view.Show();
+                var ownProfile = userProfileBridge.GetOwn();
+                view.SetRecipientProfilePicture(ownProfile.face256SnapshotURL);
+                view.SetSortingOrder(dataStore.HUDs.currentPassportSortingOrder.Get() + 1);
+                view.Show();
+            }
+
+            showCancellationToken = showCancellationToken.SafeRestart();
+            ShowAsync(friendRequestId, showCancellationToken.Token).Forget();
         }
 
         private void Hide()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -318,7 +318,7 @@ public class HUDController : IHUDController
 
                     if (friendsHud != null)
                     {
-                        friendsHud.Initialize();
+                        friendsHud.Initialize(FriendsHUDComponentView.Create());
                         friendsHud.OnPressWhisper -= OpenPrivateChatWindow;
                         friendsHud.OnPressWhisper += OpenPrivateChatWindow;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
@@ -346,7 +346,7 @@ public class PrivateChatWindowController : IHUD
             messageId = Guid.NewGuid().ToString(),
             messageType = ChatMessage.Type.SYSTEM,
             subType = ChatEntryModel.SubType.RECEIVED
-        });
+        }).Forget();
     }
 
     private void ResetPagination()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -393,7 +393,7 @@ namespace DCL.Chat.HUD
                 messageId = Guid.NewGuid().ToString(),
                 messageType = ChatMessage.Type.SYSTEM,
                 subType = ChatEntryModel.SubType.RECEIVED
-            });
+            }).Forget();
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PrivateChatModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PrivateChatModel.cs
@@ -2,7 +2,9 @@
 
 public struct PrivateChatModel
 {
-    public UserProfile user;
+    public string userId;
+    public string userName;
+    public string faceSnapshotUrl;
     public ChatMessage recentMessage;
     public bool isBlocked;
     public bool isOnline;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 using DCL.Interface;
@@ -216,7 +217,7 @@ namespace DCL.Chat.HUD
                 messageId = Guid.NewGuid().ToString(),
                 messageType = ChatMessage.Type.SYSTEM,
                 subType = ChatEntryModel.SubType.RECEIVED
-            });
+            }).Forget();
         }
 
         private void MuteChannel(bool muted)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowComponentViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowComponentViewShould.cs
@@ -104,9 +104,9 @@ public class WorldChatWindowComponentViewShould
     {
         GivenPrivateChat("pepe");
         GivenPrivateChat("bleh");
-        
+
         yield return null;
-        
+
         Assert.AreEqual(2, view.directChatList.Count());
         Assert.AreEqual(0, view.searchResultsList.Count());
         Assert.AreEqual(0, view.publicChannelList.Count());
@@ -137,17 +137,12 @@ public class WorldChatWindowComponentViewShould
     [UnityTest]
     public IEnumerator ReplacePrivateChat()
     {
-        const string userId = "userId";
-        var profile = ScriptableObject.CreateInstance<UserProfile>();
-        profile.UpdateData(new UserProfileModel
-        {
-            userId = userId,
-            name = "userName"
-        });
+        const string USER_ID = "userId";
 
         var model = new PrivateChatModel
         {
-            user = profile,
+            userId = USER_ID,
+            userName = "userName",
             isBlocked = false,
             isOnline = false,
             recentMessage = new ChatMessage(ChatMessage.Type.PRIVATE, "senderId", "hello!")
@@ -171,7 +166,7 @@ public class WorldChatWindowComponentViewShould
         Assert.AreEqual("Direct Messages (1)", view.directChatsHeaderLabel.text);
         Assert.AreEqual("Channels (0)", view.channelsHeaderLabel.text);
         Assert.AreEqual("Results (0)", view.searchResultsHeaderLabel.text);
-        Assert.IsNotNull(view.directChatList.Get(userId));
+        Assert.IsNotNull(view.directChatList.Get(USER_ID));
     }
 
     [UnityTest]
@@ -180,7 +175,7 @@ public class WorldChatWindowComponentViewShould
         const string channelId = "nearby";
 
         GivenPublicChannel(channelId, "nearby");
-        
+
         yield return null;
 
         Assert.AreEqual(0, view.directChatList.Count());
@@ -188,7 +183,7 @@ public class WorldChatWindowComponentViewShould
         Assert.AreEqual(1, view.publicChannelList.Count());
         Assert.IsNotNull(view.publicChannelList.Get(channelId));
     }
-    
+
     [UnityTest]
     public IEnumerator CreateManyPublicChannels()
     {
@@ -337,21 +332,23 @@ public class WorldChatWindowComponentViewShould
         yield return null;
 
         view.EnableSearchMode();
-        
+
         view.SetPrivateChat(new PrivateChatModel
         {
-            user = GivenProfile("genio"),
+            userId = "genio",
+            userName = "userName",
             recentMessage = new ChatMessage(ChatMessage.Type.PRIVATE, "senderId", "hello")
         });
         view.SetPrivateChat(new PrivateChatModel
         {
-            user = GivenProfile("pepe"),
+            userId = "pepe",
+            userName = "userName",
             recentMessage = new ChatMessage(ChatMessage.Type.PRIVATE, "senderId", "buy my nft")
         });
         view.SetPublicChat(new PublicChatModel("nearby", "nearby", "", true, 1, false, true));
 
         yield return null;
-        
+
         Assert.AreEqual(3, view.directChatList.Count());
         Assert.AreEqual(3, view.searchResultsList.Count());
         Assert.AreEqual(1, view.publicChannelList.Count());
@@ -371,9 +368,9 @@ public class WorldChatWindowComponentViewShould
     public IEnumerator ClearFilter()
     {
         yield return Filter();
-        
+
         view.DisableSearchMode();
-        
+
         Assert.AreEqual(3, view.directChatList.Count());
         Assert.AreEqual(1, view.publicChannelList.Count());
         Assert.AreEqual("Direct Messages (3)", view.directChatsHeaderLabel.text);
@@ -460,7 +457,7 @@ public class WorldChatWindowComponentViewShould
     public void ShowConnectWallet()
     {
         view.ShowConnectWallet();
-        
+
         Assert.IsTrue(view.connectWalletContainer.activeSelf);
         Assert.IsFalse(view.searchBarContainer.activeSelf);
     }
@@ -469,7 +466,7 @@ public class WorldChatWindowComponentViewShould
     public void HideConnectWallet()
     {
         view.HideConnectWallet();
-        
+
         Assert.IsFalse(view.connectWalletContainer.activeSelf);
         Assert.IsTrue(view.searchBarContainer.activeSelf);
     }
@@ -478,10 +475,10 @@ public class WorldChatWindowComponentViewShould
     public void TriggerSignUpWhenConnectWalletButtonClicks()
     {
         var called = false;
-        view.OnSignUp += () => called = true; 
-        
+        view.OnSignUp += () => called = true;
+
         view.connectWalletButton.onClick.Invoke();
-        
+
         Assert.IsTrue(called);
     }
 
@@ -498,11 +495,10 @@ public class WorldChatWindowComponentViewShould
 
     private void GivenPrivateChat(string userId)
     {
-        var profile = GivenProfile(userId);
-
         view.SetPrivateChat(new PrivateChatModel
         {
-            user = profile,
+            userId = userId,
+            userName = "userName",
             isBlocked = false,
             isOnline = false,
             recentMessage = new ChatMessage(ChatMessage.Type.PRIVATE, "senderId", "hello!")
@@ -512,16 +508,5 @@ public class WorldChatWindowComponentViewShould
     private void GivenPublicChannel(string channelId, string name)
     {
         view.SetPublicChat(new PublicChatModel(channelId, name, "any description", true, 0, false, true));
-    }
-
-    private UserProfile GivenProfile(string userId)
-    {
-        var profile = ScriptableObject.CreateInstance<UserProfile>();
-        profile.UpdateData(new UserProfileModel
-        {
-            userId = userId,
-            name = "userName"
-        });
-        return profile;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
@@ -283,6 +283,7 @@ public class WorldChatWindowControllerShould
     {
         controller.Initialize(view, false);
         friendsController.TotalFriendsWithDirectMessagesCount.Returns(40);
+        GivenFriend("bleh", PresenceStatus.ONLINE);
 
         controller.SetVisibility(true);
         friendsController.OnAddFriendsWithDirectMessages += Raise.Event<Action<List<FriendWithDirectMessages>>>(
@@ -301,6 +302,7 @@ public class WorldChatWindowControllerShould
         friendsController.TotalFriendsWithDirectMessagesCount.Returns(26);
         controller.SetVisibility(true);
         view.ClearReceivedCalls();
+        GivenFriend("bleh", PresenceStatus.ONLINE);
 
         friendsController.OnAddFriendsWithDirectMessages += Raise.Event<Action<List<FriendWithDirectMessages>>>(
             new List<FriendWithDirectMessages>
@@ -330,6 +332,7 @@ public class WorldChatWindowControllerShould
         friendsController.TotalFriendsWithDirectMessagesCount.Returns(42);
         view.ClearReceivedCalls();
         friendsController.ClearReceivedCalls();
+        GivenFriend("bleh", PresenceStatus.ONLINE);
 
         friendsController.OnAddFriendsWithDirectMessages += Raise.Event<Action<List<FriendWithDirectMessages>>>(
             new List<FriendWithDirectMessages>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/WorldChatWindowControllerShould.cs
@@ -208,7 +208,7 @@ public class WorldChatWindowControllerShould
         chatController.OnAddMessage += Raise.Event<Action<ChatMessage[]>>(
             new[] {new ChatMessage(ChatMessage.Type.PRIVATE, FRIEND_ID, "wow")});
 
-        view.Received(1).SetPrivateChat(Arg.Is<PrivateChatModel>(p => p.user.userId == FRIEND_ID));
+        view.Received(1).SetPrivateChat(Arg.Is<PrivateChatModel>(p => p.userId == FRIEND_ID));
         view.DidNotReceiveWithAnyArgs().ShowMoreChatsToLoadHint(default);
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowComponentView.cs
@@ -48,7 +48,7 @@ namespace DCL.Chat.HUD
         [SerializeField] internal GameObject loadMoreEntriesContainer;
         [SerializeField] internal TMP_Text loadMoreEntriesLabel;
         [SerializeField] internal GameObject loadMoreEntriesLoading;
-        
+
         [Header("Guest")]
         [SerializeField] internal GameObject connectWalletContainer;
         [SerializeField] internal Button connectWalletButton;
@@ -93,7 +93,7 @@ namespace DCL.Chat.HUD
         public override void Awake()
         {
             base.Awake();
-        
+
             int SortByAlphabeticalOrder(PublicChatEntry u1, PublicChatEntry u2)
             {
                 if (u1.Model.name == NEARBY_CHANNEL)
@@ -103,7 +103,7 @@ namespace DCL.Chat.HUD
 
                 return string.Compare(u1.Model.name, u2.Model.name, StringComparison.InvariantCultureIgnoreCase);
             }
-        
+
             openChannelSearchButton.onClick.AddListener(() => OnOpenChannelSearch?.Invoke());
             closeButton.onClick.AddListener(() => OnClose?.Invoke());
             directChatList.SortingMethod = (a, b) => b.Model.lastMessageTimestamp.CompareTo(a.Model.lastMessageTimestamp);
@@ -160,7 +160,7 @@ namespace DCL.Chat.HUD
 
         public void Hide() => gameObject.SetActive(false);
 
-        public void SetPrivateChat(PrivateChatModel model) => privateChatsCreationQueue[model.user.userId] = model;
+        public void SetPrivateChat(PrivateChatModel model) => privateChatsCreationQueue[model.userId] = model;
 
         public void RemovePrivateChat(string userId)
         {
@@ -298,7 +298,7 @@ namespace DCL.Chat.HUD
         public void SetCreateChannelButtonActive(bool isActive) => createChannelButton.gameObject.SetActive(isActive);
 
         public void SetSearchAndCreateContainerActive(bool isActive) => searchAndCreateContainer.SetActive(isActive);
-        
+
         public void ShowConnectWallet()
         {
             isConnectWalletMode = true;
@@ -334,17 +334,16 @@ namespace DCL.Chat.HUD
 
         private void Set(PrivateChatModel model)
         {
-            var user = model.user;
-            var userId = user.userId;
+            string userId = model.userId;
 
             var entry = new PrivateChatEntryModel(
-                user.userId,
-                user.userName,
+                userId,
+                model.userName,
                 model.recentMessage != null ? model.recentMessage.body : string.Empty,
-                user.face256SnapshotURL,
+                model.faceSnapshotUrl,
                 model.isBlocked,
                 model.isOnline,
-                model.recentMessage != null ? model.recentMessage.timestamp : 0);
+                model.recentMessage?.timestamp ?? 0);
 
             if (isSearchMode)
                 searchResultsList.Set(entry);
@@ -355,7 +354,7 @@ namespace DCL.Chat.HUD
             UpdateLayout();
             SortLists();
         }
-    
+
         private void Set(PublicChatModel model)
         {
             var channelId = model.channelId;
@@ -402,12 +401,12 @@ namespace DCL.Chat.HUD
         {
             model.isLoadingDirectChats = visible;
             directChatsLoadingContainer.SetActive(visible);
-        
+
             if (visible)
                 directChatList.Hide();
             else if (!isSearchMode)
                 directChatList.Show();
-        
+
             scroll.enabled = !visible;
             isLoadingPrivateChannels = visible;
         }
@@ -433,21 +432,21 @@ namespace DCL.Chat.HUD
                     Set(model);
                 }
             }
-            
+
             for (var i = 0; i < CREATION_AMOUNT_PER_FRAME && publicChatsCreationQueue.Count > 0; i++)
             {
                 var (userId, model) = publicChatsCreationQueue.First();
                 publicChatsCreationQueue.Remove(userId);
                 Set(model);
             }
-            
+
             HideMoreChatsLoading();
         }
 
         private void FetchProfilePicturesForVisibleEntries()
         {
             if (isSearchMode) return;
-            
+
             foreach (var entry in directChatList.Entries.Values.Skip(currentAvatarSnapshotIndex)
                          .Take(AVATAR_SNAPSHOTS_PER_FRAME))
             {
@@ -462,7 +461,7 @@ namespace DCL.Chat.HUD
             if (currentAvatarSnapshotIndex >= directChatList.Entries.Count)
                 currentAvatarSnapshotIndex = 0;
         }
-        
+
         private void RequestMorePrivateChats(Vector2 position)
         {
             if (!loadMoreEntriesContainer.activeInHierarchy
@@ -483,7 +482,7 @@ namespace DCL.Chat.HUD
 
             lastScrollPosition = position;
         }
-    
+
         private IEnumerator WaitThenRequireMoreEntries()
         {
             yield return new WaitForSeconds(1f);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/WorldChatWindowHUD.asmdef
@@ -33,7 +33,8 @@
         "GUID:7fe146b43e76fe745aeaf2020feb54b7",
         "GUID:4d7712e4b2446440a8af21fd3ce8690e",
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
-        "GUID:760a1d365aad58044916992b072cf2a6"
+        "GUID:760a1d365aad58044916992b072cf2a6",
+        "GUID:4d3366a36e77f41cfb7436340334e236"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
@@ -8,6 +8,8 @@ using UnityEngine;
 
 public class UserProfileController : MonoBehaviour
 {
+    private const int REQUEST_TIMEOUT = 30;
+
     public static UserProfileController i { get; private set; }
 
     public event Action OnBaseWereablesFail;
@@ -144,6 +146,6 @@ public class UserProfileController : MonoBehaviour
         cancellationToken.RegisterWithoutCaptureExecutionContext(() => task.TrySetCanceled());
         pendingUserProfileTasks[userId] = task;
 
-        return task.Task;
+        return task.Task.Timeout(TimeSpan.FromSeconds(REQUEST_TIMEOUT));
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Interface;
 using DCLServices.WearablesCatalogService;
 using System;
 using JetBrains.Annotations;
@@ -145,6 +146,8 @@ public class UserProfileController : MonoBehaviour
         var task = new UniTaskCompletionSource<UserProfile>();
         cancellationToken.RegisterWithoutCaptureExecutionContext(() => task.TrySetCanceled());
         pendingUserProfileTasks[userId] = task;
+
+        WebInterface.SendRequestUserProfile(userId);
 
         return task.Task.Timeout(TimeSpan.FromSeconds(REQUEST_TIMEOUT));
     }


### PR DESCRIPTION
## What does this PR change?

Fetches the user profile when is not in cache in many social features:
- friend requests
- channel members
- friend list
- friend request list
- direct message list

## How to test the changes?

1. Go to: https://play.decentraland.zone/?explorer-branch=fix/ensure-user-profiles
2. Check that the described social features are working as expected
3. Check that the pagination is working correctly when is possible
4. Check that the chat is working properly: #nearby, #channels, private messages

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
