### PR TITLE
Add Map Interactivity Controller and Map Render Image

### DIFF
--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Addressables/MapCameraObject.prefab
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Addressables/MapCameraObject.prefab
@@ -71,10 +71,10 @@ Camera:
     width: 1
     height: 1
   near clip plane: 0.3
-  far clip plane: 1000
+  far clip plane: 10
   field of view: 60
-  orthographic: 0
-  orthographic size: 5
+  orthographic: 1
+  orthographic size: 10
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/MapRendererConfiguration.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/MapRendererConfiguration.cs
@@ -17,6 +17,9 @@ namespace DCLServices.MapRendererV2.ComponentsFactory
         public Transform HotUserMarkersRoot { get; private set; }
 
         [field: SerializeField]
+        public Transform ParcelHighlightRoot { get; private set; }
+
+        [field: SerializeField]
         public Transform MapCamerasRoot { get; private set; }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapCameraController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapCameraController.cs
@@ -1,5 +1,4 @@
 ﻿using DCLServices.MapRendererV2.MapLayers;
-using System;
 using UnityEngine;
 
 namespace DCLServices.MapRendererV2.MapCameraController
@@ -9,6 +8,8 @@ namespace DCLServices.MapRendererV2.MapCameraController
         MapLayer EnabledLayers { get; }
 
         RenderTexture GetRenderTexture();
