### PR TITLE
feat: open ~nearby channel by default when hitting ENTER key

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -393,6 +393,9 @@ public class TaskbarHUDController : IHUD
             ? ChatUtils.NEARBY_CHANNEL_ID
             : lastOpenedChat;
 
+        if (newChat == ChatUtils.CONVERSATION_LIST_ID)
+            newChat = ChatUtils.NEARBY_CHANNEL_ID;
+
         openChat.Set(newChat, true);
     }
 


### PR DESCRIPTION
## What does this PR change?

`Fixes #4612 `

## How to test the changes?

1. Go to: https://play.decentraland.zone/?explorer-branch=feat/nearby-default
2. Hit ENTER key
3. The ~nearby channel should open
4. Hit back and then open the conversation list
5. Close the conversation list
6. Hit ENTER key
7. The ~nearby channel should open
8. Go to the conversation list and open any #channel or DM
9. Close the chat window
10. Hit ENTER key, the last chat window should be opened (#channel or DM)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
