### PR TITLE
feat: spawn point based on teleport position and nearest spawn point

### DIFF
--- a/browser-interface/packages/shared/scene-loader/sagas.ts
+++ b/browser-interface/packages/shared/scene-loader/sagas.ts
@@ -1,4 +1,4 @@
-import { Vector2 } from '@dcl/ecs-math'
+import { Vector2, Vector3 } from '@dcl/ecs-math'
 import { ENABLE_EMPTY_SCENES, isRunningTest } from 'config'
 import { encodeParcelPosition } from 'lib/decentraland/parcels/encodeParcelPosition'
 import { gridToWorld } from 'lib/decentraland/parcels/gridToWorld'
@@ -142,7 +142,7 @@ function* teleportHandler(action: TeleportToAction) {
 
       const scene: SceneWorker | undefined = yield call(getSceneWorkerBySceneID, settlerScene)
 
-      const spawnPoint = pickWorldSpawnpoint(scene?.metadata || command.scenes[0].entity.metadata) || action.payload
+      const spawnPoint = pickWorldSpawnpoint(scene?.metadata || command.scenes[0].entity.metadata, new Vector3(action.payload.position.x, action.payload.position.y, action.payload.position.z)) || action.payload
       if (scene?.isStarted()) {
         // if the scene is loaded then there is no unsettlement of the position
         // we teleport directly to that scene

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -153,15 +153,10 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
 
   // 5 - If the final position is outside the scene limits, we zero it
   if (!DEBUG) {
-    const sceneBaseParcelCoords = land.scene.base.split(',')
-    const sceneBaseParcelWorldPos = gridToWorld(
-      parseInt(sceneBaseParcelCoords[0], 10),
-      parseInt(sceneBaseParcelCoords[1], 10)
-    )
     const finalWorldPosition = {
-      x: sceneBaseParcelWorldPos.x + finalPosition.x,
+      x: basePosition.x + finalPosition.x,
       y: finalPosition.y,
-      z: sceneBaseParcelWorldPos.z + finalPosition.z
+      z: basePosition.z + finalPosition.z
     }
 
     if (!isWorldPositionInsideParcels(land.scene.parcels, finalWorldPosition)) {

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -140,6 +140,7 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
     {
         closestDist = spawnDistances[i]
         closestIndex = i
+        console.log(i)
     }
   }
   const { position, cameraTarget } = eligiblePoints[closestIndex]
@@ -152,7 +153,7 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
   }
 
   // 5 - If the final position is outside the scene limits, we zero it
-  if (!DEBUG) {
+  /*if (!DEBUG) {
     const finalWorldPosition = {
       x: basePosition.x + finalPosition.x,
       y: finalPosition.y,
@@ -163,7 +164,7 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
       finalPosition.x = 1
       finalPosition.z = 1
     }
-  }
+  }*/
 
   return {
     position: finalPosition,

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -128,13 +128,10 @@ function pickSpawnpoint(land: Scene, targetWorldPosition: Vector3, basePosition:
   let closestIndex = 0
   let closestDist = Number.MAX_SAFE_INTEGER
 
-  console.log("[TEST] base position is " + basePosition)
-  console.log("[TEST] Getting spawn points near " + targetWorldPosition.toString())
   // we compare world positions from the target parcel and the spawn points
   const spawnDistances = eligiblePoints.map( (value: SpawnPoint, index: number , array: SpawnPoint[]) => { 
     const pos = getSpawnPointWorldPosition(value).add(basePosition);
     const dist = Vector3.Distance(targetWorldPosition, pos) 
-    console.log("[TEST] Spawn point at " + pos + " with distance " + dist)
     return dist
   } )
 

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -101,7 +101,7 @@ export function pickWorldSpawnpoint(land: Scene, loadPosition: Vector3): Instanc
   }
 }
 
-function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition: Vector3): InstancedSpawnPoint {
+function pickSpawnpoint(land: Scene, targetWorldPosition: Vector3, basePosition: Vector3): InstancedSpawnPoint {
   let spawnPoints = land.spawnPoints
   if (!Array.isArray(spawnPoints) || spawnPoints.length === 0) {
     spawnPoints = [
@@ -125,7 +125,6 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
   const eligiblePoints = defaults.length === 0 ? spawnPoints : defaults
 
   // 3 - get the closest spawn point
-  const targetWorldPosition = new Vector3(targetParcelPosition.x * parcelSize, 0, targetParcelPosition.z * parcelSize)
   let closestIndex = 0
   let closestDist = Number.MAX_SAFE_INTEGER
 

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -6,6 +6,7 @@ import { isWorldPositionInsideParcels } from 'lib/decentraland/parcels/isWorldPo
 import { gridToWorld } from 'lib/decentraland/parcels/gridToWorld'
 import { DEBUG, playerHeight } from 'config'
 import { isInsideWorldLimits, Scene, SpawnPoint } from '@dcl/schemas'
+import { parcelSize } from 'lib/decentraland/parcels/limits'
 
 export type PositionReport = {
   /** Camera position, world space */
@@ -125,10 +126,11 @@ function pickSpawnpoint(land: Scene, loadPosition: Vector3): InstancedSpawnPoint
   const eligiblePoints = defaults.length === 0 ? spawnPoints : defaults
 
   // 3 - get the closest spawn point
+  const worldPosition = new Vector3(loadPosition.x * parcelSize, 0, loadPosition.z * parcelSize)
   let closestIndex = 0;
   let closestDist = Number.MAX_SAFE_INTEGER;
   const spawnDistances = eligiblePoints.map( (value: SpawnPoint, index: number , array: SpawnPoint[]) => { 
-    return Vector3.DistanceSquared(loadPosition, getSpawnPointCenter(value)) 
+    return Vector3.DistanceSquared(worldPosition, getSpawnPointCenter(value)) 
   } )
 
   for(let i = 0; i < spawnDistances.length; i++)

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -126,12 +126,16 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
 
   // 3 - get the closest spawn point
   const targetWorldPosition = new Vector3(targetParcelPosition.x * parcelSize, 0, targetParcelPosition.z * parcelSize)
-  let closestIndex = 0;
-  let closestDist = Number.MAX_SAFE_INTEGER;
+  let closestIndex = 0
+  let closestDist = Number.MAX_SAFE_INTEGER
 
+  console.log("[TEST] Getting spawn points near " + targetWorldPosition.toString())
   // we compare world positions from the target parcel and the spawn points
   const spawnDistances = eligiblePoints.map( (value: SpawnPoint, index: number , array: SpawnPoint[]) => { 
-    return Vector3.DistanceSquared(targetWorldPosition, getSpawnPointWorldPosition(value, basePosition)) 
+    const pos = getSpawnPointWorldPosition(value, basePosition)
+    const dist = Vector3.DistanceSquared(targetWorldPosition, pos) 
+    console.log("[TEST] spawn point at " + pos + " with distance " + dist)
+    return dist
   } )
 
   for(let i = 0; i < spawnDistances.length; i++)
@@ -140,9 +144,9 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
     {
         closestDist = spawnDistances[i]
         closestIndex = i
-        console.log(i)
     }
   }
+
   const { position, cameraTarget } = eligiblePoints[closestIndex]
 
   // 4 - generate random x, y, z components when in arrays
@@ -153,18 +157,21 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
   }
 
   // 5 - If the final position is outside the scene limits, we zero it
-  /*if (!DEBUG) {
+  if (!DEBUG) {
     const finalWorldPosition = {
       x: basePosition.x + finalPosition.x,
       y: finalPosition.y,
       z: basePosition.z + finalPosition.z
     }
 
+    console.log("[TEST] selected spawn point at index " + closestIndex + " with position " + finalPosition)
+
     if (!isWorldPositionInsideParcels(land.scene.parcels, finalWorldPosition)) {
       finalPosition.x = 1
       finalPosition.z = 1
+      console.log("[TEST] spawn position out of bounds has been reset to 1,1");
     }
-  }*/
+  }
 
   return {
     position: finalPosition,

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -127,21 +127,28 @@ function pickSpawnpoint(land: Scene, targetWorldPosition: Vector3, basePosition:
   let closestIndex = 0
   let closestDist = Number.MAX_SAFE_INTEGER
 
-  targetWorldPosition.x += halfParcelSize
-  targetWorldPosition.z += halfParcelSize
+  const centeredWorldPos = new Vector3(
+    targetWorldPosition.x + halfParcelSize,
+    targetWorldPosition.y,
+    targetWorldPosition.z + halfParcelSize
+  )
 
   // we compare world positions from the target parcel and the spawn points
-  const spawnDistances = eligiblePoints.map((value: SpawnPoint) => {
-    const pos = getSpawnPointWorldPosition(value).add(basePosition)
-    const dist = Vector3.Distance(targetWorldPosition, pos)
-    return dist
-  })
+  if (eligiblePoints.length > 1) {
+    const spawnDistances = eligiblePoints.map((value: SpawnPoint) => {
+      const pos = getSpawnPointWorldPosition(value).add(basePosition)
+      const dist = Vector3.Distance(centeredWorldPos, pos)
+      return dist
+    })
 
-  for (let i = 0; i < spawnDistances.length; i++) {
-    if (spawnDistances[i] < closestDist) {
-      closestDist = spawnDistances[i]
-      closestIndex = i
+    for (let i = 0; i < spawnDistances.length; i++) {
+      if (spawnDistances[i] < closestDist) {
+        closestDist = spawnDistances[i]
+        closestIndex = i
+      }
     }
+  } else {
+    closestIndex = 0
   }
 
   const { position, cameraTarget } = eligiblePoints[closestIndex]

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -161,12 +161,9 @@ function pickSpawnpoint(land: Scene, targetWorldPosition: Vector3, basePosition:
       z: basePosition.z + finalPosition.z
     }
 
-    console.log("[TEST] selected spawn point at index " + closestIndex + " with position " + finalPosition.x + "," + finalPosition.y + "," + finalPosition.z)
-
     if (!isWorldPositionInsideParcels(land.scene.parcels, finalWorldPosition)) {
       finalPosition.x = 1
       finalPosition.z = 1
-      console.log("[TEST] spawn position out of bounds has been reset to 1,1");
     }
   }
 

--- a/browser-interface/packages/shared/world/positionThings.ts
+++ b/browser-interface/packages/shared/world/positionThings.ts
@@ -129,12 +129,13 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
   let closestIndex = 0
   let closestDist = Number.MAX_SAFE_INTEGER
 
+  console.log("[TEST] base position is " + basePosition)
   console.log("[TEST] Getting spawn points near " + targetWorldPosition.toString())
   // we compare world positions from the target parcel and the spawn points
   const spawnDistances = eligiblePoints.map( (value: SpawnPoint, index: number , array: SpawnPoint[]) => { 
-    const pos = getSpawnPointWorldPosition(value, basePosition)
-    const dist = Vector3.DistanceSquared(targetWorldPosition, pos) 
-    console.log("[TEST] spawn point at " + pos + " with distance " + dist)
+    const pos = getSpawnPointWorldPosition(value).add(basePosition);
+    const dist = Vector3.Distance(targetWorldPosition, pos) 
+    console.log("[TEST] Spawn point at " + pos + " with distance " + dist)
     return dist
   } )
 
@@ -164,7 +165,7 @@ function pickSpawnpoint(land: Scene, targetParcelPosition: Vector3, basePosition
       z: basePosition.z + finalPosition.z
     }
 
-    console.log("[TEST] selected spawn point at index " + closestIndex + " with position " + finalPosition)
+    console.log("[TEST] selected spawn point at index " + closestIndex + " with position " + finalPosition.x + "," + finalPosition.y + "," + finalPosition.z)
 
     if (!isWorldPositionInsideParcels(land.scene.parcels, finalWorldPosition)) {
       finalPosition.x = 1
@@ -206,7 +207,7 @@ function computeComponentValue(x: number | number[]) {
   return Math.random() * (max - min) + min
 }
 
-function getSpawnPointWorldPosition(spawnPoint: SpawnPoint, basePosition: Vector3)
+function getSpawnPointWorldPosition(spawnPoint: SpawnPoint)
 {
   const x = spawnPoint.position.x;
   const y = spawnPoint.position.y;
@@ -214,8 +215,8 @@ function getSpawnPointWorldPosition(spawnPoint: SpawnPoint, basePosition: Vector
 
   if (typeof x === "number" && typeof y === "number" && typeof z === "number")
   {
-    return new Vector3(x, y ,z).add(basePosition); 
+    return new Vector3(x, y ,z); 
   } else {
-    return new Vector3(x[0], y[0], z[0]).add(basePosition); 
+    return new Vector3(x[0], y[0], z[0]); 
   }
 }

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -40,12 +40,12 @@ describe('pickWorldSpawnPoint unit tests', function () {
       },
       spawnPoints: [
         {
-          position: { x: 1, y: 2, z: 3 },
-          cameraTarget: { x: 9, y: 8, z: 7 }
+          position: { x: 1, y: 1, z: 1 },
+          cameraTarget: { x: 1, y: 1, z: 1 }
         },
         {
-          position: { x: 11, y: 2, z: 13 },
-          cameraTarget: { x: 9, y: 8, z: 7 }
+          position: { x: 12, y: 2, z: 2 },
+          cameraTarget: { x: 12, y: 2, z: 2 }
         }
       ]
     }
@@ -55,8 +55,8 @@ describe('pickWorldSpawnPoint unit tests', function () {
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 11 + basePosition.x, y: 2 + basePosition.y, z: 13 + basePosition.z },
-        cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
+        position: { x: 2 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z },
+        cameraTarget: { x: 2 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z }
       })
     )
   })
@@ -103,13 +103,13 @@ describe('pickWorldSpawnPoint unit tests', function () {
       },
       spawnPoints: [
         {
-          position: { x: 1, y: 2, z: 3 },
-          cameraTarget: { x: 9, y: 8, z: 7 },
+          position: { x: 1, y: 1, z: 1 },
+          cameraTarget: { x: 1, y: 1, z: 1 },
           default: true
         },
         {
-          position: { x: 11, y: 2, z: 13 },
-          cameraTarget: { x: 9, y: 8, z: 7 },
+          position: { x: 12, y: 2, z: 2 },
+          cameraTarget: { x: 12, y: 2, z: 2 },
           default: true
         },
         {
@@ -126,8 +126,8 @@ describe('pickWorldSpawnPoint unit tests', function () {
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 11 + basePosition.x, y: 2 + basePosition.y, z: 13 + basePosition.z },
-        cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
+        position: { x: 2 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z },
+        cameraTarget: { x: 2 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z }
       })
     )
   })

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -1,7 +1,8 @@
 import { expect } from 'chai'
 import { pickWorldSpawnpoint } from 'shared/world/positionThings'
-import { gridToWorld } from 'lib/decentraland/parcels/gridToWorld'
 import { isInsideWorldLimits, Scene } from '@dcl/schemas'
+import { Vector3 } from '@dcl/ecs-math'
+import { parcelSize } from 'lib/decentraland'
 
 describe('pickWorldSpawnPoint unit tests', function () {
   it('picks a spawn point from the defined ones when no default', () => {
@@ -18,13 +19,43 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = gridToWorld(10, 10)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
 
-    const pick = pickWorldSpawnpoint(land)
+    const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
         position: { x: 1 + basePosition.x, y: 2 + basePosition.y, z: 3 + basePosition.z },
+        cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
+      })
+    )
+  })
+
+  it('picks the nearest spawn point from the defined ones when no default', () => {
+    const land: Scene = {
+      main: '',
+      scene: {
+        base: '10,10',
+        parcels: ['10,10', '11,10']
+      },
+      spawnPoints: [
+        {
+          position: { x: 1, y: 2, z: 3 },
+          cameraTarget: { x: 9, y: 8, z: 7 }
+        },
+        {
+          position: { x: 11, y: 2, z: 13 },
+          cameraTarget: { x: 9, y: 8, z: 7 }
+        }
+      ]
+    }
+    const basePosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
+
+    const pick = pickWorldSpawnpoint(land, basePosition)
+
+    expect(JSON.stringify(pick)).to.deep.equal(
+      JSON.stringify({
+        position: { x: 11 + basePosition.x, y: 2 + basePosition.y, z: 13 + basePosition.z },
         cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
       })
     )
@@ -51,13 +82,51 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = gridToWorld(10, 10)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
 
-    const pick = pickWorldSpawnpoint(land)
+    const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
         position: { x: 1 + basePosition.x, y: 2 + basePosition.y, z: 3 + basePosition.z },
+        cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
+      })
+    )
+  })
+
+  it('picks the nearest spawn point from the default ones when existing', () => {
+    const land: Scene = {
+      main: '',
+      scene: {
+        base: '10,10',
+        parcels: ['10,10', '11,10']
+      },
+      spawnPoints: [
+        {
+          position: { x: 1, y: 2, z: 3 },
+          cameraTarget: { x: 9, y: 8, z: 7 },
+          default: true
+        },
+        {
+          position: { x: 11, y: 2, z: 13 },
+          cameraTarget: { x: 9, y: 8, z: 7 },
+          default: true
+        },
+        {
+          position: { x: 2, y: 3, z: 4 }
+        },
+        {
+          position: { x: 3, y: 4, z: 5 }
+        }
+      ]
+    }
+    const basePosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
+
+    const pick = pickWorldSpawnpoint(land, basePosition)
+
+    expect(JSON.stringify(pick)).to.deep.equal(
+      JSON.stringify({
+        position: { x: 11 + basePosition.x, y: 2 + basePosition.y, z: 13 + basePosition.z },
         cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
       })
     )
@@ -76,9 +145,9 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = gridToWorld(10, 10)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
 
-    const pick = pickWorldSpawnpoint(land)
+    const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(pick.position.x).to.be.within(1 + basePosition.x, 2 + basePosition.x)
     expect(pick.position.y).to.be.within(2 + basePosition.y, 3 + basePosition.y)
@@ -93,7 +162,8 @@ describe('pickWorldSpawnPoint unit tests', function () {
         parcels: ['10,10']
       }
     }
-    const pick = pickWorldSpawnpoint(land)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
+    const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(pick.position.x).to.be.at.least(160) 
     expect(pick.position.x).to.be.below(176) 

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -44,8 +44,8 @@ describe('pickWorldSpawnPoint unit tests', function () {
           cameraTarget: { x: 1, y: 1, z: 1 }
         },
         {
-          position: { x: 12, y: 2, z: 2 },
-          cameraTarget: { x: 12, y: 2, z: 2 }
+          position: { x: 16, y: 1, z: 1 },
+          cameraTarget: { x: 16, y: 1, z: 1 }
         }
       ]
     }
@@ -55,8 +55,8 @@ describe('pickWorldSpawnPoint unit tests', function () {
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 12 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 2 + basePosition.z * parcelSize },
-        cameraTarget: { x: 12 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 2 + basePosition.z * parcelSize }
+        position: { x: 16 + basePosition.x * parcelSize, y: 1 + basePosition.y * parcelSize, z: 21 + basePosition.z * parcelSize },
+        cameraTarget: { x: 16 + basePosition.x * parcelSize, y: 1 + basePosition.y * parcelSize, z: 1 + basePosition.z * parcelSize }
       })
     )
   })

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -19,14 +19,14 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
+    const basePosition = new Vector3(10, 0, 10)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 1 + basePosition.x, y: 2 + basePosition.y, z: 3 + basePosition.z },
-        cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
+        position: { x: 1 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 3 + basePosition.z * parcelSize },
+        cameraTarget: { x: 9 + basePosition.x * parcelSize, y: 8 + basePosition.y * parcelSize, z: 7 + basePosition.z * parcelSize }
       })
     )
   })
