### PR TITLE
Fix: fixed clickable coordinates in chat

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -112,8 +112,6 @@ namespace DCL.Chat.HUD
 
         private string GetCoordinatesLink(string body)
         {
-            if (!CoordinateUtils.HasValidTextCoordinates(body)) return body;
-
             return CoordinateUtils.ReplaceTextCoordinates(body, (text, coordinates) =>
                 $"</noparse><link={text}><color=#4886E3><u>{text}</u></color></link><noparse>");
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Utils/CoordinateUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Utils/CoordinateUtils.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 
 public class CoordinateUtils
 {
-    private const string COORDINATE_MATCH_REGEX = @"(?<!\S)[-]?\d{1,3},[-]?\d{1,3}(?!\S)";
+    private const string COORDINATE_MATCH_REGEX = @"(?<!\w)(?<!<\/noparse>)[-]?\d{1,3},[-]?\d{1,3}(?!\w)(?!<\/\/noparse>)";
     private const int MAX_X_COORDINATE = 163;
     private const int MIN_X_COORDINATE = -150;
     private const int MAX_Y_COORDINATE = 158;


### PR DESCRIPTION
## What does this PR change?

Fix #4669
Fixes clickable coordinates in chat

...

## How to test the changes?

1. Launch the explorer
2. Type some valid coordinates in chat
3. Verify they are highlighted and are clickable without any issues

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
