### PR TITLE
fix: InputModule KeyNotFoundException

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/StandaloneInputModuleDCL.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/UIHelpers/StandaloneInputModuleDCL.cs
@@ -4,7 +4,10 @@ namespace MainScripts.DCL.Helpers.UIHelpers
 {
     public class StandaloneInputModuleDCL : StandaloneInputModule
     {
-        public PointerEventData GetPointerData() =>
-            m_PointerData[kMouseLeftId];
+        public PointerEventData GetPointerData()
+        {
+            GetPointerData(kMouseLeftId, out PointerEventData data, true);
+            return data;
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?
Closes #4658 (Probably)

**Problem** - in the direct access to the `key` in the `Dictionary` which could be not present there at the time of the request. 
**Solution**  - usage of the method in the parent class `PointerInputModule.GetPointerData(..)` that check if key exist and if not, it creates one;
**Note** - the only user of this call was `NeedToUnhoverWhileCursorUnlocked` (in `PointerEventsController`)

## How to test the changes?

1. Launch the explorer
2. Check that unhovering behavior for the cursor behaves as previously (for example when action buttons are pressed)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