@@ -49,14 +49,14 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
+    const basePosition = new Vector3(11, 0, 10)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 2 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z },
-        cameraTarget: { x: 2 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z }
+        position: { x: 12 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 2 + basePosition.z * parcelSize },
+        cameraTarget: { x: 12 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 2 + basePosition.z * parcelSize }
       })
     )
   })
@@ -82,14 +82,14 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
+    const basePosition = new Vector3(10, 0, 10)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 1 + basePosition.x, y: 2 + basePosition.y, z: 3 + basePosition.z },
-        cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
+        position: { x: 1 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 3 + basePosition.z * parcelSize },
+        cameraTarget: { x: 9 + basePosition.x * parcelSize, y: 8 + basePosition.y * parcelSize, z: 7 + basePosition.z * parcelSize }
       })
     )
   })
@@ -120,14 +120,14 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
+    const basePosition = new Vector3(11, 0, 10)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 2 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z },
-        cameraTarget: { x: 2 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z }
+        position: { x: 12 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 2 + basePosition.z * parcelSize },
+        cameraTarget: { x: 12 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 2 + basePosition.z * parcelSize }
       })
     )
   })
@@ -145,7 +145,7 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
+    const basePosition = new Vector3(10, 0, 10)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -49,9 +49,10 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
+    const targetPosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
 
