### PR TITLE
hotfix: change SentryWebRequestMonitor to track IWebRequestAsyncOperation

### DIFF
--- a/unity-renderer/Assets/DCLServices/Lambdas/LambdasService.cs
+++ b/unity-renderer/Assets/DCLServices/Lambdas/LambdasService.cs
@@ -29,7 +29,7 @@ namespace DCLServices.Lambdas
             var postDataJson = JsonUtility.ToJson(postData);
             var url = GetUrl(endPoint, urlEncodedParams);
             var wr = webRequestController.Ref.Post(url, postDataJson, requestAttemps: attemptsNumber, timeout: timeout, disposeOnCompleted: false);
-            var transaction = urlTransactionMonitor.Ref.TrackWebRequest(wr.asyncOp, endPointTemplate, data: postDataJson, finishTransactionOnWebRequestFinish: false);
+            var transaction = urlTransactionMonitor.Ref.TrackWebRequest(wr, endPointTemplate, data: postDataJson, finishTransactionOnWebRequestFinish: false);
 
             return SendRequestAsync<TResponse>(wr, cancellationToken, endPoint, transaction, urlEncodedParams);
         }
@@ -44,7 +44,7 @@ namespace DCLServices.Lambdas
         {
             var url = GetUrl(endPoint, urlEncodedParams);
             var wr = webRequestController.Ref.Get(url, requestAttemps: attemptsNumber, timeout: timeout, disposeOnCompleted: false);
-            var transaction = urlTransactionMonitor.Ref.TrackWebRequest(wr.asyncOp, endPointTemplate, finishTransactionOnWebRequestFinish: false);
+            var transaction = urlTransactionMonitor.Ref.TrackWebRequest(wr, endPointTemplate, finishTransactionOnWebRequestFinish: false);
 
             return SendRequestAsync<TResponse>(wr, cancellationToken, endPoint, transaction, urlEncodedParams);
         }

