### PR TITLE
feat: (preview mode) enable pipe the console .log and .error to the parent in a iframe

### DIFF
--- a/browser-interface/packages/config/index.ts
+++ b/browser-interface/packages/config/index.ts
@@ -51,6 +51,8 @@ export const DEBUG_SCENE_LOG = DEBUG || location.search.includes('DEBUG_SCENE_LO
 export const DEBUG_KERNEL_LOG = !PREVIEW || location.search.includes('DEBUG_KERNEL_LOG')
 export const DEBUG_WS_MESSAGES = location.search.includes('DEBUG_WS_MESSAGES')
 
+export const PIPE_SCENE_CONSOLE = location.search.includes('PIPE_SCENE_CONSOLE')
+
 export const RESET_TUTORIAL = location.search.includes('RESET_TUTORIAL')
 
 export const CATALYSTS_FROM_DAO_CONTRACT = location.search.includes('CATALYSTS_FROM_DAO_CONTRACT')

--- a/browser-interface/packages/lib/logger/logger.ts
+++ b/browser-interface/packages/lib/logger/logger.ts
@@ -88,12 +88,12 @@ export function createForwardedLogger(type: 'kernel' | 'unity', prefix: string, 
     info(message: string, ...args: any[]): void {
       const computedArgs = [kernelPrefix, subPrefix, message, ...args]
       console.info.apply(null, computedArgs)
-      forwardMessage('logger.warn', computedArgs)
+      forwardMessage('logger.info', computedArgs)
     },
     trace(message: string, ...args: any[]): void {
       const computedArgs = [kernelPrefix, subPrefix, message, ...args]
       console.trace.apply(null, computedArgs)
-      forwardMessage('logger.warn', computedArgs)
+      forwardMessage('logger.trace', computedArgs)
     }
   }
 }

--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -11,13 +11,14 @@ import {
   ETHEREUM_NETWORK,
   FORCE_SEND_MESSAGE,
   getAssetBundlesBaseUrl,
+  PIPE_SCENE_CONSOLE,
   playerHeight,
   WSS_ENABLED
 } from 'config'
 import { gridToWorld } from 'lib/decentraland/parcels/gridToWorld'
 import { parseParcelPosition } from 'lib/decentraland/parcels/parseParcelPosition'
 import { getSceneNameFromJsonData } from 'lib/decentraland/sceneJson/getSceneNameFromJsonData'
-import defaultLogger, { createDummyLogger, createLogger, ILogger } from 'lib/logger'
+import defaultLogger, { createDummyLogger, createForwardedLogger, createLogger, ILogger } from 'lib/logger'
 import mitt from 'mitt'
 import { trackEvent } from 'shared/analytics/trackEvent'
 import { registerServices } from 'shared/apis/host'
@@ -147,7 +148,11 @@ export class SceneWorker {
 
     const loggerName = getSceneNameFromJsonData(this.metadata) || loadableScene.id
     const loggerPrefix = `scene: [${loggerName}]`
-    this.logger = DEBUG_SCENE_LOG ? createLogger(loggerPrefix) : createDummyLogger()
+    this.logger = DEBUG_SCENE_LOG
+      ? PIPE_SCENE_CONSOLE
+        ? createForwardedLogger('kernel', loggerPrefix)
+        : createLogger(loggerPrefix)
+      : createDummyLogger()
 
     if (!Scene.validate(loadableScene.entity.metadata)) {
       defaultLogger.error('Invalid scene metadata', loadableScene.entity.metadata, Scene.validate.errors)

--- a/browser-interface/static/preview.html
+++ b/browser-interface/static/preview.html
@@ -537,23 +537,6 @@
 
     <script>
       globalThis.preview = true
-
-      const queryParameters = new URLSearchParams(document.location.search)
-      if (queryParameters.has('PIPE_CONSOLE_TO_PARENT')) {
-        function pipe(type, originalFunctionCallback) {
-          return (...args) => {
-            const targetWindow = window.parent || window
-            targetWindow && targetWindow.postMessage({ type, payload: args }, '*')
-            originalFunctionCallback(...args)
-          }
-        }
-
-        console.log('Pipe the console log and error enabled.')
-
-        globalThis.originalConsole = { log: globalThis.console.log, error: globalThis.console.error }
-        globalThis.console.log = pipe('log', globalThis.originalConsole.log)
-        globalThis.console.error = pipe('error', globalThis.originalConsole.error)
-      }
     </script>
 
     <script>

--- a/browser-interface/static/preview.html
+++ b/browser-interface/static/preview.html
@@ -537,6 +537,23 @@
 
     <script>
       globalThis.preview = true
+
+      const queryParameters = new URLSearchParams(document.location.search)
+      if (queryParameters.has('PIPE_CONSOLE_TO_PARENT')) {
+        function pipe(type, originalFunctionCallback) {
+          return (...args) => {
+            const targetWindow = window.parent || window
+            targetWindow && targetWindow.postMessage({ type, payload: args }, '*')
+            originalFunctionCallback(...args)
+          }
+        }
+
+        console.log('Pipe the console log and error enabled.')
+
+        globalThis.originalConsole = { log: globalThis.console.log, error: globalThis.console.error }
+        globalThis.console.log = pipe('log', globalThis.originalConsole.log)
+        globalThis.console.error = pipe('error', globalThis.originalConsole.error)
+      }
     </script>
 
     <script>


### PR DESCRIPTION
## What does this PR change?
This enables to pipe of the console calls to an iframe parent

Editor counterpart: https://github.com/decentraland/editor-sdk7/pull/12

## Why?
https://github.com/decentraland/sdk/issues/631