-    const pick = pickWorldSpawnpoint(land, basePosition)
+    const pick = pickWorldSpawnpoint(land, targetPosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
@@ -120,9 +121,10 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
+    const targetPosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
 
-    const pick = pickWorldSpawnpoint(land, basePosition)
+    const pick = pickWorldSpawnpoint(land, targetPosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -19,14 +19,14 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(10, 0, 10)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 1 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 3 + basePosition.z * parcelSize },
-        cameraTarget: { x: 9 + basePosition.x * parcelSize, y: 8 + basePosition.y * parcelSize, z: 7 + basePosition.z * parcelSize }
+        position: { x: 1 + basePosition.x, y: 2 + basePosition.y, z: 3 + basePosition.z },
+        cameraTarget: { x: 9 + basePosition.x , y: 8 + basePosition.y, z: 7 + basePosition.z }
       })
     )
   })
@@ -49,14 +49,14 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(11, 0, 10)
+    const basePosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 16 + basePosition.x * parcelSize, y: 1 + basePosition.y * parcelSize, z: 1 + basePosition.z * parcelSize },
-        cameraTarget: { x: 16 + basePosition.x * parcelSize, y: 1 + basePosition.y * parcelSize, z: 1 + basePosition.z * parcelSize }
+        position: { x: 16 + basePosition.x, y: 1 + basePosition.y, z: 1 + basePosition.z},
+        cameraTarget: { x: 16 + basePosition.x, y: 1 + basePosition.y, z: 1 + basePosition.z}
       })
     )
   })
