### PR TITLE
chore: set rollout to .org to 100%

### DIFF
--- a/.github/workflows/set-rollout.yml
+++ b/.github/workflows/set-rollout.yml
@@ -62,4 +62,4 @@ jobs:
           # Rollout information
           deploymentDomain: "play.decentraland.org"
           deploymentName: "@dcl/explorer"
-          percentage: 0
+          percentage: 100


### PR DESCRIPTION
The rollout to .org was set to 0% due to a failure on the cdn-uploader. Now that it is working again, there is no need to have the rollout to 0%.

Reverts decentraland/unity-renderer#4407