### PR TITLE
hotfix: global scenes disorder

### DIFF
--- a/browser-interface/packages/shared/portableExperiences/sagas.ts
+++ b/browser-interface/packages/shared/portableExperiences/sagas.ts
@@ -67,6 +67,9 @@ export function* fetchInitialPortableExperiences() {
   if (Array.isArray(globalPortableExperiences)) {
     for (const id of globalPortableExperiences) {
       try {
+        // TODO: this is a horrible hack to give enough time to set the correct order between the px and
+        // the global avatar scene
+        yield delay(500)
         const px: LoadableScene = yield call(getPortableExperienceFromUrn, id)
         yield put(addKernelPortableExperience(px))
       } catch (err: any) {

--- a/browser-interface/packages/shared/portableExperiences/sagas.ts
+++ b/browser-interface/packages/shared/portableExperiences/sagas.ts
@@ -3,7 +3,7 @@ import { call, debounce, delay, fork, put, select, takeEvery } from 'redux-saga/
 import { trackEvent } from 'shared/analytics/trackEvent'
 import { waitForMetaConfigurationInitialization } from 'shared/meta/sagas'
 import { getFeatureFlagVariantValue } from 'shared/meta/selectors'
-import { waitForRendererRpcConnection } from 'shared/renderer/sagas-helper'
+import { waitForAvatarSceneInitialized, waitForRendererRpcConnection } from 'shared/renderer/sagas-helper'
 import { LoadableScene } from 'shared/types'
 import {
   ADD_DESIRED_PORTABLE_EXPERIENCE,
@@ -57,6 +57,8 @@ export function* portableExperienceSaga(): any {
 
 export function* fetchInitialPortableExperiences() {
   yield waitForMetaConfigurationInitialization()
+
+  yield waitForAvatarSceneInitialized()
 
   const qs = new URLSearchParams(globalThis.location.search)
 

--- a/browser-interface/packages/shared/portableExperiences/sagas.ts
+++ b/browser-interface/packages/shared/portableExperiences/sagas.ts
@@ -69,9 +69,6 @@ export function* fetchInitialPortableExperiences() {
   if (Array.isArray(globalPortableExperiences)) {
     for (const id of globalPortableExperiences) {
       try {
-        // TODO: this is a horrible hack to give enough time to set the correct order between the px and
-        // the global avatar scene
-        yield delay(10000)
         const px: LoadableScene = yield call(getPortableExperienceFromUrn, id)
         yield put(addKernelPortableExperience(px))
       } catch (err: any) {

--- a/browser-interface/packages/shared/renderer/actions.ts
+++ b/browser-interface/packages/shared/renderer/actions.ts
@@ -2,7 +2,13 @@ import { action } from 'typesafe-actions'
 
 import type { UnityGame } from 'unity-interface/loader'
 
-import { RENDERER_INITIALIZED_CORRECTLY, PARCEL_LOADING_STARTED, RENDERER_INITIALIZE, RendererModules } from './types'
+import {
+  RENDERER_INITIALIZED_CORRECTLY,
+  PARCEL_LOADING_STARTED,
+  RENDERER_INITIALIZE,
+  RendererModules,
+  AVATAR_SCENE_INITIALIZED
+} from './types'
 import { RpcClient, RpcClientPort, Transport } from '@dcl/rpc'
 
 export const initializeRenderer = (
@@ -25,3 +31,6 @@ export type SignalParcelLoadingStarted = ReturnType<typeof signalParcelLoadingSt
 export const REGISTER_RPC_MODULES = 'REGISTER_RPC_MODULES'
 export const registerRendererModules = (modules: RendererModules) => action(REGISTER_RPC_MODULES, { modules })
 export type RegisterRendererModules = ReturnType<typeof registerRendererModules>
+
+export const avatarSceneInitialized = () => action(AVATAR_SCENE_INITIALIZED)
+export type SignalAvatarSceneInitialized = ReturnType<typeof avatarSceneInitialized>

--- a/browser-interface/packages/shared/renderer/reducer.ts
+++ b/browser-interface/packages/shared/renderer/reducer.ts
@@ -1,13 +1,19 @@
 import { AnyAction } from 'redux'
 import { RegisterRendererModules, RegisterRendererPort, REGISTER_RPC_MODULES, REGISTER_RPC_PORT } from './actions'
-import { PARCEL_LOADING_STARTED, RendererState, RENDERER_INITIALIZED_CORRECTLY } from './types'
+import {
+  PARCEL_LOADING_STARTED,
+  RendererState,
+  RENDERER_INITIALIZED_CORRECTLY,
+  AVATAR_SCENE_INITIALIZED
+} from './types'
 
 const INITIAL_STATE: RendererState = {
   initialized: false,
   parcelLoadingStarted: false,
   clientPort: undefined,
   rpcClient: undefined,
-  modules: undefined
+  modules: undefined,
+  avatarSceneInitialized: false
 }
 
 export function rendererReducer(state?: RendererState, action?: AnyAction): RendererState {
@@ -22,6 +28,11 @@ export function rendererReducer(state?: RendererState, action?: AnyAction): Rend
       return {
         ...state,
         initialized: true
+      }
+    case AVATAR_SCENE_INITIALIZED:
+      return {
+        ...state,
+        avatarSceneInitialized: true
       }
     case REGISTER_RPC_PORT:
       const { payload } = action as RegisterRendererPort

--- a/browser-interface/packages/shared/renderer/sagas-helper.ts
+++ b/browser-interface/packages/shared/renderer/sagas-helper.ts
@@ -1,8 +1,10 @@
 import { waitFor } from 'lib/redux'
 import { REGISTER_RPC_PORT } from './actions'
-import { getClient, isRendererInitialized } from './selectors'
-import { RENDERER_INITIALIZED_CORRECTLY } from './types'
+import { getClient, isAvatarSceneInitialized, isRendererInitialized } from './selectors'
+import { AVATAR_SCENE_INITIALIZED, RENDERER_INITIALIZED_CORRECTLY } from './types'
 
 export const waitForRendererInstance = waitFor(isRendererInitialized, RENDERER_INITIALIZED_CORRECTLY)
+
+export const waitForAvatarSceneInitialized = waitFor(isAvatarSceneInitialized, AVATAR_SCENE_INITIALIZED)
 
 export const waitForRendererRpcConnection = waitFor(getClient, REGISTER_RPC_PORT)

--- a/browser-interface/packages/shared/renderer/selectors.ts
+++ b/browser-interface/packages/shared/renderer/selectors.ts
@@ -5,6 +5,10 @@ export function isRendererInitialized(state: RootRendererState) {
   return state && state.renderer && state.renderer.initialized
 }
 
+export function isAvatarSceneInitialized(state: RootRendererState) {
+  return state && state.renderer && state.renderer.avatarSceneInitialized
+}
+
 export function getParcelLoadingStarted(state: RootRendererState) {
   return state && state.renderer && state.renderer.parcelLoadingStarted
 }

--- a/browser-interface/packages/shared/renderer/types.ts
+++ b/browser-interface/packages/shared/renderer/types.ts
@@ -1,6 +1,7 @@
 import { RpcClient, RpcClientPort } from '@dcl/rpc'
 
 export const RENDERER_INITIALIZED_CORRECTLY = '[RENDERER] Renderer initialized correctly'
+export const AVATAR_SCENE_INITIALIZED = '[RENDERER] Avatar initialized correctly'
 export const PARCEL_LOADING_STARTED = '[RENDERER] Parcel loading started'
 export const RENDERER_INITIALIZE = '[RENDERER] Initializing'
 import * as codegen from '@dcl/rpc/dist/codegen'
@@ -13,6 +14,7 @@ export type RendererState = {
   clientPort: RpcClientPort | undefined
   rpcClient: RpcClient | undefined
   modules: RendererModules | undefined
+  avatarSceneInitialized: boolean
 }
 
 export type RendererModules = {

--- a/browser-interface/packages/unity-interface/dcl.ts
+++ b/browser-interface/packages/unity-interface/dcl.ts
@@ -19,7 +19,7 @@ import { reloadScenePortableExperience } from 'shared/portableExperiences/action
 import { wearableToSceneEntity } from 'shared/wearablesPortableExperience/sagas'
 import { fetchScenesByLocation } from 'shared/scene-loader/sagas'
 import { sleep } from 'lib/javascript/sleep'
-import { signalRendererInitializedCorrectly } from 'shared/renderer/actions'
+import { avatarSceneInitialized, signalRendererInitializedCorrectly } from 'shared/renderer/actions'
 import { browserInterface } from './BrowserInterface'
 import { LoadableScene } from 'shared/types'
 
@@ -77,6 +77,8 @@ export async function initializeEngine(_gameInstance: UnityGame): Promise<void> 
   }
 
   await startGlobalScene('dcl-gs-avatars', 'Avatars', hudWorkerUrl)
+
+  store.dispatch(avatarSceneInitialized())
 }
 
 type GlobalSceneOptions = {


### PR DESCRIPTION
## What does this PR change?

A race condition on scene initialization was not allowing avatars to be clicked when a PX was present

## How to test the changes?

1. Enter using the PX https://play.decentraland.org/?explorer-branch=hotfix/global-scenes-disorder&GLOBAL_PX=urn%3Adecentraland%3Aentity%3Abafkreie2hjsspbw37gbgkgftuhm5ppjvy2wzuxbjsdeif26z7tuig4cxfq%3FbaseUrl%3Dhttps%3A%2F%2Fsdk-content-server.decentraland.org%2Fipfs%2F&realm=heimdallr
2. Check that you can click on other avatars
3. Teleport using the PX. Check if you can click on avatars there as well
4. Remove the PX from the url. Enter DCL and check that you can click in avatars.
5. Repeat the [1 - 2] steps but entering using https://play.decentraland.org/?explorer-branch=hotfix/global-scenes-disorder&GLOBAL_PX=urn:decentraland:entity:bafkreihpipyhrt75xyquwrynrtjadwb373xfosy7a5rhlh5vogjajye3im?baseUrl=https://sdk-content-server.decentraland.org/ipfs/&realm=heimdallr

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md