### PR TITLE
hotfix: making comms loop for fetching profiles concurrently using spawn

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/handleCommsProfile.ts
+++ b/browser-interface/packages/shared/profiles/sagas/handleCommsProfile.ts
@@ -1,6 +1,6 @@
 import type { Avatar } from '@dcl/schemas'
 import type { EventChannel } from 'redux-saga'
-import { call, put, select, take } from 'redux-saga/effects'
+import { call, put, select, spawn, take } from 'redux-saga/effects'
 import { createReceiveProfileOverCommsChannel, createVersionUpdateOverCommsChannel } from 'shared/comms/handlers'
 import { getCommsRoom } from 'shared/comms/selectors'
 import { profileSuccess } from '../actions'
@@ -43,7 +43,7 @@ export function* handleCommsVersionUpdates() {
 
     if (!existingProfile || existingProfile.data?.version <= version) {
       const roomConnection = yield select(getCommsRoom)
-      yield call(fetchPeerProfile, roomConnection, userId, version)
+      yield spawn(fetchPeerProfile, roomConnection, userId, version)
     }
   }
 }


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

With the motivation of loading near profiles quicker, this PR changes the call to fetch peer profile in the comms loop (whenever a profile is announced around the player) to make the call non-blocking, changing the `call` from redux-sagas framework to a `spawn` one.

This change makes the call to `fetchPeerProfile` from a blocking one having to wait for the answer/timeout to a non-blocking one which should still be consistent writing the responses to the common store.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. Go to a scene with many other players present (e.g. the poker scene or Genesis plaza starting point)
3. See how avatars should appear quicker than in the current released version (at least the ghost of them should appear much faster)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
