### PR TITLE
fix: fixed color reset for notifications with mention

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -31,6 +31,7 @@ namespace DCL.Chat.HUD
         private bool isShowingPreview;
         private ParcelCoordinates currentCoordinates;
         private ChatEntryModel model;
+        private Color initialEntryColor;
 
         private readonly CancellationTokenSource populationTaskCancellationTokenSource = new CancellationTokenSource();
 
@@ -46,6 +47,11 @@ namespace DCL.Chat.HUD
         public override event Action OnCancelHover;
         public override event Action OnCancelGotoHover;
 
+        public void Awake()
+        {
+            initialEntryColor = backgroundImage.color;
+        }
+
         public override void Populate(ChatEntryModel chatEntryModel) =>
             PopulateTask(chatEntryModel, populationTaskCancellationTokenSource.Token).Forget();
 
@@ -54,7 +60,7 @@ namespace DCL.Chat.HUD
             model = chatEntryModel;
 
             if(chatEntryModel.subType == ChatEntryModel.SubType.RECEIVED && chatEntryModel.messageType == ChatMessage.Type.PUBLIC)
-                backgroundImage.color = Color.white;
+                backgroundImage.color = initialEntryColor;
 
             chatEntryModel.bodyText = body.ReplaceUnsupportedCharacters(chatEntryModel.bodyText, '?');
             chatEntryModel.bodyText = RemoveTabs(chatEntryModel.bodyText);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -53,6 +53,9 @@ namespace DCL.Chat.HUD
         {
             model = chatEntryModel;
 
+            if(chatEntryModel.subType == ChatEntryModel.SubType.RECEIVED && chatEntryModel.messageType == ChatMessage.Type.PUBLIC)
+                backgroundImage.color = Color.white;
+
             chatEntryModel.bodyText = body.ReplaceUnsupportedCharacters(chatEntryModel.bodyText, '?');
             chatEntryModel.bodyText = RemoveTabs(chatEntryModel.bodyText);
             var userString = GetUserString(chatEntryModel);


### PR DESCRIPTION
## What does this PR change?

Fix #4786
Avoids pooled messages to appear yellow when no mention is detected

...

## How to test the changes?

1. Launch the explorer
2. Send 30+ messages with mentions from a second account
3. Verify that after the 30 messages by sending regular messages without mentions the background is white and not yellow

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
