### PR TITLE
hotfix: check for claimed name locally and consolidate if owned

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -37,10 +37,23 @@ export function* initialRemoteProfileLoad() {
   const net: ETHEREUM_NETWORK = yield select(getCurrentNetwork)
   const names: string[] = yield call(fetchOwnedENS, ethereumConfigurations[net].names, userId)
 
-  // check that the user still has the claimed name, otherwise pick one
-
+  // Check for consildating strategies if the user has claimed name or owned names are available for the address
   if (profile.hasClaimedName || names.length) {
-    if (!names.includes(profile.name)) {
+    if (names.includes(profile.name)) {
+      if (!profile.hasClaimedName) {
+        // If the user has a name assigned and matches one of their owned names, consolidate the hasClaimedName setting to true
+        defaultLogger.info(
+          `Name currently set (${profile.name}) matches a claimed name for profile ${userId}, consolidating profile...`
+        )
+        profile = {
+          ...profile,
+          hasClaimedName: true,
+          version: profile?.version || 0
+        }
+        profileDirty = true
+      }
+    } else {
+      // User no longer has the current name but might have another, pick that one if available
       if (names.length) {
         defaultLogger.info(`Found missing claimed name '${names[0]}' for profile ${userId}, consolidating profile... `)
         profile = {

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -37,7 +37,7 @@ export function* initialRemoteProfileLoad() {
   const net: ETHEREUM_NETWORK = yield select(getCurrentNetwork)
   const names: string[] = yield call(fetchOwnedENS, ethereumConfigurations[net].names, userId)
 
-  // Check for consildating strategies if the user has claimed name or owned names are available for the address
+  // Check for consolidating strategies if the user has claimed name or owned names are available for the address
   if (profile.hasClaimedName || names.length) {
     if (names.includes(profile.name)) {
       if (!profile.hasClaimedName) {
@@ -64,6 +64,7 @@ export function* initialRemoteProfileLoad() {
           tutorialStep: 0xfff
         }
       } else {
+        // User has no available names, set the hasClaimedName to false
         profile = { ...profile, hasClaimedName: false, tutorialStep: 0x0 }
       }
       profileDirty = true


### PR DESCRIPTION
## What does this PR change?

This PR fixes the case where the local profile has a wrong `hasClaimedName` value set to `false`, showing the owned ENS name as any other guest name and propagating this data to other peers. This could be caused by a faulty connection or any error from The Graph query which was then persisted locally and a version number higher than the one found remotely.

The current PR consolidates the name and hasClaimedName values in the profile and tries to update the local and remote ones when a change is detected on startup and increments the version number appropriately to avoid prior versions shadowing the correct status.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
