### PR TITLE
fix: error loading wearables for guest users in worlds

### DIFF
--- a/unity-renderer/Assets/DCLServices/Lambdas/LambdasService.cs
+++ b/unity-renderer/Assets/DCLServices/Lambdas/LambdasService.cs
@@ -74,6 +74,7 @@ namespace DCLServices.Lambdas
             var urlBuilder = GenericPool<StringBuilder>.Get();
             urlBuilder.Clear();
             urlBuilder.Append(GetLambdasUrl());
+            urlBuilder.Append('/');
 
             var endPointSpan = endPoint.AsSpan();
 

--- a/unity-renderer/Assets/DCLServices/Lambdas/LambdasService.cs
+++ b/unity-renderer/Assets/DCLServices/Lambdas/LambdasService.cs
@@ -74,7 +74,8 @@ namespace DCLServices.Lambdas
             var urlBuilder = GenericPool<StringBuilder>.Get();
             urlBuilder.Clear();
             urlBuilder.Append(GetLambdasUrl());
-            urlBuilder.Append('/');
+            if (!urlBuilder.ToString().EndsWith('/'))
+                urlBuilder.Append('/');
 
             var endPointSpan = endPoint.AsSpan();
 


### PR DESCRIPTION
## What does this PR change?
Url param `DISABLE_force_to_request_wearables_through_kernel]` causing issues with wearables when entering world `menduz.dcl.eth` directly on startup.

## How to test the changes?
Clear cache, log in with "DISABLE_force_to_request_wearables_through_kernel" and "realm=menduz.dcl.eth" params. Guest arrives at the initial character creation screen with "Problem loading your wearables" error and a blank avatar. Wallet: (After a lengthy loading) logs in with "loading scene timeout" error message and a blue hologram-looking avatar missing its wearables.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
