### PR TITLE
chore: enable incremental gc

### DIFF
--- a/unity-renderer/ProjectSettings/ProjectSettings.asset
+++ b/unity-renderer/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 1, g: 1, b: 1, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1

--- a/unity-renderer/ProjectSettings/ProjectSettings.asset
+++ b/unity-renderer/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 1, g: 1, b: 1, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
@@ -785,7 +785,7 @@ PlayerSettings:
   selectedPlatform: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
-  gcIncremental: 0
+  gcIncremental: 1
   assemblyVersionValidation: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform:


### PR DESCRIPTION
## What does this PR change?

To analyze the toggle, I made a test in which I enter DCL and leave through the North door. The following conclusion are observed: 

**With IGC disabled**

On GC fired: 134.26 ms
Constant GC: Around 6.55 ms

![Screen Shot 2023-03-06 at 17 27 53](https://user-images.githubusercontent.com/1999557/223224466-87373d69-0ad5-4aff-9a09-9e052cae2616.png)

![Screen Shot 2023-03-06 at 17 28 03](https://user-images.githubusercontent.com/1999557/223224491-1bd0dee2-544d-44ec-9bcb-661c86daadea.png)

**With IGC enabled**

Worst GC spike: Worst 21.77 ms, 12.67 ms during a couple of frames
Constant GC: Around 8.03 ms

![Screen Shot 2023-03-06 at 17 31 06](https://user-images.githubusercontent.com/1999557/223224431-cfa3cb65-96f9-47c6-b132-3d4cda3dc4b2.png)

![Screen Shot 2023-03-06 at 17 31 15](https://user-images.githubusercontent.com/1999557/223224382-c0e6693a-aa87-4dc6-91f0-7cc600e4d3e4.png)

![Screen Shot 2023-03-06 at 17 31 22](https://user-images.githubusercontent.com/1999557/223224336-7bfb8d5e-edf9-464b-9e2d-32ab9559c3db.png)

When IGC enabled, we can see that we got **dismissable** increase GC occurring on every frame. Most importantly, on a GC spike, we can see it clearly distributed.

If the IGC is disabled, we have one huge spike that most probably will cause a hiccup.

Therefore, it is recommended to move forward and integrate the IGC. 

## How to test the changes?

No QA needed

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
