### PR TITLE
revert: "feat: use hostnames as realmname"

### DIFF
--- a/browser-interface/packages/shared/realm/resolver.ts
+++ b/browser-interface/packages/shared/realm/resolver.ts
@@ -79,6 +79,10 @@ function dclWorldUrl(dclName: string) {
 export function realmToConnectionString(realm: IRealmAdapter) {
   const realmName = realm.about.configurations?.realmName
 
+  if ((realm.about.comms?.protocol === 'v2' || realm.about.comms?.protocol === 'v3') && realmName?.match(/^[a-z]+$/i)) {
+    return realmName
+  }
+
   if (isDclEns(realmName) && realm.baseUrl === dclWorldUrl(realmName)) {
     return realmName
   }


### PR DESCRIPTION
Reverts decentraland/unity-renderer#4477 -- introduces problems when loading worlds