### PR TITLE
chore: increase scene timeout to 120

### DIFF
--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -324,7 +324,7 @@ export class SceneWorker {
 
     sceneEvents.emit(SCENE_LOAD, signalSceneLoad(this.loadableScene))
 
-    const WORKER_TIMEOUT = 180_000
+    const WORKER_TIMEOUT = 120_000
     setTimeout(() => this.onLoadTimeout(), WORKER_TIMEOUT)
   }
 

--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -324,7 +324,7 @@ export class SceneWorker {
 
     sceneEvents.emit(SCENE_LOAD, signalSceneLoad(this.loadableScene))
 
-    const WORKER_TIMEOUT = 90_000 // ninety seconds to mars
+    const WORKER_TIMEOUT = 180_000
     setTimeout(() => this.onLoadTimeout(), WORKER_TIMEOUT)
   }
 


### PR DESCRIPTION
## What does this PR change?

Increases scene timeout to 2 minutes. This is a requirement for MVFW 2023, since there are a couple of scenes not loadings. The current scene shows whatever is in the scene once the timeout is reached, and this is a problem, since many times it shows uncompleted assets or even an empty scene alltogether. The increased timeout will give more time to users with slower connection.

The increasing or decreasing of this number is flawed, and its currently just a mitigation. A new PoC is in the works which would allow proper handling of download times and its corresponding realtime feedback. Also, it will include a user feddback and decision system, in which the user will be able to take action when the scene is not loading; like keep waiting or go where he came from.

More info on the [PoC](https://github.com/decentraland/unity-renderer/issues/4665) here

## How to test the changes?



## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
