### PR TITLE
fix: add tracking for error events

### DIFF
--- a/browser-interface/packages/shared/comms/adapters/LivekitAdapter.ts
+++ b/browser-interface/packages/shared/comms/adapters/LivekitAdapter.ts
@@ -41,7 +41,12 @@ export class LivekitAdapter implements MinimumCommunicationsAdapter {
         this.config.logger.log('remote participant left', _.identity)
       })
       .on(RoomEvent.Disconnected, (_reason: DisconnectReason | undefined) => {
-        this.config.logger.log('disconnected from room')
+        this.config.logger.log('disconnected from room', _reason)
+        trackEvent('error', {
+          context: 'livekit-adapter',
+          message: `Got RoomEvent.Disconnected. Reason: ${_reason}`,
+          stack: ""
+        })
         this.disconnect().catch((err) => {
           this.config.logger.error(`error during disconnection ${err.toString()}`)
         })
@@ -84,6 +89,11 @@ export class LivekitAdapter implements MinimumCommunicationsAdapter {
         }
       }
     } catch (err: any) {
+      trackEvent('error', {
+        context: 'livekit-adapter',
+        message: `Error trying to send data. Reason: ${err.message}`,
+        stack: err.stack
+      })
       // this fails in some cases, catch is needed
       this.config.logger.error(err)
     }


### PR DESCRIPTION
## What does this PR change?
Adds event tracking in 2 particular situations:
* When there is a comms error trying to send data to LiveKit.
* When receiving a disconnect event from the server.

This would capture the events and/or exceptions and allow us to determine why disconnections happen. This might (or might not) be related to https://github.com/decentraland/unity-renderer/issues/4489.