+
+        IMapInteractivityController GetInteractivityController();
 
         /// <summary>
         /// Zoom level normalized between 0 and 1

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapCameraControllerInternal.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapCameraControllerInternal.cs
@@ -12,6 +12,8 @@ namespace DCLServices.MapRendererV2.MapCameraController
     {
         event Action<IMapCameraControllerInternal> OnReleasing;
 
+        Camera Camera { get; }
+
         void Initialize(Vector2Int textureResolution, Vector2Int zoomValues, MapLayer layers);
 
         void SetActive(bool active);

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapInteractivityController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapInteractivityController.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+namespace DCLServices.MapRendererV2.MapCameraController
+{
+    public interface IMapInteractivityController
+    {
+        bool HighlightEnabled { get; }
+
+        /// <summary>
+        /// Highlights the (hovered) parcel
+        /// </summary>
+        void HighlightParcel(Vector2 normalizedCoordinates);
+
+        void RemoveHighlight();
+
+        /// <summary>
+        /// Returns Parcel corresponding to the given (cursor) position within UI `RawImage`
+        /// </summary>
+        Vector2Int GetParcel(Vector2 normalizedCoordinates);
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapInteractivityController.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapInteractivityController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 434cb6366cbd4224a412338fca330151
+timeCreated: 1677762888

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapInteractivityControllerInternal.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapInteractivityControllerInternal.cs
@@ -1,0 +1,12 @@
+﻿using DCLServices.MapRendererV2.MapLayers;
+using System;
+
+namespace DCLServices.MapRendererV2.MapCameraController
+{
+    internal interface IMapInteractivityControllerInternal : IMapInteractivityController, IDisposable
+    {
+        void Initialize(MapLayer layers);
+
+        void Release();
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapInteractivityControllerInternal.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapInteractivityControllerInternal.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c7065464afc0417cbd9babf2a290ff93
+timeCreated: 1677770524

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraInteractivityController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraInteractivityController.cs
@@ -1,0 +1,85 @@
+﻿using DCLServices.MapRendererV2.CoordsUtils;
+using DCLServices.MapRendererV2.MapLayers;
+using DCLServices.MapRendererV2.MapLayers.ParcelHighlight;
+using MainScripts.DCL.Helpers.Utils;
+using UnityEngine;
+using UnityEngine.Pool;
+
+namespace DCLServices.MapRendererV2.MapCameraController
+{
+    internal class MapCameraInteractivityController : IMapInteractivityControllerInternal
+    {
+        private readonly Transform cameraParent;
+        private readonly IObjectPool<IParcelHighlightMarker> markersPool;
+        private readonly ICoordsUtils coordsUtils;
+        private readonly Camera camera;
+
+        private IParcelHighlightMarker marker;
+
+        public bool HighlightEnabled { get; private set; }
+
+        public MapCameraInteractivityController(
+            Transform cameraParent,
+            Camera camera,
+            IObjectPool<IParcelHighlightMarker> markersPool,
+            ICoordsUtils coordsUtils)
+        {
+            this.cameraParent = cameraParent;
+            this.markersPool = markersPool;
+            this.coordsUtils = coordsUtils;
+            this.camera = camera;
+        }
+
+        public void HighlightParcel(Vector2 normalizedCoordinates)
+        {
+            if (marker == null)
+                return;
+
+            marker.Activate();
+            marker.SetPosition(GetLocalPosition(normalizedCoordinates));
+        }
+
+        public void Initialize(MapLayer layers)
+        {
+            HighlightEnabled = EnumUtils.HasFlag(layers, MapLayer.ParcelHoverHighlight);
+
+            if (HighlightEnabled)
+                marker = markersPool.Get();
+        }
+
+        public void RemoveHighlight()
+        {
+            if (marker == null)
+                return;
+
+            marker.Deactivate();
+        }
+
+        public Vector2Int GetParcel(Vector2 normalizedCoordinates) =>
+            coordsUtils.PositionToCoords(GetLocalPosition(normalizedCoordinates));
+
+        private Vector3 GetLocalPosition(Vector2 normalizedCoordinates)
+        {
+            // normalized position is equal to viewport position
+            var worldPoint = camera.ViewportToWorldPoint(normalizedCoordinates);
+
+            var localPosition = cameraParent ? cameraParent.InverseTransformPoint(worldPoint) : worldPoint;
+            localPosition.z = 0;
+            return localPosition;
+        }
+
+        public void Dispose()
+        {
+            Release();
+        }
+
+        public void Release()
+        {
+            if (marker != null)
+            {
+                markersPool.Release(marker);
+                marker = null;
+            }
+        }
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraInteractivityController.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraInteractivityController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ad128167097d4488b724ad8bb70cadf2
+timeCreated: 1677770512

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapRenderImage.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapRenderImage.cs
@@ -1,0 +1,47 @@
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace DCLServices.MapRendererV2.MapCameraController
+{
+    /// <summary>
+    /// Extends <see cref="RawImage"/> to provide interactivity functionality
+    /// </summary>
+    public class MapRenderImage : RawImage, IPointerMoveHandler, IPointerExitHandler
+    {
+        private bool highlightEnabled;
+        private IMapInteractivityController interactivityController;
+        private Camera hudCamera;
+
+        public void SetCameraController(Camera hudCamera, RenderTexture renderTexture, IMapInteractivityController interactivityController)
+        {
+            this.highlightEnabled = interactivityController.HighlightEnabled;
+            this.hudCamera = hudCamera;
+            this.interactivityController = interactivityController;
+
+            texture = renderTexture;
+        }
+
+        public void OnPointerMove(PointerEventData eventData)
+        {
+            if (!highlightEnabled)
+                return;
+
+            var screenPoint = eventData.position;
+
+            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, screenPoint, hudCamera, out var localPoint))
+            {
+                var normalizedPoint = rectTransform.rect.size * localPoint;
+                interactivityController.HighlightParcel(normalizedPoint);
+            }
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            if (!highlightEnabled)
+                return;
+
+            interactivityController.RemoveHighlight();
+        }
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapRenderImage.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapRenderImage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 216365a7538341638bb1926366c89aab
+timeCreated: 1677760049

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/MapLayer.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/MapLayer.cs
@@ -11,7 +11,8 @@ namespace DCLServices.MapRendererV2.MapLayers
         PointsOfInterest = 1 << 2,
         PlayerMarker = 1 << 3,
         HotUsersMarkers = 1 << 4,
-        ColdUsersMarkers = 1 << 5
+        ColdUsersMarkers = 1 << 5,
+        ParcelHoverHighlight = 1 << 6
         // Add yours
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ba6356392113488a9a6c0cb1fde71e56
+timeCreated: 1677764348

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/IParcelHighlightMarker.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/IParcelHighlightMarker.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using UnityEngine;
+
+namespace DCLServices.MapRendererV2.MapLayers.ParcelHighlight
+{
+    internal interface IParcelHighlightMarker : IDisposable
+    {
+        void SetPosition(Vector3 position);
+
+        void Activate();
+
+        void Deactivate();
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/IParcelHighlightMarker.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/IParcelHighlightMarker.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: de707e447fc048728c590761b5a0c205
+timeCreated: 1677769935

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/ParcelHighlightMarker.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/ParcelHighlightMarker.cs
@@ -1,0 +1,36 @@
+﻿using DCL.Helpers;
+using UnityEngine;
+
+namespace DCLServices.MapRendererV2.MapLayers.ParcelHighlight
+{
+    internal class ParcelHighlightMarker : IParcelHighlightMarker
+    {
+        private readonly ParcelHighlightMarkerObject obj;
+
+        public ParcelHighlightMarker(ParcelHighlightMarkerObject obj)
+        {
+            this.obj = obj;
+            Deactivate();
+        }
+
+        public void SetPosition(Vector3 position)
+        {
+            obj.transform.localPosition = position;
+        }
+
+        public void Activate()
+        {
+            obj.gameObject.SetActive(true);
+        }
+
+        public void Deactivate()
+        {
+            obj.gameObject.SetActive(false);
+        }
+
+        public void Dispose()
+        {
+            Utils.SafeDestroy(obj.gameObject);
+        }
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/ParcelHighlightMarker.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/ParcelHighlightMarker.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 87cf6dc2168241fd8c2a824642ece7b8
+timeCreated: 1677769938

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/ParcelHighlightMarkerObject.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/ParcelHighlightMarkerObject.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+
+namespace DCLServices.MapRendererV2.MapLayers.ParcelHighlight
+{
+    internal class ParcelHighlightMarkerObject : MonoBehaviour
+    {
+        [field: SerializeField]
+        internal SpriteRenderer spriteRenderer { get; private set; }
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/ParcelHighlightMarkerObject.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/ParcelHighlight/ParcelHighlightMarkerObject.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 60a70c562b494a2083a5902cc61d5e13
+timeCreated: 1677767634

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/MapCameraController/MapCameraControllerShould.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/MapCameraController/MapCameraControllerShould.cs
@@ -21,7 +21,8 @@ namespace DCLServices.MapRendererV2.Tests.MapCameraController
             mapCameraObject = go.AddComponent<MapCameraObject>();
             mapCameraObject.mapCamera = go.AddComponent<Camera>();
             coordsUtils = Substitute.For<ICoordsUtils>();
-            mapCamera = new MapRendererV2.MapCameraController.MapCameraController(mapCameraObject, coordsUtils);
+            mapCamera = new MapRendererV2.MapCameraController.MapCameraController(
+                Substitute.For<IMapInteractivityControllerInternal>(), mapCameraObject, coordsUtils);
         }
 
         [Test]

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/MapCameraController/MapCameraInteractivityControllerShould.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/MapCameraController/MapCameraInteractivityControllerShould.cs
@@ -1,0 +1,99 @@
+﻿using DCLServices.MapRendererV2.CoordsUtils;
+using DCLServices.MapRendererV2.MapCameraController;
+using DCLServices.MapRendererV2.MapLayers;
+using DCLServices.MapRendererV2.MapLayers.ParcelHighlight;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Pool;
+
+namespace DCLServices.MapRendererV2.Tests.MapCameraController
+{
+    [TestFixture]
+    public class MapCameraInteractivityControllerShould
+    {
+        private MapCameraInteractivityController controller;
+        private Camera camera;
+        private IObjectPool<IParcelHighlightMarker> pool;
+        private IParcelHighlightMarker marker;
+
+        [SetUp]
+        public void Setup()
+        {
+            camera = new GameObject("Camera").AddComponent<Camera>();
+            camera.orthographic = true;
+            camera.orthographicSize = 5;
+            camera.aspect = 1f;
+            camera.transform.position = Vector3.zero;
+
+            pool = Substitute.For<IObjectPool<IParcelHighlightMarker>>();
+            pool.Get().Returns(marker = Substitute.For<IParcelHighlightMarker>());
+
+            var coordUtils = Substitute.For<ICoordsUtils>();
+            coordUtils.PositionToCoords(Arg.Any<Vector3>()).Returns(call => new Vector2Int((int)call.Arg<Vector3>().x, (int)call.Arg<Vector3>().y));
+
+            controller = new MapCameraInteractivityController(null, camera, pool, coordUtils);
+        }
+
+        [Test]
+        [TestCase(MapLayer.HomePoint | MapLayer.ColdUsersMarkers | MapLayer.PlayerMarker | MapLayer.ParcelHoverHighlight)]
+        [TestCase(MapLayer.ParcelHoverHighlight)]
+        [TestCase(MapLayer.ParcelHoverHighlight | MapLayer.Atlas)]
+        public void InitializedInActiveState(MapLayer layer)
+        {
+            controller.Initialize(layer);
+            Assert.IsTrue(controller.HighlightEnabled);
+            pool.Received(1).Get();
+        }
+
+        [Test]
+        [TestCase(MapLayer.HomePoint | MapLayer.ColdUsersMarkers | MapLayer.PlayerMarker)]
+        [TestCase(MapLayer.Atlas)]
+        [TestCase(MapLayer.HotUsersMarkers | MapLayer.Atlas)]
+        public void InitializeInInActiveState(MapLayer layer)
+        {
+            controller.Initialize(layer);
+            Assert.IsFalse(controller.HighlightEnabled);
+            pool.DidNotReceive().Get();
+        }
+
+        [Test]
+        public void ActivateOnHighlight()
+        {
+            controller.Initialize(MapLayer.ParcelHoverHighlight);
+            controller.HighlightParcel(new Vector2(0.5f, 0.5f));
+
+            marker.Received(1).Activate();
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SetPositionOnHighlightTestCases))]
+        public void SetPositionOnHighlight(Vector3 cameraPos, Vector2 norm, Vector3 expected)
+        {
+            camera.transform.localPosition = cameraPos;
+
+            controller.Initialize(MapLayer.ParcelHoverHighlight);
+            controller.HighlightParcel(norm);
+
+            marker.Received(1).SetPosition(expected);
+        }
+
+
+        public static object[] SetPositionOnHighlightTestCases =
+        {
+            new object[] { Vector3.zero, new Vector2(0.5f, 0.5f), Vector3.zero},
+            new object[] { new Vector3(1f, 1f, -2f), new Vector2(0.5f, 0.5f), new Vector3(1f, 1f, 0)},
+            new object[] { new Vector3(4f, 0f, 30f), new Vector2(0.2f, 0.1f), new Vector3(1f, -4f, 0f)},
+            new object[] { new Vector3(-2f, 2f, 10f), new Vector2(1f, 1f), new Vector3(3f, 7f, 0f)}
+        };
+
+        [Test]
+        public void RemoveHighlight()
+        {
+            controller.Initialize(MapLayer.ParcelHoverHighlight);
+            controller.Release();
+
+            pool.Received(1).Release(marker);
+        }
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/MapCameraController/MapCameraInteractivityControllerShould.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/MapCameraController/MapCameraInteractivityControllerShould.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9330e2fa172b48abb52406f23bafd7bc
+timeCreated: 1677772673


### PR DESCRIPTION
Closes #4264

- Added `MapCameraInteractivityController` that handles high-level input events on camera basis:
  - `HighlightParcel` to highlight the hovered parcel
  - `GetParcel` under the cursor to comply with the current API of `NavmapToastView`
- Added `MapRenderImage`: a lower level class to handle pointer events and transform them for the higher level API