### PR TITLE
fix: gpuSkinningThrottlerService.Register() called twice

### DIFF
--- a/unity-renderer/Assets/Rendering/Utils/GPUSkinning/GPUSkinningThrottlerService.cs
+++ b/unity-renderer/Assets/Rendering/Utils/GPUSkinning/GPUSkinningThrottlerService.cs
@@ -10,6 +10,16 @@ public class GPUSkinningThrottlerService : IGPUSkinningThrottlerService
 
     private CancellationTokenSource cts;
 
+    public static GPUSkinningThrottlerService Create(bool initializeOnSpawn)
+    {
+        GPUSkinningThrottlerService service = new GPUSkinningThrottlerService();
+
+        if (initializeOnSpawn)
+            service.Initialize();
+
+        return service;
+    }
+
     public void Initialize()
     {
         cts = new CancellationTokenSource();
@@ -21,7 +31,7 @@ public class GPUSkinningThrottlerService : IGPUSkinningThrottlerService
         if (!gpuSkinnings.ContainsKey(gpuSkinning))
             gpuSkinnings.Add(gpuSkinning, framesBetweenUpdates);
         else
-            Debug.LogWarning($"GPUSkinningThrottlerService: Register called twice for the same IGPUSkinning {gpuSkinning}", gpuSkinning.renderer.gameObject);
+            ModifyThrottling(gpuSkinning, framesBetweenUpdates);
     }
 
     public void Unregister(IGPUSkinning gpuSkinning)
@@ -47,16 +57,6 @@ public class GPUSkinningThrottlerService : IGPUSkinningThrottlerService
         gpuSkinnings.Clear();
     }
 
-    public static GPUSkinningThrottlerService Create(bool initializeOnSpawn)
-    {
-        GPUSkinningThrottlerService service = new GPUSkinningThrottlerService();
-
-        if (initializeOnSpawn)
-            service.Initialize();
-
-        return service;
-    }
-
     private void Cancel()
     {
         if (cts != null)
@@ -69,18 +69,16 @@ public class GPUSkinningThrottlerService : IGPUSkinningThrottlerService
 
     private async UniTaskVoid ThrottleUpdateAsync(CancellationToken ct)
     {
-        await UniTask.DelayFrame(1, PlayerLoopTiming.PostLateUpdate);
+        await UniTask.DelayFrame(1, PlayerLoopTiming.PostLateUpdate, ct);
 
         // Cancel gracefully
         while (!ct.IsCancellationRequested)
         {
             foreach (KeyValuePair<IGPUSkinning, int> entry in gpuSkinnings)
-            {
                 if (Time.frameCount % entry.Value == 0)
                     entry.Key.Update();
-            }
 
-            await UniTask.DelayFrame(1, PlayerLoopTiming.PostLateUpdate);
+            await UniTask.DelayFrame(1, PlayerLoopTiming.PostLateUpdate, ct);
         }
     }
 }

--- a/unity-renderer/Assets/Rendering/Utils/GPUSkinning/GPUSkinningThrottlerService.cs
+++ b/unity-renderer/Assets/Rendering/Utils/GPUSkinning/GPUSkinningThrottlerService.cs
@@ -21,7 +21,7 @@ public class GPUSkinningThrottlerService : IGPUSkinningThrottlerService
         if (!gpuSkinnings.ContainsKey(gpuSkinning))
             gpuSkinnings.Add(gpuSkinning, framesBetweenUpdates);
         else
-            Debug.LogWarning("GPUSkinningThrottlerService: Register called twice for the same IGPUSkinning");
+            Debug.LogWarning($"GPUSkinningThrottlerService: Register called twice for the same IGPUSkinning {gpuSkinning}", gpuSkinning.renderer.gameObject);
     }
 
     public void Unregister(IGPUSkinning gpuSkinning)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -16,8 +16,8 @@ namespace AvatarSystem
 
         protected readonly ILoader loader;
         protected readonly IVisibility visibility;
+        protected readonly IAnimator animator;
         private readonly IAvatarCurator avatarCurator;
-        private readonly IAnimator animator;
         private readonly ILOD lod;
         private readonly IGPUSkinning gpuSkinning;
         private readonly IGPUSkinningThrottlerService gpuSkinningThrottlerService;
