### PR TITLE
fix: disable offscreen culling for SkinnedMeshRenderer by feature flag

### DIFF
--- a/unity-renderer/Assets/Rendering/Culling/Tests/CullingControllerShould.cs
+++ b/unity-renderer/Assets/Rendering/Culling/Tests/CullingControllerShould.cs
@@ -175,7 +175,6 @@ namespace CullingControllerTests
 
             // Assert
             Assert.IsFalse(r.forceRenderingOff);
-            Assert.IsTrue(skr.updateWhenOffscreen);
             Assert.IsTrue(anim.cullingType == AnimationCullingType.AlwaysAnimate);
 
             // Annihilate


### PR DESCRIPTION
CullingController is messing up with the Offscreen Update of SkinnedMeshRenderer even with the CullingController disabled. 

Ideally objects should be constructed in a proper manner so the pivot doesnt stray too far away from the model (even when animated). 

Since we are evaluating removing the whole system I added a feature flag to allow the changes in `Offscreen Update` or not so we can A/B test it's implications in performance.

## Test
This is hard to test, you have to find a skinned mesh renderer (like the humanoids walking around genesis plaza). With `ENABLE_SMR_OFFSCREEN_UPDATE_STATUS` and the Detail Culling in Settings disabled luckily you will be able to reproduce that looking at the models from weird angles make them dissapear. On contrary, with not using `ENABLE_SMR_OFFSCREEN_UPDATE_STATUS` or explicitly using `DISABLE_SMR_OFFSCREEN_UPDATE_STATUS` this should never happen.