### PR TITLE
chore: Readded scene hash on external link clicked for analytics

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/AnalyticsHelper/AnalyticsHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/AnalyticsHelper/AnalyticsHelper.cs
@@ -12,7 +12,7 @@ public static class AnalyticsHelper
         if (!worldState.TryGetScene(sceneNumber, out var scene))
             return;
 
-        if (sceneNumber > 0)
+        if (sceneNumber > 0 && !string.IsNullOrEmpty(sceneHash))
         {
             analyticDict.Add("base_parcel_position", scene.sceneData.basePosition.x + "," + scene.sceneData.basePosition.y );
             analyticDict.Add("scene", $"scene:{sceneHash}");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/AnalyticsHelper/AnalyticsHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/AnalyticsHelper/AnalyticsHelper.cs
@@ -7,14 +7,15 @@ public static class AnalyticsHelper
     {
         IWorldState worldState = Environment.i.world.state;
         int sceneNumber = worldState.GetCurrentSceneNumber();
+        string sceneHash = worldState.GetCurrentSceneHash();
 
         if (!worldState.TryGetScene(sceneNumber, out var scene))
             return;
-        
+
         if (sceneNumber > 0)
         {
             analyticDict.Add("base_parcel_position", scene.sceneData.basePosition.x + "," + scene.sceneData.basePosition.y );
-            analyticDict.Add("scene", $"scene number: {sceneNumber}");
+            analyticDict.Add("scene", $"scene:{sceneHash}");
         }
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IWorldState.cs
@@ -9,6 +9,7 @@ namespace DCL
     public interface IWorldState : ISceneHandler, IService
     {
         int GetCurrentSceneNumber();
+        string GetCurrentSceneHash();
         IEnumerable<KeyValuePair<int, IParcelScene>> GetLoadedScenes();
         List<IParcelScene> GetGlobalScenes();
         bool TryGetScene(int sceneNumber, out IParcelScene scene);
@@ -25,6 +26,6 @@ namespace DCL
         void SortScenesByDistance(Vector2Int position);
         void AddScene(IParcelScene newScene);
         void RemoveScene(int sceneNumber);
-        void ForceCurrentScene(int sceneNumber);
+        void ForceCurrentScene(int sceneNumber, string sceneHash);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/WorldState.cs
@@ -16,13 +16,16 @@ namespace DCL
         private Vector2Int sortAuxiliaryVector = new Vector2Int(EnvironmentSettings.MORDOR_SCALAR, EnvironmentSettings.MORDOR_SCALAR);
         private readonly List<IParcelScene> globalScenes = new List<IParcelScene>();
         private int currentSceneNumber;
-        
+        private string currentSceneHash;
+
         public int GetCurrentSceneNumber() => currentSceneNumber;
-        
+        public string GetCurrentSceneHash() => currentSceneHash;
+
+
         public IEnumerable<KeyValuePair<int, IParcelScene>> GetLoadedScenes() => loadedScenes;
 
         public List<IParcelScene> GetGlobalScenes() => globalScenes;
-        
+
         public List<IParcelScene> GetScenesSortedByDistance() => scenesSortedByDistance;
 
         public IParcelScene GetScene(int sceneNumber)
@@ -134,21 +137,23 @@ namespace DCL
         {
             if (entity == null || entity.meshRootGameObject == null)
                 return;
-            
+
             attachedLoaders.Remove(entity.meshRootGameObject);
         }
-        
+
         public int GetSceneNumberByCoords(Vector2Int coords)
         {
             if (loadedScenesByCoordinate.ContainsKey(coords))
                 return loadedScenesByCoordinate[coords];
-            
+
             return -1;
         }
-        
+
         public void SortScenesByDistance(Vector2Int position)
         {
             currentSceneNumber = -1;
+            currentSceneHash = "";
+
             scenesSortedByDistance.Sort((sceneA, sceneB) =>
             {
                 sortAuxiliaryVector = sceneA.sceneData.basePosition - position;
@@ -176,26 +181,29 @@ namespace DCL
                     continue;
 
                 currentSceneNumber = scene.sceneData.sceneNumber;
+                currentSceneHash = scene.sceneData.id;
 
                 break;
             }
 
         }
-        
-        public void ForceCurrentScene(int sceneNumber)
+
+        public void ForceCurrentScene(int sceneNumber, string sceneHash)
         {
             currentSceneNumber = sceneNumber;
+            currentSceneHash = sceneHash;
         }
-        
+
         public void AddScene(IParcelScene newScene)
         {
             int sceneNumber = newScene.sceneData.sceneNumber;
+
             if (loadedScenes.ContainsKey(sceneNumber))
             {
                 Debug.LogWarning($"The scene {newScene.sceneData.id} already exists! scene number: {sceneNumber}");
                 return;
             }
-            
+
             if (newScene.isPersistent)
             {
                 globalSceneNumbers.Add(sceneNumber);
@@ -204,20 +212,23 @@ namespace DCL
                 if (newScene.isPortableExperience)
                     loadedPortableExperienceScenes.Add(newScene.sceneData.id, newScene);
             }
-            
+
             loadedScenes.Add(sceneNumber, newScene);
-            
+
             foreach (Vector2Int parcelPosition in newScene.GetParcels())
             {
                 loadedScenesByCoordinate[parcelPosition] = sceneNumber;
             }
-                
+
             scenesSortedByDistance.Add(newScene);
 
             if (currentSceneNumber <= 0)
+            {
                 currentSceneNumber = sceneNumber;
+                currentSceneHash = newScene.sceneData.id;
+            }
         }
-        
+
         public void RemoveScene(int sceneNumber)
         {
             IParcelScene loadedScene = loadedScenes[sceneNumber];
@@ -252,8 +263,6 @@ namespace DCL
             currentSceneNumber = -1;
         }
 
-        public void Initialize()
-        {
-        }
+        public void Initialize() { }
     }
 }

--- a/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
+++ b/unity-renderer/Assets/Scripts/Tests/TestUtils.cs
@@ -1348,7 +1348,7 @@ namespace DCL.Helpers
                 newScene.InitializeDebugPlane();
 
             Environment.i.world.state.AddScene(newScene);
-            Environment.i.world.state.ForceCurrentScene(data.sceneNumber);
+            Environment.i.world.state.ForceCurrentScene(data.sceneNumber, data.id);
 
             return newScene;
         }

--- a/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
+++ b/unity-renderer/Assets/Scripts/Tests/VisualTests/VisualTestsBase.cs
@@ -65,15 +65,15 @@ public class VisualTestsBase : IntegrationTestSuite_Legacy
         UnityEngine.RenderSettings.fogStartDistance = 100;
         UnityEngine.RenderSettings.fogEndDistance = 110;
 
-        DCL.Environment.i.world.state.ForceCurrentScene( scene.sceneData.sceneNumber);
-        
+        DCL.Environment.i.world.state.ForceCurrentScene( scene.sceneData.sceneNumber, scene.sceneData.id);
+
         VisualTestUtils.RepositionVisualTestsCamera(camera, new Vector3(0, 2, 0));
     }
 
     protected override IEnumerator TearDown()
     {
         coreComponentsPlugin.Dispose();
-        uiComponentsPlugin.Dispose();   
+        uiComponentsPlugin.Dispose();
         uiRefresherPlugin.Dispose();
         Object.Destroy(camera.gameObject);
         QualitySettings.anisotropicFiltering = originalAnisoSetting;


### PR DESCRIPTION
## What does this PR change?

Fixes [#4527](https://app.zenhub.com/workspaces/workstream-core-experience-63aaac346e1c8d00104586e8/issues/gh/decentraland/unity-renderer/4572)

Following this [requirement](https://decentralandteam.slack.com/archives/C01QVR7TJK1/p1678300342901829) from analytics team, we are readding the `sceneHash` on the external url click event

## How to test the changes?

No QA needed

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