@@ -88,6 +88,7 @@ namespace AvatarSystem
         protected virtual async UniTask LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
         {
             List<WearableItem> emotes = await LoadWearables(wearablesIds, emotesIds, settings, linkedCt: linkedCt);
+            animator.Prepare(settings.bodyshapeId, loader.bodyshapeContainer);
             Prepare(settings, emotes, loader.bodyshapeContainer);
             Bind();
             Inform(loader.combinedRenderer);
@@ -117,7 +118,6 @@ namespace AvatarSystem
             //Scale the bounds due to the giant avatar not being skinned yet
             extents = loader.combinedRenderer.localBounds.extents * 2f / RESCALING_BOUNDS_FACTOR;
 
-            animator.Prepare(settings.bodyshapeId, loaderBodyshapeContainer);
             emoteAnimationEquipper.SetEquippedEmotes(settings.bodyshapeId, emotes);
             gpuSkinning.Prepare(loader.combinedRenderer);
             gpuSkinningThrottlerService.Register(gpuSkinning);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -4,6 +4,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using GPUSkinning;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace AvatarSystem
@@ -13,15 +14,17 @@ namespace AvatarSystem
     {
         private const float RESCALING_BOUNDS_FACTOR = 100f;
         internal const string LOADING_VISIBILITY_CONSTRAIN = "Loading";
+
         private readonly IAvatarCurator avatarCurator;
-        private readonly ILoader loader;
+        protected readonly ILoader loader;
         private readonly IAnimator animator;
-        private readonly IVisibility visibility;
+        protected readonly IVisibility visibility;
         private readonly ILOD lod;
         private readonly IGPUSkinning gpuSkinning;
         private readonly IGPUSkinningThrottlerService gpuSkinningThrottlerService;
         private readonly IEmoteAnimationEquipper emoteAnimationEquipper;
-        private CancellationTokenSource disposeCts = new CancellationTokenSource();
+
+        private CancellationTokenSource disposeCts = new ();
         private bool gpuSkinningIsRegistered;
 
         public IAvatar.Status status { get; private set; } = IAvatar.Status.Idle;
@@ -29,7 +32,9 @@ namespace AvatarSystem
         public int lodLevel => lod?.lodIndex ?? 0;
         public event Action<Renderer> OnCombinedRendererUpdate;
 
-        internal Avatar(IAvatarCurator avatarCurator, ILoader loader, IAnimator animator, IVisibility visibility, ILOD lod, IGPUSkinning gpuSkinning, IGPUSkinningThrottlerService gpuSkinningThrottlerService, IEmoteAnimationEquipper emoteAnimationEquipper)
+        internal Avatar(IAvatarCurator avatarCurator, ILoader loader, IAnimator animator,
+            IVisibility visibility, ILOD lod, IGPUSkinning gpuSkinning, IGPUSkinningThrottlerService gpuSkinningThrottlerService,
+            IEmoteAnimationEquipper emoteAnimationEquipper)
         {
             this.avatarCurator = avatarCurator;
             this.loader = loader;
@@ -58,40 +63,7 @@ namespace AvatarSystem
 
             try
             {
-                WearableItem bodyshape = null;
-                WearableItem eyes = null;
-                WearableItem eyebrows = null;
-                WearableItem mouth = null;
-                List<WearableItem> wearables = null;
-                List<WearableItem> emotes = null;
-
-                (bodyshape, eyes, eyebrows, mouth, wearables, emotes) = await avatarCurator.Curate(settings, wearablesIds, emotesIds, linkedCt);
-                if (!loader.IsValidForBodyShape(bodyshape, eyes, eyebrows, mouth))
-                {
-                    visibility.AddGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
-                }
-                await loader.Load(bodyshape, eyes, eyebrows, mouth, wearables, settings, linkedCt);
-
-                //Scale the bounds due to the giant avatar not being skinned yet
-                extents = loader.combinedRenderer.localBounds.extents * 2f / RESCALING_BOUNDS_FACTOR;
-                animator.Prepare(settings.bodyshapeId, loader.bodyshapeContainer);
-                emoteAnimationEquipper.SetEquippedEmotes(settings.bodyshapeId, emotes);
-                gpuSkinning.Prepare(loader.combinedRenderer);
-
-                visibility.Bind(gpuSkinning.renderer, loader.facialFeaturesRenderers);
-                visibility.RemoveGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
-
-                lod.Bind(gpuSkinning.renderer);
-
-                if (!gpuSkinningIsRegistered)
-                {
-                    gpuSkinningThrottlerService.Register(gpuSkinning);
-                    gpuSkinningIsRegistered = true;
-                }
-
-                status = IAvatar.Status.Loaded;
-
-                OnCombinedRendererUpdate?.Invoke(loader.combinedRenderer);
+                await LoadTry(wearablesIds, emotesIds, settings, linkedCt);
             }
             catch (OperationCanceledException)
             {
@@ -115,24 +87,87 @@ namespace AvatarSystem
             }
         }
 
-        public void AddVisibilityConstraint(string key) { visibility.AddGlobalConstrain(key); }
-
-        public void RemoveVisibilityConstrain(string key) { visibility.RemoveGlobalConstrain(key); }
-
-        public void PlayEmote(string emoteId, long timestamps) { animator?.PlayEmote(emoteId, timestamps); }
-
-        public void SetLODLevel(int lodIndex) { lod.SetLodIndex(lodIndex); }
-
-        public void SetAnimationThrottling(int framesBetweenUpdate)
+        protected virtual async Task LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
         {
-            gpuSkinningThrottlerService.ModifyThrottling(gpuSkinning, framesBetweenUpdate);
+            List<WearableItem> emotes = await LoadWearables(wearablesIds, emotesIds, settings, linkedCt: linkedCt);
+            Prepare(settings, emotes, loader.bodyshapeContainer);
+            Bind();
+            Inform(loader.combinedRenderer);
         }
 
-        public void SetImpostorTexture(Texture2D impostorTexture) { lod.SetImpostorTexture(impostorTexture); }
+        protected async Task<List<WearableItem>> LoadWearables(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, SkinnedMeshRenderer bonesRenderers = null, CancellationToken linkedCt = default)
+        {
+            WearableItem bodyshape;
+            WearableItem eyes;
+            WearableItem eyebrows;
+            WearableItem mouth;
+            List<WearableItem> wearables;
+            List<WearableItem> emotes;
 
-        public void SetImpostorTint(Color color) { lod.SetImpostorTint(color); }
+            (bodyshape, eyes, eyebrows, mouth, wearables, emotes) =
+                await avatarCurator.Curate(settings, wearablesIds, emotesIds, linkedCt);
 
-        public Transform[] GetBones() => loader.GetBones();
+            if (!loader.IsValidForBodyShape(bodyshape, eyes, eyebrows, mouth))
+                visibility.AddGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
+
+            await loader.Load(bodyshape, eyes, eyebrows, mouth, wearables, settings, bonesRenderers, linkedCt);
+            return emotes;
+        }
+
+        protected void Prepare(AvatarSettings settings, List<WearableItem> emotes, GameObject loaderBodyshapeContainer)
+        {
+            //Scale the bounds due to the giant avatar not being skinned yet
+            extents = loader.combinedRenderer.localBounds.extents * 2f / RESCALING_BOUNDS_FACTOR;
+
+            animator.Prepare(settings.bodyshapeId, loaderBodyshapeContainer);
+            emoteAnimationEquipper.SetEquippedEmotes(settings.bodyshapeId, emotes);
+            gpuSkinning.Prepare(loader.combinedRenderer);
+
+            if (!gpuSkinningIsRegistered)
+            {
+                gpuSkinningThrottlerService.Register(gpuSkinning);
+                gpuSkinningIsRegistered = true;
+            }
+        }
+
+        protected void Bind()
+        {
+            visibility.Bind(gpuSkinning.renderer, loader.facialFeaturesRenderers);
+            visibility.RemoveGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
+            lod.Bind(gpuSkinning.renderer);
+        }
+
+        protected void Inform(Renderer loaderCombinedRenderer)
+        {
+            status = IAvatar.Status.Loaded;
+            OnCombinedRendererUpdate?.Invoke(loaderCombinedRenderer);
+        }
+
+        public virtual void AddVisibilityConstraint(string key)
+        {
+            visibility.AddGlobalConstrain(key);
+        }
+
+        public void RemoveVisibilityConstrain(string key) =>
+            visibility.RemoveGlobalConstrain(key);
+
+        public void PlayEmote(string emoteId, long timestamps) =>
+            animator?.PlayEmote(emoteId, timestamps);
+
+        public void SetLODLevel(int lodIndex) =>
+            lod.SetLodIndex(lodIndex);
+
+        public void SetAnimationThrottling(int framesBetweenUpdate) =>
+            gpuSkinningThrottlerService.ModifyThrottling(gpuSkinning, framesBetweenUpdate);
+
+        public void SetImpostorTexture(Texture2D impostorTexture) =>
+            lod.SetImpostorTexture(impostorTexture);
+
+        public void SetImpostorTint(Color color) =>
+            lod.SetImpostorTint(color);
+
+        public Transform[] GetBones() =>
+            loader.GetBones();
 
         public Renderer GetMainRenderer() =>
             gpuSkinning.renderer;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -4,7 +4,6 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using GPUSkinning;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace AvatarSystem
@@ -86,7 +85,7 @@ namespace AvatarSystem
             }
         }
 
