### PR TITLE
fix: show guest panel only when trying to add friend from passport

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentController.cs
@@ -150,6 +150,12 @@ namespace DCL.Social.Passports
 
         private void AddPlayerAsFriend()
         {
+            if (userProfileBridge.GetOwn().isGuest)
+            {
+                dataStore.HUDs.connectWalletModalVisible.Set(true);
+                return;
+            }
+
             if (isNewFriendRequestsEnabled)
                 dataStore.HUDs.sendFriendRequest.Set(currentPlayerId, true);
             else
@@ -272,6 +278,12 @@ namespace DCL.Social.Passports
 
         private void WhisperUser(string userId)
         {
+            if (userProfileBridge.GetOwn().isGuest)
+            {
+                dataStore.HUDs.connectWalletModalVisible.Set(true);
+                return;
+            }
+
             dataStore.HUDs.openChat.Set(userId, true);
             socialAnalytics.SendStartedConversation(PlayerActionSource.Passport);
             OnClosePassport?.Invoke();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentController.cs
@@ -148,7 +148,7 @@ namespace DCL.Social.Passports
             return dataStore.settings.profanityChatFilteringEnabled.Get();
         }
 
-        private void AddPlayerAsFriend()
+        internal void AddPlayerAsFriend()
         {
             if (userProfileBridge.GetOwn().isGuest)
             {
@@ -278,12 +278,6 @@ namespace DCL.Social.Passports
 
         private void WhisperUser(string userId)
         {
-            if (userProfileBridge.GetOwn().isGuest)
-            {
-                dataStore.HUDs.connectWalletModalVisible.Set(true);
-                return;
-            }
-
             dataStore.HUDs.openChat.Set(userId, true);
             socialAnalytics.SendStartedConversation(PlayerActionSource.Passport);
             OnClosePassport?.Invoke();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
@@ -76,17 +76,7 @@ namespace DCL.Social.Passports
             OnCurrentPlayerIdChanged(currentPlayerId, null);
 
             playerInfoController.OnClosePassport += ClosePassport;
-            dataStore.HUDs.closedWalletModal.OnChange += ClosedGuestWalletPanel;
             dataStore.HUDs.currentPassportSortingOrder.Set(view.PassportCurrentSortingOrder);
-        }
-
-        private void ClosedGuestWalletPanel(bool current, bool previous)
-        {
-            if (current)
-            {
-                ClosePassport();
-                dataStore.HUDs.closedWalletModal.Set(false, false);
-            }
         }
 
         private void ClosePassport()
@@ -128,7 +118,6 @@ namespace DCL.Social.Passports
             closeWindowTrigger.OnTriggered -= OnCloseButtonPressed;
             currentPlayerId.OnChange -= OnCurrentPlayerIdChanged;
             playerInfoController.OnClosePassport -= ClosePassport;
-            dataStore.HUDs.closedWalletModal.OnChange -= ClosedGuestWalletPanel;
 
             playerInfoController.Dispose();
             playerPreviewController.Dispose();
@@ -169,10 +158,6 @@ namespace DCL.Social.Passports
         {
             isOpen = visible;
 
-            if (visible && userProfileBridge.GetOwn().isGuest)
-            {
-                dataStore.HUDs.connectWalletModalVisible.Set(true);
-            }
             playerInfoCardVisibleState.Set(visible);
             view.SetPassportPanelVisibility(visible);
             playerPreviewController.SetPassportPanelVisibility(visible);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Tests/PassportInfoHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Tests/PassportInfoHUDControllerShould.cs
@@ -1,0 +1,75 @@
+using AvatarSystem;
+using DCL.ProfanityFiltering;
+using DCL.Social.Friends;
+using NSubstitute;
+using NUnit.Framework;
+using SocialFeaturesAnalytics;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DCL.Social.Passports
+{
+    public class PassportInfoHUDControllerShould
+    {
+        private PassportPlayerInfoComponentController playerInfoController;
+        private StringVariable currentPlayerInfoCardId;
+        private IUserProfileBridge userProfileBridge;
+        private ISocialAnalytics socialAnalytics;
+        private DataStore dataStore;
+        private IProfanityFilter profanityFilter;
+        private IPassportApiBridge passportApiBridge;
+        private IFriendsController friendsController;
+        private IPassportPlayerInfoComponentView playerInfoView;
+
+        [SetUp]
+        public void Setup()
+        {
+            currentPlayerInfoCardId = ScriptableObject.CreateInstance<StringVariable>();
+            userProfileBridge = Substitute.For<IUserProfileBridge>();
+            socialAnalytics = Substitute.For<ISocialAnalytics>();
+            dataStore = Substitute.For<DataStore>();
+            profanityFilter = Substitute.For<IProfanityFilter>();
+            passportApiBridge = Substitute.For<IPassportApiBridge>();
+            friendsController = Substitute.For<IFriendsController>();
+            playerInfoView = Substitute.For<IPassportPlayerInfoComponentView>();
+
+            playerInfoController = new PassportPlayerInfoComponentController(
+                currentPlayerInfoCardId,
+                playerInfoView,
+                dataStore,
+                profanityFilter,
+                friendsController,
+                userProfileBridge,
+                socialAnalytics,
+                Substitute.For<IClipboard>(),
+                passportApiBridge);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            playerInfoController.Dispose();
+        }
+
+
+        [Test]
+        public void OpenGuestPanelWhenAddingFriendAsGuest()
+        {
+            var ownUserProfile = ScriptableObject.CreateInstance<UserProfile>();
+            ownUserProfile.UpdateData(new UserProfileModel
+            {
+                userId = "ownId",
+                hasConnectedWeb3 = false
+            });
+            var connectWalletModalVisibilityWasCalled = false;
+            dataStore.HUDs.connectWalletModalVisible.OnChange += (current, previous) => connectWalletModalVisibilityWasCalled = true;
+
+            userProfileBridge.GetOwn().Returns(ownUserProfile);
+            playerInfoView.OnAddFriend += Raise.Event<Action>();
+
+            Assert.IsTrue(connectWalletModalVisibilityWasCalled);
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Tests/PassportInfoHUDControllerShould.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Tests/PassportInfoHUDControllerShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 493c6c2124be94bb398627fd9a506788
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?

Fix #4654
Adds the guest panel notification only when trying to add friend in passport and not in passport open

...

## How to test the changes?

1. Launch the explorer as a guest https://play.decentraland.org/?explorer-branch=fix/guest-panel-passport
2. Open a passport
3. Check the passport can be used
4. Press add friend
5. verify that the guest panel appears
_______
1. Launch the explorer as a regular user https://play.decentraland.org/?explorer-branch=fix/guest-panel-passport
2. verify that the passport works as always

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