@@ -82,14 +82,14 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(10, 0, 10)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 1 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 3 + basePosition.z * parcelSize },
-        cameraTarget: { x: 9 + basePosition.x * parcelSize, y: 8 + basePosition.y * parcelSize, z: 7 + basePosition.z * parcelSize }
+        position: { x: 1 + basePosition.x, y: 2 + basePosition.y, z: 3 + basePosition.z },
+        cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
       })
     )
   })
@@ -120,14 +120,14 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(11, 0, 10)
+    const basePosition = new Vector3(11 * parcelSize, 0, 10 * parcelSize)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 12 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 2 + basePosition.z * parcelSize },
-        cameraTarget: { x: 12 + basePosition.x * parcelSize, y: 2 + basePosition.y * parcelSize, z: 2 + basePosition.z * parcelSize }
+        position: { x: 12 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z},
+        cameraTarget: { x: 12 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z}
       })
     )
   })
@@ -145,7 +145,7 @@ describe('pickWorldSpawnPoint unit tests', function () {
         }
       ]
     }
-    const basePosition = new Vector3(10, 0, 10)
+    const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
 
     const pick = pickWorldSpawnpoint(land, basePosition)
 

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -55,7 +55,7 @@ describe('pickWorldSpawnPoint unit tests', function () {
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 16 + basePosition.x * parcelSize, y: 1 + basePosition.y * parcelSize, z: 21 + basePosition.z * parcelSize },
+        position: { x: 16 + basePosition.x * parcelSize, y: 1 + basePosition.y * parcelSize, z: 1 + basePosition.z * parcelSize },
         cameraTarget: { x: 16 + basePosition.x * parcelSize, y: 1 + basePosition.y * parcelSize, z: 1 + basePosition.z * parcelSize }
       })
     )

