### PR TITLE
fix: fps limit settings does not persist after restart

### DIFF
--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/FPSLimitControlController.cs
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/FPSLimitControlController.cs
@@ -5,7 +5,7 @@ namespace MainScripts.DCL.Controllers.SettingsDesktop.SettingsControllers
     [CreateAssetMenu(menuName = "Settings/Controllers/Controls/FPS Limit", fileName = "FPSLimitControlController")]
     public class FPSLimitControlController : SpinBoxSettingsControlControllerDesktop
     {
-        int[] allFpsValues;
+        private int[] allFpsValues;
 
         public override void Initialize()
         {
@@ -14,31 +14,26 @@ namespace MainScripts.DCL.Controllers.SettingsDesktop.SettingsControllers
             SetupLabels();
         }
 
-        public override object GetStoredValue()
-        {
-            return currentDisplaySettings.fpsCapIndex;
-        }
+        public override object GetStoredValue() =>
+            currentDisplaySettings.fpsCapIndex;
 
         private void SetupLabels()
         {
-            var length = allFpsValues.Length;
+            int length = allFpsValues.Length;
             var fpsLabels = new string[length];
 
-            for (var i = 0; i < length; i++) { fpsLabels[i] = allFpsValues[i] > 0 ? allFpsValues[i].ToString() + " FPS" : "Max"; }
+            for (var i = 0; i < length; i++)
+                fpsLabels[i] = allFpsValues[i] > 0 ? allFpsValues[i] + " FPS" : "Max";
 
             RaiseOnOverrideIndicatorLabel(fpsLabels);
         }
 
         public override void UpdateSetting(object newValue)
         {
-            var fpsValue = (int)allFpsValues[(int)newValue];
             currentDisplaySettings.fpsCapIndex = (int)newValue;
-            ToggleFPSCap(fpsValue);
-        }
+            Application.targetFrameRate = allFpsValues[(int)newValue];
 
-        public static void ToggleFPSCap(int fpsValue)
-        {
-            Application.targetFrameRate = fpsValue;
+            ApplySettings();
         }
     }
 }

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/PlayerPrefsDesktopDisplaySettingsRepository.cs
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/PlayerPrefsDesktopDisplaySettingsRepository.cs
@@ -9,6 +9,7 @@ namespace MainScripts.DCL.Controllers.SettingsDesktop
         public const string VSYNC = "vSync";
         public const string RESOLUTION_SIZE_INDEX = "resolutionSizeIndexV2";
         public const string WINDOW_MODE = "windowMode";
+        public const string FPS_CAP = "fpsCap";
 
         private readonly IPlayerPrefsSettingsByKey settingsByKey;
         private readonly DisplaySettings defaultSettings;
@@ -44,6 +45,7 @@ namespace MainScripts.DCL.Controllers.SettingsDesktop
             settingsByKey.SetBool(VSYNC, currentSettings.vSync);
             settingsByKey.SetInt(RESOLUTION_SIZE_INDEX, currentSettings.resolutionSizeIndex);
             settingsByKey.SetEnum(WINDOW_MODE, currentSettings.windowMode);
+            settingsByKey.SetInt(FPS_CAP, currentSettings.fpsCapIndex);
         }
 
         public bool HasAnyData() =>
@@ -56,10 +58,9 @@ namespace MainScripts.DCL.Controllers.SettingsDesktop
             try
             {
                 settings.vSync = settingsByKey.GetBool(VSYNC, defaultSettings.vSync);
-
                 settings.resolutionSizeIndex = settingsByKey.GetInt(RESOLUTION_SIZE_INDEX, -1);
-
                 settings.windowMode = settingsByKey.GetEnum(WINDOW_MODE, defaultSettings.windowMode);
+                settings.fpsCapIndex = settingsByKey.GetInt(FPS_CAP, defaultSettings.fpsCapIndex);
             }
             catch (Exception e) { Debug.LogException(e); }
 

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/PlayerPrefsDesktopDisplaySettingsRepositoryShould.cs
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/PlayerPrefsDesktopDisplaySettingsRepositoryShould.cs
@@ -39,11 +39,6 @@ namespace DCL.SettingsCommon
 
             var settings = WhenGetSettings(repository);
 
-            Debug.Log(defaultSettings.vSync + " - " + settings.vSync);
-            Debug.Log(defaultSettings.windowMode + " - " + settings.windowMode);
-            Debug.Log(defaultSettings.fpsCapIndex + " - " + settings.fpsCapIndex);
-            Debug.Log(defaultSettings.resolutionSizeIndex + " - " + settings.resolutionSizeIndex);
-
             Assert.AreEqual(defaultSettings, settings);
         }
 

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/PlayerPrefsDesktopDisplaySettingsRepositoryShould.cs
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/PlayerPrefsDesktopDisplaySettingsRepositoryShould.cs
@@ -1,6 +1,7 @@
 ﻿using MainScripts.DCL.Controllers.SettingsDesktop;
 using NSubstitute;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace DCL.SettingsCommon
 {
@@ -13,7 +14,8 @@ namespace DCL.SettingsCommon
             {
                 vSync = true,
                 windowMode = WindowMode.Borderless,
-                resolutionSizeIndex = 3
+                resolutionSizeIndex = 3,
+                fpsCapIndex = 90
             };
 
             var settingsByKey = GivenStoredSettings(storedSettings);
@@ -36,6 +38,11 @@ namespace DCL.SettingsCommon
                 defaultSettings);
 
             var settings = WhenGetSettings(repository);
