### PR TITLE
hotfix: add fatal error when no valid catalyst are found

### DIFF
--- a/browser-interface/packages/shared/dao/sagas.ts
+++ b/browser-interface/packages/shared/dao/sagas.ts
@@ -172,7 +172,9 @@ function* selectRealm() {
     // cached in local storage
     (yield call(getRealmFromLocalStorage, network))
 
-  if (!realm) debugger
+  if (!realm) {
+    BringDownClientAndReportFatalError(new Error('No valid realm found'), 'comms#init')
+  }
 
   console.log(`Trying to connect to realm `, realm)
 

--- a/browser-interface/packages/shared/dao/sagas.ts
+++ b/browser-interface/packages/shared/dao/sagas.ts
@@ -173,7 +173,7 @@ function* selectRealm() {
     (yield call(getRealmFromLocalStorage, network))
 
   if (!realm) {
-    BringDownClientAndReportFatalError(new Error('No valid realm found'), 'comms#init')
+    BringDownClientAndReportFatalError(new Error('Could not connect to any catalyst servers. Please check your internet connection and try again.'), 'comms#init')
   }
 
   console.log(`Trying to connect to realm `, realm)


### PR DESCRIPTION
Possible edge case: If your internet goes down, the client will try to reconnect to a different realm, and it could set all the realms to already connected, and the realm selected could be null. So on that case, we bring a fatal error.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