--- a/browser-interface/test/unit/positionThings.test.tsx
+++ b/browser-interface/test/unit/positionThings.test.tsx
@@ -26,7 +26,7 @@ describe('pickWorldSpawnPoint unit tests', function () {
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
         position: { x: 1 + basePosition.x, y: 2 + basePosition.y, z: 3 + basePosition.z },
-        cameraTarget: { x: 9 + basePosition.x , y: 8 + basePosition.y, z: 7 + basePosition.z }
+        cameraTarget: { x: 9 + basePosition.x, y: 8 + basePosition.y, z: 7 + basePosition.z }
       })
     )
   })
@@ -56,8 +56,8 @@ describe('pickWorldSpawnPoint unit tests', function () {
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 16 + basePosition.x, y: 1 + basePosition.y, z: 1 + basePosition.z},
-        cameraTarget: { x: 16 + basePosition.x, y: 1 + basePosition.y, z: 1 + basePosition.z}
+        position: { x: 16 + basePosition.x, y: 1 + basePosition.y, z: 1 + basePosition.z },
+        cameraTarget: { x: 16 + basePosition.x, y: 1 + basePosition.y, z: 1 + basePosition.z }
       })
     )
   })
@@ -128,8 +128,8 @@ describe('pickWorldSpawnPoint unit tests', function () {
 
     expect(JSON.stringify(pick)).to.deep.equal(
       JSON.stringify({
-        position: { x: 12 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z},
-        cameraTarget: { x: 12 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z}
+        position: { x: 12 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z },
+        cameraTarget: { x: 12 + basePosition.x, y: 2 + basePosition.y, z: 2 + basePosition.z }
       })
     )
   })