+
+            Debug.Log(defaultSettings.vSync + " - " + settings.vSync);
+            Debug.Log(defaultSettings.windowMode + " - " + settings.windowMode);
+            Debug.Log(defaultSettings.fpsCapIndex + " - " + settings.fpsCapIndex);
+            Debug.Log(defaultSettings.resolutionSizeIndex + " - " + settings.resolutionSizeIndex);
 
             Assert.AreEqual(defaultSettings, settings);
         }
@@ -106,6 +113,10 @@ namespace DCL.SettingsCommon
             settingsByKey.Received(1)
                          .SetEnum(PlayerPrefsDesktopDisplaySettingsRepository.WINDOW_MODE,
                               settings.windowMode);
+
+            settingsByKey.Received(1)
+                         .SetInt(PlayerPrefsDesktopDisplaySettingsRepository.FPS_CAP,
+                              settings.fpsCapIndex);
         }
 
         private IPlayerPrefsSettingsByKey GivenStoredSettings(DisplaySettings settings)
@@ -120,6 +131,9 @@ namespace DCL.SettingsCommon
 
             settingsByKey.GetEnum(PlayerPrefsDesktopDisplaySettingsRepository.WINDOW_MODE, Arg.Any<WindowMode>())
                          .Returns(settings.windowMode);
+
+            settingsByKey.GetInt(PlayerPrefsDesktopDisplaySettingsRepository.FPS_CAP, Arg.Any<int>())
+                         .Returns(settings.fpsCapIndex);
 
             return settingsByKey;
         }
@@ -145,8 +159,9 @@ namespace DCL.SettingsCommon
             return new DisplaySettings
             {
                 windowMode = WindowMode.FullScreen,
-                resolutionSizeIndex = 0,
-                vSync = false
+                resolutionSizeIndex = -1,
+                vSync = false,
+                fpsCapIndex = 0
             };
         }
     }

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -92,6 +92,8 @@ namespace DCL
 
         protected override void Dispose()
         {
+            SettingsDesktop.i.displaySettings.Save();
+
             try
             {
                 DataStore.i.wsCommunication.communicationEstablished.OnChange -= OnCommunicationEstablished;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/ShadowResolutionControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/ShadowResolutionControlController.cs
@@ -9,8 +9,10 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
     [CreateAssetMenu(menuName = "Settings/Controllers/Controls/Shadow Resolution", fileName = "ShadowResolutionControlController")]
     public class ShadowResolutionControlController : SpinBoxSettingsControlController
     {
-        private UniversalRenderPipelineAsset lightweightRenderPipelineAsset = null;
-        private FieldInfo lwrpaShadowResolutionField = null;
+        private const int LOG2_256 = 8; // log2(256), where 256 is the lowest Resolution in Unity (it goes [256, 512, 1024,...])
+
+        private UniversalRenderPipelineAsset lightweightRenderPipelineAsset;
+        private FieldInfo lwrpaShadowResolutionField;
 
         public override void Initialize()
         {
@@ -25,7 +27,7 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
         }
 
         public override object GetStoredValue() =>
-            (int)Mathf.Log((int)currentQualitySetting.shadowResolution, 2) - 8;
+            (int)Mathf.Log((int)currentQualitySetting.shadowResolution, 2) - LOG2_256;
 
         public override void UpdateSetting(object newValue)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/ShadowResolutionControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/ShadowResolutionControlController.cs
@@ -24,7 +24,8 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
             lwrpaShadowResolutionField = lightweightRenderPipelineAsset.GetType().GetField("m_MainLightShadowmapResolution", BindingFlags.NonPublic | BindingFlags.Instance);
         }
 
-        public override object GetStoredValue() { return (int)Mathf.Log((int)currentQualitySetting.shadowResolution, 2) - 8; }
+        public override object GetStoredValue() =>
+            (int)Mathf.Log((int)currentQualitySetting.shadowResolution, 2) - 8;
 
         public override void UpdateSetting(object newValue)
         {


### PR DESCRIPTION
## What does this PR change?
Closes #3567

- add saving on value changed
- add saving desktop settings `OnApplicationQuit`
- add fps cap to Save/Load prefs
- fix test

## How to test the changes?

1. Launch the desktop explorer
2. Change fps cap setting 
3. Exit the client by clicking on exit button 
4. Re-launch and observe fpsCap setting to be saved

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
