### PR TITLE
fix: run tests in ~1s

### DIFF
--- a/browser-interface/packages/config/index.ts
+++ b/browser-interface/packages/config/index.ts
@@ -204,7 +204,14 @@ export namespace ethereumConfigurations {
   }
 }
 
-export const isRunningTest: boolean = (globalThis as any)['isRunningTests'] === true
+const testConfig = {
+  isRunningTest: false
+}
+export const setRunningTest = (test: boolean) => {
+  testConfig.isRunningTest = test
+}
+export const isRunningTest = () => testConfig.isRunningTest
+export const PORTABLE_EXPERIENCES_DEBOUNCE_DELAY = () => isRunningTest() ? 1 : 250
 
 function addHttpsIfNoProtocolIsSet(domain: string): string
 function addHttpsIfNoProtocolIsSet(domain: undefined): undefined

--- a/browser-interface/packages/config/index.ts
+++ b/browser-interface/packages/config/index.ts
@@ -211,7 +211,7 @@ export const setRunningTest = (test: boolean) => {
   testConfig.isRunningTest = test
 }
 export const isRunningTest = () => testConfig.isRunningTest
-export const PORTABLE_EXPERIENCES_DEBOUNCE_DELAY = () => isRunningTest() ? 1 : 250
+export const PORTABLE_EXPERIENCES_DEBOUNCE_DELAY = () => isRunningTest() ? 1 : 100
 
 function addHttpsIfNoProtocolIsSet(domain: string): string
 function addHttpsIfNoProtocolIsSet(domain: undefined): undefined