--- a/unity-renderer/Assets/DCLServices/Lambdas/Tests/LambdasServiceShould.cs
+++ b/unity-renderer/Assets/DCLServices/Lambdas/Tests/LambdasServiceShould.cs
@@ -66,14 +66,14 @@ namespace DCLServices.Lambdas.Tests
         public void InvokeTransactionMonitorOnGet()
         {
             lambdasService.Get<TestClass>(END_POINT, END_POINT, timeout: 60, attemptsNumber: 5, cancellationToken: CancellationToken.None, urlEncodedParams: ("param1", "45"));
-            transactionMonitor.Received(1).TrackWebRequest(Arg.Any<UnityWebRequestAsyncOperation>(), END_POINT);
+            transactionMonitor.Received(1).TrackWebRequest(Arg.Any<IWebRequestAsyncOperation>(), END_POINT);
         }
 
         [Test]
         public void InvokeTransactionMonitorOnPost()
         {
             lambdasService.Post<TestClass, TestResponse>(END_POINT, END_POINT, new TestResponse(), 50, 4, CancellationToken.None, ("param2", "str"));
-            transactionMonitor.Received(1).TrackWebRequest(Arg.Any<UnityWebRequestAsyncOperation>(), END_POINT, data: JsonUtility.ToJson(new TestResponse()));
+            transactionMonitor.Received(1).TrackWebRequest(Arg.Any<IWebRequestAsyncOperation>(), END_POINT, data: JsonUtility.ToJson(new TestResponse()));
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/WebRequest/Interfaces/IWebRequestAsyncOperation.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/WebRequest/Interfaces/IWebRequestAsyncOperation.cs
@@ -9,7 +9,7 @@ namespace DCL
         /// <summary>
         /// Event that will be invoked when the request has been completed.
         /// </summary>
-        event Action<WebRequestAsyncOperation> completed;
+        event Action<IWebRequestAsyncOperation> completed;
 
         /// <summary>
         /// WebRequest that is being managed.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/WebRequest/Interfaces/WebRequestAsyncOperation.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/WebRequest/Interfaces/WebRequestAsyncOperation.cs
@@ -12,7 +12,7 @@ namespace DCL
         /// <summary>
         /// Event that will be invoked when the request has been completed.
         /// </summary>
-        public event Action<WebRequestAsyncOperation> completed;
+        public event Action<IWebRequestAsyncOperation> completed;
 
         /// <summary>
         /// WebRequest that is being managed.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/WebRequest/WebRequestExtensions.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/WebRequest/WebRequestExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine.Networking;
 
 namespace DCL
@@ -27,7 +28,7 @@ namespace DCL
                    request.result == UnityWebRequest.Result.ConnectionError &&
                    request.result == UnityWebRequest.Result.ProtocolError &&
                    !string.IsNullOrEmpty(request.error) &&
-                   request.error.ToLower().Contains("aborted");
+                   request.error.Contains("aborted", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/SentryUtils/IWebRequestMonitor.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/SentryUtils/IWebRequestMonitor.cs
@@ -1,7 +1,4 @@
 ﻿using DCL;
-using Sentry;
-using System;
-using UnityEngine.Networking;
 
 namespace MainScripts.DCL.Helpers.SentryUtils
 {
@@ -15,7 +12,7 @@ namespace MainScripts.DCL.Helpers.SentryUtils
         /// <param name="queryString">The query string component of the URL (e.g. query=foobar&page=2)</param>
         /// <param name="data">Submitted data in JSON, if omitted raw data is taken from `WebRequest`</param>
         /// <param name="finishTransactionOnWebRequestFinish">If 'true' finishes transaction automatically</param>
-        DisposableTransaction TrackWebRequest(UnityWebRequestAsyncOperation webRequestOp, string endPointTemplate, string queryString = null,
+        DisposableTransaction TrackWebRequest(IWebRequestAsyncOperation webRequestOp, string endPointTemplate, string queryString = null,
             string data = null, bool finishTransactionOnWebRequestFinish = false);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/SentryUtils/SentryUtils.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/SentryUtils/SentryUtils.asmdef
@@ -1,4 +1,4 @@
 ﻿{
   "name": "SentryUtils",
-  "references":[ "GUID:3b80b0b562b1cbc489513f09fc1b8f69", "GUID:e9cee4050cfa5534d9b26e2782df20be" ]
+  "references":[ "GUID:3b80b0b562b1cbc489513f09fc1b8f69", "GUID:e9cee4050cfa5534d9b26e2782df20be", "GUID:ee6523961ef177343ad763fcd55c7c46" ]
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/SentryUtils/SentryWebRequestMonitor.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/SentryUtils/SentryWebRequestMonitor.cs
@@ -9,7 +9,7 @@ namespace MainScripts.DCL.Helpers.SentryUtils
     {
         private const int DATA_LIMIT = 150;
 
-        public DisposableTransaction TrackWebRequest(UnityWebRequestAsyncOperation webRequestOp, string endPointTemplate, string queryString = null,
+        public DisposableTransaction TrackWebRequest(IWebRequestAsyncOperation webRequestOp, string endPointTemplate, string queryString = null,
             string data = null, bool finishTransactionOnWebRequestFinish = false)
         {
             var webRequest = webRequestOp.webRequest;
@@ -28,11 +28,13 @@ namespace MainScripts.DCL.Helpers.SentryUtils
                 };
             });
 
-            void WebRequestOpCompleted(AsyncOperation asyncOperation)
+            void WebRequestOpCompleted(IWebRequestAsyncOperation webRequestAsyncOperation)
             {
                 // if we don't set the span status manually it will be inferred from the errors happening while the transaction
                 // is active: it's not correct
-                SetSpanStatus(transaction, webRequest);
+
+                // Due to possible repetitions webRequestAsyncOperation.webRequest can represent the web request that was created with the last attempt
+                SetSpanStatus(transaction, webRequestAsyncOperation.webRequest);
                 if (finishTransactionOnWebRequestFinish)
                     transaction.Finish();
             }


### PR DESCRIPTION
Fixes #4052 


Source of the issue:
`SentryWebRequestMonitor`
```
private static void SetSpanStatus(ITransaction transaction, UnityWebRequest webRequest)
        {
            if (webRequest.WebRequestTimedOut())
                transaction.Status = SpanStatus.DeadlineExceeded;
            else
            {
                transaction.Status = webRequest.responseCode switch
                                     {
                                         200 => SpanStatus.Ok,
                                         404 => SpanStatus.NotFound,
                                         400 => SpanStatus.InvalidArgument,
                                         403 => SpanStatus.PermissionDenied,
                                         409 => SpanStatus.Aborted,
                                         500 => SpanStatus.InternalError,
                                         503 => SpanStatus.Unavailable,
                                         401 => SpanStatus.Unauthenticated,
                                         429 => SpanStatus.ResourceExhausted,
                                         504 => SpanStatus.DeadlineExceeded,
                                         _ => SpanStatus.UnknownError
                                     };
            }
        }
```
was calling `UnityWebRequest `'s API on the disposed instance.
The instance was disposed if a first attempt fails as `WebRequestController` disposes a previous request and creates a new one in that case; there is no way to check if it is disposed.

Solution:
Change to use a wrap instead: thus `SentryWebRequestMonitor` can access the latest `WebRequest` that was created in the very last attempt.

Good news:
It was not breaking anything as the problematic subscription was executing the last so the delegate for repetitions itself was still ok.