### PR TITLE
chore: rollout to 0%

### DIFF
--- a/.github/workflows/set-rollout.yml
+++ b/.github/workflows/set-rollout.yml
@@ -62,4 +62,4 @@ jobs:
           # Rollout information
           deploymentDomain: "play.decentraland.org"
           deploymentName: "@dcl/explorer"
-          percentage: 100
+          percentage: 0


### PR DESCRIPTION
Due to the unstability of the CI artifacts, we are setting the rollouts to 0%

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
