### PR TITLE
hotfix: nearby chat sorting

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntrySortingByTimestamp.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntrySortingByTimestamp.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace DCL.Social.Chat
+{
+    public class ChatEntrySortingByTimestamp : IComparer<ChatEntryModel>
+    {
+        public int Compare(ChatEntryModel x, ChatEntryModel y) =>
+            x.timestamp.CompareTo(y.timestamp);
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntrySortingByTimestamp.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntrySortingByTimestamp.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 97b60381187b4297af6d74303c5a6aec
+timeCreated: 1679515109

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntrySortingSequentally.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntrySortingSequentally.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace DCL.Social.Chat
+{
+    public class ChatEntrySortingSequentially : IComparer<ChatEntryModel>
+    {
+        public int Compare(ChatEntryModel x, ChatEntryModel y) => 0;
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntrySortingSequentally.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntrySortingSequentally.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8f426dacf6714520ba66f5cb0b099932
+timeCreated: 1679515321

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -4,6 +4,7 @@ using DCL.Chat;
 using DCL.Chat.HUD;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
+using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using DCL.Tasks;
 using SocialFeaturesAnalytics;
@@ -24,10 +25,6 @@ public class ChatHUDController : IHUD
 
     public delegate UniTask<List<UserProfile>> GetSuggestedUserProfiles(string name, int maxCount, CancellationToken cancellationToken);
 
-    public event Action OnInputFieldSelected;
-    public event Action<ChatMessage> OnSendMessage;
-    public event Action<ChatMessage> OnMessageSentBlockedBySpam;
-
     private readonly DataStore dataStore;
     private readonly IUserProfileBridge userProfileBridge;
     private readonly bool detectWhisper;
@@ -46,8 +43,26 @@ public class ChatHUDController : IHUD
     private int mentionLength;
     private int mentionFromIndex;
     private Dictionary<string, UserProfile> mentionSuggestedProfiles;
+    private IComparer<ChatEntryModel> sortingStrategy;
 
     private bool isMentionsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("chat_mentions_enabled");
+
+    public IComparer<ChatEntryModel> SortingStrategy
+    {
+        get => sortingStrategy;
+
+        set
+        {
+            sortingStrategy = value;
+
+            if (view != null)
+                view.SortingStrategy = value;
+        }
+    }
+
+    public event Action OnInputFieldSelected;
+    public event Action<ChatMessage> OnSendMessage;
+    public event Action<ChatMessage> OnMessageSentBlockedBySpam;
 
     public ChatHUDController(DataStore dataStore,
         IUserProfileBridge userProfileBridge,
@@ -62,6 +77,7 @@ public class ChatHUDController : IHUD
         this.getSuggestedUserProfiles = getSuggestedUserProfiles;
         this.socialAnalytics = socialAnalytics;
         this.profanityFilter = profanityFilter;
+        SortingStrategy = new ChatEntrySortingByTimestamp();
     }
 
     public void Initialize(IChatHUDComponentView view)
@@ -85,6 +101,7 @@ public class ChatHUDController : IHUD
         this.view.OnMentionSuggestionSelected += HandleMentionSuggestionSelected;
         this.view.OnOpenedContextMenu -= OpenedContextMenu;
         this.view.OnOpenedContextMenu += OpenedContextMenu;
+        this.view.SortingStrategy = SortingStrategy;
     }
 
     private void OpenedContextMenu()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -4,7 +4,6 @@ using DCL.Chat;
 using DCL.Chat.HUD;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
-using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using DCL.Tasks;
 using SocialFeaturesAnalytics;
@@ -44,6 +43,7 @@ public class ChatHUDController : IHUD
     private int mentionFromIndex;
     private Dictionary<string, UserProfile> mentionSuggestedProfiles;
 
+    private bool useLegacySorting => dataStore.featureFlags.flags.Get().IsFeatureEnabled("legacy_chat_sorting_enabled");
     private bool isMentionsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("chat_mentions_enabled");
 
     public IComparer<ChatEntryModel> SortingStrategy
@@ -95,6 +95,7 @@ public class ChatHUDController : IHUD
         this.view.OnMentionSuggestionSelected += HandleMentionSuggestionSelected;
         this.view.OnOpenedContextMenu -= OpenedContextMenu;
         this.view.OnOpenedContextMenu += OpenedContextMenu;
+        this.view.UseLegacySorting = useLegacySorting;
     }
 
     private void OpenedContextMenu()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -43,18 +43,13 @@ public class ChatHUDController : IHUD
     private int mentionLength;
     private int mentionFromIndex;
     private Dictionary<string, UserProfile> mentionSuggestedProfiles;
-    private IComparer<ChatEntryModel> sortingStrategy;
 
     private bool isMentionsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("chat_mentions_enabled");
 
     public IComparer<ChatEntryModel> SortingStrategy
     {
-        get => sortingStrategy;
-
         set
         {
-            sortingStrategy = value;
-
             if (view != null)
                 view.SortingStrategy = value;
         }
@@ -77,7 +72,6 @@ public class ChatHUDController : IHUD
         this.getSuggestedUserProfiles = getSuggestedUserProfiles;
         this.socialAnalytics = socialAnalytics;
         this.profanityFilter = profanityFilter;
-        SortingStrategy = new ChatEntrySortingByTimestamp();
     }
 
     public void Initialize(IChatHUDComponentView view)
@@ -101,7 +95,6 @@ public class ChatHUDController : IHUD
         this.view.OnMentionSuggestionSelected += HandleMentionSuggestionSelected;
         this.view.OnOpenedContextMenu -= OpenedContextMenu;
         this.view.OnOpenedContextMenu += OpenedContextMenu;
-        this.view.SortingStrategy = SortingStrategy;
     }
 
     private void OpenedContextMenu()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -114,6 +114,7 @@ namespace DCL.Social.Chat
 
         public int EntryCount => entries.Count;
         public IChatEntryFactory ChatEntryFactory { get; set; }
+        public IComparer<ChatEntryModel> SortingStrategy { get; set; } = new ChatEntrySortingByTimestamp();
 
         public static ChatHUDView Create()
         {
@@ -452,13 +453,8 @@ namespace DCL.Social.Chat
         {
             if (this.entries.Count <= 0) return;
 
-            var entries = this.entries.Values.OrderBy(x => x.Model.timestamp).ToList();
-
-            for (var i = 0; i < entries.Count; i++)
-            {
-                if (entries[i].transform.GetSiblingIndex() != i)
-                    entries[i].transform.SetSiblingIndex(i);
-            }
+            foreach (var entry in entries.Values.OrderBy(obj => obj.Model, SortingStrategy))
+                entry.transform.SetAsLastSibling();
         }
 
         private void HandleNextChatInHistoryInput(DCLAction_Trigger action)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -114,7 +114,7 @@ namespace DCL.Social.Chat
 
         public int EntryCount => entries.Count;
         public IChatEntryFactory ChatEntryFactory { get; set; }
-        public IComparer<ChatEntryModel> SortingStrategy { get; set; } = new ChatEntrySortingByTimestamp();
+        public IComparer<ChatEntryModel> SortingStrategy { get; set; }
 
         public static ChatHUDView Create()
         {
@@ -452,6 +452,7 @@ namespace DCL.Social.Chat
         private void SortEntriesImmediate()
         {
             if (this.entries.Count <= 0) return;
+            if (SortingStrategy == null) return;
 
             foreach (var entry in entries.Values.OrderBy(obj => obj.Model, SortingStrategy))
                 entry.transform.SetAsLastSibling();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -115,6 +115,7 @@ namespace DCL.Social.Chat
         public int EntryCount => entries.Count;
         public IChatEntryFactory ChatEntryFactory { get; set; }
         public IComparer<ChatEntryModel> SortingStrategy { get; set; }
+        public bool UseLegacySorting { private get; set; }
 
         public static ChatHUDView Create()
         {
@@ -452,6 +453,20 @@ namespace DCL.Social.Chat
         private void SortEntriesImmediate()
         {
             if (this.entries.Count <= 0) return;
+
+            if (UseLegacySorting)
+            {
+                var entries = this.entries.Values.OrderBy(x => x.Model.timestamp).ToList();
+
+                for (var i = 0; i < entries.Count; i++)
+                {
+                    if (entries[i].transform.GetSiblingIndex() != i)
+                        entries[i].transform.SetSiblingIndex(i);
+                }
+
+                return;
+            }
+
             if (SortingStrategy == null) return;
 
             foreach (var entry in entries.Values.OrderBy(obj => obj.Model, SortingStrategy))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using DCL.Chat.HUD;
+﻿using DCL.Chat.HUD;
 using DCL.Interface;
+using System;
 using System.Collections.Generic;
 
 public interface IChatHUDComponentView
@@ -16,6 +16,7 @@ public interface IChatHUDComponentView
     event Action<string> OnMentionSuggestionSelected;
 
     int EntryCount { get; }
+    IComparer<ChatEntryModel> SortingStrategy { get; set; }
 
     void OnMessageCancelHover();
     void AddEntry(ChatEntryModel model, bool setScrollPositionToBottom = false);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
@@ -16,7 +16,8 @@ public interface IChatHUDComponentView
     event Action<string> OnMentionSuggestionSelected;
 
     int EntryCount { get; }
-    IComparer<ChatEntryModel> SortingStrategy { get; set; }
+    IComparer<ChatEntryModel> SortingStrategy { set; }
+    bool UseLegacySorting { set; }
 
     void OnMessageCancelHover();
     void AddEntry(ChatEntryModel model, bool setScrollPositionToBottom = false);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDTests.asmdef
@@ -19,7 +19,11 @@
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
         "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca",
-        "GUID:2995626b54c60644988f134a69a77450"
+        "GUID:2995626b54c60644988f134a69a77450",
+        "GUID:1320d33ea2522ba4e8e60cf9e6a351dd",
+        "GUID:fbcc413e192ef9048811d47ab0aca0c0",
+        "GUID:ee6523961ef177343ad763fcd55c7c46",
+        "GUID:c9fbb75c15a4cd042b731877ede4a5c1"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDViewShould.cs
@@ -110,6 +110,8 @@ namespace DCL.Social.Chat
         [UnityTest]
         public IEnumerator SortEntriesByTimestamp()
         {
+            view.SortingStrategy = new ChatEntrySortingByTimestamp();
+
             var newMsg = new ChatEntryModel
             {
                 timestamp = 200,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDViewShould.cs
@@ -1,22 +1,29 @@
 using DCL.Chat.HUD;
+using DCL.Interface;
+using NSubstitute;
 using NUnit.Framework;
+using System.Collections;
 using System.Collections.Generic;
+using Tests;
+using UnityEngine.TestTools;
 
 namespace DCL.Social.Chat
 {
-    public class ChatHUDViewShould
+    public class ChatHUDViewShould : IntegrationTestSuite
     {
         private ChatHUDView view;
 
-        [SetUp]
-        public void SetUp()
+        protected override IEnumerator SetUp()
         {
+            yield return base.SetUp();
             view = ChatHUDView.Create();
+            IWebRequestAsyncOperation webRequestAsyncOperation = Substitute.For<IWebRequestAsyncOperation>();
+            Environment.i.platform.webRequest.GetTexture(default).ReturnsForAnyArgs(webRequestAsyncOperation);
         }
 
-        [TearDown]
-        public void TearDown()
+        protected override IEnumerator TearDown()
         {
+            yield return base.TearDown();
             view.Dispose();
         }
 
@@ -98,6 +105,104 @@ namespace DCL.Social.Chat
             entries[0].selectButton.onClick.Invoke();
 
             Assert.AreEqual("u1", suggestionSelected);
+        }
+
+        [UnityTest]
+        public IEnumerator SortEntriesByTimestamp()
+        {
+            var newMsg = new ChatEntryModel
+            {
+                timestamp = 200,
+                bodyText = "new",
+                isChannelMessage = false,
+                messageId = "msg1",
+                messageType = ChatMessage.Type.PRIVATE,
+                recipientName = "recipient",
+                senderName = "sender",
+                senderId = "senderId",
+                subType = ChatEntryModel.SubType.SENT,
+            };
+
+            var oldMsg = new ChatEntryModel
+            {
+                timestamp = 100,
+                bodyText = "old",
+                isChannelMessage = false,
+                messageId = "msg2",
+                messageType = ChatMessage.Type.PRIVATE,
+                recipientName = "recipient",
+                senderName = "sender",
+                senderId = "senderId",
+                subType = ChatEntryModel.SubType.RECEIVED,
+            };
+
+            view.AddEntry(newMsg);
+            view.AddEntry(oldMsg);
+
+            yield return null;
+
+            ChatEntry chatEntry = view.chatEntriesContainer.GetChild(0).GetComponent<ChatEntry>();
+            Assert.AreEqual(oldMsg, chatEntry.Model);
+
+            chatEntry = view.chatEntriesContainer.GetChild(1).GetComponent<ChatEntry>();
+            Assert.AreEqual(newMsg, chatEntry.Model);
+        }
+
+        [UnityTest]
+        public IEnumerator DontSortEntries()
+        {
+            view.SortingStrategy = new ChatEntrySortingSequentially();
+
+            var msg1 = new ChatEntryModel
+            {
+                timestamp = 100,
+                bodyText = "msg1",
+                isChannelMessage = false,
+                messageId = "msg1",
+                messageType = ChatMessage.Type.PUBLIC,
+                senderName = "sender",
+                senderId = "senderId",
+                subType = ChatEntryModel.SubType.SENT,
+            };
+
+            var msg2 = new ChatEntryModel
+            {
+                timestamp = 200,
+                bodyText = "msg2",
+                isChannelMessage = false,
+                messageId = "msg2",
+                messageType = ChatMessage.Type.PUBLIC,
+                senderName = "sender",
+                senderId = "senderId",
+                subType = ChatEntryModel.SubType.RECEIVED,
+            };
+
+            var msg3 = new ChatEntryModel
+            {
+                timestamp = 300,
+                bodyText = "msg3",
+                isChannelMessage = false,
+                messageId = "msg3",
+                messageType = ChatMessage.Type.PUBLIC,
+                senderName = "sender",
+                senderId = "senderId",
+                subType = ChatEntryModel.SubType.SENT,
+            };
+
+            view.AddEntry(msg1);
+            view.AddEntry(msg2);
+            view.AddEntry(msg3);
+
+            yield return null;
+
+            ChatEntry chatEntry = view.chatEntriesContainer.GetChild(0).GetComponent<ChatEntry>();
+            Assert.AreEqual(msg1, chatEntry.Model);
+
+            chatEntry = view.chatEntriesContainer.GetChild(1).GetComponent<ChatEntry>();
+            Assert.AreEqual(msg2, chatEntry.Model);
+
+            chatEntry = view.chatEntriesContainer.GetChild(2).GetComponent<ChatEntry>();
+            Assert.AreEqual(msg3, chatEntry.Model);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL;
 using DCL.Interface;
+using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using DCL.Social.Friends;
 using SocialFeaturesAnalytics;
@@ -83,6 +84,7 @@ public class PrivateChatWindowController : IHUD
                 }, ct);
             },
           socialAnalytics);
+        chatHudController.SortingStrategy = new ChatEntrySortingByTimestamp();
         chatHudController.Initialize(view.ChatHUD);
         chatHudController.OnInputFieldSelected += HandleInputFieldSelected;
         chatHudController.OnSendMessage += HandleSendChatMessage;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
@@ -84,8 +84,9 @@ public class PrivateChatWindowController : IHUD
                 }, ct);
             },
           socialAnalytics);
-        chatHudController.SortingStrategy = new ChatEntrySortingByTimestamp();
+
         chatHudController.Initialize(view.ChatHUD);
+        chatHudController.SortingStrategy = new ChatEntrySortingByTimestamp();
         chatHudController.OnInputFieldSelected += HandleInputFieldSelected;
         chatHudController.OnSendMessage += HandleSendChatMessage;
         chatHudController.OnMessageSentBlockedBySpam += HandleMessageBlockedBySpam;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
+using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using SocialFeaturesAnalytics;
 using UnityEngine;
@@ -77,6 +78,8 @@ namespace DCL.Chat.HUD
             chatHudController = new ChatHUDController(dataStore, userProfileBridge, false,
                (name, count, ct) => chatMentionSuggestionProvider.GetProfilesFromChatChannelsStartingWith(name, channelId, count, ct),
                 socialAnalytics, profanityFilter);
+
+            chatHudController.SortingStrategy = new ChatEntrySortingByTimestamp();
             chatHudController.Initialize(view.ChatHUD);
             chatHudController.OnSendMessage += HandleSendChatMessage;
             chatHudController.OnMessageSentBlockedBySpam += HandleMessageBlockedBySpam;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -79,8 +79,8 @@ namespace DCL.Chat.HUD
                (name, count, ct) => chatMentionSuggestionProvider.GetProfilesFromChatChannelsStartingWith(name, channelId, count, ct),
                 socialAnalytics, profanityFilter);
 
-            chatHudController.SortingStrategy = new ChatEntrySortingByTimestamp();
             chatHudController.Initialize(view.ChatHUD);
+            chatHudController.SortingStrategy = new ChatEntrySortingByTimestamp();
             chatHudController.OnSendMessage += HandleSendChatMessage;
             chatHudController.OnMessageSentBlockedBySpam += HandleMessageBlockedBySpam;
             chatController.OnAddMessage += HandleMessageReceived;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
@@ -67,9 +67,6 @@ namespace DCL.Chat.HUD
                 (name, count, ct) => chatMentionSuggestionProvider.GetNearbyProfilesStartingWith(name, count, ct),
                 socialAnalytics,
                 profanityFilter);
