### PR TITLE
fix: several null refs and added better errors for content creators

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
@@ -197,9 +197,19 @@ namespace DCL.Components
             }
             else
             {
+                var message = $"LoadableShape '{model.src}' not found";
+
+                if (DataStore.i.debugConfig.isDebugMode.Get())
+                {
+                    Debug.LogError(message);
+                }
+                else
+                {
 #if UNITY_EDITOR
-                Debug.LogWarning($"LoadableShape '{model.src}' not found in scene '{scene.sceneData.sceneNumber}' mappings");
+                    Debug.LogWarning(message);
 #endif
+                }
+
                 failed = true;
             }
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -2,6 +2,7 @@
 using DCL;
 using DCL.Helpers;
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
 
@@ -78,8 +79,15 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
                 asset.Setup(sceneAb, contentUrl);
             }
             catch (OperationCanceledException) { }
+            catch (Exception)
+            {
+                if (!IsEmptyScene())
+                    Debug.LogError("No Asset Bundles for scene " + finalUrl);
+            }
             finally { onSuccess(); }
         }
+
+        private bool IsEmptyScene() => hash.Contains(",");
 
         protected override void OnBeforeLoadOrReuse() { }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -78,7 +78,7 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
                 asset.Setup(sceneAb, contentUrl);
             }
             catch (OperationCanceledException) { }
-            catch (Exception)
+            catch (UnityWebRequestException)
             {
                 if (!IsEmptyScene())
                     Debug.LogError("No Asset Bundles for scene " + finalUrl);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -2,7 +2,6 @@
 using DCL;
 using DCL.Helpers;
 using System;
-using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFDownloaderWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFDownloaderWrapper.cs
@@ -46,6 +46,7 @@ namespace DCL.GLTFast.Wrappers
 
         private static bool IsGltfBinary(byte[] data)
         {
+            if (data == null) return false;
             var gltfBinarySignature = BitConverter.ToUInt32(data, 0);
             return gltfBinarySignature == GLB_SIGNATURE;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
@@ -72,9 +72,9 @@ namespace DCL
 
         public virtual bool HasContentsUrl(string url)
         {
-            url = url.ToLower();
-
             if (string.IsNullOrEmpty(url)) { return false; }
+
+            url = url.ToLower();
 
 #if UNITY_EDITOR
             if (HasTestSchema(url)) { return true; }


### PR DESCRIPTION
## What does this PR change?

Fixed several null references caused by unexpected empty or invalid assets, promises should fail gracefully now.

## How to test the changes?

- Go to [-76,-9](https://play.decentraland.org/?explorer-branch=fix%2Fnull-ref&position=-77%2C-9)
- The scene loads

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
