### PR TITLE
chore: add library cache versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,8 @@ commands:
       - restore_cache: &RESTORE_LIBRARY_CACHE
           name: Restore library if exists
           keys:
-            - library-{{ checksum "/tmp/target" }}-{{ .Branch }}
-            - library-{{ checksum "/tmp/target" }}-dev
+            - library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-{{ .Branch }}
+            - library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-dev
       - run:
           name: Build Unity Project
           no_output_timeout: 45m
@@ -144,7 +144,7 @@ commands:
           paths: *CACHED_PATHS
       - save_cache:
           name: Store library
-          key: library-{{ checksum "/tmp/target" }}-{{ .Branch }}
+          key: library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-{{ .Branch }}
           paths:
             - ./unity-renderer/Library
       - run:


### PR DESCRIPTION
If we change the LIBRARY_CACHE_VERSION from the CircleCI Environment Variables, all the builds will start over without the cache of the library. We can use this when the library cache is corrupt.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
