### PR TITLE
refactor: sdk7 change crdt header and transform binary endianness (LE)

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Serialization/ECSTransformSerialization.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Serialization/ECSTransformSerialization.cs
@@ -7,26 +7,22 @@ namespace DCL.ECSComponents
     {
         private const int TRANSFORM_LENGTH = 44;
 
-        private static readonly byte[] toLittleEndianBuffer = new byte[TRANSFORM_LENGTH];
         private static readonly MemoryStream memoryStream = new MemoryStream(TRANSFORM_LENGTH);
         private static readonly BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
 
         public static unsafe ECSTransform Deserialize(object data)
         {
             byte[] bytes = (byte[])data;
-            for (int i = 0; i < TRANSFORM_LENGTH; i++)
-            {
-                toLittleEndianBuffer[i] = bytes[TRANSFORM_LENGTH - 1 - i];
-            }
 
             ECSTransform model = new ECSTransform();
-            fixed (byte* numPtr = &toLittleEndianBuffer[0])
+
+            fixed (byte* numPtr = &bytes[0])
             {
                 float* arr = (float*)numPtr;
-                model.position.Set(arr[10], arr[9], arr[8]);
-                model.rotation.Set(arr[7], arr[6], arr[5], arr[4]);
-                model.scale.Set(arr[3], arr[2], arr[1]);
-                model.parentId = *(int*)numPtr;
+                model.position.Set(arr[0], arr[1], arr[2]);
+                model.rotation.Set(arr[3], arr[4], arr[5], arr[6]);
+                model.scale.Set(arr[7], arr[8], arr[9]);
+                model.parentId = *(int*)(numPtr + 40);
             }
 
             return model;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/CRDTProtocol/Deserializer/Tests/CRDTDeserializerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/CRDTProtocol/Deserializer/Tests/CRDTDeserializerShould.cs
@@ -20,9 +20,9 @@ namespace Tests
         {
             byte[] bytes =
             {
-                0, 0, 0, 64, 0, 0, 0, 1, 0, 0, 2, 154,
-                0, 0, 0, 1, 0, 0, 29, 242,
-                0, 0, 0, 40
+                64, 0, 0, 0, 1, 0, 0, 0, 154, 2, 0, 0,
+                1, 0, 0, 0, 242, 29, 0, 0,
+                40, 0, 0, 0
             };
 
             bytes = bytes.Concat(componentDataBytes).ToArray();
@@ -44,17 +44,17 @@ namespace Tests
         {
             byte[] bytesMsgA =
             {
-                0, 0, 0, 64, 0, 0, 0, 1, 0, 0, 2, 154,
-                0, 0, 0, 1, 0, 0, 29, 242,
-                0, 0, 0, 40,
+                64, 0, 0, 0, 1, 0, 0, 0, 154, 2, 0, 0,
+                1, 0, 0, 0, 242, 29, 0, 0,
+                40, 0, 0, 0
             };
             bytesMsgA = bytesMsgA.Concat(componentDataBytes).ToArray();
 
             byte[] bytesMsgB =
             {
-                0, 0, 0, 64, 0, 0, 0, 1, 0, 0, 2, 154,
-                0, 0, 0, 1, 0, 0, 29, 242,
-                0, 0, 0, 40
+                64, 0, 0, 0, 1, 0, 0, 0, 154, 2, 0, 0,
+                1, 0, 0, 0, 242, 29, 0, 0,
+                40, 0, 0, 0
             };
             bytesMsgB = bytesMsgB.Concat(componentDataBytes).ToArray();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/CRDTProtocol/Serializer/Tests/CRDTSerializerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/CRDTProtocol/Serializer/Tests/CRDTSerializerShould.cs
@@ -9,10 +9,28 @@ namespace Tests
     {
         [Test]
         [TestCase(0, 1, 100, null,
-            ExpectedResult = new byte[] { 0,0,0,24,0,0,0,1,0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 100, 0, 0, 0, 0 })]
+            ExpectedResult = new byte[]
+            {
+                24, 0, 0, 0,    //msg_length
+                1, 0, 0, 0,     //msg_type
+                0, 0, 0, 0,     //entityId
+                1, 0, 0, 0,     //componentId
+                100, 0, 0, 0,   //timestamp
+                0, 0, 0, 0      //data_length
+            })]
+
         [TestCase(32424, 67867, 2138996092, new byte[] { 42, 33, 67, 22 },
-            ExpectedResult = new byte[] { 0, 0, 0, 28, 0, 0, 0, 1, 0, 0, 126, 168, 0, 1, 9, 27, 127, 126, 125, 124, 0, 0, 0, 4, 42, 33, 67, 22 })]
-                                    //    msg_length |  msg_type |    entityId   | componentId|     timestamp     |data_length| data
+            ExpectedResult = new byte[]
+            {
+                28, 0, 0, 0,        //msg_length
+                1, 0, 0, 0,         //msg_type
+                168, 126, 0, 0,     //entityId
+                27, 9, 1, 0,        //componentId
+                124, 125, 126, 127, //timestamp
+                4, 0, 0, 0,         //data_length
+                42, 33, 67, 22      //data
+            })]
+
         public byte[] SerializeCorrectlyPutComponent(int entityId, int componentId, int timestamp, byte[] data)
         {
             var message = new CRDTMessage()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/BinaryMessage/BinaryReader/ByteUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/BinaryMessage/BinaryReader/ByteUtils.cs
@@ -6,19 +6,19 @@ namespace KernelCommunication
     {
         public static unsafe int PointerToInt32(byte* ptr)
         {
-            return (int)*ptr << 24 | (int)ptr[1] << 16 | (int)ptr[2] << 8 | (int)ptr[3];
+            return *(int*)ptr;
         }
 
         public static unsafe long PointerToInt64(byte* ptr)
         {
-            int num = (int)*ptr << 24 | (int)ptr[1] << 16 | (int)ptr[2] << 8 | (int)ptr[3];
-            return (long)((uint)((int)ptr[4] << 24 | (int)ptr[5] << 16 | (int)ptr[6] << 8) | (uint)ptr[7]) | (long)num << 32;
+            return *(long*)ptr;
         }
 
         public static unsafe int ReadInt32(ReadOnlySpan<byte> span, int position)
         {
             if ((long)(uint)position >= (long)span.Length)
                 throw new IndexOutOfRangeException("offset is bigger than bytes array lenght");
+
             if (position > span.Length - 4)
                 throw new IndexOutOfRangeException("bytes.Length is not large enough to contain a valid Int32");
 
@@ -32,6 +32,7 @@ namespace KernelCommunication
         {
             if ((long)(uint)position >= (long)span.Length)
                 throw new IndexOutOfRangeException("offset is bigger than bytes array lenght");
+
             if (position > span.Length - 8)
                 throw new IndexOutOfRangeException("bytes.Length is not large enough to contain a valid Int64");
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/BinaryMessage/BinaryWriter/BinaryWriter.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/BinaryMessage/BinaryWriter/BinaryWriter.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace KernelCommunication
 {
-    // Write BigEndian binary to stream
+    // Write LittleEndian binary to stream
     public class BinaryWriter : IDisposable
     {
         private Stream stream;
@@ -17,32 +17,32 @@ namespace KernelCommunication
         public unsafe void WriteInt32(int value)
         {
             byte* ptr = (byte*)&value;
-            stream.WriteByte(ptr[3]);
-            stream.WriteByte(ptr[2]);
-            stream.WriteByte(ptr[1]);
             stream.WriteByte(ptr[0]);
+            stream.WriteByte(ptr[1]);
+            stream.WriteByte(ptr[2]);
+            stream.WriteByte(ptr[3]);
         }
 
         public unsafe void WriteSingle(float value)
         {
             byte* ptr = (byte*)&value;
-            stream.WriteByte(ptr[3]);
-            stream.WriteByte(ptr[2]);
-            stream.WriteByte(ptr[1]);
             stream.WriteByte(ptr[0]);
-        }        
+            stream.WriteByte(ptr[1]);
+            stream.WriteByte(ptr[2]);
+            stream.WriteByte(ptr[3]);
+        }
 
         public unsafe void WriteInt64(long value)
         {
             byte* ptr = (byte*)&value;
-            stream.WriteByte(ptr[7]);
-            stream.WriteByte(ptr[6]);
-            stream.WriteByte(ptr[5]);
-            stream.WriteByte(ptr[4]);
-            stream.WriteByte(ptr[3]);
-            stream.WriteByte(ptr[2]);
-            stream.WriteByte(ptr[1]);
             stream.WriteByte(ptr[0]);
+            stream.WriteByte(ptr[1]);
+            stream.WriteByte(ptr[2]);
+            stream.WriteByte(ptr[3]);
+            stream.WriteByte(ptr[4]);
+            stream.WriteByte(ptr[5]);
+            stream.WriteByte(ptr[6]);
+            stream.WriteByte(ptr[7]);
         }
 
         public void WriteBytes(byte[] value)


### PR DESCRIPTION
change binary endianness from big-endian to little-endian
for crdt's header and transform component
this change should improve performance while parsing messages since it avoid the step of converting byte arrays to little-endian

js-sdk pr: https://github.com/decentraland/js-sdk-toolchain/pull/446