### PR TITLE
hotfix: delay and return value issues in fetch peer profile

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/comms/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/comms/index.ts
@@ -23,7 +23,7 @@ export async function fetchPeerProfile(
         return state.profiles.userInfo[userId]!.data
       }
     }),
-    sleep(COMMS_PROFILE_TIMEOUT).then(() => null)
+    sleep(COMMS_PROFILE_TIMEOUT)
   ])
   incrementCounter(result ? 'profile-over-comms-succesful' : 'profile-over-comms-failed')
   if (!result) {

--- a/browser-interface/packages/shared/profiles/sagas/comms/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/comms/index.ts
@@ -1,11 +1,11 @@
 import type { Avatar } from '@dcl/schemas'
 import { COMMS_PROFILE_TIMEOUT } from 'config'
 import { storeCondition } from 'lib/redux'
-import { delay } from 'redux-saga/effects'
 import { requestProfileFromPeers } from 'shared/comms/handlers'
 import { RoomConnection } from 'shared/comms/interface'
 import { incrementCounter } from 'shared/analytics/occurences'
 import { RootProfileState } from 'shared/profiles/types'
+import { sleep } from 'lib/javascript/sleep'
 
 export async function fetchPeerProfile(
   room: RoomConnection,
@@ -23,11 +23,12 @@ export async function fetchPeerProfile(
         return state.profiles.userInfo[userId]!.data
       }
     }),
-    delay(COMMS_PROFILE_TIMEOUT)
+    sleep(COMMS_PROFILE_TIMEOUT).then(() => null)
   ])
   incrementCounter(result ? 'profile-over-comms-succesful' : 'profile-over-comms-failed')
   if (!result) {
     return null
   }
+
   return result as Avatar
 }


### PR DESCRIPTION
## What does this PR change?

Function `fetchPeerProfile` was wrongly setting a timer with redux-sagas delay which generated no delay and returned a static `CallEffect` object meant to be used by the `race` generator from that same framework, in a vanilla promise race this was interpreted as a return value and then an invalid avatar.

This in turn was generating a random profile every time the profile view was opened and thus a new name was picked for the same address every time.

This change introduces:
- `sleep` function instead of `delay` to actually create that delay inside a `Promise#race`
- Ensures that the result of the `Promise#race `is actually the avatar from the store or a `null` value from the sleep.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
