### PR TITLE
fix: typo on gh build commenter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
             ### Web
             This branch can be previewed at:
-            - https://play.decentraland.org/?explorer-branch=${{ github.head_ref }})
+            - https://play.decentraland.org/?explorer-branch=${{ github.head_ref }}
             - https://play.decentraland.zone/?explorer-branch=${{ github.head_ref }}
 
             ### Desktop:


### PR DESCRIPTION
Fixes an extra parenthesis on gh action bot commenting with links