@@ -167,11 +167,11 @@ describe('pickWorldSpawnPoint unit tests', function () {
     const basePosition = new Vector3(10 * parcelSize, 0, 10 * parcelSize)
     const pick = pickWorldSpawnpoint(land, basePosition)
 
-    expect(pick.position.x).to.be.at.least(160) 
-    expect(pick.position.x).to.be.below(176) 
+    expect(pick.position.x).to.be.at.least(160)
+    expect(pick.position.x).to.be.below(176)
     expect(pick.position.y).to.equal(0)
-    expect(pick.position.z).to.be.at.least(160) 
-    expect(pick.position.z).to.be.below(176) 
+    expect(pick.position.z).to.be.at.least(160)
+    expect(pick.position.z).to.be.below(176)
     expect(pick.cameraTarget).to.equal(undefined)
   })
 })


### PR DESCRIPTION
## What does this PR change?

Closes #4652

When jumping to a scene we used to select a random spawn point defined by the scene.

Now we are selecting the spawn point that is nearest to our jump coordinates.
This means that if we have a scene that is 4x4 parcels and has a spawn point at each corner, the teleport positions will be:

| B 	| B 	| C 	| C 	|
|---:	|:---:	|:---:	|---	|
| B 	| B 	| C 	| C 	|
| A 	| A 	| D 	| D 	|
| A 	| A 	| D 	| D 	|

Being:
A: Lower-left
B: Top-Left
C: Top-Right
D: Lower-Right

## How to test the changes?

- Go to [MVFW Road scenes](https://play.decentraland.org/?explorer-branch=feat%2Fspawn-points&realm=baldr&position=-73%2C6)
- Open the map and click near the corners (that are inside the green box), if that parcel is a road, you will get teleported to the nearest spawn point (at the time I'm writing this, the scene has 4 spawn points, one at each corner )

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
