### PR TITLE
fix: ab not loading with new cdn flow for worlds

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -4,6 +4,7 @@ using DCL.Helpers;
 using System;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.Rendering.UI;
 
 namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
 {
@@ -18,14 +19,29 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
 
     public class AssetPromise_SceneAB : AssetPromise_WithUrl<Asset_SceneAB>
     {
+        private const string URN_PREFIX = "urn:decentraland:entity:";
         private readonly CancellationTokenSource cancellationTokenSource;
         private Service<IWebRequestController> webRequestController;
 
         private Action onSuccess;
 
-        public AssetPromise_SceneAB(string contentUrl, string hash) : base(contentUrl, hash)
+        public AssetPromise_SceneAB(string contentUrl, string sceneId) : base(contentUrl, sceneId)
         {
             cancellationTokenSource = new CancellationTokenSource();
+            this.hash = GetEntityIdFromSceneId(sceneId);
+            Debug.Log(this.hash);
+        }
+
+        private string GetEntityIdFromSceneId(string sceneId)
+        {
+            // This case happens when loading worlds
+            if (sceneId.StartsWith(URN_PREFIX))
+            {
+                int prefixLength = URN_PREFIX.Length;
+                return sceneId.Substring(prefixLength, sceneId.IndexOf("?", StringComparison.Ordinal) - prefixLength);
+            }
+
+            return sceneId;
         }
 
         protected override void OnCancelLoading()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -28,7 +28,6 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
         {
             cancellationTokenSource = new CancellationTokenSource();
             this.hash = GetEntityIdFromSceneId(sceneId);
-            Debug.Log(this.hash);
         }
 
         private string GetEntityIdFromSceneId(string sceneId)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -4,7 +4,6 @@ using DCL.Helpers;
 using System;
 using System.Threading;
 using UnityEngine;
-using UnityEngine.Rendering.UI;
 
 namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
 {


### PR DESCRIPTION
## What does this PR change?

Closes #4558 after enabling the new feature flag `AB-NEW-CDN`

When loading worlds the scene-id has a different format so we had to fix this case to get the correct entity id to load the asset bundles with the new CDN flow

![image](https://user-images.githubusercontent.com/7646450/223758719-a804beee-ad6a-4d4e-b9c7-7c3263b015f7.png)

## How to test the changes?

- Go to: https://play.decentraland.org/?explorer-branch=fix/new-cdn-worlds&ENABLE_AB-NEW-CDN&realm=dclonboarding.dcl.eth
- use `/detectabs` chat command 
- Check that most/all assets should be green ( blue for the colliders ) 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
