### PR TITLE
fix: hide message button in the user context menu when is guest

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
@@ -137,7 +137,12 @@ public class UserContextMenu : MonoBehaviour
 
         if (userProfile != null)
         {
-            Setup(userProfile.userId, menuConfigFlags);
+            if (!Setup(userProfile.userId, menuConfigFlags))
+            {
+                ShowUserNotificationError(userName);
+                return;
+            }
+
             Show(userProfile.userId, currentConfigFlags);
         }
         else
@@ -325,12 +330,6 @@ public class UserContextMenu : MonoBehaviour
         Hide();
     }
 
-    private void UpdateBlockButton()
-    {
-        blockText.text = isBlocked ? BLOCK_BTN_UNBLOCK_TEXT : BLOCK_BTN_BLOCK_TEXT;
-        messageButton.gameObject.SetActive(!isBlocked && enableSendMessage);
-    }
-
     private void HideIfClickedOutside()
     {
         if (!Input.GetMouseButtonDown(0)) return;
@@ -385,7 +384,7 @@ public class UserContextMenu : MonoBehaviour
         if ((configFlags & MenuConfigFlags.Block) != 0)
         {
             isBlocked = UserProfile.GetOwnUserProfile().blocked.Contains(userId);
-            UpdateBlockButton();
+            blockText.text = isBlocked ? BLOCK_BTN_UNBLOCK_TEXT : BLOCK_BTN_BLOCK_TEXT;
         }
 
         if ((configFlags & MenuConfigFlags.Name) != 0)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/UserContextMenu/Scripts/UserContextMenu.cs
@@ -118,7 +118,8 @@ public class UserContextMenu : MonoBehaviour
         if (!Setup(userId, configFlags))
             return;
 
-        if (currentConfirmationDialog == null && confirmationDialog != null) { SetConfirmationDialog(confirmationDialog); }
+        if (currentConfirmationDialog == null && confirmationDialog != null)
+            SetConfirmationDialog(confirmationDialog);
 
         gameObject.SetActive(true);
         OnShowMenu?.Invoke();
@@ -130,9 +131,15 @@ public class UserContextMenu : MonoBehaviour
     /// <param name="userName">User name</param>
     public void ShowByUserName(string userName)
     {
-        var userProfile = UserProfileController.userProfilesCatalog.GetValues().FirstOrDefault(p => p.userName.ToLower() == userName.ToLower());
+        var userProfile = UserProfileController.userProfilesCatalog
+                                               .GetValues()
+                                               .FirstOrDefault(p => p.userName.Equals(userName, StringComparison.OrdinalIgnoreCase));
+
         if (userProfile != null)
-            Show(userProfile.userId);
+        {
+            Setup(userProfile.userId, menuConfigFlags);
+            Show(userProfile.userId, currentConfigFlags);
+        }
         else
             ShowUserNotificationError(userName);
     }
@@ -369,9 +376,8 @@ public class UserContextMenu : MonoBehaviour
             return false;
         }
 
-        bool userHasWallet = profile?.hasConnectedWeb3 ?? false;
-
-        if (!userHasWallet || !UserProfile.GetOwnUserProfile().hasConnectedWeb3) { configFlags &= ~usesFriendsApiFlags; }
+        if (profile.isGuest || !UserProfile.GetOwnUserProfile().hasConnectedWeb3)
+            configFlags &= ~usesFriendsApiFlags;
 
         currentConfigFlags = configFlags;
         ProcessActiveElements(configFlags);


### PR DESCRIPTION
## What does this PR change?

You were able to send a DM to a guest when opening the context menu through a mention in chat or opening the context menu in any other flow.

## How to test the changes?

1. Mention a guest user
2. In the chat window click on the highlighted name
3. "Message" should not be available

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
