### PR TITLE
fix: sdk7 playground

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/SceneBoundsCheckerSystem/ECSSceneBoundsCheckerSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/SceneBoundsCheckerSystem/ECSSceneBoundsCheckerSystem.cs
@@ -54,6 +54,7 @@ namespace ECSSystems.ECSSceneBoundsCheckerSystem
 
         private void OnSceneAdded(IParcelScene scene)
         {
+            // global scenes do not have boundaries to check
             if (scene.isPersistent)
                 return;
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/SceneBoundsCheckerSystem/ECSSceneBoundsCheckerSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/SceneBoundsCheckerSystem/ECSSceneBoundsCheckerSystem.cs
@@ -54,6 +54,9 @@ namespace ECSSystems.ECSSceneBoundsCheckerSystem
 
         private void OnSceneAdded(IParcelScene scene)
         {
+            if (scene.isPersistent)
+                return;
+
             IReadOnlyList<Vector2Int> parcels = scene.sceneData.parcels;
             var sceneNumber = scene.sceneData.sceneNumber;
 


### PR DESCRIPTION
lack of parcels array in global scenes was triggering a null exception on the scene boundaries checker while running playground