--- a/browser-interface/packages/shared/portableExperiences/sagas.ts
+++ b/browser-interface/packages/shared/portableExperiences/sagas.ts
@@ -1,3 +1,4 @@
+import { PORTABLE_EXPERIENCES_DEBOUNCE_DELAY } from 'config'
 import { call, takeEvery, debounce, select, put, delay } from 'redux-saga/effects'
 import { LoadableScene } from 'shared/types'
 import {
@@ -21,16 +22,18 @@ import {
 import { getDesiredPortableExperiences } from './selectors'
 
 export function* portableExperienceSaga(): any {
-  yield takeEvery(REMOVE_DESIRED_PORTABLE_EXPERIENCE, handlePortableExperienceChanges)
-  yield takeEvery(ADD_DESIRED_PORTABLE_EXPERIENCE, handlePortableExperienceChanges)
-  yield takeEvery(SHUTDOWN_ALL_PORTABLE_EXPERIENCES, handlePortableExperienceChanges)
-  yield takeEvery(ACTIVATE_ALL_PORTABLE_EXPERIENCES, handlePortableExperienceChanges)
-  yield takeEvery(DENY_PORTABLE_EXPERIENCES, handlePortableExperienceChanges)
-  yield takeEvery(ADD_SCENE_PX, handlePortableExperienceChanges)
-  yield takeEvery(ADD_KERNEL_PX, handlePortableExperienceChanges)
-  yield takeEvery(REMOVE_SCENE_PX, handlePortableExperienceChanges)
+  yield takeEvery([
+    REMOVE_DESIRED_PORTABLE_EXPERIENCE,
+    ADD_DESIRED_PORTABLE_EXPERIENCE,
+    SHUTDOWN_ALL_PORTABLE_EXPERIENCES,
+    ACTIVATE_ALL_PORTABLE_EXPERIENCES,
+    DENY_PORTABLE_EXPERIENCES,
+    ADD_SCENE_PX,
+    ADD_KERNEL_PX,
+    REMOVE_SCENE_PX
+  ], handlePortableExperienceChanges)
   yield takeEvery(RELOAD_SCENE_PX, reloadPortableExperienceChanges)
-  yield debounce(100 /* ms */, UPDATE_ENGINE_PX, handlePortableExperienceChangesEffect)
+  yield debounce(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY(), UPDATE_ENGINE_PX, handlePortableExperienceChangesEffect)
 }
 
 // every time the desired portable experiences change, the action `updateEnginePortableExperiences` should be dispatched

--- a/browser-interface/test/index.ts
+++ b/browser-interface/test/index.ts
@@ -1,4 +1,5 @@
-globalThis['isRunningTests'] = true
+import { setRunningTest } from 'config'
+setRunningTest(true)
 
 /**
  * Hello, this file is the tests entry point.
@@ -21,7 +22,7 @@ import './unit/profiles.saga.test'
 import './unit/getPerformanceInfo.test'
 import './unit/positionThings.test'
 import './unit/RestrictedActions.test'
-import './unit/portable-experiences.test'
+import './unit/portableExperiences.test'
 import './unit/logger.spec'
 import './unit/comms-resolver.test'
 import './unit/friends.saga.test'

--- a/browser-interface/test/sceneEvents/comms.spec.ts
+++ b/browser-interface/test/sceneEvents/comms.spec.ts
@@ -4,21 +4,21 @@ import mitt from 'mitt'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga/effects'
 import { toEnvironmentRealmType } from 'shared/apis/host/EnvironmentAPI'
+import { setCommsIsland, setRoomConnection } from 'shared/comms/actions'
 import { bindHandlersToCommsContext } from 'shared/comms/handlers'
 import { RoomConnection } from 'shared/comms/interface'
 import { disconnectRoom, handleNewCommsContext } from 'shared/comms/sagas'
 import { commsEstablished } from 'shared/loading/types'
+import { saveProfileDelta } from 'shared/profiles/actions'
 import { getCurrentUserProfile } from 'shared/profiles/selectors'
 import { setRealmAdapter } from 'shared/realm/actions'
+import { localCommsService } from 'shared/realm/local-services/comms'
 import { legacyServices } from 'shared/realm/local-services/legacy'
 import { realmToConnectionString } from 'shared/realm/resolver'
 import { IRealmAdapter } from 'shared/realm/types'
+import { getRealmAdapterAndIsland, sceneEventsSaga, updateLocation } from 'shared/sceneEvents/sagas'
 import { reducers } from 'shared/store/rootReducer'
-import { setCommsIsland, setRoomConnection } from '../../packages/shared/comms/actions'
-import { saveProfileDelta } from '../../packages/shared/profiles/actions'
-import { localCommsService } from '../../packages/shared/realm/local-services/comms'
-import { getRealmAdapterAndIsland, sceneEventsSaga, updateLocation } from '../../packages/shared/sceneEvents/sagas'
-import { allScenesEvent } from '../../packages/shared/world/parcelSceneManager'
+import { allScenesEvent } from 'shared/world/parcelSceneManager'
 
 const about: AboutResponse = {
   comms: { healthy: false, protocol: 'v2' },
@@ -71,7 +71,7 @@ describe('when the realm change: SET_WORLD_CONTEXT', () => {
       .dispatch(action)
       .call(allScenesEvent, { eventType: 'onRealmChanged', payload: toEnvironmentRealmType(realmAdapter, island) })
       .call(updateLocation, realmToConnectionString(realmAdapter), island)
-      .run()
+      .silentRun(0)
   })
 
   it('should call allScene events with null island', () => {
@@ -82,7 +82,7 @@ describe('when the realm change: SET_WORLD_CONTEXT', () => {
       .dispatch(action)
       .call(allScenesEvent, { eventType: 'onRealmChanged', payload: toEnvironmentRealmType(realmAdapter, island) })
       .call(updateLocation, realmToConnectionString(realmAdapter), island)
-      .run()
+      .silentRun(0)
   })
 
   it('should call allScene events fn with the specified realm & island', () => {
@@ -94,7 +94,7 @@ describe('when the realm change: SET_WORLD_CONTEXT', () => {
       .dispatch(action)
       .call(allScenesEvent, { eventType: 'onRealmChanged', payload: toEnvironmentRealmType(realmAdapter, island) })
       .call(updateLocation, realmToConnectionString(realmAdapter), island)
-      .run()
+      .silentRun(0)
   })
 })
 
@@ -108,7 +108,7 @@ describe('Comms adapter', () => {
       .dispatch(action)
       .call(bindHandlersToCommsContext, action.payload)
       .put(commsEstablished())
-      .run()
+      .silentRun(0)
   })
 
   it('setting new adapter disconnects old adapter', async () => {
@@ -127,7 +127,7 @@ describe('Comms adapter', () => {
       .call(bindHandlersToCommsContext, action.payload)
       .put(commsEstablished())
       .call(disconnectRoom, oldAdapter)
-      .run()
+      .silentRun(0)
   })
 })
 
@@ -141,7 +141,7 @@ describe('when the island changes: SET_COMMS_ISLAND', () => {
       .dispatch(action)
       .not.call.fn(allScenesEvent)
       .call(updateLocation, undefined, island)
-      .run()
+      .silentRun(0)
   })
 
   it('should call allScene events fn with the specified realm & island', () => {
@@ -154,7 +154,7 @@ describe('when the island changes: SET_COMMS_ISLAND', () => {
       .dispatch(action)
       .call(allScenesEvent, { eventType: 'onRealmChanged', payload: toEnvironmentRealmType(realmAdapter, island) })
       .call(updateLocation, realmToConnectionString(realmAdapter), island)
-      .run()
+      .silentRun(0)
   })
 })
 
@@ -170,6 +170,6 @@ describe('when the profile updates successfully: SAVE_PROFILE_SUCCESS', () => {
       .provide([[select(getCurrentUserProfile), payload]])
       .dispatch(action)
       .call(allScenesEvent, { eventType: 'profileChanged', payload })
-      .run()
+      .silentRun(0)
   })
 })

--- a/browser-interface/test/unit/RestrictedActions.test.tsx
+++ b/browser-interface/test/unit/RestrictedActions.test.tsx
@@ -1,16 +1,15 @@
-import * as sinon from 'sinon'
-import { getUnityInstance, setUnityInstance } from '../../packages/unity-interface/IUnityInterface'
-import defaultLogger from '../../packages/lib/logger'
-import { lastPlayerPosition } from '../../packages/shared/world/positionThings'
-import { PermissionItem, permissionItemToJSON } from '@dcl/protocol/out-ts/decentraland/kernel/apis/permissions.gen'
-import { movePlayerTo, triggerEmote } from 'shared/apis/host/RestrictedActions'
-import { PortContext } from 'shared/apis/host/context'
 import { Vector3 } from '@dcl/ecs-math'
+import { PermissionItem, permissionItemToJSON } from '@dcl/protocol/out-ts/decentraland/kernel/apis/permissions.gen'
 import { EntityType, Scene } from '@dcl/schemas'
 import { expect } from 'chai'
-import Sinon from 'sinon'
-import { UnityInterface } from 'unity-interface/UnityInterface'
+import { PortContext } from 'shared/apis/host/context'
+import { movePlayerTo, triggerEmote } from 'shared/apis/host/RestrictedActions'
 import { buildStore } from 'shared/store/store'
+import Sinon, * as sinon from 'sinon'
+import { UnityInterface } from 'unity-interface/UnityInterface'
+import defaultLogger from 'lib/logger'
+import { lastPlayerPosition } from 'shared/world/positionThings'
+import { getUnityInstance, setUnityInstance } from 'unity-interface/IUnityInterface'
 
 describe('RestrictedActions tests', () => {
   beforeEach(() => {
@@ -66,11 +65,16 @@ describe('RestrictedActions tests', () => {
     it('should move the player', async () => {
       setLastPlayerPosition()
       const ctx = getContextWithPermissions(PermissionItem.PI_ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE)
-      const stub = sinon.stub(getUnityInstance(), 'Teleport')
+      const spy = sinon.spy(getUnityInstance(), 'Teleport')
 
       movePlayerTo({ newRelativePosition: new Vector3(8, 0, 8) }, ctx)
-
-      Sinon.assert.calledWithExactly(stub, { position: { x: 8, y: 0, z: 1624 }, cameraTarget: undefined }, false)
+      const callArguments = spy.firstCall.args
+      expect(callArguments[0].position.x).to.eq(8)
+      expect(callArguments[0].position.y).to.eq(0)
+      expect(callArguments[0].position.z).to.eq(1624)
+      expect(callArguments[0].cameraTarget).to.be.undefined
+      expect(callArguments[1]).to.eq(false)
+      sinon.assert.calledOnce(spy)
     })
 
     it('should fail when position is outside scene', async () => {
@@ -79,8 +83,14 @@ describe('RestrictedActions tests', () => {
       const errorSpy = sinon.spy(defaultLogger, 'error')
       const stub = sinon.stub(getUnityInstance(), 'Teleport')
       movePlayerTo({ newRelativePosition: new Vector3(21, 0, 32) }, ctx)
-      Sinon.assert.calledWithExactly(errorSpy, 'Error: Position is out of scene', { x: 21, y: 0, z: 1648 })
-      Sinon.assert.callCount(stub, 0)
+
+      const callArguments = errorSpy.firstCall.args
+      expect(callArguments[0]).to.eq('Error: Position is out of scene')
+      expect((callArguments[1]! as any).x).to.eq(21)
+      expect((callArguments[1]! as any).y).to.eq(0)
+      expect((callArguments[1]! as any).z).to.eq(1648)
+      sinon.assert.notCalled(stub)
+      sinon.assert.calledOnce(errorSpy)
     })
 
     it('should fail when scene does not have permissions', async () => {

--- a/browser-interface/test/unit/friends.saga.test.ts
+++ b/browser-interface/test/unit/friends.saga.test.ts
@@ -601,7 +601,7 @@ describe('Friends sagas', () => {
           ]
         ])
         .dispatch(setMatrixClient(stubClient))
-        .silentRun() // due to initializeStatusUpdateInterval saga is a while(true) gen
+        .silentRun(0) // due to initializeStatusUpdateInterval saga is a while(true) gen
       unityMock.verify()
     })
 
@@ -645,7 +645,7 @@ describe('Friends sagas', () => {
           ]
         ])
         .dispatch(setMatrixClient(client))
-        .silentRun()
+        .silentRun(0)
       unityMock.verify()
     })
 
@@ -668,7 +668,7 @@ describe('Friends sagas', () => {
           ]
         ])
         .dispatch(setMatrixClient(stubClient))
-        .silentRun()
+        .silentRun(0)
       unityMock.verify()
     })
   })

--- a/browser-interface/test/unit/portableExperiences.test.tsx
+++ b/browser-interface/test/unit/portableExperiences.test.tsx
@@ -1,7 +1,6 @@
 import { expectSaga } from 'redux-saga-test-plan'
 import { delay, call, select } from 'redux-saga/effects'
-
-import { portableExperienceSaga } from '../../packages/shared/portableExperiences/sagas'
+import { portableExperienceSaga } from 'shared/portableExperiences/sagas'
 import {
   addScenePortableExperience,
   denyPortableExperiences,
@@ -13,11 +12,12 @@ import {
 } from 'shared/portableExperiences/actions'
 import { LoadableScene } from 'shared/types'
 import { getDesiredPortableExperiences } from 'shared/portableExperiences/selectors'
-import { declareWantedPortableExperiences } from 'unity-interface/portableExperiencesUtils'
 import { RootPortableExperiencesState } from 'shared/portableExperiences/types'
 import { reducers } from 'shared/store/rootReducer'
 import { expect } from 'chai'
 import { EntityType } from '@dcl/schemas'
+import { PORTABLE_EXPERIENCES_DEBOUNCE_DELAY } from 'config'
+import { declareWantedPortableExperiences } from 'unity-interface/portableExperiencesUtils'
 
 describe('Portable experiences sagas test', () => {
   const createLoadablePX = (urn: string): LoadableScene => ({
@@ -46,7 +46,7 @@ describe('Portable experiences sagas test', () => {
       ])
       .dispatch(action)
       .put(updateEnginePortableExperiences([]))
-      .run()
+      .silentRun(0)
   })
 
   it('returning one PX in debug', () => {
@@ -60,7 +60,7 @@ describe('Portable experiences sagas test', () => {
       ])
       .dispatch(action)
       .put(updateEnginePortableExperiences([px]))
-      .run()
+      .silentRun(0)
   })
 
   it('reload PX should call declare wanted once empty and again with the desired px', () => {
@@ -78,7 +78,7 @@ describe('Portable experiences sagas test', () => {
       .call(declareWantedPortableExperiences, [])
       .delay(250)
       .call(declareWantedPortableExperiences, [px])
-      .run()
+      .silentRun(0)
   })
 
   it('updateEnginePortableExperiences triggers a change in the engine (debounced)', () => {
@@ -90,7 +90,7 @@ describe('Portable experiences sagas test', () => {
       .dispatch(updateEnginePortableExperiences([px]))
       .not.call(declareWantedPortableExperiences, [])
       .call(declareWantedPortableExperiences, [px])
-      .run()
+      .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY())
   })
 
   it('returning a PX multiple times should dedup the px', () => {
@@ -159,7 +159,7 @@ describe('Portable experiences sagas test', () => {
           })
         )
         .put(updateEnginePortableExperiences([pxOld, pxDenied]))
-        .run()
+        .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY())
     })
 
     it('adding a denied PX should not trigger any action', () => {
@@ -197,7 +197,7 @@ describe('Portable experiences sagas test', () => {
           })
         )
         .put(updateEnginePortableExperiences([pxOld]))
-        .run()
+        .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY())
     })
 
     it('removing a scene-created PX should remove it from the final list', () => {
@@ -231,7 +231,7 @@ describe('Portable experiences sagas test', () => {
           })
         )
         .put(updateEnginePortableExperiences([]))
-        .run()
+        .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY())
     })
   })
 
@@ -268,7 +268,7 @@ describe('Portable experiences sagas test', () => {
           })
         )
         .put(updateEnginePortableExperiences([px]))
-        .run())
+        .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY()))
 
     // deny list it
     it('add it to the denylist, now the desired PX should be an empty list', () =>
@@ -302,7 +302,7 @@ describe('Portable experiences sagas test', () => {
           })
         )
         .put(updateEnginePortableExperiences([]))
-        .run())
+        .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY()))
 
     // remove from deny list
     it('remove it from the denylist, the desired PX should include the allowed PX', () =>
@@ -336,7 +336,7 @@ describe('Portable experiences sagas test', () => {
           })
         )
         .put(updateEnginePortableExperiences([px]))
-        .run())
+        .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY()))
 
     it('shutdown the PX, this should shutdown all the PX', () =>
       expectSaga(portableExperienceSaga)
@@ -366,7 +366,7 @@ describe('Portable experiences sagas test', () => {
             }
           })
         )
-        .run())
+        .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY()))
 
     it('activate the PX, this should activate all the PX that has been shutdown', () =>
       expectSaga(portableExperienceSaga)
@@ -392,6 +392,6 @@ describe('Portable experiences sagas test', () => {
             }
           })
         )
-        .run())
+        .silentRun(PORTABLE_EXPERIENCES_DEBOUNCE_DELAY()))
   })
 })

--- a/browser-interface/test/unit/world.saga.test.tsx
+++ b/browser-interface/test/unit/world.saga.test.tsx
@@ -30,7 +30,7 @@ describe('World', () => {
         ]
       ])
       .dispatch(action)
-      .run()
+      .silentRun(0)
     expect({ called }).to.deep.eq({ called: true })
   })
 
@@ -49,7 +49,7 @@ describe('World', () => {
         ]
       ])
       .dispatch(action)
-      .run()
+      .silentRun(0)
     expect({ called }).to.deep.eq({ called: true })
   })
 
@@ -76,7 +76,7 @@ describe('World', () => {
         [select(getCurrentUserId), 'userid1']
       ])
       .dispatch(action)
-      .run()
+      .silentRun(0)
 
     expect({ userIdFromCall }).to.deep.eq({ userIdFromCall: 'userid1' })
   })
@@ -105,7 +105,7 @@ describe('World', () => {
         [select(getCurrentUserId), 'userid1']
       ])
       .dispatch(action)
-      .run()
+      .silentRun(0)
 
     expect({ userIdFromCall }).to.deep.eq({ userIdFromCall: 'userid1' })
   })


### PR DESCRIPTION
## What does this PR change?

Fixes the tests of the browser-interface so that they only take ~1s

## How to test the changes?

(Developers only -- no change in production)
1. Run `make watch` in `browser-interface`
2. Open http://localhost:8080/?test
3. Check the duration of running the tests