### PR TITLE
hotfix: race comms and catalyst fetching for profile with version

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
@@ -2,6 +2,7 @@ import type { Avatar } from '@dcl/schemas'
 import { FETCH_REMOTE_PROFILE_RETRIES } from 'config'
 import { generateRandomUserProfile } from 'lib/decentraland/profiles/generateRandomUserProfile'
 import { ensureAvatarCompatibilityFormat } from 'lib/decentraland/profiles/transformations/profileToServerFormat'
+import defaultLogger from 'lib/logger'
 import { call, CallEffect, put, race, select } from 'redux-saga/effects'
 import { trackEvent } from 'shared/analytics/trackEvent'
 import type { RoomConnection } from 'shared/comms/interface'
@@ -110,8 +111,12 @@ function* fetchFromComms(roomConnection: RoomConnection, userId: string, version
 
 function* fetchFromCatalyst(userId: string, version: number) {
   const catalyst: Avatar | null = yield call(fetchCatalystProfile, userId, version)
-  if (catalyst && catalyst.version >= version) {
-    return catalyst
+  if (catalyst) {
+    if (catalyst.version >= version) {
+      return catalyst
+    }
+
+    defaultLogger.warn(`expected profile min version ${version} from catalyst but got ${catalyst.version}`)
   }
   return null
 }


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

To mitigate the current timeouts when fetching profiles from comms peers and trying to optimize the use of the catalysts, this PR introduces a race between the both while also checking the version of the profile returned for the catalyst branch.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. Go to the channels tab and enter one
3. Click on the menu for a given user and show profile
4. The profile should be taking considerable less time to load (the state of things before this PR would be >4.5s for a set timeout and retry strategy nonworking as expected for the use case)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
