### PR TITLE
fix: sdk7 scene bounds checker transform scale

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -82,16 +82,22 @@ namespace DCL.ECSComponents
             }
 
             Transform transform = entity.gameObject.transform;
+            bool positionChange = transform.localPosition != model.position;
+            bool scaleChange = transform.localScale != model.scale;
+            bool rotationChange = transform.localRotation != model.rotation;
+
             transform.localPosition = model.position;
             transform.localRotation = model.rotation;
             transform.localScale = model.scale;
 
             if (entity.parentId != model.parentId)
-            {
                 ProcessNewParent(scene, entity, model.parentId);
-            }
 
-            sbcInternalComponent.SetPosition(scene, entity, transform.position);
+            if(positionChange)
+                sbcInternalComponent.SetPosition(scene, entity, transform.position);
+
+            if(scaleChange || rotationChange)
+                sbcInternalComponent.OnTransformScaleRotationChanged(scene, entity);
         }
 
         private static void ProcessNewParent(IParcelScene scene, IDCLEntity entity, long parentId)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/InternalECSComponents/Interfaces/Extensions/InternalSceneBoundsCheckExtensions.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/InternalECSComponents/Interfaces/Extensions/InternalSceneBoundsCheckExtensions.cs
@@ -26,12 +26,32 @@ namespace DCL.ECS7.InternalComponents
 
             // Update children position in their SBCComponent as well
             IList<long> childrenId = entity.childrenId;
-
             for (int i = 0; i < childrenId.Count; i++)
             {
                 if (scene.entities.TryGetValue(childrenId[i], out IDCLEntity childEntity))
                 {
                     sbcInternalComponent.SetPosition(scene, childEntity, childEntity.gameObject.transform.position, createComponentIfMissing);
+                }
+            }
+        }
+
+        public static void OnTransformScaleRotationChanged(this IInternalECSComponent<InternalSceneBoundsCheck> sbcInternalComponent,
+            IParcelScene scene, IDCLEntity entity)
+        {
+            var model = sbcInternalComponent.GetFor(scene, entity)?.model ?? new InternalSceneBoundsCheck();
+
+            // Mesh bounds need to be recalculated
+            model.meshesDirty = true;
+
+            sbcInternalComponent.PutFor(scene, entity, model);
+
+            // Update children 'meshesDirty' in their SBCComponent as well
+            IList<long> childrenId = entity.childrenId;
+            for (int i = 0; i < childrenId.Count; i++)
+            {
+                if (scene.entities.TryGetValue(childrenId[i], out IDCLEntity childEntity))
+                {
+                    sbcInternalComponent.OnTransformScaleRotationChanged(scene, childEntity);
                 }
             }
         }


### PR DESCRIPTION
### WHY
When a transform `scale` or `rotation` is changed, the Scene Bounds Checker is not recalculating the mesh bounds and it should.

### WHAT

implemented meshesDirty change when a transform scale or rotation is changed