### PR TITLE
chore: update livekit sdk

### DIFF
--- a/browser-interface/package-lock.json
+++ b/browser-interface/package-lock.json
@@ -34,7 +34,7 @@
         "fp-future": "^1.0.1",
         "gifuct-js": "^2.1.2",
         "hls.js": "^1.3.4",
-        "livekit-client": "^1.6.6",
+        "livekit-client": "^1.7.1",
         "mitt": "^3.0.0",
         "mz-observable": "^1.0.1",
         "redux": "^4.2.1",
@@ -5670,9 +5670,9 @@
       "dev": true
     },
     "node_modules/livekit-client": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-1.6.8.tgz",
-      "integrity": "sha512-QuzPwuW2bETuLo20SGgd0AOf8WJQwnZRkakiza3AYE+T9Oj+8h9UFQE7rtLYz1F3D5iYgFEuv1sC1WTAwUojPw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-1.7.1.tgz",
+      "integrity": "sha512-MFLgXdyxd6VateuHFn+diXqFtuaQc/cB4TZBkAJMCMN7oXIvo0IxEEK+wsqRyEloln4eEBNjpFNZiIffJ2Ph9A==",
       "dependencies": {
         "async-await-queue": "^1.2.1",
         "events": "^3.3.0",

--- a/browser-interface/package.json
+++ b/browser-interface/package.json
@@ -80,7 +80,7 @@
     "fp-future": "^1.0.1",
     "gifuct-js": "^2.1.2",
     "hls.js": "^1.3.4",
-    "livekit-client": "^1.6.6",
+    "livekit-client": "^1.7.1",
     "mitt": "^3.0.0",
     "mz-observable": "^1.0.1",
     "redux": "^4.2.1",


### PR DESCRIPTION
## What does this PR change?
Bumps LiveKit client-sdk-js to latest version (`1.7.1`). It includes a few fixes related to disconnections / reconnections that may help with current connectivity issues.
