### PR TITLE
fix: transparent objects and SSAO

### DIFF
--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.coffee.ui-particle": "4.1.6",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src",
-    "com.decentraland.unity-shared-dependencies": "https://github.com/decentraland/unity-shared-dependencies.git#fix/disable-ssao-in-transparents",
+    "com.decentraland.unity-shared-dependencies": "https://github.com/decentraland/unity-shared-dependencies.git",
     "com.decentraland.videoplayer": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",
     "com.decentraland.webgl-ime-input": "https://github.com/decentraland/webgl-ime-input.git",
     "com.madsbangh.easybuttons": "1.3.0",

--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.coffee.ui-particle": "4.1.6",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src",
-    "com.decentraland.unity-shared-dependencies": "https://github.com/decentraland/unity-shared-dependencies.git",
+    "com.decentraland.unity-shared-dependencies": "https://github.com/decentraland/unity-shared-dependencies.git#fix/disable-ssao-in-transparents",
     "com.decentraland.videoplayer": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",
     "com.decentraland.webgl-ime-input": "https://github.com/decentraland/webgl-ime-input.git",
     "com.madsbangh.easybuttons": "1.3.0",

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -50,11 +50,11 @@
       "hash": "434f7c2dd0a831d259858e6ba3482ffcc24b7268"
     },
     "com.decentraland.unity-shared-dependencies": {
-      "version": "https://github.com/decentraland/unity-shared-dependencies.git",
+      "version": "https://github.com/decentraland/unity-shared-dependencies.git#fix/disable-ssao-in-transparents",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "5577bd123883e2fa96f51b8d534abd75bad0535f"
+      "hash": "232a4d1cdb88311a1d9163d5c3ec8be4b9e43d12"
     },
     "com.decentraland.videoplayer": {
       "version": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -50,11 +50,11 @@
       "hash": "434f7c2dd0a831d259858e6ba3482ffcc24b7268"
     },
     "com.decentraland.unity-shared-dependencies": {
-      "version": "https://github.com/decentraland/unity-shared-dependencies.git#fix/disable-ssao-in-transparents",
+      "version": "https://github.com/decentraland/unity-shared-dependencies.git",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "232a4d1cdb88311a1d9163d5c3ec8be4b9e43d12"
+      "hash": "1b462119ed2ca0a100d22cea1e482d28dde41dc8"
     },
     "com.decentraland.videoplayer": {
       "version": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",


### PR DESCRIPTION
Transparent objects should ignore SSAO. The main reason SSAO was bleeding into transparent objects is because the SSAO pass is performed after the opaque objects and before the transparent ones. This cannot be changed, and therefore the postprocessing layer was painting the AO calculated behind some transparent objects.

To fix this, I modified the shared dependency at https://github.com/decentraland/unity-shared-dependencies/pull/18.

This PR above must be merged before this one, which updates the package version.

## Test
Go to -109 -18. The "clock-man" face should no longer bleed AO.
![image](https://user-images.githubusercontent.com/50231608/226658668-8d1684cc-e9b9-49ea-924e-6878a26b5331.png)

Take a look at the rest of the world and look for regressions in SSAO.