### PR TITLE
revert: spawn on the middle of the scene

### DIFF
--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -107,9 +107,9 @@ function pickSpawnpoint(land: Scene): InstancedSpawnPoint {
     spawnPoints = [
       {
         position: {
-          x: [1, 15],
-          y: [0, 0],
-          z: [1, 15]
+          x: 1,
+          y: 0,
+          z: 1
         }
       }
     ]
@@ -148,8 +148,8 @@ function pickSpawnpoint(land: Scene): InstancedSpawnPoint {
     }
 
     if (!isWorldPositionInsideParcels(land.scene.parcels, finalWorldPosition)) {
-      finalPosition.x = 8
-      finalPosition.z = 8
+      finalPosition.x = 1
+      finalPosition.z = 1
     }
   }
 


### PR DESCRIPTION
Reverts #4410, and moves the spawn position by default to be (1,1) instead of 0,0 to avoid green blockers

Rationale:
* All sample scenes and templates from the CLI have a hard-coded 0,0 spawn point. So, the change introduced in #4410 is only effective on scenes created manually, copying code, or by builder.decentraland.org
* builder.decentraland.org has no way of setting spawn points, so the user is likely to appear in the middle of buildings or, maybe even worse, colliders.
* Thus, the rationale for #4410 is probably only effective on empty parcels, and introducing undesirable effects on all builder-created scenes.