### PR TITLE
chore: added handy override to change wearables catalog based on another user id

### DIFF
--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL;
 using DCL.Tasks;
 using DCLServices.Lambdas;
 using MainScripts.DCL.Helpers.Utils;
@@ -129,6 +130,13 @@ namespace DCLServices.WearablesCatalogService
 
         public async UniTask<(IReadOnlyList<WearableItem> wearables, int totalAmount)> RequestOwnedWearablesAsync(string userId, int pageNumber, int pageSize, bool cleanCachedPages, CancellationToken ct)
         {
+
+#if UNITY_EDITOR
+            DebugConfig debugConfig = DataStore.i.debugConfig;
+            if (!string.IsNullOrEmpty(debugConfig.overrideUserID))
+                userId = debugConfig.overrideUserID;
+#endif
+
             var createNewPointer = false;
             if (!ownerWearablesPagePointers.TryGetValue((userId, pageSize), out var pagePointer))
             {

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -36,6 +36,9 @@ namespace DCLServices.WearablesCatalogService
         private CancellationTokenSource serviceCts;
         private UniTaskCompletionSource<IReadOnlyList<WearableItem>> lastRequestSource;
 
+#if UNITY_EDITOR
+        private readonly DebugConfig debugConfig = DataStore.i.debugConfig;
+#endif
         public LambdasWearablesCatalogService(BaseDictionary<string, WearableItem> wearablesCatalog,
             ILambdasService lambdasService)
         {
@@ -132,9 +135,10 @@ namespace DCLServices.WearablesCatalogService
         {
 
 #if UNITY_EDITOR
-            DebugConfig debugConfig = DataStore.i.debugConfig;
-            if (!string.IsNullOrEmpty(debugConfig.overrideUserID))
-                userId = debugConfig.overrideUserID;
+            string debugUserId = debugConfig.overrideUserID;
+
+            if (!string.IsNullOrEmpty(debugUserId))
+                userId = debugUserId;
 #endif
 
             var createNewPointer = false;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DebugConfig.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DebugConfig.cs
@@ -66,5 +66,6 @@ namespace DCL
         /// </summary>
         public bool msgStepByStep = false;
         public bool logWs;
+        public string overrideUserID;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugConfigComponent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugConfigComponent.cs
@@ -68,6 +68,9 @@ namespace DCL
 
         public Vector2 startInCoords = new Vector2(-99, 109);
 
+        [Tooltip("Set this value to load the catalog from another wallet for debug purposes")]
+        public string overrideUserID = "";
+
         [Header("Kernel Misc Settings")] public bool forceLocalComms = true;
 
         public bool enableTutorial = false;
@@ -93,6 +96,7 @@ namespace DCL
             DataStore.i.debugConfig.soloSceneCoords = debugConfig.soloSceneCoords;
             DataStore.i.debugConfig.ignoreGlobalScenes = debugConfig.ignoreGlobalScenes;
             DataStore.i.debugConfig.msgStepByStep = debugConfig.msgStepByStep;
+            DataStore.i.debugConfig.overrideUserID = overrideUserID;
             DataStore.i.performance.multithreading.Set(multithreaded);
             if (disableGLTFDownloadThrottle) DataStore.i.performance.maxDownloads.Set(999);
             Texture.allowThreadedTextureCreation = multithreaded;


### PR DESCRIPTION
## What does this PR change?

Sometimes we need to load another user's wearables for debugging reasons.

This override will make that chore a bit easier

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
