### PR TITLE
chore: fixed avpro package in desktop

### DIFF
--- a/ci-import-avpro.sh
+++ b/ci-import-avpro.sh
@@ -3,9 +3,9 @@ echo Downloading AVProVideo
 
 echo "${GPG_PRIVATE_KEY_BASE64}" | base64 -d > private.gpg
 gpg  --batch --import private.gpg
-curl -L 'https://renderer-artifacts.decentraland.org/artifacts/DCL_AVProVideo_2.6.7_ULTRA.unitypackage.gpg' -o DCL_AVProVideo_2.6.7_ULTRA.unitypackage.gpg
+curl -L 'https://renderer-artifacts.decentraland.org/artifacts/DCL_AVProVideo_2.7.3_ULTRA.unitypackage.gpg' -o DCL_AVProVideo_2.7.3_ULTRA.unitypackage.gpg
 
-gpg --output DCL_AVProVideo_2.6.7_ULTRA.unitypackage --decrypt DCL_AVProVideo_2.6.7_ULTRA.unitypackage.gpg
+gpg --output DCL_AVProVideo_2.7.3_ULTRA.unitypackage --decrypt DCL_AVProVideo_2.7.3_ULTRA.unitypackage.gpg
 
 echo Finished downloading AVProVideo
 
@@ -14,7 +14,7 @@ echo Begin importing AVProVideo
 xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' $UNITY_PATH/Editor/Unity \
 -quit \
 -batchmode \
--importPackage $(pwd)/DCL_AVProVideo_2.6.7_ULTRA.unitypackage \
+-importPackage $(pwd)/DCL_AVProVideo_2.7.3_ULTRA.unitypackage \
 -projectPath "$PROJECT_PATH"
 
 echo Ended importing AvProVideo

--- a/ci-import-avpro.sh
+++ b/ci-import-avpro.sh
@@ -3,9 +3,9 @@ echo Downloading AVProVideo
 
 echo "${GPG_PRIVATE_KEY_BASE64}" | base64 -d > private.gpg
 gpg  --batch --import private.gpg
-curl -L 'https://renderer-artifacts.decentraland.org/artifacts/Custom_AVProVideo_2.6.7_ULTRA.unitypackage.gpg' -o Custom_AVProVideo_2.6.7_ULTRA.unitypackage.gpg
+curl -L 'https://renderer-artifacts.decentraland.org/artifacts/DCL_AVProVideo_2.6.7_ULTRA.unitypackage.gpg' -o DCL_AVProVideo_2.6.7_ULTRA.unitypackage.gpg
 
-gpg --output Custom_AVProVideo_2.6.7_ULTRA.unitypackage --decrypt Custom_AVProVideo_2.6.7_ULTRA.unitypackage.gpg
+gpg --output DCL_AVProVideo_2.6.7_ULTRA.unitypackage --decrypt DCL_AVProVideo_2.6.7_ULTRA.unitypackage.gpg
 
 echo Finished downloading AVProVideo
 
@@ -14,7 +14,7 @@ echo Begin importing AVProVideo
 xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' $UNITY_PATH/Editor/Unity \
 -quit \
 -batchmode \
--importPackage $(pwd)/Custom_AVProVideo_2.6.7_ULTRA.unitypackage \
+-importPackage $(pwd)/DCL_AVProVideo_2.6.7_ULTRA.unitypackage \
 -projectPath "$PROJECT_PATH"
 
 echo Ended importing AvProVideo


### PR DESCRIPTION
## What does this PR change?

AVPro package was not being imported correctly in desktop. This PR fixes that

## How to test the changes?

1. Launch the explorer version
2. Go to a parcel with videos (like 64,64)
3. See a couple of videos
4. Check the Player.log. Check that you have AVPros log (like AVPro initializing)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
