### PR TITLE
hotfix: hide friendship if friends are not initialized

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentController.cs
@@ -125,7 +125,7 @@ namespace DCL.Social.Passports
                     isBlocked = ownUserProfile.IsBlocked(userProfile.userId),
                     hasBlocked = userProfile.IsBlocked(ownUserProfile.userId),
                     friendshipStatus = await friendsController.GetFriendshipStatus(userProfile.userId, cancellationToken),
-                    isFriendshipVisible = isFriendsEnabled,
+                    isFriendshipVisible = isFriendsEnabled && friendsController.IsInitialized,
                 };
             }
 


### PR DESCRIPTION
## What does this PR change?

Friendship button in the passport should not be available if the friends service is not initialized.

## How to test the changes?

1. Launch the explorer
2. Open the friend list, if its loading means friends are not initialized yet
3. Inspect your passport and other user passports
4. Check that the friendship button is hidden
5. After friends service initializes, check that the friendship button is shown as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
