### PR TITLE
fix: crash in GltfTextureDownloaderWrapper

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
@@ -26,11 +26,8 @@ namespace DCL.GLTFast.Wrappers
         public Texture2D GetTexture(bool linear)
         {
             Texture2D texture2D = new Texture2D(1, 1, TextureFormat.RGBA32, 0, linear);
-            Debug.Log($"DEBUG NULL 1: {asyncOp == null}");
-            Debug.Log($"DEBUG NULL 2: {asyncOp.webRequest == null}");
-            Debug.Log($"DEBUG NULL 3: {asyncOp.webRequest.downloadHandler == null}");
 
-            if (asyncOp.webRequest.downloadHandler.data != null)
+            if (asyncOp.webRequest != null && asyncOp.webRequest.downloadHandler.data != null)
             {
                 try { texture2D.LoadImage(asyncOp.webRequest.downloadHandler.data); }
                 catch (Exception e)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
@@ -26,6 +26,9 @@ namespace DCL.GLTFast.Wrappers
         public Texture2D GetTexture(bool linear)
         {
             Texture2D texture2D = new Texture2D(1, 1, TextureFormat.RGBA32, 0, linear);
+            Debug.Log($"DEBUG NULL 1: {asyncOp == null}");
+            Debug.Log($"DEBUG NULL 2: {asyncOp.webRequest == null}");
+            Debug.Log($"DEBUG NULL 3: {asyncOp.webRequest.downloadHandler == null}");
 
             if (asyncOp.webRequest.downloadHandler.data != null)
             {


### PR DESCRIPTION
## What does this PR change?

I ve managed to reproduce an error previous to an abnormal situation crash. This PR just adds a nullcheck to avoid said crash

Here are the debug logs, previous to the error, which motivated me to create the nullcheck


## How to test the changes?

Its very hard to reproduce. Walk around the MVFW for about 10 mins, look for places with plenty of people. The error caused by `GltfTextureDownloaderWrapper` should not appear 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