-        protected virtual async Task LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
+        protected virtual async UniTask LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
         {
             List<WearableItem> emotes = await LoadWearables(wearablesIds, emotesIds, settings, linkedCt: linkedCt);
             Prepare(settings, emotes, loader.bodyshapeContainer);
@@ -94,7 +93,7 @@ namespace AvatarSystem
             Inform(loader.combinedRenderer);
         }
 
-        protected async Task<List<WearableItem>> LoadWearables(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, SkinnedMeshRenderer bonesRenderers = null, CancellationToken linkedCt = default)
+        protected async UniTask<List<WearableItem>> LoadWearables(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, SkinnedMeshRenderer bonesRenderers = null, CancellationToken linkedCt = default)
         {
             WearableItem bodyshape;
             WearableItem eyes;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -82,7 +82,6 @@ namespace AvatarSystem
                 visibility.RemoveGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
 
                 lod.Bind(gpuSkinning.renderer);
-                Debug.Log($"Avatar {gpuSkinning.renderer.name} - LOAD {gpuSkinning} {gpuSkinning.renderer.name}", gpuSkinning.renderer.gameObject);
 
                 if (!gpuSkinningIsRegistered)
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -15,17 +15,16 @@ namespace AvatarSystem
         private const float RESCALING_BOUNDS_FACTOR = 100f;
         internal const string LOADING_VISIBILITY_CONSTRAIN = "Loading";
 
-        private readonly IAvatarCurator avatarCurator;
         protected readonly ILoader loader;
-        private readonly IAnimator animator;
         protected readonly IVisibility visibility;
+        private readonly IAvatarCurator avatarCurator;
+        private readonly IAnimator animator;
         private readonly ILOD lod;
         private readonly IGPUSkinning gpuSkinning;
         private readonly IGPUSkinningThrottlerService gpuSkinningThrottlerService;
         private readonly IEmoteAnimationEquipper emoteAnimationEquipper;
 
         private CancellationTokenSource disposeCts = new ();
-        private bool gpuSkinningIsRegistered;
 
         public IAvatar.Status status { get; private set; } = IAvatar.Status.Idle;
         public Vector3 extents { get; private set; }
@@ -122,12 +121,7 @@ namespace AvatarSystem
             animator.Prepare(settings.bodyshapeId, loaderBodyshapeContainer);
             emoteAnimationEquipper.SetEquippedEmotes(settings.bodyshapeId, emotes);
             gpuSkinning.Prepare(loader.combinedRenderer);
-
-            if (!gpuSkinningIsRegistered)
-            {
-                gpuSkinningThrottlerService.Register(gpuSkinning);
-                gpuSkinningIsRegistered = true;
-            }
+            gpuSkinningThrottlerService.Register(gpuSkinning);
         }
 
         protected void Bind()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -22,6 +22,7 @@ namespace AvatarSystem
         private readonly IGPUSkinningThrottlerService gpuSkinningThrottlerService;
         private readonly IEmoteAnimationEquipper emoteAnimationEquipper;
         private CancellationTokenSource disposeCts = new CancellationTokenSource();
