### PR TITLE
fix: hiding blit image of loading screen on show

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenView.cs
@@ -56,6 +56,7 @@ namespace DCL.LoadingScreen
         public void FadeOut()
         {
             if (!isVisible) return;
+            rawImage.gameObject.SetActive(false);
 
             Hide();
         }


### PR DESCRIPTION
## What does this PR change?

Turns off the blit loading image before it starts to fade out.

## How to test the changes?

Teleport around. Eveything should be the same

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
