### PR TITLE
hotfix: texture resize with incorrect color format

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
@@ -23,34 +23,26 @@ namespace DCL.GLTFast.Wrappers
         public bool MoveNext() =>
             asyncOp.MoveNext();
 
-        public Texture2D Texture
+        public Texture2D GetTexture(bool linear)
         {
-            get
+            Texture2D texture2D = new Texture2D(1, 1);
+
+            if (asyncOp.webRequest.downloadHandler.data != null)
             {
-                Texture2D texture2D = new Texture2D(1, 1);
-                if (asyncOp.webRequest.downloadHandler.data != null)
+                try { texture2D.LoadImage(asyncOp.webRequest.downloadHandler.data); }
+                catch (Exception e)
                 {
-                    try
-                    {
-                        texture2D.LoadImage(asyncOp.webRequest.downloadHandler.data);
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.LogError($"Texture promise failed: {e}");
-                        return null;
-                    }
-                }
-                else
-                {
+                    Debug.LogError($"Texture promise failed: {e}");
                     return null;
                 }
+            }
+            else { return null; }
 #if UNITY_WEBGL
                 texture2D.Compress(false);
 #endif
-                texture2D = TextureHelpers.ClampSize(texture2D, DataStore.i.textureConfig.gltfMaxSize.Get(), true);
+            texture2D = TextureHelpers.ClampSize(texture2D, DataStore.i.textureConfig.gltfMaxSize.Get(), linear);
 
-                return texture2D;
-            }
+            return texture2D;
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
@@ -25,7 +25,7 @@ namespace DCL.GLTFast.Wrappers
 
         public Texture2D GetTexture(bool linear)
         {
-            Texture2D texture2D = new Texture2D(1, 1);
+            Texture2D texture2D = new Texture2D(1, 1, TextureFormat.RGBA32, 0, linear);
 
             if (asyncOp.webRequest.downloadHandler.data != null)
             {

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -19,7 +19,7 @@
         "com.unity.mathematics": "1.2.6",
         "com.unity.burst": "1.6.6"
       },
-      "hash": "fdbba5350fda2da9708aafbcb9336c59cb2b6a32"
+      "hash": "cd8485999522daafc7cb5b990fce8f6fdf3f74ab"
     },
     "com.brunomikoski.animationsequencer": {
       "version": "0.3.8",


### PR DESCRIPTION
## What does this PR change?

Fixes #4708 

Related commit https://github.com/decentraland/glTFast/commit/cd8485999522daafc7cb5b990fce8f6fdf3f74ab

## How to test the changes?

### For QA

- There shouldn't be color differences between WebGL and Desktop

### For Developers

- in `LambdasWearablesCatalogService.cs` add this line at 59:
```C#
userId = "0x87956abC4078a0Cc3b89b419928b857B8AF826Ed";
```
- Disable Asset bundles
- Open your backpack and equip the steampunk wearables.
- Their colors should be fine

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