+        private bool gpuSkinningIsRegistered;
 
         public IAvatar.Status status { get; private set; } = IAvatar.Status.Idle;
         public Vector3 extents { get; private set; }
@@ -81,7 +82,13 @@ namespace AvatarSystem
                 visibility.RemoveGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
 
                 lod.Bind(gpuSkinning.renderer);
-                gpuSkinningThrottlerService.Register(gpuSkinning);
+                Debug.Log($"Avatar {gpuSkinning.renderer.name} - LOAD {gpuSkinning} {gpuSkinning.renderer.name}", gpuSkinning.renderer.gameObject);
+
+                if (!gpuSkinningIsRegistered)
+                {
+                    gpuSkinningThrottlerService.Register(gpuSkinning);
+                    gpuSkinningIsRegistered = true;
+                }
 
                 status = IAvatar.Status.Loaded;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
@@ -1,7 +1,7 @@
+using Cysharp.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
 using GPUSkinning;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace AvatarSystem
@@ -18,7 +18,7 @@ namespace AvatarSystem
             this.baseAvatar = baseAvatar;
         }
 
-        protected override async Task LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
+        protected override async UniTask LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
         {
             baseAvatar.Initialize();
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
@@ -1,165 +1,41 @@
-using System;
 using System.Collections.Generic;
-using System.Runtime.ExceptionServices;
 using System.Threading;
-using Cysharp.Threading.Tasks;
 using GPUSkinning;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace AvatarSystem
 {
     // [ADR 65 - https://github.com/decentraland/adr]
-    public class AvatarWithHologram : IAvatar
+    public class AvatarWithHologram : Avatar
     {
-        private const float RESCALING_BOUNDS_FACTOR = 100f;
-        internal const string LOADING_VISIBILITY_CONSTRAIN = "Loading";
-        private readonly IAvatarCurator avatarCurator;
-        private readonly ILoader loader;
-        private readonly IAnimator animator;
-        private readonly IVisibility visibility;
-        private readonly ILOD lod;
-        private readonly IGPUSkinning gpuSkinning;
-        private readonly IGPUSkinningThrottlerService gpuSkinningThrottlerService;
-        private readonly IEmoteAnimationEquipper emoteAnimationEquipper;
-        private CancellationTokenSource disposeCts = new CancellationTokenSource();
         private readonly IBaseAvatar baseAvatar;
 
-        public event Action<Renderer> OnCombinedRendererUpdate;
-
-        public IAvatar.Status status { get; private set; } = IAvatar.Status.Idle;
-        public Vector3 extents { get; private set; }
-        public int lodLevel => lod?.lodIndex ?? 0;
-
-        internal AvatarWithHologram(IBaseAvatar baseAvatar, IAvatarCurator avatarCurator, ILoader loader, IAnimator animator,
-            IVisibility visibility, ILOD lod, IGPUSkinning gpuSkinning, IGPUSkinningThrottlerService gpuSkinningThrottlerService,
-            IEmoteAnimationEquipper emoteAnimationEquipper)
+        internal AvatarWithHologram(IBaseAvatar baseAvatar, IAvatarCurator avatarCurator, ILoader loader, IAnimator animator, IVisibility visibility,
+            ILOD lod, IGPUSkinning gpuSkinning, IGPUSkinningThrottlerService gpuSkinningThrottlerService, IEmoteAnimationEquipper emoteAnimationEquipper)
+            : base(avatarCurator, loader, animator, visibility, lod, gpuSkinning, gpuSkinningThrottlerService, emoteAnimationEquipper)
         {
             this.baseAvatar = baseAvatar;
-            this.avatarCurator = avatarCurator;
-            this.loader = loader;
-            this.animator = animator;
-            this.visibility = visibility;
-            this.lod = lod;
-            this.gpuSkinning = gpuSkinning;
-            this.gpuSkinningThrottlerService = gpuSkinningThrottlerService;
-            this.emoteAnimationEquipper = emoteAnimationEquipper;
         }
 
-        /// <summary>
-        /// Starts the loading process for the Avatar.
-        /// </summary>
-        /// <param name="wearablesIds"></param>
-        /// <param name="settings"></param>
-        /// <param name="ct"></param>
-        public async UniTask Load(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken ct = default)
+        protected override async Task LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
         {
-            disposeCts ??= new CancellationTokenSource();
+            baseAvatar.Initialize();
 
-            status = IAvatar.Status.Idle;
-            CancellationToken linkedCt = CancellationTokenSource.CreateLinkedTokenSource(ct, disposeCts.Token).Token;
+            List<WearableItem> emotes = await LoadWearables(wearablesIds, emotesIds, settings, baseAvatar.GetMainRenderer(), linkedCt: linkedCt);
+            Prepare(settings, emotes, baseAvatar.GetArmatureContainer());
+            Bind();
 
-            linkedCt.ThrowIfCancellationRequested();
+            MeshRenderer newCombinedRenderer = loader.combinedRenderer.GetComponent<MeshRenderer>();
+            Inform(newCombinedRenderer);
 
-            try
-            {
-                WearableItem bodyshape = null;
-                WearableItem eyes = null;
-                WearableItem eyebrows = null;
-                WearableItem mouth = null;
-                List<WearableItem> wearables = null;
-                List<WearableItem> emotes = null;
-
-                baseAvatar.Initialize();
-                animator.Prepare(settings.bodyshapeId, baseAvatar.GetArmatureContainer());
-                (bodyshape, eyes, eyebrows, mouth, wearables, emotes) = await avatarCurator.Curate(settings, wearablesIds, emotesIds, linkedCt);
-                if (!loader.IsValidForBodyShape(bodyshape, eyes, eyebrows, mouth))
-                {
-                    visibility.AddGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
-                }
-                await loader.Load(bodyshape, eyes, eyebrows, mouth, wearables, settings, baseAvatar.GetMainRenderer(), linkedCt);
-
-                //Scale the bounds due to the giant avatar not being skinned yet
-                extents = loader.combinedRenderer.localBounds.extents * 2f / RESCALING_BOUNDS_FACTOR;
-
-                emoteAnimationEquipper.SetEquippedEmotes(settings.bodyshapeId, emotes);
-                gpuSkinning.Prepare(loader.combinedRenderer);
-                gpuSkinningThrottlerService.Register(gpuSkinning);
-
-                visibility.Bind(gpuSkinning.renderer, loader.facialFeaturesRenderers);
-                visibility.RemoveGlobalConstrain(LOADING_VISIBILITY_CONSTRAIN);
-
-                lod.Bind(gpuSkinning.renderer);
-
-                status = IAvatar.Status.Loaded;
-
-                MeshRenderer newCombinedRenderer = loader.combinedRenderer.GetComponent<MeshRenderer>();
-                OnCombinedRendererUpdate?.Invoke(newCombinedRenderer);
-                await baseAvatar.FadeOut(newCombinedRenderer, visibility.IsMainRenderVisible(), linkedCt);
-            }
-            catch (OperationCanceledException)
-            {
-                Dispose();
-                throw;
-            }
-            catch (Exception e)
-            {
-                Dispose();
-                Debug.Log($"Avatar.Load failed with wearables:[{string.Join(",", wearablesIds)}] for bodyshape:{settings.bodyshapeId} and player {settings.playerName}");
-                if (e.InnerException != null)
-                    ExceptionDispatchInfo.Capture(e.InnerException).Throw();
-                else
-                    throw;
-            }
-            finally
-            {
-                disposeCts?.Dispose();
-                disposeCts = null;
-            }
+            await baseAvatar.FadeOut(newCombinedRenderer, visibility.IsMainRenderVisible(), linkedCt);
         }
 
-        public void AddVisibilityConstraint(string key)
+        public override void AddVisibilityConstraint(string key)
         {
-            visibility.AddGlobalConstrain(key);
+            base.AddVisibilityConstraint(key);
             baseAvatar.CancelTransition();
-        }
-
-        public void RemoveVisibilityConstrain(string key)
-        {
-            visibility.RemoveGlobalConstrain(key);
-        }
-
-        public void PlayEmote(string emoteId, long timestamps)
-        {
-            animator?.PlayEmote(emoteId, timestamps);
-        }
-
-        public void SetLODLevel(int lodIndex) { lod.SetLodIndex(lodIndex); }
-
-        public void SetAnimationThrottling(int framesBetweenUpdate)
-        {
-            gpuSkinningThrottlerService.ModifyThrottling(gpuSkinning, framesBetweenUpdate);
-        }
-
-        public void SetImpostorTexture(Texture2D impostorTexture) { lod.SetImpostorTexture(impostorTexture); }
-
-        public void SetImpostorTint(Color color) { lod.SetImpostorTint(color); }
-
-        public Transform[] GetBones() => loader.GetBones();
-
-        public Renderer GetMainRenderer() =>
-            gpuSkinning.renderer;
-
-        public void Dispose()
-        {
-            status = IAvatar.Status.Idle;
-            disposeCts?.Cancel();
-            disposeCts?.Dispose();
-            disposeCts = null;
-            avatarCurator?.Dispose();
-            loader?.Dispose();
-            visibility?.Dispose();
-            lod?.Dispose();
-            gpuSkinningThrottlerService?.Unregister(gpuSkinning);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
@@ -21,14 +21,13 @@ namespace AvatarSystem
         protected override async UniTask LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
         {
             baseAvatar.Initialize();
-
+            animator.Prepare(settings.bodyshapeId, baseAvatar.GetArmatureContainer());
             List<WearableItem> emotes = await LoadWearables(wearablesIds, emotesIds, settings, baseAvatar.GetMainRenderer(), linkedCt: linkedCt);
             Prepare(settings, emotes, baseAvatar.GetArmatureContainer());
             Bind();
 
             MeshRenderer newCombinedRenderer = loader.combinedRenderer.GetComponent<MeshRenderer>();
             Inform(newCombinedRenderer);
-
             await baseAvatar.FadeOut(newCombinedRenderer, visibility.IsMainRenderVisible(), linkedCt);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/LoaderDefinitions/ILoader.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/LoaderDefinitions/ILoader.cs
@@ -22,8 +22,7 @@ namespace AvatarSystem
         List<Renderer> facialFeaturesRenderers { get; }
         Status status { get; }
 
-        UniTask Load(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth, List<WearableItem> wearables, AvatarSettings settings, CancellationToken ct = default);
-        UniTask Load(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth, List<WearableItem> wearables, AvatarSettings settings, SkinnedMeshRenderer bonesRenderers, CancellationToken ct = default);
+        UniTask Load(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth, List<WearableItem> wearables, AvatarSettings settings, SkinnedMeshRenderer bonesRenderers = null, CancellationToken cancellationToken = default);
         Transform[] GetBones();
         bool IsValidForBodyShape(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/Loader.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/Loader.cs
@@ -33,22 +33,16 @@ namespace AvatarSystem
             avatarMeshCombiner.uploadMeshToGpu = true;
         }
 
-        public async UniTask Load(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth,
-            List<WearableItem> wearables, AvatarSettings settings, CancellationToken ct = default)
+        public async UniTask Load(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth, List<WearableItem> wearables, AvatarSettings settings, SkinnedMeshRenderer bonesContainer = null, CancellationToken cancellationToken = default)
         {
-            await Load(bodyshape, eyes, eyebrows, mouth, wearables, settings, null, ct);
-        }
-
-        public async UniTask Load(WearableItem bodyshape, WearableItem eyes, WearableItem eyebrows, WearableItem mouth, List<WearableItem> wearables, AvatarSettings settings, SkinnedMeshRenderer bonesContainer = null, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
 
             List<IWearableLoader> toCleanUp = new List<IWearableLoader>();
             try
             {
                 status = ILoader.Status.Loading;
-                await LoadBodyshape(settings, bodyshape, eyes, eyebrows, mouth, toCleanUp, ct);
-                await LoadWearables(wearables, settings, toCleanUp, ct);
+                await LoadBodyshape(settings, bodyshape, eyes, eyebrows, mouth, toCleanUp, cancellationToken);
+                await LoadWearables(wearables, settings, toCleanUp, cancellationToken);
                 SkinnedMeshRenderer skinnedContainer = bonesContainer == null ? bodyshapeLoader.upperBodyRenderer : bonesContainer;
                 // Update Status accordingly
                 status = ComposeStatus(loaders);
@@ -68,7 +62,7 @@ namespace AvatarSystem
 
                 (bool headVisible, bool upperBodyVisible, bool lowerBodyVisible, bool feetVisible) = AvatarSystemUtils.GetActiveBodyParts(settings.bodyshapeId, wearables);
 
-                combinedRenderer = await MergeAvatar(settings, wearables, headVisible, upperBodyVisible, lowerBodyVisible, feetVisible, skinnedContainer, ct);
+                combinedRenderer = await MergeAvatar(settings, wearables, headVisible, upperBodyVisible, lowerBodyVisible, feetVisible, skinnedContainer, cancellationToken);
                 facialFeaturesRenderers = new List<Renderer>();
                 if (headVisible)
                 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Tests/AvatarShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Tests/AvatarShould.cs
@@ -110,7 +110,7 @@ namespace Test.AvatarSystem
             await TestUtils.ThrowsAsync<Exception>(avatar.Load(new List<string>(), new List<string>(), settings));
 
             loader.Received()
-                .Load(bodyshape, eyes, eyebrows, mouth, wearables, settings, Arg.Any<CancellationToken>());
+                .Load(bodyshape, eyes, eyebrows, mouth, wearables, settings, cancellationToken:Arg.Any<CancellationToken>());
         });
 
         [UnityTest]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarLOD/AvatarLODController/AvatarLODController.cs
@@ -25,9 +25,7 @@ namespace DCL
         public AvatarLODController(Player player)
         {
             this.player = player;
-            if (player?.avatar == null)
-                return;
-            player.avatar.SetLODLevel(0);
+            player?.avatar?.SetLODLevel(0);
         }
 
         public void SetLOD0()
@@ -69,13 +67,8 @@ namespace DCL
             player.onPointerDownCollider.SetColliderEnabled(false);
         }
 
-        public void SetAnimationThrottling(int framesBetweenUpdates)
-        {
-            if (player?.avatar == null)
-                return;
-            
-            player.avatar.SetAnimationThrottling(framesBetweenUpdates);
-        }
+        public void SetAnimationThrottling(int framesBetweenUpdates) =>
+            player?.avatar?.SetAnimationThrottling(framesBetweenUpdates);
 
         public void SetNameVisible(bool visible)
         {
@@ -84,13 +77,8 @@ namespace DCL
             else
                 player?.playerName.Hide();
         }
-        public void UpdateImpostorTint(float distanceToMainPlayer)
-        {
-            if (player?.avatar == null)
-                return;
-            
-            player.avatar.SetImpostorTint(AvatarRendererHelpers.CalculateImpostorTint(distanceToMainPlayer));
-        }
+        public void UpdateImpostorTint(float distanceToMainPlayer) =>
+            player?.avatar?.SetImpostorTint(AvatarRendererHelpers.CalculateImpostorTint(distanceToMainPlayer));
 
         public void Dispose() { }
     }

--- a/unity-renderer/ProjectSettings/Physics2DSettings.asset
+++ b/unity-renderer/ProjectSettings/Physics2DSettings.asset
@@ -38,7 +38,7 @@ Physics2DSettings:
     m_IslandSolverJointCostScale: 10
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
-  m_SimulationMode: 2
+  m_AutoSimulation: 0
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1

--- a/unity-renderer/ProjectSettings/Physics2DSettings.asset
+++ b/unity-renderer/ProjectSettings/Physics2DSettings.asset
@@ -38,7 +38,7 @@ Physics2DSettings:
     m_IslandSolverJointCostScale: 10
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
-  m_AutoSimulation: 0
+  m_SimulationMode: 2
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1


### PR DESCRIPTION
## What does this PR change?

Avatar was registering its `gpuSkinning `each time when calling `Load() `method. This cause the problem, since gpuSkinning instance is readonly assigned on Avatar creation, but `Load `called often - for example by `CharacterPreviewController` when changing wearables from backpack.

- now, when GPUSkinning is re-register, we just modify its timeBetweenFrames
- removed duplication in Avatar and AvatarWithHologramm classes (via inheritance and variation of Template Method pattern)

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

[Devs Only]
1. Launch the explorer
2. Change wearables in Backpack
3. [DevsOnly]: Observe no LogWarning in console from `gpuSkinningThrottlerService`
4. Check that Avatar and Hologrammed avatar behaves correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
