### PR TITLE
feat: profile messages need not be reliable

### DIFF
--- a/browser-interface/packages/shared/comms/logic/rfc-4-room-connection.ts
+++ b/browser-interface/packages/shared/comms/logic/rfc-4-room-connection.ts
@@ -43,13 +43,13 @@ export class Rfc4RoomConnection implements RoomConnection {
     return this.sendMessage(false, { message: { $case: 'scene', scene } })
   }
   sendProfileMessage(profileVersion: proto.AnnounceProfileVersion): Promise<void> {
-    return this.sendMessage(true, { message: { $case: 'profileVersion', profileVersion } })
+    return this.sendMessage(false, { message: { $case: 'profileVersion', profileVersion } })
   }
   sendProfileRequest(profileRequest: proto.ProfileRequest): Promise<void> {
-    return this.sendMessage(true, { message: { $case: 'profileRequest', profileRequest } })
+    return this.sendMessage(false, { message: { $case: 'profileRequest', profileRequest } })
   }
   sendProfileResponse(profileResponse: proto.ProfileResponse): Promise<void> {
-    return this.sendMessage(true, { message: { $case: 'profileResponse', profileResponse } })
+    return this.sendMessage(false, { message: { $case: 'profileResponse', profileResponse } })
   }
   sendChatMessage(chat: proto.Chat): Promise<void> {
     return this.sendMessage(true, { message: { $case: 'chat', chat } })


### PR DESCRIPTION
According to this report, a large number of requests are waiting for a reliable response, thus increasing the EventEmitter listener count.

Upon taking a look at the comms protocol, it looks like profile requests are asking to be reliably transmitted. This includes the profile updates and the "RPC" protocol to request profiles from peers. Since the profile updates get sent every second, and the RPC protocol has a retry mechanism, there is no need for these three kinds of messages to be sent with the reliable flag.

![image](https://user-images.githubusercontent.com/42750/228368381-0e2db77a-9b2e-492a-8bfc-fa8da4cdc005.png)