-            // Keep messages sequentially, without any sorting
-            // Comms cannot calculate a server timestamp for each message, so we assume that the arrival time is the correct order
-            chatHudController.SortingStrategy = new ChatEntrySortingSequentially();
             chatHudController.Initialize(view.ChatHUD);
             chatHudController.OnSendMessage += SendChatMessage;
             chatHudController.OnMessageSentBlockedBySpam += HandleMessageBlockedBySpam;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
@@ -67,6 +67,8 @@ namespace DCL.Chat.HUD
                 (name, count, ct) => chatMentionSuggestionProvider.GetNearbyProfilesStartingWith(name, count, ct),
                 socialAnalytics,
                 profanityFilter);
+            // dont set any message's sorting strategy, just add them sequentally
+            // comms cannot calculate a server timestamp for each message
             chatHudController.Initialize(view.ChatHUD);
             chatHudController.OnSendMessage += SendChatMessage;
             chatHudController.OnMessageSentBlockedBySpam += HandleMessageBlockedBySpam;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
+using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using SocialFeaturesAnalytics;
 using Channel = DCL.Chat.Channels.Channel;
@@ -66,7 +67,9 @@ namespace DCL.Chat.HUD
                 (name, count, ct) => chatMentionSuggestionProvider.GetNearbyProfilesStartingWith(name, count, ct),
                 socialAnalytics,
                 profanityFilter);
-
+            // Keep messages sequentially, without any sorting
+            // Comms cannot calculate a server timestamp for each message, so we assume that the arrival time is the correct order
+            chatHudController.SortingStrategy = new ChatEntrySortingSequentially();
             chatHudController.Initialize(view.ChatHUD);
             chatHudController.OnSendMessage += SendChatMessage;
             chatHudController.OnMessageSentBlockedBySpam += HandleMessageBlockedBySpam;


### PR DESCRIPTION
## What does this PR change?

Fixes chat sorting for ~nearby messages.
Nearby messages are not being sorted. Private messages & channel messages are sorted by timestamp.

## How to test the changes?

1. Launch the explorer
2. Send and receive more than 30 messages in ~nearby channel
3. Send and receive more than 30 messages in private conversation
4. Send and receive more than 30 messages in #test channel

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
