### PR TITLE
fix: force a compatible texture format for the platform

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/MapTexturePlugin/MapTexturePlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/MapTexturePlugin/MapTexturePlugin.cs
@@ -2,8 +2,8 @@ using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL;
-using System.Linq;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 using UnityEngine.Networking;
 
 public class MapTexturePlugin : IPlugin
@@ -30,16 +30,11 @@ public class MapTexturePlugin : IPlugin
         DataStore.i.HUDs.mapMainTexture.Set(Resources.Load<Texture2D>("MapDefault"));
         DataStore.i.HUDs.mapEstatesTexture.Set(Resources.Load<Texture2D>("MapDefaultEstates"));
 
-        var textureFormat = PRIORITIZED_FORMATS.FirstOrDefault(f => SystemInfo.SupportsTextureFormat(f.Value));
-
-        if (textureFormat == null)
-            return;
-
-        DownloadTexture(MAIN_TEXTURE_URL, DataStore.i.HUDs.mapMainTexture, textureFormat.Value, cts.Token);
-        DownloadTexture(ESTATES_TEXTURE_URL, DataStore.i.HUDs.mapEstatesTexture, textureFormat.Value, cts.Token);
+        DownloadTexture(MAIN_TEXTURE_URL, DataStore.i.HUDs.mapMainTexture, cts.Token);
+        DownloadTexture(ESTATES_TEXTURE_URL, DataStore.i.HUDs.mapEstatesTexture, cts.Token);
     }
 
-    private static async UniTaskVoid DownloadTexture(string url, BaseVariable<Texture> textureVariable, TextureFormat textureFormat, CancellationToken ct)
+    private static async UniTaskVoid DownloadTexture(string url, BaseVariable<Texture> textureVariable, CancellationToken ct)
     {
         while (true)
         {
@@ -52,7 +47,7 @@ public class MapTexturePlugin : IPlugin
                 }
                 else
                 {
-                    Texture2D tex = new Texture2D(0, 0, TextureFormat.ETC2_RGBA8, false, true);
+                    Texture2D tex = new Texture2D(0, 0, GraphicsFormatUtility.GetGraphicsFormat(TextureFormat.RGBA32, false), TextureCreationFlags.None);
                     tex.filterMode = FilterMode.Point;
                     tex.wrapMode = TextureWrapMode.Clamp;
                     tex.LoadImage(www.downloadHandler.data);

--- a/unity-renderer/Assets/DCLPlugins/MapTexturePlugin/MapTexturePlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/MapTexturePlugin/MapTexturePlugin.cs
@@ -14,15 +14,6 @@ public class MapTexturePlugin : IPlugin
 
     private CancellationTokenSource cts;
 
-    private static readonly TextureFormat?[] PRIORITIZED_FORMATS =
-    {
-        // available for iOS/Android WebGL player
-        TextureFormat.ETC2_RGBA8,
-        TextureFormat.BC7,
-        TextureFormat.DXT5,
-        TextureFormat.RGBA32
-    };
-
     public MapTexturePlugin()
     {
         cts = new CancellationTokenSource();


### PR DESCRIPTION
Use GraphicsFormatUtility to get a compatible texture for every platform.

## Test
 No "Texture creation failed" should appear, check WebGL, Windows and Mac builds. Additionally, the infinite floor should look correct.