### PR TITLE
revert: "feat: use hostnames as realmname (#4477)"

### DIFF
--- a/browser-interface/packages/shared/realm/resolver.ts
+++ b/browser-interface/packages/shared/realm/resolver.ts
@@ -79,6 +79,10 @@ function dclWorldUrl(dclName: string) {
 export function realmToConnectionString(realm: IRealmAdapter) {
   const realmName = realm.about.configurations?.realmName
 
+  if ((realm.about.comms?.protocol === 'v2' || realm.about.comms?.protocol === 'v3') && realmName?.match(/^[a-z]+$/i)) {
+    return realmName
+  }
+
   if (isDclEns(realmName) && realm.baseUrl === dclWorldUrl(realmName)) {
     return realmName
   }


### PR DESCRIPTION
This reverts commit a6b445ecb70cc25f9e8192c0b1c1d5ab73d51bcf. Related to https://github.com/decentraland/unity-renderer/pull/4494