### PR TITLE
fix: AB colliders not working because they are not readable on WebGL

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -185,14 +185,21 @@ namespace DCL
         {
             foreach (Mesh mesh in meshesList)
             {
+
                 if (!mesh.isReadable)
                     continue;
 
                 asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
                 asset.meshes.Add(mesh);
 
-                //Physics.BakeMesh(mesh.GetInstanceID(), false);
-                //mesh.UploadMeshData(true);
+                bool isCollider = mesh.name.Contains("_collider", StringComparison.InvariantCultureIgnoreCase);
+
+                // colliders will fail to be created if they are not readable on WebGL
+                if (!isCollider)
+                {
+                    Physics.BakeMesh(mesh.GetInstanceID(), false);
+                    mesh.UploadMeshData(true);
+                }
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -177,7 +177,7 @@ namespace DCL
 #if UNITY_EDITOR
                 assetBundleModelGO.name = subPromise.asset.GetName();
 #endif
-                
+
             }
         }
 
@@ -191,8 +191,8 @@ namespace DCL
                 asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
                 asset.meshes.Add(mesh);
 
-                Physics.BakeMesh(mesh.GetInstanceID(), false);
-                mesh.UploadMeshData(true);
+                //Physics.BakeMesh(mesh.GetInstanceID(), false);
+                //mesh.UploadMeshData(true);
             }
         }
 


### PR DESCRIPTION
## What does this PR change?

![image](https://user-images.githubusercontent.com/7646450/223854782-4e4622e4-8897-4e88-8824-33cc1f48e109.png)

When we load the Asset Bundles we upload the Meshes to the GPU and mark them as non-readable since that free's up some memory, but some meshes might fail to be used as colliders on WebGL.

## How to test the changes?

Base Example: https://play.decentraland.org/?explorer-branch=fix/new-cdn-worlds&ENABLE_AB-NEW-CDN&realm=dclonboarding.dcl.eth

This branch: https://play.decentraland.org/?explorer-branch=test/remove-gpu-meshes&ENABLE_AB-NEW-CDN&realm=dclonboarding.dcl.eth

On the base Example if you go to the end of the tutorial ( the part of the portals ) you can move through the portals and clip into the mesh.

On this PR the mesh collider works correctly.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
