### PR TITLE
hotfix: Secure AvatarEditorHUDController from not loaded Avatar

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -368,7 +368,7 @@ public class AvatarEditorHUDController : IHUD
         DataStore.i.common.isPlayerRendererLoaded.OnChange -= PlayerRendererLoaded;
     }
 
-    public void LoadUserProfile(UserProfile userProfile, bool forceLoading)
+    private void LoadUserProfile(UserProfile userProfile, bool forceLoading)
     {
         bool avatarEditorNotVisible = renderingEnabled && !view.isOpen;
         bool isPlaying = !Application.isBatchMode;
@@ -732,6 +732,7 @@ public class AvatarEditorHUDController : IHUD
                 if (supportedWearables.Length == 0)
                 {
                     Debug.LogError($"Couldn't get any wearable for category {category} and bodyshape {model.bodyShape.id}");
+                    continue;
                 }
 
                 var wearable = supportedWearables[Random.Range(0, supportedWearables.Length - 1)];

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDModel.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class AvatarEditorHUDModel
 {
-    public WearableItem bodyShape;
+    public WearableItem bodyShape = new WearableItem { id = "NOT_LOADED" };
     public List<WearableItem> wearables = new List<WearableItem>();
     public Color hairColor;
     public Color skinColor;


### PR DESCRIPTION
Users experience exceptions in `Avatar Editor HUD` if their `Avatar` is not loaded [yet] for some reason.

This PR should relieve the symptoms.