### PR TITLE
feat: browser-interface for windows and tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ To test against a build made on this repository, you can use a link with this fo
 
 In order to run browser interface in any platform follow the next instructions
 
-### Steps
+### How to run `make watch`
 
 1. Open browser-interface with `Visual Studio Code`
 2. Make sure you have the `devcontainers` extension installed
 3. Make sure [Docker Desktop](https://www.docker.com/) is running
-4. `At Visual Studio Code` you will find a green button at the bottom-left corner of your screen, if you press it, a menu will appear and you have to press `Reopen in Container`
-5. Once the process ends, open a terminal with `cltr+j` or `cmd+j` and enter `make watch` 
+4. `At Visual Studio Code` press `F1` execute `Reopen in Container` and wait for it to finish.
+5. Go to `Terminal > New Terminal` menu and run `make watch` command. 
 
 ## How to run browser-interface unit tests
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ To test against a build made on this repository, you can use a link with this fo
 
 # Advanced debugging scenarios
 
+## Running the browser-interface
+
+In order to run browser interface in any platform follow the next instructions
+
+### Steps
+
+1. Open browser-interface with `Visual Studio Code`
+2. Make sure you have the `devcontainers` extension installed
+3. Make sure [Docker Desktop](https://www.docker.com/) is running
+4. `At Visual Studio Code` you will find a green button at the bottom-left corner of your screen, if you press it, a menu will appear and you have to press `Reopen in Container`
+5. Once the process ends, open a terminal with `cltr+j` or `cmd+j` and enter `make watch` 
+
+## How to run browser-interface unit tests
+
+1. Follow the previous process to run `make watch` 
+2. Open `localhost:8080/test` in your browser
+3. Watch the results
+
 ## Debug with Unity Editor + local Browser Interface
 
 Use this approach when working on any features that need both Browser Interface and Unity modifications, and you need to watch Unity code changes fast without the need of injecting a wasm targeted build in the browser.
@@ -84,11 +102,11 @@ When the steps are followed, you will be able to run the local Unity build by go
 ### Steps
 
 1. Make sure you have the proper Unity version up and running
-2. Make sure you are running browser-interface through `make watch` command in the browser-interface directory (`npm i` first just in case).
-3. Produce a Unity wasm targeted build using the Build menu.
-4. When the build finishes, copy all the files inside the resulting `/build` folder (`unity.loader.js` is not necessary as we use a modified loader) and paste them inside `browser-interface/node_modules/@dcl/unity-renderer`.
-5. Run the browser explorer through `localhost:8080&ENABLE_WEB3`. Now, it should use your local Unity build. Don't mind the white screen at the beginning, that's because the website repo is not being used and it's only loading Browser Interface with the build.
-6. If you need a Unity re-build, you can just replace the files and reload the browser without restarting the `make watch` process.
+3. Make sure you are running browser-interface through `make watch` command.
+4. Produce a Unity wasm targeted build using the Build menu.
+5. When the build finishes, copy all the files inside the resulting `/build` folder (`unity.loader.js` is not necessary as we use a modified loader) and paste them inside `browser-interface/node_modules/@dcl/unity-renderer`.
+6. Run the browser explorer through `localhost:8080&ENABLE_WEB3`. Now, it should use your local Unity build. Don't mind the white screen at the beginning, that's because the website repo is not being used and it's only loading Browser Interface with the build.
+7. If you need a Unity re-build, you can just replace the files and reload the browser without restarting the `make watch` process.
 
 Alternatively you can go through these 2 steps after step 3 and load the build locally using `localhost:3000` 
 1. Make sure you have the [explorer website repository](https://github.com/decentraland/explorer-website) cloned.

--- a/browser-interface/Makefile
+++ b/browser-interface/Makefile
@@ -72,7 +72,7 @@ build-unity-local:
 	cp node_modules/\@dcl/explorer/unity* static/
 	cp -r node_modules/\@dcl/explorer/StreamingAssets static/
 watch: touch-local build ## Watch the files required for hacking the explorer
-	@NODE_ENV=development ./build.js -watch
+	@NODE_ENV=development node ./build.js -watch
 
 # Makefile
 


### PR DESCRIPTION
## What does this PR change?

Fixed the `Makefile` of `browser-interface` for it to work with Windows.

Added a tutorial to setup `browser-interface` using `Visual Studio Code` with `devcontainer` extension. 

## How to test the changes?

Follow the` browser-tutorial` setup-guide

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
