### PR TITLE
chore: reintroduce "remove realm name from URL" from #4477

### DIFF
--- a/browser-interface/packages/shared/realm/resolver.ts
+++ b/browser-interface/packages/shared/realm/resolver.ts
@@ -79,10 +79,6 @@ function dclWorldUrl(dclName: string) {
 export function realmToConnectionString(realm: IRealmAdapter) {
   const realmName = realm.about.configurations?.realmName
 
-  if ((realm.about.comms?.protocol === 'v2' || realm.about.comms?.protocol === 'v3') && realmName?.match(/^[a-z]+$/i)) {
-    return realmName
-  }
-
   if (isDclEns(realmName) && realm.baseUrl === dclWorldUrl(realmName)) {
     return realmName
   }


### PR DESCRIPTION
## What does this PR change?

Reintroduces the changes from #4477

---

<img width="1014" alt="Screenshot 2023-02-28 at 11 28 56" src="https://user-images.githubusercontent.com/260114/221884794-58b56c93-5897-4650-a1b2-c1622decc442.png">

Replaces the realmName for its hostname or base URL
- To foster transparency and to provide meaningful information about where you are connected to
- To reduce issues caused by repeated realm names (unresolvable)
- To enable reload of the explorer keeping the previous connection.
 
QA checks:
- **To test the feature's happy path**
   1. Load https://play.decentraland.org
   2. `/changerealm https://sdk-test-scenes.decentraland.zone/` must show `realm=sdk-test-scenes.decentraland.zone` in the browser's URL instead of `realm=LocalPreview`
   3. Reload the explorer
   4. It should get reconnected to `sdk-test-scenes.decentraland.zone`, not loading the genesis city
- **Changing to a catalyst realm** "the resolution based on a name" of the catalysts was not changed.
   1. Load https://play.decentraland.org
   2. `/changerealm dg` must successfully change the catalyst
   3. `/changerealm unicorn` must successfully change the catalyst
   4. `/changerealm https://sdk-test-scenes.decentraland.zone/` must successfully unload the city and take you to the sdk-test-scenes realm
   5. `/changerealm menduz.dcl.eth` must successfully unload the city and take you to the `menduz.dcl.eth` world
- **Checking worlds is not broken** 
   1. Load https://play.decentraland.org
   1. `/changerealm menduz.dcl.eth` must successfully unload the city and take you to the `menduz.dcl.eth` world
   1. `/changerealm https://sdk-test-scenes.decentraland.zone/` must successfully unload the city and take you to the sdk-test-scenes realm
   1. `/changerealm menduz.dcl.eth` must successfully unload the city and take you to the `menduz.dcl.eth` world
   1. `/changerealm dg` must successfully unload the world and take you to genesis city