### PR TITLE
fix: usernames in chat messages

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs
@@ -394,7 +394,6 @@ Invite others to join by quoting the channel name in other chats or include it a
                 {
                     recipient = channel.ChannelId,
                     timestamp = 0,
-                    isChannelMessage = true,
                     messageId = Guid.NewGuid().ToString()
                 };
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatControllerContextMenuUtility.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatControllerContextMenuUtility.cs
@@ -92,7 +92,7 @@ namespace DCL.Social.Chat
                 messageType = ChatMessage.Type.PRIVATE,
                 timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
             };
-            
+
             AddMessages(new[] {msg, msg2});
         }
 
@@ -125,7 +125,6 @@ namespace DCL.Social.Chat
                     recipient = null,
                     messageType = ChatMessage.Type.PUBLIC,
                     timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                    isChannelMessage = true,
                     messageId = Guid.NewGuid().ToString(),
                     senderName = user.name
                 };
@@ -165,7 +164,6 @@ namespace DCL.Social.Chat
                     recipient = GetAllocatedChannelByName("global").ChannelId,
                     messageType = ChatMessage.Type.PUBLIC,
                     timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                    isChannelMessage = true,
                     messageId = Guid.NewGuid().ToString(),
                     senderName = user.name
                 };

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatMessage/ChatMessage.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatMessage/ChatMessage.cs
@@ -18,7 +18,7 @@ namespace DCL.Interface
             this.sender = sender;
             this.body = body;
         }
-                
+
         public ChatMessage(Type messageType, string sender, string body, ulong timestamp)
         {
             this.messageType = messageType;
@@ -44,7 +44,5 @@ namespace DCL.Interface
         public string recipient;
         public ulong timestamp;
         public string body;
-        public bool isChannelMessage;
-
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntry.cs
@@ -7,7 +7,7 @@ namespace DCL.Chat.HUD
     {
         [SerializeField] internal CanvasGroup group;
 
-        public abstract string DateString { get; }
+        public abstract string HoverString { get; }
 
         public abstract event Action<ChatEntry> OnUserNameClicked;
         public abstract event Action<ChatEntry> OnTriggerHover;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntryModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntryModel.cs
@@ -17,7 +17,7 @@ public struct ChatEntryModel
     public string bodyText;
     public string senderId;
     public string senderName;
-    [FormerlySerializedAs("isSenderNameLoading")] public bool isLoadingNames;
+    public bool isLoadingNames;
     public string recipientName;
     public ulong timestamp;
     public SubType subType;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntryModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntryModel.cs
@@ -17,9 +17,9 @@ public struct ChatEntryModel
     public string bodyText;
     public string senderId;
     public string senderName;
-    public bool isLoadingNames;
     public string recipientName;
     public ulong timestamp;
     public SubType subType;
     public bool isChannelMessage;
+    public bool isLoadingNames;
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntryModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatEntryModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using DCL.Interface;
+using UnityEngine.Serialization;
 
 [Serializable]
 public struct ChatEntryModel
@@ -16,6 +17,7 @@ public struct ChatEntryModel
     public string bodyText;
     public string senderId;
     public string senderName;
+    [FormerlySerializedAs("isSenderNameLoading")] public bool isLoadingNames;
     public string recipientName;
     public ulong timestamp;
     public SubType subType;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -165,6 +165,7 @@ public class ChatHUDController : IHUD
             else
             {
                 model.recipientName = GetEllipsisFormat(message.recipient);
+                model.isLoadingNames = true;
 
                 // sometimes there is no cached profile, so we request it
                 // dont block the operation of showing the message immediately
@@ -186,6 +187,7 @@ public class ChatHUDController : IHUD
             else
             {
                 model.senderName = GetEllipsisFormat(message.sender);
+                model.isLoadingNames = true;
 
                 // sometimes there is no cached profile, so we request it
                 // dont block the operation of showing the message immediately

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -1,5 +1,4 @@
 using Cysharp.Threading.Tasks;
-using DCL;
 using DCL.Chat;
 using DCL.Chat.HUD;
 using DCL.Interface;
@@ -12,432 +11,493 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using UnityEngine;
 
-public class ChatHUDController : IHUD
+namespace DCL.Social.Chat
 {
-    public const int MAX_CHAT_ENTRIES = 30;
-    private const int TEMPORARILY_MUTE_MINUTES = 3;
-    private const int MAX_CONTINUOUS_MESSAGES = 10;
-    private const int MIN_MILLISECONDS_BETWEEN_MESSAGES = 1500;
-    private const int MAX_HISTORY_ITERATION = 10;
-    private const int MAX_MENTION_SUGGESTIONS = 5;
-
-    public delegate UniTask<List<UserProfile>> GetSuggestedUserProfiles(string name, int maxCount, CancellationToken cancellationToken);
-
-    private readonly DataStore dataStore;
-    private readonly IUserProfileBridge userProfileBridge;
-    private readonly bool detectWhisper;
-    private readonly GetSuggestedUserProfiles getSuggestedUserProfiles;
-    private readonly InputAction_Trigger closeMentionSuggestionsTrigger;
-    private readonly IProfanityFilter profanityFilter;
-    private readonly ISocialAnalytics socialAnalytics;
-    private readonly Regex mentionRegex = new (@"(\B@\w+)|(\B@+)");
-    private readonly Regex whisperRegex = new (@"(?i)^\/(whisper|w) (\S+)( *)(.*)");
-    private readonly Dictionary<string, ulong> temporarilyMutedSenders = new ();
-    private readonly List<ChatEntryModel> spamMessages = new ();
-    private readonly List<string> lastMessagesSent = new ();
-    private int currentHistoryIteration;
-    private IChatHUDComponentView view;
-    private CancellationTokenSource mentionSuggestionCancellationToken = new ();
-    private int mentionLength;
-    private int mentionFromIndex;
-    private Dictionary<string, UserProfile> mentionSuggestedProfiles;
-
-    private bool useLegacySorting => dataStore.featureFlags.flags.Get().IsFeatureEnabled("legacy_chat_sorting_enabled");
-    private bool isMentionsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("chat_mentions_enabled");
-
-    public IComparer<ChatEntryModel> SortingStrategy
+    public class ChatHUDController : IHUD
     {
-        set
+        public const int MAX_CHAT_ENTRIES = 30;
+        private const int TEMPORARILY_MUTE_MINUTES = 3;
+        private const int MAX_CONTINUOUS_MESSAGES = 10;
+        private const int MIN_MILLISECONDS_BETWEEN_MESSAGES = 1500;
+        private const int MAX_HISTORY_ITERATION = 10;
+        private const int MAX_MENTION_SUGGESTIONS = 5;
+        private const int MAX_FETCH_PROFILE_TRIES = 3;
+
+        public delegate UniTask<List<UserProfile>> GetSuggestedUserProfiles(string name, int maxCount, CancellationToken cancellationToken);
+
+        private readonly DataStore dataStore;
+        private readonly IUserProfileBridge userProfileBridge;
+        private readonly bool detectWhisper;
+        private readonly GetSuggestedUserProfiles getSuggestedUserProfiles;
+        private readonly InputAction_Trigger closeMentionSuggestionsTrigger;
+        private readonly IProfanityFilter profanityFilter;
+        private readonly ISocialAnalytics socialAnalytics;
+        private readonly Regex mentionRegex = new (@"(\B@\w+)|(\B@+)");
+        private readonly Regex whisperRegex = new (@"(?i)^\/(whisper|w) (\S+)( *)(.*)");
+        private readonly Dictionary<string, ulong> temporarilyMutedSenders = new ();
+        private readonly List<ChatEntryModel> spamMessages = new ();
+        private readonly List<string> lastMessagesSent = new ();
+        private readonly CancellationTokenSource profileFetchingCancellationToken = new ();
+        private readonly CancellationTokenSource addMessagesCancellationToken = new ();
+
+        private int currentHistoryIteration;
+        private IChatHUDComponentView view;
+        private CancellationTokenSource mentionSuggestionCancellationToken = new ();
+        private int mentionLength;
+        private int mentionFromIndex;
+        private Dictionary<string, UserProfile> mentionSuggestedProfiles;
+
+        private bool useLegacySorting => dataStore.featureFlags.flags.Get().IsFeatureEnabled("legacy_chat_sorting_enabled");
+        private bool isMentionsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("chat_mentions_enabled");
+
+        public IComparer<ChatEntryModel> SortingStrategy
         {
-            if (view != null)
-                view.SortingStrategy = value;
-        }
-    }
-
-    public event Action OnInputFieldSelected;
-    public event Action<ChatMessage> OnSendMessage;
-    public event Action<ChatMessage> OnMessageSentBlockedBySpam;
-
-    public ChatHUDController(DataStore dataStore,
-        IUserProfileBridge userProfileBridge,
-        bool detectWhisper,
-        GetSuggestedUserProfiles getSuggestedUserProfiles,
-        ISocialAnalytics socialAnalytics,
-        IProfanityFilter profanityFilter = null)
-    {
-        this.dataStore = dataStore;
-        this.userProfileBridge = userProfileBridge;
-        this.detectWhisper = detectWhisper;
-        this.getSuggestedUserProfiles = getSuggestedUserProfiles;
-        this.socialAnalytics = socialAnalytics;
-        this.profanityFilter = profanityFilter;
-    }
-
-    public void Initialize(IChatHUDComponentView view)
-    {
-        this.view = view;
-        this.view.OnPreviousChatInHistory -= FillInputWithPreviousMessage;
-        this.view.OnPreviousChatInHistory += FillInputWithPreviousMessage;
-        this.view.OnNextChatInHistory -= FillInputWithNextMessage;
-        this.view.OnNextChatInHistory += FillInputWithNextMessage;
-        this.view.OnShowMenu -= ContextMenu_OnShowMenu;
-        this.view.OnShowMenu += ContextMenu_OnShowMenu;
-        this.view.OnInputFieldSelected -= HandleInputFieldSelected;
-        this.view.OnInputFieldSelected += HandleInputFieldSelected;
-        this.view.OnInputFieldDeselected -= HandleInputFieldDeselected;
-        this.view.OnInputFieldDeselected += HandleInputFieldDeselected;
-        this.view.OnSendMessage -= HandleSendMessage;
-        this.view.OnSendMessage += HandleSendMessage;
-        this.view.OnMessageUpdated -= HandleMessageUpdated;
-        this.view.OnMessageUpdated += HandleMessageUpdated;
-        this.view.OnMentionSuggestionSelected -= HandleMentionSuggestionSelected;
-        this.view.OnMentionSuggestionSelected += HandleMentionSuggestionSelected;
-        this.view.OnOpenedContextMenu -= OpenedContextMenu;
-        this.view.OnOpenedContextMenu += OpenedContextMenu;
-        this.view.UseLegacySorting = useLegacySorting;
-    }
-
-    private void OpenedContextMenu()
-    {
-        socialAnalytics.SendClickedMention();
-    }
-
-    public void SetVisibility(bool visible)
-    {
-        if (!visible)
-            HideMentionSuggestions();
-    }
-
-    public void AddChatMessage(ChatMessage message, bool setScrollPositionToBottom = false, bool spamFiltering = true, bool limitMaxEntries = true)
-    {
-        AddChatMessage(ChatMessageToChatEntry(message), setScrollPositionToBottom, spamFiltering, limitMaxEntries).Forget();
-    }
-
-    public async UniTask AddChatMessage(ChatEntryModel chatEntryModel, bool setScrollPositionToBottom = false, bool spamFiltering = true, bool limitMaxEntries = true)
-    {
-        if (IsSpamming(chatEntryModel.senderName) && spamFiltering) return;
-
-        chatEntryModel.bodyText = ChatUtils.AddNoParse(chatEntryModel.bodyText);
-
-        if (IsProfanityFilteringEnabled() && chatEntryModel.messageType != ChatMessage.Type.PRIVATE)
-        {
-            chatEntryModel.bodyText = await profanityFilter.Filter(chatEntryModel.bodyText);
-
-            if (!string.IsNullOrEmpty(chatEntryModel.senderName))
-                chatEntryModel.senderName = await profanityFilter.Filter(chatEntryModel.senderName);
-
-            if (!string.IsNullOrEmpty(chatEntryModel.recipientName))
-                chatEntryModel.recipientName = await profanityFilter.Filter(chatEntryModel.recipientName);
-        }
-
-        await UniTask.SwitchToMainThread();
-
-        view.AddEntry(chatEntryModel, setScrollPositionToBottom);
-
-        if (limitMaxEntries && view.EntryCount > MAX_CHAT_ENTRIES)
-            view.RemoveOldestEntry();
-
-        if (string.IsNullOrEmpty(chatEntryModel.senderId)) return;
-
-        if (spamFiltering)
-            UpdateSpam(chatEntryModel);
-    }
-
-    public void Dispose()
-    {
-        view.OnShowMenu -= ContextMenu_OnShowMenu;
-        view.OnMessageUpdated -= HandleMessageUpdated;
-        view.OnSendMessage -= HandleSendMessage;
-        view.OnInputFieldSelected -= HandleInputFieldSelected;
-        view.OnInputFieldDeselected -= HandleInputFieldDeselected;
-        view.OnPreviousChatInHistory -= FillInputWithPreviousMessage;
-        view.OnNextChatInHistory -= FillInputWithNextMessage;
-        view.OnMentionSuggestionSelected -= HandleMentionSuggestionSelected;
-        OnSendMessage = null;
-        OnInputFieldSelected = null;
-        view.Dispose();
-        mentionSuggestionCancellationToken.SafeCancelAndDispose();
-    }
-
-    public void ClearAllEntries() =>
-        view.ClearAllEntries();
-
-    public void ResetInputField(bool loseFocus = false) =>
-        view.ResetInputField(loseFocus);
-
-    public void FocusInputField() =>
-        view.FocusInputField();
-
-    public void SetInputFieldText(string setInputText) =>
-        view.SetInputFieldText(setInputText);
-
-    public void UnfocusInputField() =>
-        view.UnfocusInputField();
-
-    private ChatEntryModel ChatMessageToChatEntry(ChatMessage message)
-    {
-        var model = new ChatEntryModel();
-        var ownProfile = userProfileBridge.GetOwn();
-
-        model.messageId = message.messageId;
-        model.messageType = message.messageType;
-        model.bodyText = message.body;
-        model.timestamp = message.timestamp;
-        model.isChannelMessage = message.isChannelMessage;
-
-        if (message.recipient != null)
-        {
-            var recipientProfile = userProfileBridge.Get(message.recipient);
-            model.recipientName = recipientProfile != null ? recipientProfile.userName : message.recipient;
-        }
-
-        if (message.sender != null)
-        {
-            var senderProfile = userProfileBridge.Get(message.sender);
-            model.senderName = senderProfile != null ? senderProfile.userName : message.sender;
-            model.senderId = message.sender;
-        }
-
-        if (message.messageType == ChatMessage.Type.PRIVATE)
-        {
-            model.subType = message.sender == ownProfile.userId
-                ? ChatEntryModel.SubType.SENT
-                : ChatEntryModel.SubType.RECEIVED;
-        }
-        else if (message.messageType == ChatMessage.Type.PUBLIC)
-        {
-            model.subType = message.sender == ownProfile.userId
-                ? ChatEntryModel.SubType.SENT
-                : ChatEntryModel.SubType.RECEIVED;
-        }
-
-        return model;
-    }
-
-    private void ContextMenu_OnShowMenu() =>
-        view.OnMessageCancelHover();
-
-    private bool IsProfanityFilteringEnabled() =>
-        dataStore.settings.profanityChatFilteringEnabled.Get()
-        && profanityFilter != null;
-
-    private void HandleMessageUpdated(string message, int cursorPosition) =>
-        UpdateMentions(message, cursorPosition);
-
-    private void UpdateMentions(string message, int cursorPosition)
-    {
-        if (!isMentionsEnabled) return;
-
-        if (string.IsNullOrEmpty(message))
-        {
-            HideMentionSuggestions();
-            return;
-        }
-
-        async UniTaskVoid ShowMentionSuggestionsAsync(string name, CancellationToken cancellationToken)
-        {
-            try
+            set
             {
-                List<UserProfile> suggestions = await getSuggestedUserProfiles.Invoke(name, MAX_MENTION_SUGGESTIONS, cancellationToken);
+                if (view != null)
+                    view.SortingStrategy = value;
+            }
+        }
 
-                mentionSuggestedProfiles = suggestions.ToDictionary(profile => profile.userId, profile => profile);
+        public event Action OnInputFieldSelected;
+        public event Action<ChatMessage> OnSendMessage;
+        public event Action<ChatMessage> OnMessageSentBlockedBySpam;
 
-                if (suggestions.Count == 0)
-                    HideMentionSuggestions();
+        public ChatHUDController(DataStore dataStore,
+            IUserProfileBridge userProfileBridge,
+            bool detectWhisper,
+            GetSuggestedUserProfiles getSuggestedUserProfiles,
+            ISocialAnalytics socialAnalytics,
+            IProfanityFilter profanityFilter = null)
+        {
+            this.dataStore = dataStore;
+            this.userProfileBridge = userProfileBridge;
+            this.detectWhisper = detectWhisper;
+            this.getSuggestedUserProfiles = getSuggestedUserProfiles;
+            this.socialAnalytics = socialAnalytics;
+            this.profanityFilter = profanityFilter;
+        }
+
+        public void Initialize(IChatHUDComponentView view)
+        {
+            this.view = view;
+            this.view.OnPreviousChatInHistory -= FillInputWithPreviousMessage;
+            this.view.OnPreviousChatInHistory += FillInputWithPreviousMessage;
+            this.view.OnNextChatInHistory -= FillInputWithNextMessage;
+            this.view.OnNextChatInHistory += FillInputWithNextMessage;
+            this.view.OnShowMenu -= ContextMenu_OnShowMenu;
+            this.view.OnShowMenu += ContextMenu_OnShowMenu;
+            this.view.OnInputFieldSelected -= HandleInputFieldSelected;
+            this.view.OnInputFieldSelected += HandleInputFieldSelected;
+            this.view.OnInputFieldDeselected -= HandleInputFieldDeselected;
+            this.view.OnInputFieldDeselected += HandleInputFieldDeselected;
+            this.view.OnSendMessage -= HandleSendMessage;
+            this.view.OnSendMessage += HandleSendMessage;
+            this.view.OnMessageUpdated -= HandleMessageUpdated;
+            this.view.OnMessageUpdated += HandleMessageUpdated;
+            this.view.OnMentionSuggestionSelected -= HandleMentionSuggestionSelected;
+            this.view.OnMentionSuggestionSelected += HandleMentionSuggestionSelected;
+            this.view.OnOpenedContextMenu -= OpenedContextMenu;
+            this.view.OnOpenedContextMenu += OpenedContextMenu;
+            this.view.UseLegacySorting = useLegacySorting;
+        }
+
+        private void OpenedContextMenu()
+        {
+            socialAnalytics.SendClickedMention();
+        }
+
+        public void SetVisibility(bool visible)
+        {
+            if (!visible)
+                HideMentionSuggestions();
+        }
+
+        public void AddChatMessage(ChatMessage message, bool setScrollPositionToBottom = false,
+            bool spamFiltering = true, bool limitMaxEntries = true, int fetchProfileTries = 0)
+        {
+            async UniTaskVoid EnsureProfileThenUpdateMessage(string profileId, ChatMessage message,
+                bool setScrollPositionToBottom, bool spamFiltering, bool limitMaxEntries,
+                int fetchProfileTries,
+                CancellationToken cancellationToken)
+            {
+                if (fetchProfileTries >= MAX_FETCH_PROFILE_TRIES)
+                {
+                    Debug.LogWarning($"Profile fetching max retries limit reached for {profileId}");
+                    return;
+                }
+
+                try
+                {
+                    UserProfile requestedProfile = await userProfileBridge.RequestFullUserProfileAsync(profileId, cancellationToken);
+
+                    if (requestedProfile != null)
+                    {
+                        // avoid any possible race condition with the current AddChatMessage operation
+                        await UniTask.NextFrame(cancellationToken: cancellationToken);
+
+                        AddChatMessage(message, setScrollPositionToBottom, spamFiltering, limitMaxEntries, fetchProfileTries + 1);
+                    }
+                }
+                catch (Exception e) when (e is not OperationCanceledException) { Debug.LogException(e); }
+            }
+
+            var model = new ChatEntryModel();
+            var ownProfile = userProfileBridge.GetOwn();
+
+            model.messageId = message.messageId;
+            model.messageType = message.messageType;
+            model.bodyText = message.body;
+            model.timestamp = message.timestamp;
+            model.isChannelMessage = message.isChannelMessage;
+
+            if (message.recipient != null)
+            {
+                var recipientProfile = userProfileBridge.Get(message.recipient);
+
+                if (recipientProfile != null)
+                    model.recipientName = recipientProfile.userName;
                 else
                 {
-                    view.ShowMentionSuggestions();
-                    dataStore.mentions.isMentionSuggestionVisible.Set(true);
-
-                    view.SetMentionSuggestions(suggestions.Select(profile => new ChatMentionSuggestionModel
-                                                           {
-                                                               userId = profile.userId,
-                                                               userName = profile.userName,
-                                                               imageUrl = profile.face256SnapshotURL,
-                                                           })
-                                                          .ToList());
+                    model.recipientName = message.recipient;
+                    // sometimes there is no cached profile, so we request it
+                    // dont block the operation of showing the message immediately
+                    // just update the message information after we get the profile
+                    EnsureProfileThenUpdateMessage(message.recipient, message, setScrollPositionToBottom, spamFiltering,
+                            limitMaxEntries, fetchProfileTries,
+                            profileFetchingCancellationToken.Token)
+                       .Forget();
                 }
             }
-            catch (Exception e) when (e is not OperationCanceledException) { HideMentionSuggestions(); }
-        }
 
-        int lastWrittenCharacterIndex = Math.Max(0, cursorPosition - 1);
-
-        if (mentionFromIndex >= message.Length || message[lastWrittenCharacterIndex] == ' ')
-            mentionFromIndex = cursorPosition;
-
-        Match match = mentionRegex.Match(message, mentionFromIndex);
-
-        if (match.Success)
-        {
-            mentionSuggestionCancellationToken = mentionSuggestionCancellationToken.SafeRestart();
-            mentionFromIndex = match.Index;
-            mentionLength = match.Length;
-            string name = match.Value[1..];
-            ShowMentionSuggestionsAsync(name, mentionSuggestionCancellationToken.Token).Forget();
-        }
-        else
-        {
-            mentionSuggestionCancellationToken.SafeCancelAndDispose();
-            mentionFromIndex = lastWrittenCharacterIndex;
-            HideMentionSuggestions();
-        }
-    }
-
-    private void HandleSendMessage(ChatMessage message)
-    {
-        mentionFromIndex = 0;
-        HideMentionSuggestions();
-
-        var ownProfile = userProfileBridge.GetOwn();
-        message.sender = ownProfile.userId;
-
-        RegisterMessageHistory(message);
-        currentHistoryIteration = 0;
-
-        if (IsSpamming(message.sender) || (IsSpamming(ownProfile.userName) && !string.IsNullOrEmpty(message.body)))
-        {
-            OnMessageSentBlockedBySpam?.Invoke(message);
-            return;
-        }
-
-        if (MentionsUtils.TextContainsMention(message.body))
-            socialAnalytics.SendMessageWithMention();
-
-        ApplyWhisperAttributes(message);
-
-        if (message.body.ToLower().StartsWith("/join"))
-        {
-            if (!ownProfile.isGuest)
-                dataStore.channels.channelJoinedSource.Set(ChannelJoinedSource.Command);
-            else
+            if (message.sender != null)
             {
-                dataStore.HUDs.connectWalletModalVisible.Set(true);
+                model.senderId = message.sender;
+                var senderProfile = userProfileBridge.Get(message.sender);
+
+                if (senderProfile != null)
+                    model.senderName = senderProfile.userName;
+                else
+                {
+                    model.senderName = message.sender;
+                    // sometimes there is no cached profile, so we request it
+                    // dont block the operation of showing the message immediately
+                    // just update the message information after we get the profile
+                    EnsureProfileThenUpdateMessage(message.sender, message, setScrollPositionToBottom, spamFiltering,
+                            limitMaxEntries, fetchProfileTries,
+                            profileFetchingCancellationToken.Token)
+                       .Forget();
+                }
+            }
+
+            if (message.messageType == ChatMessage.Type.PRIVATE)
+            {
+                model.subType = message.sender == ownProfile.userId
+                    ? ChatEntryModel.SubType.SENT
+                    : ChatEntryModel.SubType.RECEIVED;
+            }
+            else if (message.messageType == ChatMessage.Type.PUBLIC)
+            {
+                model.subType = message.sender == ownProfile.userId
+                    ? ChatEntryModel.SubType.SENT
+                    : ChatEntryModel.SubType.RECEIVED;
+            }
+
+            AddChatMessage(model, setScrollPositionToBottom, spamFiltering, limitMaxEntries,
+                    addMessagesCancellationToken.Token)
+               .Forget();
+        }
+
+        public async UniTask AddChatMessage(ChatEntryModel chatEntryModel, bool setScrollPositionToBottom = false, bool spamFiltering = true, bool limitMaxEntries = true,
+            CancellationToken cancellationToken = default)
+        {
+            if (IsSpamming(chatEntryModel.senderName) && spamFiltering) return;
+
+            chatEntryModel.bodyText = ChatUtils.AddNoParse(chatEntryModel.bodyText);
+
+            if (IsProfanityFilteringEnabled() && chatEntryModel.messageType != ChatMessage.Type.PRIVATE)
+            {
+                chatEntryModel.bodyText = await profanityFilter.Filter(chatEntryModel.bodyText, cancellationToken);
+
+                if (!string.IsNullOrEmpty(chatEntryModel.senderName))
+                    chatEntryModel.senderName = await profanityFilter.Filter(chatEntryModel.senderName, cancellationToken);
+
+                if (!string.IsNullOrEmpty(chatEntryModel.recipientName))
+                    chatEntryModel.recipientName = await profanityFilter.Filter(chatEntryModel.recipientName, cancellationToken);
+            }
+
+            await UniTask.SwitchToMainThread(cancellationToken: cancellationToken);
+
+            view.AddEntry(chatEntryModel, setScrollPositionToBottom);
+
+            if (limitMaxEntries && view.EntryCount > MAX_CHAT_ENTRIES)
+                view.RemoveOldestEntry();
+
+            if (string.IsNullOrEmpty(chatEntryModel.senderId)) return;
+
+            if (spamFiltering)
+                UpdateSpam(chatEntryModel);
+        }
+
+        public void Dispose()
+        {
+            view.OnShowMenu -= ContextMenu_OnShowMenu;
+            view.OnMessageUpdated -= HandleMessageUpdated;
+            view.OnSendMessage -= HandleSendMessage;
+            view.OnInputFieldSelected -= HandleInputFieldSelected;
+            view.OnInputFieldDeselected -= HandleInputFieldDeselected;
+            view.OnPreviousChatInHistory -= FillInputWithPreviousMessage;
+            view.OnNextChatInHistory -= FillInputWithNextMessage;
+            view.OnMentionSuggestionSelected -= HandleMentionSuggestionSelected;
+            OnSendMessage = null;
+            OnInputFieldSelected = null;
+            view.Dispose();
+            mentionSuggestionCancellationToken.SafeCancelAndDispose();
+            profileFetchingCancellationToken.SafeCancelAndDispose();
+            addMessagesCancellationToken.SafeCancelAndDispose();
+        }
+
+        public void ClearAllEntries() =>
+            view.ClearAllEntries();
+
+        public void ResetInputField(bool loseFocus = false) =>
+            view.ResetInputField(loseFocus);
+
+        public void FocusInputField() =>
+            view.FocusInputField();
+
+        public void SetInputFieldText(string setInputText) =>
+            view.SetInputFieldText(setInputText);
+
+        public void UnfocusInputField() =>
+            view.UnfocusInputField();
+
+        private void ContextMenu_OnShowMenu() =>
+            view.OnMessageCancelHover();
+
+        private bool IsProfanityFilteringEnabled() =>
+            dataStore.settings.profanityChatFilteringEnabled.Get()
+            && profanityFilter != null;
+
+        private void HandleMessageUpdated(string message, int cursorPosition) =>
+            UpdateMentions(message, cursorPosition);
+
+        private void UpdateMentions(string message, int cursorPosition)
+        {
+            if (!isMentionsEnabled) return;
+
+            if (string.IsNullOrEmpty(message))
+            {
+                HideMentionSuggestions();
                 return;
             }
+
+            async UniTaskVoid ShowMentionSuggestionsAsync(string name, CancellationToken cancellationToken)
+            {
+                try
+                {
+                    List<UserProfile> suggestions = await getSuggestedUserProfiles.Invoke(name, MAX_MENTION_SUGGESTIONS, cancellationToken);
+
+                    mentionSuggestedProfiles = suggestions.ToDictionary(profile => profile.userId, profile => profile);
+
+                    if (suggestions.Count == 0)
+                        HideMentionSuggestions();
+                    else
+                    {
+                        view.ShowMentionSuggestions();
+                        dataStore.mentions.isMentionSuggestionVisible.Set(true);
+
+                        view.SetMentionSuggestions(suggestions.Select(profile => new ChatMentionSuggestionModel
+                                                               {
+                                                                   userId = profile.userId,
+                                                                   userName = profile.userName,
+                                                                   imageUrl = profile.face256SnapshotURL,
+                                                               })
+                                                              .ToList());
+                    }
+                }
+                catch (Exception e) when (e is not OperationCanceledException) { HideMentionSuggestions(); }
+            }
+
+            int lastWrittenCharacterIndex = Math.Max(0, cursorPosition - 1);
+
+            if (mentionFromIndex >= message.Length || message[lastWrittenCharacterIndex] == ' ')
+                mentionFromIndex = cursorPosition;
+
+            Match match = mentionRegex.Match(message, mentionFromIndex);
+
+            if (match.Success)
+            {
+                mentionSuggestionCancellationToken = mentionSuggestionCancellationToken.SafeRestart();
+                mentionFromIndex = match.Index;
+                mentionLength = match.Length;
+                string name = match.Value[1..];
+                ShowMentionSuggestionsAsync(name, mentionSuggestionCancellationToken.Token).Forget();
+            }
+            else
+            {
+                mentionSuggestionCancellationToken.SafeCancelAndDispose();
+                mentionFromIndex = lastWrittenCharacterIndex;
+                HideMentionSuggestions();
+            }
         }
 
-        OnSendMessage?.Invoke(message);
-    }
-
-    private void RegisterMessageHistory(ChatMessage message)
-    {
-        if (string.IsNullOrEmpty(message.body)) return;
-
-        lastMessagesSent.RemoveAll(s => s.Equals(message.body));
-        lastMessagesSent.Insert(0, message.body);
-
-        if (lastMessagesSent.Count > MAX_HISTORY_ITERATION)
-            lastMessagesSent.RemoveAt(lastMessagesSent.Count - 1);
-    }
-
-    private void ApplyWhisperAttributes(ChatMessage message)
-    {
-        if (!detectWhisper) return;
-        var body = message.body;
-        if (string.IsNullOrWhiteSpace(body)) return;
-
-        var match = whisperRegex.Match(body);
-        if (!match.Success) return;
-
-        message.messageType = ChatMessage.Type.PRIVATE;
-        message.recipient = match.Groups[2].Value;
-        message.body = match.Groups[4].Value;
-    }
-
-    private void HandleInputFieldSelected()
-    {
-        currentHistoryIteration = 0;
-        OnInputFieldSelected?.Invoke();
-    }
-
-    private void HandleInputFieldDeselected() =>
-        currentHistoryIteration = 0;
-
-    private bool IsSpamming(string senderName)
-    {
-        if (string.IsNullOrEmpty(senderName)) return false;
-
-        var isSpamming = false;
-
-        if (!temporarilyMutedSenders.ContainsKey(senderName)) return false;
-
-        var muteTimestamp = DateTimeOffset.FromUnixTimeMilliseconds((long)temporarilyMutedSenders[senderName]);
-
-        if ((DateTimeOffset.UtcNow - muteTimestamp).Minutes < TEMPORARILY_MUTE_MINUTES)
-            isSpamming = true;
-        else
-            temporarilyMutedSenders.Remove(senderName);
-
-        return isSpamming;
-    }
-
-    private void UpdateSpam(ChatEntryModel model)
-    {
-        if (spamMessages.Count == 0)
-            spamMessages.Add(model);
-        else if (spamMessages[^1].senderName == model.senderName)
+        private void HandleSendMessage(ChatMessage message)
         {
-            if (MessagesSentTooFast(spamMessages[^1].timestamp, model.timestamp))
-            {
-                spamMessages.Add(model);
+            mentionFromIndex = 0;
+            HideMentionSuggestions();
 
-                if (spamMessages.Count >= MAX_CONTINUOUS_MESSAGES)
+            var ownProfile = userProfileBridge.GetOwn();
+            message.sender = ownProfile.userId;
+
+            RegisterMessageHistory(message);
+            currentHistoryIteration = 0;
+
+            if (IsSpamming(message.sender) || (IsSpamming(ownProfile.userName) && !string.IsNullOrEmpty(message.body)))
+            {
+                OnMessageSentBlockedBySpam?.Invoke(message);
+                return;
+            }
+
+            if (MentionsUtils.TextContainsMention(message.body))
+                socialAnalytics.SendMessageWithMention();
+
+            ApplyWhisperAttributes(message);
+
+            if (message.body.ToLower().StartsWith("/join"))
+            {
+                if (!ownProfile.isGuest)
+                    dataStore.channels.channelJoinedSource.Set(ChannelJoinedSource.Command);
+                else
                 {
-                    temporarilyMutedSenders.Add(model.senderName, model.timestamp);
-                    spamMessages.Clear();
+                    dataStore.HUDs.connectWalletModalVisible.Set(true);
+                    return;
                 }
+            }
+
+            OnSendMessage?.Invoke(message);
+        }
+
+        private void RegisterMessageHistory(ChatMessage message)
+        {
+            if (string.IsNullOrEmpty(message.body)) return;
+
+            lastMessagesSent.RemoveAll(s => s.Equals(message.body));
+            lastMessagesSent.Insert(0, message.body);
+
+            if (lastMessagesSent.Count > MAX_HISTORY_ITERATION)
+                lastMessagesSent.RemoveAt(lastMessagesSent.Count - 1);
+        }
+
+        private void ApplyWhisperAttributes(ChatMessage message)
+        {
+            if (!detectWhisper) return;
+            var body = message.body;
+            if (string.IsNullOrWhiteSpace(body)) return;
+
+            var match = whisperRegex.Match(body);
+            if (!match.Success) return;
+
+            message.messageType = ChatMessage.Type.PRIVATE;
+            message.recipient = match.Groups[2].Value;
+            message.body = match.Groups[4].Value;
+        }
+
+        private void HandleInputFieldSelected()
+        {
+            currentHistoryIteration = 0;
+            OnInputFieldSelected?.Invoke();
+        }
+
+        private void HandleInputFieldDeselected() =>
+            currentHistoryIteration = 0;
+
+        private bool IsSpamming(string senderName)
+        {
+            if (string.IsNullOrEmpty(senderName)) return false;
+
+            var isSpamming = false;
+
+            if (!temporarilyMutedSenders.ContainsKey(senderName)) return false;
+
+            var muteTimestamp = DateTimeOffset.FromUnixTimeMilliseconds((long)temporarilyMutedSenders[senderName]);
+
+            if ((DateTimeOffset.UtcNow - muteTimestamp).Minutes < TEMPORARILY_MUTE_MINUTES)
+                isSpamming = true;
+            else
+                temporarilyMutedSenders.Remove(senderName);
+
+            return isSpamming;
+        }
+
+        private void UpdateSpam(ChatEntryModel model)
+        {
+            if (spamMessages.Count == 0)
+                spamMessages.Add(model);
+            else if (spamMessages[^1].senderName == model.senderName)
+            {
+                if (MessagesSentTooFast(spamMessages[^1].timestamp, model.timestamp))
+                {
+                    spamMessages.Add(model);
+
+                    if (spamMessages.Count >= MAX_CONTINUOUS_MESSAGES)
+                    {
+                        temporarilyMutedSenders.Add(model.senderName, model.timestamp);
+                        spamMessages.Clear();
+                    }
+                }
+                else
+                    spamMessages.Clear();
             }
             else
                 spamMessages.Clear();
         }
-        else
-            spamMessages.Clear();
-    }
 
-    private bool MessagesSentTooFast(ulong oldMessageTimeStamp, ulong newMessageTimeStamp)
-    {
-        var oldDateTime = DateTimeOffset.FromUnixTimeMilliseconds((long)oldMessageTimeStamp);
-        var newDateTime = DateTimeOffset.FromUnixTimeMilliseconds((long)newMessageTimeStamp);
-        return (newDateTime - oldDateTime).TotalMilliseconds < MIN_MILLISECONDS_BETWEEN_MESSAGES;
-    }
-
-    private void FillInputWithNextMessage()
-    {
-        if (lastMessagesSent.Count == 0) return;
-        view.FocusInputField();
-        view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
-        currentHistoryIteration = (currentHistoryIteration + 1) % lastMessagesSent.Count;
-    }
-
-    private void FillInputWithPreviousMessage()
-    {
-        if (lastMessagesSent.Count == 0)
+        private bool MessagesSentTooFast(ulong oldMessageTimeStamp, ulong newMessageTimeStamp)
         {
-            view.ResetInputField();
-            return;
+            var oldDateTime = DateTimeOffset.FromUnixTimeMilliseconds((long)oldMessageTimeStamp);
+            var newDateTime = DateTimeOffset.FromUnixTimeMilliseconds((long)newMessageTimeStamp);
+            return (newDateTime - oldDateTime).TotalMilliseconds < MIN_MILLISECONDS_BETWEEN_MESSAGES;
         }
 
-        currentHistoryIteration--;
+        private void FillInputWithNextMessage()
+        {
+            if (lastMessagesSent.Count == 0) return;
+            view.FocusInputField();
+            view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
+            currentHistoryIteration = (currentHistoryIteration + 1) % lastMessagesSent.Count;
+        }
 
-        if (currentHistoryIteration < 0)
-            currentHistoryIteration = lastMessagesSent.Count - 1;
+        private void FillInputWithPreviousMessage()
+        {
+            if (lastMessagesSent.Count == 0)
+            {
+                view.ResetInputField();
+                return;
+            }
 
-        view.FocusInputField();
-        view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
-    }
+            currentHistoryIteration--;
 
-    private void HandleMentionSuggestionSelected(string userId)
-    {
-        view.AddMentionToInputField(mentionFromIndex, mentionLength, userId, mentionSuggestedProfiles[userId].userName);
-        socialAnalytics.SendMentionCreated(MentionCreationSource.SuggestionList);
-        HideMentionSuggestions();
-    }
+            if (currentHistoryIteration < 0)
+                currentHistoryIteration = lastMessagesSent.Count - 1;
 
-    private void HideMentionSuggestions()
-    {
-        view.HideMentionSuggestions();
-        dataStore.mentions.isMentionSuggestionVisible.Set(false);
+            view.FocusInputField();
+            view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
+        }
+
+        private void HandleMentionSuggestionSelected(string userId)
+        {
+            view.AddMentionToInputField(mentionFromIndex, mentionLength, userId, mentionSuggestedProfiles[userId].userName);
+            socialAnalytics.SendMentionCreated(MentionCreationSource.SuggestionList);
+            HideMentionSuggestions();
+        }
+
+        private void HideMentionSuggestions()
+        {
+            view.HideMentionSuggestions();
+            dataStore.mentions.isMentionSuggestionVisible.Set(false);
+        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -1,8 +1,10 @@
 using Cysharp.Threading.Tasks;
+using DCL;
 using DCL.Chat;
 using DCL.Chat.HUD;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
+using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using DCL.Tasks;
 using SocialFeaturesAnalytics;
@@ -13,491 +15,490 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
 
-namespace DCL.Social.Chat
+public class ChatHUDController : IHUD
 {
-    public class ChatHUDController : IHUD
+    public const int MAX_CHAT_ENTRIES = 30;
+    private const int TEMPORARILY_MUTE_MINUTES = 3;
+    private const int MAX_CONTINUOUS_MESSAGES = 10;
+    private const int MIN_MILLISECONDS_BETWEEN_MESSAGES = 1500;
+    private const int MAX_HISTORY_ITERATION = 10;
+    private const int MAX_MENTION_SUGGESTIONS = 5;
+    private const int MAX_FETCH_PROFILE_TRIES = 3;
+
+    public delegate UniTask<List<UserProfile>> GetSuggestedUserProfiles(string name, int maxCount, CancellationToken cancellationToken);
+
+    private readonly DataStore dataStore;
+    private readonly IUserProfileBridge userProfileBridge;
+    private readonly bool detectWhisper;
+    private readonly GetSuggestedUserProfiles getSuggestedUserProfiles;
+    private readonly InputAction_Trigger closeMentionSuggestionsTrigger;
+    private readonly IProfanityFilter profanityFilter;
+    private readonly ISocialAnalytics socialAnalytics;
+    private readonly Regex mentionRegex = new (@"(\B@\w+)|(\B@+)");
+    private readonly Regex whisperRegex = new (@"(?i)^\/(whisper|w) (\S+)( *)(.*)");
+    private readonly Dictionary<string, ulong> temporarilyMutedSenders = new ();
+    private readonly List<ChatEntryModel> spamMessages = new ();
+    private readonly List<string> lastMessagesSent = new ();
+    private readonly CancellationTokenSource profileFetchingCancellationToken = new ();
+    private readonly CancellationTokenSource addMessagesCancellationToken = new ();
+
+    private int currentHistoryIteration;
+    private IChatHUDComponentView view;
+    private CancellationTokenSource mentionSuggestionCancellationToken = new ();
+    private int mentionLength;
+    private int mentionFromIndex;
+    private Dictionary<string, UserProfile> mentionSuggestedProfiles;
+
+    private bool useLegacySorting => dataStore.featureFlags.flags.Get().IsFeatureEnabled("legacy_chat_sorting_enabled");
+    private bool isMentionsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("chat_mentions_enabled");
+
+    public IComparer<ChatEntryModel> SortingStrategy
     {
-        public const int MAX_CHAT_ENTRIES = 30;
-        private const int TEMPORARILY_MUTE_MINUTES = 3;
-        private const int MAX_CONTINUOUS_MESSAGES = 10;
-        private const int MIN_MILLISECONDS_BETWEEN_MESSAGES = 1500;
-        private const int MAX_HISTORY_ITERATION = 10;
-        private const int MAX_MENTION_SUGGESTIONS = 5;
-        private const int MAX_FETCH_PROFILE_TRIES = 3;
-
-        public delegate UniTask<List<UserProfile>> GetSuggestedUserProfiles(string name, int maxCount, CancellationToken cancellationToken);
-
-        private readonly DataStore dataStore;
-        private readonly IUserProfileBridge userProfileBridge;
-        private readonly bool detectWhisper;
-        private readonly GetSuggestedUserProfiles getSuggestedUserProfiles;
-        private readonly InputAction_Trigger closeMentionSuggestionsTrigger;
-        private readonly IProfanityFilter profanityFilter;
-        private readonly ISocialAnalytics socialAnalytics;
-        private readonly Regex mentionRegex = new (@"(\B@\w+)|(\B@+)");
-        private readonly Regex whisperRegex = new (@"(?i)^\/(whisper|w) (\S+)( *)(.*)");
-        private readonly Dictionary<string, ulong> temporarilyMutedSenders = new ();
-        private readonly List<ChatEntryModel> spamMessages = new ();
-        private readonly List<string> lastMessagesSent = new ();
-        private readonly CancellationTokenSource profileFetchingCancellationToken = new ();
-        private readonly CancellationTokenSource addMessagesCancellationToken = new ();
-
-        private int currentHistoryIteration;
-        private IChatHUDComponentView view;
-        private CancellationTokenSource mentionSuggestionCancellationToken = new ();
-        private int mentionLength;
-        private int mentionFromIndex;
-        private Dictionary<string, UserProfile> mentionSuggestedProfiles;
-
-        private bool useLegacySorting => dataStore.featureFlags.flags.Get().IsFeatureEnabled("legacy_chat_sorting_enabled");
-        private bool isMentionsEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled("chat_mentions_enabled");
-
-        public IComparer<ChatEntryModel> SortingStrategy
+        set
         {
-            set
-            {
-                if (view != null)
-                    view.SortingStrategy = value;
-            }
+            if (view != null)
+                view.SortingStrategy = value;
         }
+    }
 
-        public event Action OnInputFieldSelected;
-        public event Action<ChatMessage> OnSendMessage;
-        public event Action<ChatMessage> OnMessageSentBlockedBySpam;
+    public event Action OnInputFieldSelected;
+    public event Action<ChatMessage> OnSendMessage;
+    public event Action<ChatMessage> OnMessageSentBlockedBySpam;
 
-        public ChatHUDController(DataStore dataStore,
-            IUserProfileBridge userProfileBridge,
-            bool detectWhisper,
-            GetSuggestedUserProfiles getSuggestedUserProfiles,
-            ISocialAnalytics socialAnalytics,
-            IProfanityFilter profanityFilter = null)
-        {
-            this.dataStore = dataStore;
-            this.userProfileBridge = userProfileBridge;
-            this.detectWhisper = detectWhisper;
-            this.getSuggestedUserProfiles = getSuggestedUserProfiles;
-            this.socialAnalytics = socialAnalytics;
-            this.profanityFilter = profanityFilter;
-        }
+    public ChatHUDController(DataStore dataStore,
+        IUserProfileBridge userProfileBridge,
+        bool detectWhisper,
+        GetSuggestedUserProfiles getSuggestedUserProfiles,
+        ISocialAnalytics socialAnalytics,
+        IProfanityFilter profanityFilter = null)
+    {
+        this.dataStore = dataStore;
+        this.userProfileBridge = userProfileBridge;
+        this.detectWhisper = detectWhisper;
+        this.getSuggestedUserProfiles = getSuggestedUserProfiles;
+        this.socialAnalytics = socialAnalytics;
+        this.profanityFilter = profanityFilter;
+    }
 
-        public void Initialize(IChatHUDComponentView view)
-        {
-            this.view = view;
-            this.view.OnPreviousChatInHistory -= FillInputWithPreviousMessage;
-            this.view.OnPreviousChatInHistory += FillInputWithPreviousMessage;
-            this.view.OnNextChatInHistory -= FillInputWithNextMessage;
-            this.view.OnNextChatInHistory += FillInputWithNextMessage;
-            this.view.OnShowMenu -= ContextMenu_OnShowMenu;
-            this.view.OnShowMenu += ContextMenu_OnShowMenu;
-            this.view.OnInputFieldSelected -= HandleInputFieldSelected;
-            this.view.OnInputFieldSelected += HandleInputFieldSelected;
-            this.view.OnInputFieldDeselected -= HandleInputFieldDeselected;
-            this.view.OnInputFieldDeselected += HandleInputFieldDeselected;
-            this.view.OnSendMessage -= HandleSendMessage;
-            this.view.OnSendMessage += HandleSendMessage;
-            this.view.OnMessageUpdated -= HandleMessageUpdated;
-            this.view.OnMessageUpdated += HandleMessageUpdated;
-            this.view.OnMentionSuggestionSelected -= HandleMentionSuggestionSelected;
-            this.view.OnMentionSuggestionSelected += HandleMentionSuggestionSelected;
-            this.view.OnOpenedContextMenu -= OpenedContextMenu;
-            this.view.OnOpenedContextMenu += OpenedContextMenu;
-            this.view.UseLegacySorting = useLegacySorting;
-        }
+    public void Initialize(IChatHUDComponentView view)
+    {
+        this.view = view;
+        this.view.OnPreviousChatInHistory -= FillInputWithPreviousMessage;
+        this.view.OnPreviousChatInHistory += FillInputWithPreviousMessage;
+        this.view.OnNextChatInHistory -= FillInputWithNextMessage;
+        this.view.OnNextChatInHistory += FillInputWithNextMessage;
+        this.view.OnShowMenu -= ContextMenu_OnShowMenu;
+        this.view.OnShowMenu += ContextMenu_OnShowMenu;
+        this.view.OnInputFieldSelected -= HandleInputFieldSelected;
+        this.view.OnInputFieldSelected += HandleInputFieldSelected;
+        this.view.OnInputFieldDeselected -= HandleInputFieldDeselected;
+        this.view.OnInputFieldDeselected += HandleInputFieldDeselected;
+        this.view.OnSendMessage -= HandleSendMessage;
+        this.view.OnSendMessage += HandleSendMessage;
+        this.view.OnMessageUpdated -= HandleMessageUpdated;
+        this.view.OnMessageUpdated += HandleMessageUpdated;
+        this.view.OnMentionSuggestionSelected -= HandleMentionSuggestionSelected;
+        this.view.OnMentionSuggestionSelected += HandleMentionSuggestionSelected;
+        this.view.OnOpenedContextMenu -= OpenedContextMenu;
+        this.view.OnOpenedContextMenu += OpenedContextMenu;
+        this.view.UseLegacySorting = useLegacySorting;
+    }
 
-        private void OpenedContextMenu()
-        {
-            socialAnalytics.SendClickedMention();
-        }
+    private void OpenedContextMenu()
+    {
+        socialAnalytics.SendClickedMention();
+    }
 
-        public void SetVisibility(bool visible)
-        {
-            if (!visible)
-                HideMentionSuggestions();
-        }
-
-        public void AddChatMessage(ChatMessage message, bool setScrollPositionToBottom = false,
-            bool spamFiltering = true, bool limitMaxEntries = true, int fetchProfileTries = 0)
-        {
-            async UniTaskVoid EnsureProfileThenUpdateMessage(string profileId, ChatMessage message,
-                bool setScrollPositionToBottom, bool spamFiltering, bool limitMaxEntries,
-                int fetchProfileTries,
-                CancellationToken cancellationToken)
-            {
-                if (fetchProfileTries >= MAX_FETCH_PROFILE_TRIES)
-                {
-                    Debug.LogWarning($"Profile fetching max retries limit reached for {profileId}");
-                    return;
-                }
-
-                try
-                {
-                    UserProfile requestedProfile = await userProfileBridge.RequestFullUserProfileAsync(profileId, cancellationToken);
-
-                    if (requestedProfile != null)
-                    {
-                        // avoid any possible race condition with the current AddChatMessage operation
-                        await UniTask.NextFrame(cancellationToken: cancellationToken);
-
-                        AddChatMessage(message, setScrollPositionToBottom, spamFiltering, limitMaxEntries, fetchProfileTries + 1);
-                    }
-                }
-                catch (Exception e) when (e is not OperationCanceledException) { Debug.LogException(e); }
-            }
-
-            var model = new ChatEntryModel();
-            var ownProfile = userProfileBridge.GetOwn();
-
-            model.messageId = message.messageId;
-            model.messageType = message.messageType;
-            model.bodyText = message.body;
-            model.timestamp = message.timestamp;
-            model.isChannelMessage = message.isChannelMessage;
-
-            if (message.recipient != null)
-            {
-                var recipientProfile = userProfileBridge.Get(message.recipient);
-
-                if (recipientProfile != null)
-                    model.recipientName = recipientProfile.userName;
-                else
-                {
-                    model.recipientName = message.recipient;
-                    // sometimes there is no cached profile, so we request it
-                    // dont block the operation of showing the message immediately
-                    // just update the message information after we get the profile
-                    EnsureProfileThenUpdateMessage(message.recipient, message, setScrollPositionToBottom, spamFiltering,
-                            limitMaxEntries, fetchProfileTries,
-                            profileFetchingCancellationToken.Token)
-                       .Forget();
-                }
-            }
-
-            if (message.sender != null)
-            {
-                model.senderId = message.sender;
-                var senderProfile = userProfileBridge.Get(message.sender);
-
-                if (senderProfile != null)
-                    model.senderName = senderProfile.userName;
-                else
-                {
-                    model.senderName = message.sender;
-                    // sometimes there is no cached profile, so we request it
-                    // dont block the operation of showing the message immediately
-                    // just update the message information after we get the profile
-                    EnsureProfileThenUpdateMessage(message.sender, message, setScrollPositionToBottom, spamFiltering,
-                            limitMaxEntries, fetchProfileTries,
-                            profileFetchingCancellationToken.Token)
-                       .Forget();
-                }
-            }
-
-            if (message.messageType == ChatMessage.Type.PRIVATE)
-            {
-                model.subType = message.sender == ownProfile.userId
-                    ? ChatEntryModel.SubType.SENT
-                    : ChatEntryModel.SubType.RECEIVED;
-            }
-            else if (message.messageType == ChatMessage.Type.PUBLIC)
-            {
-                model.subType = message.sender == ownProfile.userId
-                    ? ChatEntryModel.SubType.SENT
-                    : ChatEntryModel.SubType.RECEIVED;
-            }
-
-            AddChatMessage(model, setScrollPositionToBottom, spamFiltering, limitMaxEntries,
-                    addMessagesCancellationToken.Token)
-               .Forget();
-        }
-
-        public async UniTask AddChatMessage(ChatEntryModel chatEntryModel, bool setScrollPositionToBottom = false, bool spamFiltering = true, bool limitMaxEntries = true,
-            CancellationToken cancellationToken = default)
-        {
-            if (IsSpamming(chatEntryModel.senderName) && spamFiltering) return;
-
-            chatEntryModel.bodyText = ChatUtils.AddNoParse(chatEntryModel.bodyText);
-
-            if (IsProfanityFilteringEnabled() && chatEntryModel.messageType != ChatMessage.Type.PRIVATE)
-            {
-                chatEntryModel.bodyText = await profanityFilter.Filter(chatEntryModel.bodyText, cancellationToken);
-
-                if (!string.IsNullOrEmpty(chatEntryModel.senderName))
-                    chatEntryModel.senderName = await profanityFilter.Filter(chatEntryModel.senderName, cancellationToken);
-
-                if (!string.IsNullOrEmpty(chatEntryModel.recipientName))
-                    chatEntryModel.recipientName = await profanityFilter.Filter(chatEntryModel.recipientName, cancellationToken);
-            }
-
-            await UniTask.SwitchToMainThread(cancellationToken: cancellationToken);
-
-            view.AddEntry(chatEntryModel, setScrollPositionToBottom);
-
-            if (limitMaxEntries && view.EntryCount > MAX_CHAT_ENTRIES)
-                view.RemoveOldestEntry();
-
-            if (string.IsNullOrEmpty(chatEntryModel.senderId)) return;
-
-            if (spamFiltering)
-                UpdateSpam(chatEntryModel);
-        }
-
-        public void Dispose()
-        {
-            view.OnShowMenu -= ContextMenu_OnShowMenu;
-            view.OnMessageUpdated -= HandleMessageUpdated;
-            view.OnSendMessage -= HandleSendMessage;
-            view.OnInputFieldSelected -= HandleInputFieldSelected;
-            view.OnInputFieldDeselected -= HandleInputFieldDeselected;
-            view.OnPreviousChatInHistory -= FillInputWithPreviousMessage;
-            view.OnNextChatInHistory -= FillInputWithNextMessage;
-            view.OnMentionSuggestionSelected -= HandleMentionSuggestionSelected;
-            OnSendMessage = null;
-            OnInputFieldSelected = null;
-            view.Dispose();
-            mentionSuggestionCancellationToken.SafeCancelAndDispose();
-            profileFetchingCancellationToken.SafeCancelAndDispose();
-            addMessagesCancellationToken.SafeCancelAndDispose();
-        }
-
-        public void ClearAllEntries() =>
-            view.ClearAllEntries();
-
-        public void ResetInputField(bool loseFocus = false) =>
-            view.ResetInputField(loseFocus);
-
-        public void FocusInputField() =>
-            view.FocusInputField();
-
-        public void SetInputFieldText(string setInputText) =>
-            view.SetInputFieldText(setInputText);
-
-        public void UnfocusInputField() =>
-            view.UnfocusInputField();
-
-        private void ContextMenu_OnShowMenu() =>
-            view.OnMessageCancelHover();
-
-        private bool IsProfanityFilteringEnabled() =>
-            dataStore.settings.profanityChatFilteringEnabled.Get()
-            && profanityFilter != null;
-
-        private void HandleMessageUpdated(string message, int cursorPosition) =>
-            UpdateMentions(message, cursorPosition);
-
-        private void UpdateMentions(string message, int cursorPosition)
-        {
-            if (!isMentionsEnabled) return;
-
-            if (string.IsNullOrEmpty(message))
-            {
-                HideMentionSuggestions();
-                return;
-            }
-
-            async UniTaskVoid ShowMentionSuggestionsAsync(string name, CancellationToken cancellationToken)
-            {
-                try
-                {
-                    List<UserProfile> suggestions = await getSuggestedUserProfiles.Invoke(name, MAX_MENTION_SUGGESTIONS, cancellationToken);
-
-                    mentionSuggestedProfiles = suggestions.ToDictionary(profile => profile.userId, profile => profile);
-
-                    if (suggestions.Count == 0)
-                        HideMentionSuggestions();
-                    else
-                    {
-                        view.ShowMentionSuggestions();
-                        dataStore.mentions.isMentionSuggestionVisible.Set(true);
-
-                        view.SetMentionSuggestions(suggestions.Select(profile => new ChatMentionSuggestionModel
-                                                               {
-                                                                   userId = profile.userId,
-                                                                   userName = profile.userName,
-                                                                   imageUrl = profile.face256SnapshotURL,
-                                                               })
-                                                              .ToList());
-                    }
-                }
-                catch (Exception e) when (e is not OperationCanceledException) { HideMentionSuggestions(); }
-            }
-
-            int lastWrittenCharacterIndex = Math.Max(0, cursorPosition - 1);
-
-            if (mentionFromIndex >= message.Length || message[lastWrittenCharacterIndex] == ' ')
-                mentionFromIndex = cursorPosition;
-
-            Match match = mentionRegex.Match(message, mentionFromIndex);
-
-            if (match.Success)
-            {
-                mentionSuggestionCancellationToken = mentionSuggestionCancellationToken.SafeRestart();
-                mentionFromIndex = match.Index;
-                mentionLength = match.Length;
-                string name = match.Value[1..];
-                ShowMentionSuggestionsAsync(name, mentionSuggestionCancellationToken.Token).Forget();
-            }
-            else
-            {
-                mentionSuggestionCancellationToken.SafeCancelAndDispose();
-                mentionFromIndex = lastWrittenCharacterIndex;
-                HideMentionSuggestions();
-            }
-        }
-
-        private void HandleSendMessage(ChatMessage message)
-        {
-            mentionFromIndex = 0;
+    public void SetVisibility(bool visible)
+    {
+        if (!visible)
             HideMentionSuggestions();
+    }
 
-            var ownProfile = userProfileBridge.GetOwn();
-            message.sender = ownProfile.userId;
-
-            RegisterMessageHistory(message);
-            currentHistoryIteration = 0;
-
-            if (IsSpamming(message.sender) || (IsSpamming(ownProfile.userName) && !string.IsNullOrEmpty(message.body)))
+    public void AddChatMessage(ChatMessage message, bool setScrollPositionToBottom = false,
+        bool spamFiltering = true, bool limitMaxEntries = true, int fetchProfileTries = 0)
+    {
+        async UniTaskVoid EnsureProfileThenUpdateMessage(string profileId, ChatMessage message,
+            bool setScrollPositionToBottom, bool spamFiltering, bool limitMaxEntries,
+            int fetchProfileTries,
+            CancellationToken cancellationToken)
+        {
+            if (fetchProfileTries >= MAX_FETCH_PROFILE_TRIES)
             {
-                OnMessageSentBlockedBySpam?.Invoke(message);
+                Debug.LogWarning($"Profile fetching max retries limit reached for {profileId}");
                 return;
             }
 
-            if (MentionsUtils.TextContainsMention(message.body))
-                socialAnalytics.SendMessageWithMention();
-
-            ApplyWhisperAttributes(message);
-
-            if (message.body.ToLower().StartsWith("/join"))
+            try
             {
-                if (!ownProfile.isGuest)
-                    dataStore.channels.channelJoinedSource.Set(ChannelJoinedSource.Command);
-                else
+                UserProfile requestedProfile = await userProfileBridge.RequestFullUserProfileAsync(profileId, cancellationToken);
+
+                if (requestedProfile != null)
                 {
-                    dataStore.HUDs.connectWalletModalVisible.Set(true);
-                    return;
+                    // avoid any possible race condition with the current AddChatMessage operation
+                    await UniTask.NextFrame(cancellationToken: cancellationToken);
+
+                    AddChatMessage(message, setScrollPositionToBottom, spamFiltering, limitMaxEntries, fetchProfileTries + 1);
                 }
             }
-
-            OnSendMessage?.Invoke(message);
+            catch (Exception e) when (e is not OperationCanceledException) { Debug.LogException(e); }
         }
 
-        private void RegisterMessageHistory(ChatMessage message)
+        var model = new ChatEntryModel();
+        var ownProfile = userProfileBridge.GetOwn();
+
+        model.messageId = message.messageId;
+        model.messageType = message.messageType;
+        model.bodyText = message.body;
+        model.timestamp = message.timestamp;
+        model.isChannelMessage = message.isChannelMessage;
+
+        if (message.recipient != null)
         {
-            if (string.IsNullOrEmpty(message.body)) return;
+            var recipientProfile = userProfileBridge.Get(message.recipient);
 
-            lastMessagesSent.RemoveAll(s => s.Equals(message.body));
-            lastMessagesSent.Insert(0, message.body);
-
-            if (lastMessagesSent.Count > MAX_HISTORY_ITERATION)
-                lastMessagesSent.RemoveAt(lastMessagesSent.Count - 1);
-        }
-
-        private void ApplyWhisperAttributes(ChatMessage message)
-        {
-            if (!detectWhisper) return;
-            var body = message.body;
-            if (string.IsNullOrWhiteSpace(body)) return;
-
-            var match = whisperRegex.Match(body);
-            if (!match.Success) return;
-
-            message.messageType = ChatMessage.Type.PRIVATE;
-            message.recipient = match.Groups[2].Value;
-            message.body = match.Groups[4].Value;
-        }
-
-        private void HandleInputFieldSelected()
-        {
-            currentHistoryIteration = 0;
-            OnInputFieldSelected?.Invoke();
-        }
-
-        private void HandleInputFieldDeselected() =>
-            currentHistoryIteration = 0;
-
-        private bool IsSpamming(string senderName)
-        {
-            if (string.IsNullOrEmpty(senderName)) return false;
-
-            var isSpamming = false;
-
-            if (!temporarilyMutedSenders.ContainsKey(senderName)) return false;
-
-            var muteTimestamp = DateTimeOffset.FromUnixTimeMilliseconds((long)temporarilyMutedSenders[senderName]);
-
-            if ((DateTimeOffset.UtcNow - muteTimestamp).Minutes < TEMPORARILY_MUTE_MINUTES)
-                isSpamming = true;
+            if (recipientProfile != null)
+                model.recipientName = recipientProfile.userName;
             else
-                temporarilyMutedSenders.Remove(senderName);
+            {
+                model.recipientName = message.recipient;
 
-            return isSpamming;
+                // sometimes there is no cached profile, so we request it
+                // dont block the operation of showing the message immediately
+                // just update the message information after we get the profile
+                EnsureProfileThenUpdateMessage(message.recipient, message, setScrollPositionToBottom, spamFiltering,
+                        limitMaxEntries, fetchProfileTries,
+                        profileFetchingCancellationToken.Token)
+                   .Forget();
+            }
         }
 
-        private void UpdateSpam(ChatEntryModel model)
+        if (message.sender != null)
         {
-            if (spamMessages.Count == 0)
-                spamMessages.Add(model);
-            else if (spamMessages[^1].senderName == model.senderName)
-            {
-                if (MessagesSentTooFast(spamMessages[^1].timestamp, model.timestamp))
-                {
-                    spamMessages.Add(model);
+            model.senderId = message.sender;
+            var senderProfile = userProfileBridge.Get(message.sender);
 
-                    if (spamMessages.Count >= MAX_CONTINUOUS_MESSAGES)
-                    {
-                        temporarilyMutedSenders.Add(model.senderName, model.timestamp);
-                        spamMessages.Clear();
-                    }
-                }
+            if (senderProfile != null)
+                model.senderName = senderProfile.userName;
+            else
+            {
+                model.senderName = message.sender;
+
+                // sometimes there is no cached profile, so we request it
+                // dont block the operation of showing the message immediately
+                // just update the message information after we get the profile
+                EnsureProfileThenUpdateMessage(message.sender, message, setScrollPositionToBottom, spamFiltering,
+                        limitMaxEntries, fetchProfileTries,
+                        profileFetchingCancellationToken.Token)
+                   .Forget();
+            }
+        }
+
+        if (message.messageType == ChatMessage.Type.PRIVATE)
+        {
+            model.subType = message.sender == ownProfile.userId
+                ? ChatEntryModel.SubType.SENT
+                : ChatEntryModel.SubType.RECEIVED;
+        }
+        else if (message.messageType == ChatMessage.Type.PUBLIC)
+        {
+            model.subType = message.sender == ownProfile.userId
+                ? ChatEntryModel.SubType.SENT
+                : ChatEntryModel.SubType.RECEIVED;
+        }
+
+        AddChatMessage(model, setScrollPositionToBottom, spamFiltering, limitMaxEntries,
+                addMessagesCancellationToken.Token)
+           .Forget();
+    }
+
+    public async UniTask AddChatMessage(ChatEntryModel chatEntryModel, bool setScrollPositionToBottom = false, bool spamFiltering = true, bool limitMaxEntries = true,
+        CancellationToken cancellationToken = default)
+    {
+        if (IsSpamming(chatEntryModel.senderName) && spamFiltering) return;
+
+        chatEntryModel.bodyText = ChatUtils.AddNoParse(chatEntryModel.bodyText);
+
+        if (IsProfanityFilteringEnabled() && chatEntryModel.messageType != ChatMessage.Type.PRIVATE)
+        {
+            chatEntryModel.bodyText = await profanityFilter.Filter(chatEntryModel.bodyText, cancellationToken);
+
+            if (!string.IsNullOrEmpty(chatEntryModel.senderName))
+                chatEntryModel.senderName = await profanityFilter.Filter(chatEntryModel.senderName, cancellationToken);
+
+            if (!string.IsNullOrEmpty(chatEntryModel.recipientName))
+                chatEntryModel.recipientName = await profanityFilter.Filter(chatEntryModel.recipientName, cancellationToken);
+        }
+
+        await UniTask.SwitchToMainThread(cancellationToken: cancellationToken);
+
+        view.AddEntry(chatEntryModel, setScrollPositionToBottom);
+
+        if (limitMaxEntries && view.EntryCount > MAX_CHAT_ENTRIES)
+            view.RemoveOldestEntry();
+
+        if (string.IsNullOrEmpty(chatEntryModel.senderId)) return;
+
+        if (spamFiltering)
+            UpdateSpam(chatEntryModel);
+    }
+
+    public void Dispose()
+    {
+        view.OnShowMenu -= ContextMenu_OnShowMenu;
+        view.OnMessageUpdated -= HandleMessageUpdated;
+        view.OnSendMessage -= HandleSendMessage;
+        view.OnInputFieldSelected -= HandleInputFieldSelected;
+        view.OnInputFieldDeselected -= HandleInputFieldDeselected;
+        view.OnPreviousChatInHistory -= FillInputWithPreviousMessage;
+        view.OnNextChatInHistory -= FillInputWithNextMessage;
+        view.OnMentionSuggestionSelected -= HandleMentionSuggestionSelected;
+        OnSendMessage = null;
+        OnInputFieldSelected = null;
+        view.Dispose();
+        mentionSuggestionCancellationToken.SafeCancelAndDispose();
+        profileFetchingCancellationToken.SafeCancelAndDispose();
+        addMessagesCancellationToken.SafeCancelAndDispose();
+    }
+
+    public void ClearAllEntries() =>
+        view.ClearAllEntries();
+
+    public void ResetInputField(bool loseFocus = false) =>
+        view.ResetInputField(loseFocus);
+
+    public void FocusInputField() =>
+        view.FocusInputField();
+
+    public void SetInputFieldText(string setInputText) =>
+        view.SetInputFieldText(setInputText);
+
+    public void UnfocusInputField() =>
+        view.UnfocusInputField();
+
+    private void ContextMenu_OnShowMenu() =>
+        view.OnMessageCancelHover();
+
+    private bool IsProfanityFilteringEnabled() =>
+        dataStore.settings.profanityChatFilteringEnabled.Get()
+        && profanityFilter != null;
+
+    private void HandleMessageUpdated(string message, int cursorPosition) =>
+        UpdateMentions(message, cursorPosition);
+
+    private void UpdateMentions(string message, int cursorPosition)
+    {
+        if (!isMentionsEnabled) return;
+
+        if (string.IsNullOrEmpty(message))
+        {
+            HideMentionSuggestions();
+            return;
+        }
+
+        async UniTaskVoid ShowMentionSuggestionsAsync(string name, CancellationToken cancellationToken)
+        {
+            try
+            {
+                List<UserProfile> suggestions = await getSuggestedUserProfiles.Invoke(name, MAX_MENTION_SUGGESTIONS, cancellationToken);
+
+                mentionSuggestedProfiles = suggestions.ToDictionary(profile => profile.userId, profile => profile);
+
+                if (suggestions.Count == 0)
+                    HideMentionSuggestions();
                 else
+                {
+                    view.ShowMentionSuggestions();
+                    dataStore.mentions.isMentionSuggestionVisible.Set(true);
+
+                    view.SetMentionSuggestions(suggestions.Select(profile => new ChatMentionSuggestionModel
+                                                           {
+                                                               userId = profile.userId,
+                                                               userName = profile.userName,
+                                                               imageUrl = profile.face256SnapshotURL,
+                                                           })
+                                                          .ToList());
+                }
+            }
+            catch (Exception e) when (e is not OperationCanceledException) { HideMentionSuggestions(); }
+        }
+
+        int lastWrittenCharacterIndex = Math.Max(0, cursorPosition - 1);
+
+        if (mentionFromIndex >= message.Length || message[lastWrittenCharacterIndex] == ' ')
+            mentionFromIndex = cursorPosition;
+
+        Match match = mentionRegex.Match(message, mentionFromIndex);
+
+        if (match.Success)
+        {
+            mentionSuggestionCancellationToken = mentionSuggestionCancellationToken.SafeRestart();
+            mentionFromIndex = match.Index;
+            mentionLength = match.Length;
+            string name = match.Value[1..];
+            ShowMentionSuggestionsAsync(name, mentionSuggestionCancellationToken.Token).Forget();
+        }
+        else
+        {
+            mentionSuggestionCancellationToken.SafeCancelAndDispose();
+            mentionFromIndex = lastWrittenCharacterIndex;
+            HideMentionSuggestions();
+        }
+    }
+
+    private void HandleSendMessage(ChatMessage message)
+    {
+        mentionFromIndex = 0;
+        HideMentionSuggestions();
+
+        var ownProfile = userProfileBridge.GetOwn();
+        message.sender = ownProfile.userId;
+
+        RegisterMessageHistory(message);
+        currentHistoryIteration = 0;
+
+        if (IsSpamming(message.sender) || (IsSpamming(ownProfile.userName) && !string.IsNullOrEmpty(message.body)))
+        {
+            OnMessageSentBlockedBySpam?.Invoke(message);
+            return;
+        }
+
+        if (MentionsUtils.TextContainsMention(message.body))
+            socialAnalytics.SendMessageWithMention();
+
+        ApplyWhisperAttributes(message);
+
+        if (message.body.ToLower().StartsWith("/join"))
+        {
+            if (!ownProfile.isGuest)
+                dataStore.channels.channelJoinedSource.Set(ChannelJoinedSource.Command);
+            else
+            {
+                dataStore.HUDs.connectWalletModalVisible.Set(true);
+                return;
+            }
+        }
+
+        OnSendMessage?.Invoke(message);
+    }
+
+    private void RegisterMessageHistory(ChatMessage message)
+    {
+        if (string.IsNullOrEmpty(message.body)) return;
+
+        lastMessagesSent.RemoveAll(s => s.Equals(message.body));
+        lastMessagesSent.Insert(0, message.body);
+
+        if (lastMessagesSent.Count > MAX_HISTORY_ITERATION)
+            lastMessagesSent.RemoveAt(lastMessagesSent.Count - 1);
+    }
+
+    private void ApplyWhisperAttributes(ChatMessage message)
+    {
+        if (!detectWhisper) return;
+        var body = message.body;
+        if (string.IsNullOrWhiteSpace(body)) return;
+
+        var match = whisperRegex.Match(body);
+        if (!match.Success) return;
+
+        message.messageType = ChatMessage.Type.PRIVATE;
+        message.recipient = match.Groups[2].Value;
+        message.body = match.Groups[4].Value;
+    }
+
+    private void HandleInputFieldSelected()
+    {
+        currentHistoryIteration = 0;
+        OnInputFieldSelected?.Invoke();
+    }
+
+    private void HandleInputFieldDeselected() =>
+        currentHistoryIteration = 0;
+
+    private bool IsSpamming(string senderName)
+    {
+        if (string.IsNullOrEmpty(senderName)) return false;
+
+        var isSpamming = false;
+
+        if (!temporarilyMutedSenders.ContainsKey(senderName)) return false;
+
+        var muteTimestamp = DateTimeOffset.FromUnixTimeMilliseconds((long)temporarilyMutedSenders[senderName]);
+
+        if ((DateTimeOffset.UtcNow - muteTimestamp).Minutes < TEMPORARILY_MUTE_MINUTES)
+            isSpamming = true;
+        else
+            temporarilyMutedSenders.Remove(senderName);
+
+        return isSpamming;
+    }
+
+    private void UpdateSpam(ChatEntryModel model)
+    {
+        if (spamMessages.Count == 0)
+            spamMessages.Add(model);
+        else if (spamMessages[^1].senderName == model.senderName)
+        {
+            if (MessagesSentTooFast(spamMessages[^1].timestamp, model.timestamp))
+            {
+                spamMessages.Add(model);
+
+                if (spamMessages.Count >= MAX_CONTINUOUS_MESSAGES)
+                {
+                    temporarilyMutedSenders.Add(model.senderName, model.timestamp);
                     spamMessages.Clear();
+                }
             }
             else
                 spamMessages.Clear();
         }
+        else
+            spamMessages.Clear();
+    }
 
-        private bool MessagesSentTooFast(ulong oldMessageTimeStamp, ulong newMessageTimeStamp)
+    private bool MessagesSentTooFast(ulong oldMessageTimeStamp, ulong newMessageTimeStamp)
+    {
+        var oldDateTime = DateTimeOffset.FromUnixTimeMilliseconds((long)oldMessageTimeStamp);
+        var newDateTime = DateTimeOffset.FromUnixTimeMilliseconds((long)newMessageTimeStamp);
+        return (newDateTime - oldDateTime).TotalMilliseconds < MIN_MILLISECONDS_BETWEEN_MESSAGES;
+    }
+
+    private void FillInputWithNextMessage()
+    {
+        if (lastMessagesSent.Count == 0) return;
+        view.FocusInputField();
+        view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
+        currentHistoryIteration = (currentHistoryIteration + 1) % lastMessagesSent.Count;
+    }
+
+    private void FillInputWithPreviousMessage()
+    {
+        if (lastMessagesSent.Count == 0)
         {
-            var oldDateTime = DateTimeOffset.FromUnixTimeMilliseconds((long)oldMessageTimeStamp);
-            var newDateTime = DateTimeOffset.FromUnixTimeMilliseconds((long)newMessageTimeStamp);
-            return (newDateTime - oldDateTime).TotalMilliseconds < MIN_MILLISECONDS_BETWEEN_MESSAGES;
+            view.ResetInputField();
+            return;
         }
 
-        private void FillInputWithNextMessage()
-        {
-            if (lastMessagesSent.Count == 0) return;
-            view.FocusInputField();
-            view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
-            currentHistoryIteration = (currentHistoryIteration + 1) % lastMessagesSent.Count;
-        }
+        currentHistoryIteration--;
 
-        private void FillInputWithPreviousMessage()
-        {
-            if (lastMessagesSent.Count == 0)
-            {
-                view.ResetInputField();
-                return;
-            }
+        if (currentHistoryIteration < 0)
+            currentHistoryIteration = lastMessagesSent.Count - 1;
 
-            currentHistoryIteration--;
+        view.FocusInputField();
+        view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
+    }
 
-            if (currentHistoryIteration < 0)
-                currentHistoryIteration = lastMessagesSent.Count - 1;
+    private void HandleMentionSuggestionSelected(string userId)
+    {
+        view.AddMentionToInputField(mentionFromIndex, mentionLength, userId, mentionSuggestedProfiles[userId].userName);
+        socialAnalytics.SendMentionCreated(MentionCreationSource.SuggestionList);
+        HideMentionSuggestions();
+    }
 
-            view.FocusInputField();
-            view.SetInputFieldText(lastMessagesSent[currentHistoryIteration]);
-        }
-
-        private void HandleMentionSuggestionSelected(string userId)
-        {
-            view.AddMentionToInputField(mentionFromIndex, mentionLength, userId, mentionSuggestedProfiles[userId].userName);
-            socialAnalytics.SendMentionCreated(MentionCreationSource.SuggestionList);
-            HideMentionSuggestions();
-        }
-
-        private void HideMentionSuggestions()
-        {
-            view.HideMentionSuggestions();
-            dataStore.mentions.isMentionSuggestionVisible.Set(false);
-        }
+    private void HideMentionSuggestions()
+    {
+        view.HideMentionSuggestions();
+        dataStore.mentions.isMentionSuggestionVisible.Set(false);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDController.cs
@@ -144,6 +144,9 @@ public class ChatHUDController : IHUD
             catch (Exception e) when (e is not OperationCanceledException) { Debug.LogException(e); }
         }
 
+        string GetEllipsisFormat(string address) =>
+            address.Length <= 8 ? address : $"{address[..4]}...{address[^4..]}";
+
         var model = new ChatEntryModel();
         var ownProfile = userProfileBridge.GetOwn();
 
@@ -155,13 +158,13 @@ public class ChatHUDController : IHUD
 
         if (message.recipient != null)
         {
-            var recipientProfile = userProfileBridge.Get(message.recipient);
+            UserProfile recipientProfile = userProfileBridge.Get(message.recipient);
 
             if (recipientProfile != null)
                 model.recipientName = recipientProfile.userName;
             else
             {
-                model.recipientName = message.recipient;
+                model.recipientName = GetEllipsisFormat(message.recipient);
 
                 // sometimes there is no cached profile, so we request it
                 // dont block the operation of showing the message immediately
@@ -176,13 +179,13 @@ public class ChatHUDController : IHUD
         if (message.sender != null)
         {
             model.senderId = message.sender;
-            var senderProfile = userProfileBridge.Get(message.sender);
+            UserProfile senderProfile = userProfileBridge.Get(message.sender);
 
             if (senderProfile != null)
                 model.senderName = senderProfile.userName;
             else
             {
-                model.senderName = message.sender;
+                model.senderName = GetEllipsisFormat(message.sender);
 
                 // sometimes there is no cached profile, so we request it
                 // dont block the operation of showing the message immediately

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -429,7 +429,7 @@ namespace DCL.Social.Chat
             if (contextMenu == null || contextMenu.isVisible)
                 return;
 
-            messageHoverText.text = chatEntry.DateString;
+            messageHoverText.text = chatEntry.HoverString;
             chatEntry.DockHoverPanel((RectTransform)messageHoverPanel.transform);
             messageHoverPanel.SetActive(true);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/ChatHUDView.cs
@@ -217,7 +217,7 @@ namespace DCL.Social.Chat
             ClearAllEntries();
 
             foreach (var entry in model.entries)
-                AddEntry(entry);
+                SetEntry(entry);
         }
 
         public void FocusInputField()
@@ -271,7 +271,7 @@ namespace DCL.Social.Chat
             FocusInputField();
         }
 
-        public virtual void AddEntry(ChatEntryModel model, bool setScrollPositionToBottom = false)
+        public virtual void SetEntry(ChatEntryModel model, bool setScrollPositionToBottom = false)
         {
             if (entries.ContainsKey(model.messageId))
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DateSeparatorEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DateSeparatorEntry.cs
@@ -14,7 +14,7 @@ public class DateSeparatorEntry : ChatEntry
     private DateTime timestamp;
     private ChatEntryModel chatEntryModel;
 
-    public override string DateString =>
+    public override string HoverString =>
         GetDateFormat(GetDateTimeFromUnixTimestampMilliseconds(Model.timestamp));
     public override event Action<ChatEntry> OnUserNameClicked;
     public override event Action<ChatEntry> OnTriggerHover;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -4,6 +4,7 @@ using DCL.Interface;
 using DCL.SettingsCommon;
 using DCL.Social.Chat.Mentions;
 using System;
+using System.Globalization;
 using System.Threading;
 using TMPro;
 using UnityEngine;
@@ -36,10 +37,19 @@ namespace DCL.Chat.HUD
 
         public override ChatEntryModel Model => model;
 
-        public override string DateString =>
-            DateTimeOffset.FromUnixTimeMilliseconds((long) Model.timestamp)
-                .ToLocalTime()
-                .ToString("MM/dd/yyyy h:mm:ss tt");
+        public override string HoverString
+        {
+            get
+            {
+                var date = DateTimeOffset.FromUnixTimeMilliseconds((long)Model.timestamp)
+                                         .ToLocalTime()
+                                         .ToString("MM/dd/yy h:mm:ss tt", CultureInfo.InvariantCulture);
+
+                return Model.isLoadingNames ? $"Loading name - {date}" : date;
+            }
+        }
+
+
         public override event Action<ChatEntry> OnUserNameClicked;
         public override event Action<ChatEntry> OnTriggerHover;
         public override event Action<ChatEntry, ParcelCoordinates> OnTriggerHoverGoto;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
@@ -3,34 +3,37 @@ using DCL.Interface;
 using System;
 using System.Collections.Generic;
 
-public interface IChatHUDComponentView
+namespace DCL.Social.Chat
 {
-    event Action<ChatMessage> OnSendMessage;
-    event Action<string, int> OnMessageUpdated;
-    event Action OnOpenedContextMenu;
-    event Action OnShowMenu;
-    event Action OnInputFieldSelected;
-    event Action OnInputFieldDeselected;
-    event Action OnPreviousChatInHistory;
-    event Action OnNextChatInHistory;
-    event Action<string> OnMentionSuggestionSelected;
+    public interface IChatHUDComponentView
+    {
+        event Action<ChatMessage> OnSendMessage;
+        event Action<string, int> OnMessageUpdated;
+        event Action OnOpenedContextMenu;
+        event Action OnShowMenu;
+        event Action OnInputFieldSelected;
+        event Action OnInputFieldDeselected;
+        event Action OnPreviousChatInHistory;
+        event Action OnNextChatInHistory;
+        event Action<string> OnMentionSuggestionSelected;
 
-    int EntryCount { get; }
+        int EntryCount { get; }
     IComparer<ChatEntryModel> SortingStrategy { set; }
     bool UseLegacySorting { set; }
 
-    void OnMessageCancelHover();
-    void AddEntry(ChatEntryModel model, bool setScrollPositionToBottom = false);
-    void Dispose();
-    void RemoveOldestEntry();
-    void ClearAllEntries();
-    void ResetInputField(bool loseFocus = false);
-    void FocusInputField();
-    void UnfocusInputField();
-    void SetInputFieldText(string text);
-    void ShowMentionSuggestions();
-    void SetMentionSuggestions(List<ChatMentionSuggestionModel> suggestions);
-    void HideMentionSuggestions();
-    void AddMentionToInputField(int fromIndex, int length, string userId, string userName);
-    void AddTextIntoInputField(string text);
+        void OnMessageCancelHover();
+        void AddEntry(ChatEntryModel model, bool setScrollPositionToBottom = false);
+        void Dispose();
+        void RemoveOldestEntry();
+        void ClearAllEntries();
+        void ResetInputField(bool loseFocus = false);
+        void FocusInputField();
+        void UnfocusInputField();
+        void SetInputFieldText(string text);
+        void ShowMentionSuggestions();
+        void SetMentionSuggestions(List<ChatMentionSuggestionModel> suggestions);
+        void HideMentionSuggestions();
+        void AddMentionToInputField(int fromIndex, int length, string userId, string userName);
+        void AddTextIntoInputField(string text);
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/IChatHUDComponentView.cs
@@ -22,7 +22,7 @@ namespace DCL.Social.Chat
     bool UseLegacySorting { set; }
 
         void OnMessageCancelHover();
-        void AddEntry(ChatEntryModel model, bool setScrollPositionToBottom = false);
+        void SetEntry(ChatEntryModel model, bool setScrollPositionToBottom = false);
         void Dispose();
         void RemoveOldestEntry();
         void ClearAllEntries();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -90,7 +90,7 @@ public class ChatHUDControllerShould
                 bodyText = "test"
             };
 
-            await controller.AddChatMessage(msg);
+            await controller.SetChatMessage(msg);
 
             view.Received(1).RemoveOldestEntry();
         });
@@ -106,10 +106,10 @@ public class ChatHUDControllerShould
                 bodyText = "test"
             };
 
-            await controller.AddChatMessage(msg);
+            await controller.SetChatMessage(msg);
 
             view.Received(1)
-                .AddEntry(Arg.Is<ChatEntryModel>(
+                .SetEntry(Arg.Is<ChatEntryModel>(
                      model => model.messageType == msg.messageType && model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
         });
 
@@ -157,10 +157,10 @@ public class ChatHUDControllerShould
                     bodyText = body
                 };
 
-                await controller.AddChatMessage(msg);
+                await controller.SetChatMessage(msg);
 
                 view.Received(1)
-                    .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
+                    .SetEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
             });
 
     [UnityTest]
@@ -179,10 +179,10 @@ public class ChatHUDControllerShould
                     bodyText = body
                 };
 
-                await controller.AddChatMessage(msg);
+                await controller.SetChatMessage(msg);
 
                 view.Received(1)
-                    .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
+                    .SetEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
             });
 
     [UnityTest]
@@ -201,9 +201,9 @@ public class ChatHUDControllerShould
                     bodyText = "test"
                 };
 
-                await controller.AddChatMessage(msg);
+                await controller.SetChatMessage(msg);
 
-                view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.senderName.Equals(filteredName)));
+                view.Received(1).SetEntry(Arg.Is<ChatEntryModel>(model => model.senderName.Equals(filteredName)));
             });
 
     [UnityTest]
@@ -223,9 +223,9 @@ public class ChatHUDControllerShould
                     bodyText = "test"
                 };
 
-                await controller.AddChatMessage(msg);
+                await controller.SetChatMessage(msg);
 
-                view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.recipientName.Equals(filteredName)));
+                view.Received(1).SetEntry(Arg.Is<ChatEntryModel>(model => model.recipientName.Equals(filteredName)));
             });
 
     [UnityTest]
@@ -241,10 +241,10 @@ public class ChatHUDControllerShould
                 bodyText = "shit"
             };
 
-            await controller.AddChatMessage(msg);
+            await controller.SetChatMessage(msg);
 
             view.Received(1)
-                .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
+                .SetEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
         });
 
     [UnityTest]
@@ -258,10 +258,10 @@ public class ChatHUDControllerShould
                 bodyText = "shit"
             };
 
-            await controller.AddChatMessage(msg);
+            await controller.SetChatMessage(msg);
 
             view.Received(1)
-                .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
+                .SetEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
         });
 
     [Test]
@@ -424,19 +424,17 @@ public class ChatHUDControllerShould
             const string RECIPIENT_ID = "recId";
             const string RECIPIENT_NAME = "recipientName";
 
-            var senderProfile = ScriptableObject.CreateInstance<UserProfile>();
-            senderProfile.UpdateData(new UserProfileModel { userId = SENDER_ID, name = SENDER_NAME });
+            var senderProfile = GivenProfile(SENDER_ID, SENDER_NAME, "");
             userProfileBridge.Get(SENDER_ID).Returns(senderProfile);
 
-            var recipientProfile = ScriptableObject.CreateInstance<UserProfile>();
-            recipientProfile.UpdateData(new UserProfileModel { userId = RECIPIENT_ID, name = RECIPIENT_NAME });
+            var recipientProfile = GivenProfile(RECIPIENT_ID, RECIPIENT_NAME, "");
 
             userProfileBridge.RequestFullUserProfileAsync(RECIPIENT_ID, Arg.Any<CancellationToken>())
                              .Returns(UniTask.FromResult(recipientProfile));
 
             userProfileBridge.Get(RECIPIENT_ID).Returns(null, recipientProfile);
 
-            controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
+            controller.SetChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
             {
                 recipient = RECIPIENT_ID,
             });
@@ -447,8 +445,8 @@ public class ChatHUDControllerShould
 
             Received.InOrder(() =>
             {
-                view.AddEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_ID));
-                view.AddEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_NAME));
+                view.SetEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_ID));
+                view.SetEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_NAME));
             });
         });
 
@@ -473,7 +471,7 @@ public class ChatHUDControllerShould
 
             userProfileBridge.Get(SENDER_ID).Returns(null, senderProfile);
 
-            controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PUBLIC, SENDER_ID, "hey", 100));
+            controller.SetChatMessage(new ChatMessage("msg1", ChatMessage.Type.PUBLIC, SENDER_ID, "hey", 100));
 
             await UniTask.NextFrame();
 
@@ -481,8 +479,8 @@ public class ChatHUDControllerShould
 
             Received.InOrder(() =>
             {
-                view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_ID));
-                view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_NAME));
+                view.SetEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_ID));
+                view.SetEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_NAME));
             });
         });
 
@@ -494,14 +492,16 @@ public class ChatHUDControllerShould
             const string RECIPIENT_ID = "0xfa2d32345f2a5f352af3df";
 
             userProfileBridge.RequestFullUserProfileAsync(SENDER_ID, Arg.Any<CancellationToken>())
-                             .Returns(UniTask.FromResult((UserProfile)null));
+                             .Returns(UniTask.FromResult(GivenProfile(SENDER_ID, "senderName", "")));
+
             userProfileBridge.Get(SENDER_ID).Returns((UserProfile)null);
 
             userProfileBridge.RequestFullUserProfileAsync(RECIPIENT_ID, Arg.Any<CancellationToken>())
-                             .Returns(UniTask.FromResult((UserProfile)null));
+                             .Returns(UniTask.FromResult(GivenProfile(RECIPIENT_ID, "recipientName", "")));
+
             userProfileBridge.Get(RECIPIENT_ID).Returns((UserProfile)null);
 
-            controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
+            controller.SetChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
             {
                 recipient = RECIPIENT_ID,
             });
@@ -510,7 +510,7 @@ public class ChatHUDControllerShould
 
             userProfileBridge.Received(1).RequestFullUserProfileAsync(SENDER_ID, Arg.Any<CancellationToken>());
 
-            view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == "0xfa...7fd4" && c.recipientName == "0xfa...f3df"));
+            view.SetEntry(Arg.Is<ChatEntryModel>(c => c.senderName == "0xfa...7fd4" && c.recipientName == "0xfa...f3df"));
         });
 
     private UserProfile GivenProfile(string userId, string username, string face256)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -46,6 +46,7 @@ public class ChatHUDControllerShould
         controller = new ChatHUDController(dataStore, userProfileBridge, true,
             (name, count, token) => UniTask.FromResult(suggestedProfilesAction.Invoke()),
             Substitute.For<ISocialAnalytics>(),
+            Substitute.For<IChatController>(),
             profanityFilter);
 
         controller.Initialize(view);
@@ -438,7 +439,6 @@ public class ChatHUDControllerShould
             controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
             {
                 recipient = RECIPIENT_ID,
-                isChannelMessage = false,
             });
 
             await UniTask.NextFrame();
@@ -473,10 +473,7 @@ public class ChatHUDControllerShould
 
             userProfileBridge.Get(SENDER_ID).Returns(null, senderProfile);
 
-            controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PUBLIC, SENDER_ID, "hey", 100)
-            {
-                isChannelMessage = false,
-            });
+            controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PUBLIC, SENDER_ID, "hey", 100));
 
             await UniTask.NextFrame();
 
@@ -506,7 +503,6 @@ public class ChatHUDControllerShould
 
             controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
             {
-                isChannelMessage = false,
                 recipient = RECIPIENT_ID,
             });
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -1,7 +1,9 @@
 using Cysharp.Threading.Tasks;
+using DCL;
 using DCL.Chat.HUD;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
+using DCL.Social.Chat;
 using NSubstitute;
 using NUnit.Framework;
 using SocialFeaturesAnalytics;
@@ -12,498 +14,495 @@ using System.Threading;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace DCL.Social.Chat
+public class ChatHUDControllerShould
 {
-    public class ChatHUDControllerShould
+    private const string OWN_USER_ID = "ownUserId";
+
+    private ChatHUDController controller;
+    private IChatHUDComponentView view;
+    private DataStore dataStore;
+    private IProfanityFilter profanityFilter;
+    private Func<List<UserProfile>> suggestedProfilesAction;
+    private IUserProfileBridge userProfileBridge;
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string OWN_USER_ID = "ownUserId";
+        profanityFilter = Substitute.For<IProfanityFilter>();
 
-        private ChatHUDController controller;
-        private IChatHUDComponentView view;
-        private DataStore dataStore;
-        private IProfanityFilter profanityFilter;
-        private Func<List<UserProfile>> suggestedProfilesAction;
-        private IUserProfileBridge userProfileBridge;
+        profanityFilter.Filter(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                       .Returns(info => UniTask.FromResult(info[0].ToString()));
 
-        [SetUp]
-        public void SetUp()
+        dataStore = new DataStore();
+        dataStore.settings.profanityChatFilteringEnabled.Set(true);
+        dataStore.featureFlags.flags.Set(new FeatureFlag { flags = { ["chat_mentions_enabled"] = true } });
+        view = Substitute.For<IChatHUDComponentView>();
+        userProfileBridge = Substitute.For<IUserProfileBridge>();
+        var ownUserProfile = ScriptableObject.CreateInstance<UserProfile>();
+        ownUserProfile.UpdateData(new UserProfileModel { userId = OWN_USER_ID });
+        userProfileBridge.GetOwn().Returns(ownUserProfile);
+        suggestedProfilesAction = () => new List<UserProfile>();
+
+        controller = new ChatHUDController(dataStore, userProfileBridge, true,
+            (name, count, token) => UniTask.FromResult(suggestedProfilesAction.Invoke()),
+            Substitute.For<ISocialAnalytics>(),
+            profanityFilter);
+
+        controller.Initialize(view);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        controller.Dispose();
+    }
+
+    [Test]
+    public void SubmitMessageProperly()
+    {
+        ChatMessage sentMsg = null;
+
+        void SendMessage(ChatMessage msg) =>
+            sentMsg = msg;
+
+        controller.OnSendMessage += SendMessage;
+
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(
+            new ChatMessage(ChatMessage.Type.PUBLIC, "idk", "test message"));
+
+        Assert.AreEqual("test message", sentMsg.body);
+        Assert.AreEqual(ChatMessage.Type.PUBLIC, sentMsg.messageType);
+        Assert.AreEqual(OWN_USER_ID, sentMsg.sender);
+        controller.OnSendMessage -= SendMessage;
+    }
+
+    [UnityTest]
+    public IEnumerator TrimWhenTooMuchMessagesAreInView() =>
+        UniTask.ToCoroutine(async () =>
         {
-            profanityFilter = Substitute.For<IProfanityFilter>();
+            view.EntryCount.Returns(ChatHUDController.MAX_CHAT_ENTRIES + 1);
 
-            profanityFilter.Filter(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                           .Returns(info => UniTask.FromResult(info[0].ToString()));
-
-            dataStore = new DataStore();
-            dataStore.settings.profanityChatFilteringEnabled.Set(true);
-            dataStore.featureFlags.flags.Set(new FeatureFlag { flags = { ["chat_mentions_enabled"] = true } });
-            view = Substitute.For<IChatHUDComponentView>();
-            userProfileBridge = Substitute.For<IUserProfileBridge>();
-            var ownUserProfile = ScriptableObject.CreateInstance<UserProfile>();
-            ownUserProfile.UpdateData(new UserProfileModel { userId = OWN_USER_ID });
-            userProfileBridge.GetOwn().Returns(ownUserProfile);
-            suggestedProfilesAction = () => new List<UserProfile>();
-
-            controller = new ChatHUDController(dataStore, userProfileBridge, true,
-                (name, count, token) => UniTask.FromResult(suggestedProfilesAction.Invoke()),
-                Substitute.For<ISocialAnalytics>(),
-                profanityFilter);
-
-            controller.Initialize(view);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            controller.Dispose();
-        }
-
-        [Test]
-        public void SubmitMessageProperly()
-        {
-            ChatMessage sentMsg = null;
-
-            void SendMessage(ChatMessage msg) =>
-                sentMsg = msg;
-
-            controller.OnSendMessage += SendMessage;
-
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(
-                new ChatMessage(ChatMessage.Type.PUBLIC, "idk", "test message"));
-
-            Assert.AreEqual("test message", sentMsg.body);
-            Assert.AreEqual(ChatMessage.Type.PUBLIC, sentMsg.messageType);
-            Assert.AreEqual(OWN_USER_ID, sentMsg.sender);
-            controller.OnSendMessage -= SendMessage;
-        }
-
-        [UnityTest]
-        public IEnumerator TrimWhenTooMuchMessagesAreInView() =>
-            UniTask.ToCoroutine(async () =>
+            var msg = new ChatEntryModel
             {
-                view.EntryCount.Returns(ChatHUDController.MAX_CHAT_ENTRIES + 1);
-
-                var msg = new ChatEntryModel
-                {
-                    messageType = ChatMessage.Type.PUBLIC,
-                    senderName = "test",
-                    bodyText = "test"
-                };
-
-                await controller.AddChatMessage(msg);
-
-                view.Received(1).RemoveOldestEntry();
-            });
-
-        [UnityTest]
-        public IEnumerator AddChatEntryProperly() =>
-            UniTask.ToCoroutine(async () =>
-            {
-                var msg = new ChatEntryModel
-                {
-                    messageType = ChatMessage.Type.PUBLIC,
-                    senderName = "test",
-                    bodyText = "test"
-                };
-
-                await controller.AddChatMessage(msg);
-
-                view.Received(1)
-                    .AddEntry(Arg.Is<ChatEntryModel>(
-                         model => model.messageType == msg.messageType && model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
-            });
-
-        [TestCase("/w usr hello", "usr", "hello")]
-        [TestCase("/w usr im goku", "usr", "im goku")]
-        public void SetWhisperPropertiesWhenSendMessage(string text, string recipient, string body)
-        {
-            ChatMessage msg = null;
-            controller.OnSendMessage += m => msg = m;
-
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.NONE, "", text));
-
-            Assert.AreEqual(OWN_USER_ID, msg.sender);
-            Assert.AreEqual(ChatMessage.Type.PRIVATE, msg.messageType);
-            Assert.AreEqual(recipient, msg.recipient);
-            Assert.AreEqual(body, msg.body);
-        }
-
-        [Test]
-        public void SetSenderWhenSendingPublicMessage()
-        {
-            const string body = "how are you?";
-            ChatMessage msg = null;
-            controller.OnSendMessage += m => msg = m;
-
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.NONE, "", body));
-
-            Assert.AreEqual(OWN_USER_ID, msg.sender);
-            Assert.AreEqual(body, msg.body);
-        }
-
-        [UnityTest]
-        [TestCase("ShiT hello shithead", "**** hello shithead", ExpectedResult = (IEnumerator)null)]
-        [TestCase("ass hi grass", "*** hi grass", ExpectedResult = (IEnumerator)null)]
-        public IEnumerator FilterProfanityMessageWithExplicitWords(string body, string expected) =>
-            UniTask.ToCoroutine(
-                async () =>
-                {
-                    profanityFilter.Filter($"<noparse>{body}</noparse>").Returns(UniTask.FromResult($"<noparse>{expected}</noparse>"));
-
-                    var msg = new ChatEntryModel
-                    {
-                        messageType = ChatMessage.Type.PUBLIC,
-                        senderName = "test",
-                        bodyText = body
-                    };
-
-                    await controller.AddChatMessage(msg);
-
-                    view.Received(1)
-                        .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
-                });
-
-        [UnityTest]
-        [TestCase("fuck1 heh bitch", "****1 heh *****", ExpectedResult = (IEnumerator)null)]
-        [TestCase("assfuck bitching", "ass**** *****ing", ExpectedResult = (IEnumerator)null)]
-        public IEnumerator FilterProfanityMessageWithNonExplicitWords(string body, string expected) =>
-            UniTask.ToCoroutine(
-                async () =>
-                {
-                    profanityFilter.Filter($"<noparse>{body}</noparse>").Returns(UniTask.FromResult($"<noparse>{expected}</noparse>"));
-
-                    var msg = new ChatEntryModel
-                    {
-                        messageType = ChatMessage.Type.PUBLIC,
-                        senderName = "test",
-                        bodyText = body
-                    };
-
-                    await controller.AddChatMessage(msg);
-
-                    view.Received(1)
-                        .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
-                });
-
-        [UnityTest]
-        [TestCase("fucker123", "****er123", ExpectedResult = (IEnumerator)null)]
-        [TestCase("goodname", "goodname", ExpectedResult = (IEnumerator)null)]
-        public IEnumerator FilterProfanitySenderName(string originalName, string filteredName) =>
-            UniTask.ToCoroutine(
-                async () =>
-                {
-                    profanityFilter.Filter(originalName).Returns(UniTask.FromResult(filteredName));
-
-                    var msg = new ChatEntryModel
-                    {
-                        messageType = ChatMessage.Type.PUBLIC,
-                        senderName = originalName,
-                        bodyText = "test"
-                    };
-
-                    await controller.AddChatMessage(msg);
-
-                    view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.senderName.Equals(filteredName)));
-                });
-
-        [UnityTest]
-        [TestCase("assholeeee", "*******eee", ExpectedResult = (IEnumerator)null)]
-        [TestCase("goodname", "goodname", ExpectedResult = (IEnumerator)null)]
-        public IEnumerator FilterProfanityReceiverName(string originalName, string filteredName) =>
-            UniTask.ToCoroutine(
-                async () =>
-                {
-                    profanityFilter.Filter(originalName).Returns(UniTask.FromResult(filteredName));
-
-                    var msg = new ChatEntryModel
-                    {
-                        messageType = ChatMessage.Type.PUBLIC,
-                        senderName = "test",
-                        recipientName = originalName,
-                        bodyText = "test"
-                    };
-
-                    await controller.AddChatMessage(msg);
-
-                    view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.recipientName.Equals(filteredName)));
-                });
-
-        [UnityTest]
-        public IEnumerator DoNotFilterProfanityMessageWhenFeatureFlagIsDisabled() =>
-            UniTask.ToCoroutine(async () =>
-            {
-                dataStore.settings.profanityChatFilteringEnabled.Set(false);
-
-                var msg = new ChatEntryModel
-                {
-                    messageType = ChatMessage.Type.PUBLIC,
-                    senderName = "test",
-                    bodyText = "shit"
-                };
-
-                await controller.AddChatMessage(msg);
-
-                view.Received(1)
-                    .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
-            });
-
-        [UnityTest]
-        public IEnumerator DoNotFilterProfanityMessageWhenIsPrivate() =>
-            UniTask.ToCoroutine(async () =>
-            {
-                var msg = new ChatEntryModel
-                {
-                    messageType = ChatMessage.Type.PRIVATE,
-                    senderName = "test",
-                    bodyText = "shit"
-                };
-
-                await controller.AddChatMessage(msg);
-
-                view.Received(1)
-                    .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
-            });
-
-        [Test]
-        public void DisplayNextMessageInHistory()
-        {
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
-            view.OnNextChatInHistory += Raise.Event<Action>();
-            view.OnNextChatInHistory += Raise.Event<Action>();
-
-            Received.InOrder(() =>
-            {
-                view.SetInputFieldText("sup");
-                view.SetInputFieldText("hey");
-            });
-        }
-
-        [Test]
-        public void DisplayPreviousMessageInHistory()
-        {
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
-            view.OnPreviousChatInHistory += Raise.Event<Action>();
-            view.OnPreviousChatInHistory += Raise.Event<Action>();
-
-            Received.InOrder(() =>
-            {
-                view.SetInputFieldText("hey");
-                view.SetInputFieldText("sup");
-            });
-        }
-
-        [Test]
-        public void DoNotDuplicateMessagesInHistory()
-        {
-            const string repeatedMessage = "hey";
-
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "bleh"));
-            view.OnNextChatInHistory += Raise.Event<Action>();
-            view.OnNextChatInHistory += Raise.Event<Action>();
-            view.OnNextChatInHistory += Raise.Event<Action>();
-
-            Received.InOrder(() =>
-            {
-                view.SetInputFieldText("bleh");
-                view.SetInputFieldText(repeatedMessage);
-                view.SetInputFieldText("bleh");
-            });
-        }
-
-        [TestCase(false)]
-        [TestCase(true)]
-        public void ResetInputField(bool loseFocus)
-        {
-            controller.ResetInputField(loseFocus);
-
-            view.Received(1).ResetInputField(loseFocus);
-        }
-
-        [Test]
-        public void UnfocusInputField()
-        {
-            controller.UnfocusInputField();
-
-            view.Received(1).UnfocusInputField();
-        }
-
-        [TestCase("hehe")]
-        [TestCase("jojo")]
-        [TestCase("lelleolololohohoho")]
-        public void SetInputFieldText(string text)
-        {
-            controller.SetInputFieldText(text);
-
-            view.Received(1).SetInputFieldText(text);
-        }
-
-        [Test]
-        public void ClearAllEntries()
-        {
-            controller.ClearAllEntries();
-
-            view.Received(1).ClearAllEntries();
-        }
-
-        [Test]
-        public void SetChannelJoinSourceWhenJoinCommandIsWritten()
-        {
-            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "/join my-channel"));
-
-            Assert.AreEqual(ChannelJoinedSource.Command, dataStore.channels.channelJoinedSource.Get());
-        }
-
-        [TestCase("@", 1)]
-        [TestCase("@u", 2)]
-        [TestCase("hey @", 5)]
-        public void ShowMentionSuggestions(string text, int cursorPosition)
-        {
-            UserProfile user1 = GivenProfile("u1", "userName1", "faceU1");
-            UserProfile user2 = GivenProfile("u2", "userName2", "faceU2");
-
-            suggestedProfilesAction = () => new List<UserProfile>
-            {
-                user1,
-                user2,
+                messageType = ChatMessage.Type.PUBLIC,
+                senderName = "test",
+                bodyText = "test"
             };
 
-            view.OnMessageUpdated += Raise.Event<Action<string, int>>(text, cursorPosition);
+            await controller.AddChatMessage(msg);
 
-            view.Received(1).ShowMentionSuggestions();
+            view.Received(1).RemoveOldestEntry();
+        });
+
+    [UnityTest]
+    public IEnumerator AddChatEntryProperly() =>
+        UniTask.ToCoroutine(async () =>
+        {
+            var msg = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PUBLIC,
+                senderName = "test",
+                bodyText = "test"
+            };
+
+            await controller.AddChatMessage(msg);
 
             view.Received(1)
-                .SetMentionSuggestions(Arg.Is<List<ChatMentionSuggestionModel>>(l =>
-                     l[0].userId == "u1" && l[0].userName == "userName1" && l[0].imageUrl == "faceU1"
-                     && l[1].userId == "u2" && l[1].userName == "userName2" && l[1].imageUrl == "faceU2"));
-        }
+                .AddEntry(Arg.Is<ChatEntryModel>(
+                     model => model.messageType == msg.messageType && model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
+        });
 
-        [TestCase("h", 1)]
-        [TestCase("how are you?", 4)]
-        [TestCase("my email is something@domain.com", 0)]
-        [TestCase("i just wrote an @ ", 18)]
-        public void DoNotShowMentionSuggestionsWhenNoPatternIsMatched(string text, int cursorPosition)
-        {
-            UserProfile user1 = GivenProfile("u1", "userName1", "faceU1");
-            UserProfile user2 = GivenProfile("u2", "userName2", "faceU2");
+    [TestCase("/w usr hello", "usr", "hello")]
+    [TestCase("/w usr im goku", "usr", "im goku")]
+    public void SetWhisperPropertiesWhenSendMessage(string text, string recipient, string body)
+    {
+        ChatMessage msg = null;
+        controller.OnSendMessage += m => msg = m;
 
-            suggestedProfilesAction = () => new List<UserProfile>
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.NONE, "", text));
+
+        Assert.AreEqual(OWN_USER_ID, msg.sender);
+        Assert.AreEqual(ChatMessage.Type.PRIVATE, msg.messageType);
+        Assert.AreEqual(recipient, msg.recipient);
+        Assert.AreEqual(body, msg.body);
+    }
+
+    [Test]
+    public void SetSenderWhenSendingPublicMessage()
+    {
+        const string body = "how are you?";
+        ChatMessage msg = null;
+        controller.OnSendMessage += m => msg = m;
+
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.NONE, "", body));
+
+        Assert.AreEqual(OWN_USER_ID, msg.sender);
+        Assert.AreEqual(body, msg.body);
+    }
+
+    [UnityTest]
+    [TestCase("ShiT hello shithead", "**** hello shithead", ExpectedResult = (IEnumerator)null)]
+    [TestCase("ass hi grass", "*** hi grass", ExpectedResult = (IEnumerator)null)]
+    public IEnumerator FilterProfanityMessageWithExplicitWords(string body, string expected) =>
+        UniTask.ToCoroutine(
+            async () =>
             {
-                user1,
-                user2,
+                profanityFilter.Filter($"<noparse>{body}</noparse>").Returns(UniTask.FromResult($"<noparse>{expected}</noparse>"));
+
+                var msg = new ChatEntryModel
+                {
+                    messageType = ChatMessage.Type.PUBLIC,
+                    senderName = "test",
+                    bodyText = body
+                };
+
+                await controller.AddChatMessage(msg);
+
+                view.Received(1)
+                    .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
+            });
+
+    [UnityTest]
+    [TestCase("fuck1 heh bitch", "****1 heh *****", ExpectedResult = (IEnumerator)null)]
+    [TestCase("assfuck bitching", "ass**** *****ing", ExpectedResult = (IEnumerator)null)]
+    public IEnumerator FilterProfanityMessageWithNonExplicitWords(string body, string expected) =>
+        UniTask.ToCoroutine(
+            async () =>
+            {
+                profanityFilter.Filter($"<noparse>{body}</noparse>").Returns(UniTask.FromResult($"<noparse>{expected}</noparse>"));
+
+                var msg = new ChatEntryModel
+                {
+                    messageType = ChatMessage.Type.PUBLIC,
+                    senderName = "test",
+                    bodyText = body
+                };
+
+                await controller.AddChatMessage(msg);
+
+                view.Received(1)
+                    .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
+            });
+
+    [UnityTest]
+    [TestCase("fucker123", "****er123", ExpectedResult = (IEnumerator)null)]
+    [TestCase("goodname", "goodname", ExpectedResult = (IEnumerator)null)]
+    public IEnumerator FilterProfanitySenderName(string originalName, string filteredName) =>
+        UniTask.ToCoroutine(
+            async () =>
+            {
+                profanityFilter.Filter(originalName).Returns(UniTask.FromResult(filteredName));
+
+                var msg = new ChatEntryModel
+                {
+                    messageType = ChatMessage.Type.PUBLIC,
+                    senderName = originalName,
+                    bodyText = "test"
+                };
+
+                await controller.AddChatMessage(msg);
+
+                view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.senderName.Equals(filteredName)));
+            });
+
+    [UnityTest]
+    [TestCase("assholeeee", "*******eee", ExpectedResult = (IEnumerator)null)]
+    [TestCase("goodname", "goodname", ExpectedResult = (IEnumerator)null)]
+    public IEnumerator FilterProfanityReceiverName(string originalName, string filteredName) =>
+        UniTask.ToCoroutine(
+            async () =>
+            {
+                profanityFilter.Filter(originalName).Returns(UniTask.FromResult(filteredName));
+
+                var msg = new ChatEntryModel
+                {
+                    messageType = ChatMessage.Type.PUBLIC,
+                    senderName = "test",
+                    recipientName = originalName,
+                    bodyText = "test"
+                };
+
+                await controller.AddChatMessage(msg);
+
+                view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.recipientName.Equals(filteredName)));
+            });
+
+    [UnityTest]
+    public IEnumerator DoNotFilterProfanityMessageWhenFeatureFlagIsDisabled() =>
+        UniTask.ToCoroutine(async () =>
+        {
+            dataStore.settings.profanityChatFilteringEnabled.Set(false);
+
+            var msg = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PUBLIC,
+                senderName = "test",
+                bodyText = "shit"
             };
 
-            view.OnMessageUpdated += Raise.Event<Action<string, int>>(text, cursorPosition);
+            await controller.AddChatMessage(msg);
 
-            view.Received(0).ShowMentionSuggestions();
-            view.Received(0).SetMentionSuggestions(Arg.Any<List<ChatMentionSuggestionModel>>());
-        }
+            view.Received(1)
+                .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
+        });
 
-        [Test]
-        public void HideSuggestionsWhenExceptionOccurs()
+    [UnityTest]
+    public IEnumerator DoNotFilterProfanityMessageWhenIsPrivate() =>
+        UniTask.ToCoroutine(async () =>
         {
-            view.ClearReceivedCalls();
-            suggestedProfilesAction = () => throw new Exception("Intended exception");
-
-            view.OnMessageUpdated += Raise.Event<Action<string, int>>("@", 1);
-
-            view.Received(1).HideMentionSuggestions();
-            view.Received(0).ShowMentionSuggestions();
-            view.Received(0).SetMentionSuggestions(Arg.Any<List<ChatMentionSuggestionModel>>());
-        }
-
-        [UnityTest]
-        public IEnumerator FetchRecipientProfileWhenMissing() =>
-            UniTask.ToCoroutine(async () =>
+            var msg = new ChatEntryModel
             {
-                const string SENDER_ID = "senderId";
-                const string SENDER_NAME = "senderName";
-                const string RECIPIENT_ID = "recipientId";
-                const string RECIPIENT_NAME = "recipientName";
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "test",
+                bodyText = "shit"
+            };
 
-                var senderProfile = ScriptableObject.CreateInstance<UserProfile>();
-                senderProfile.UpdateData(new UserProfileModel { userId = SENDER_ID, name = SENDER_NAME });
-                userProfileBridge.Get(SENDER_ID).Returns(senderProfile);
+            await controller.AddChatMessage(msg);
 
-                var recipientProfile = ScriptableObject.CreateInstance<UserProfile>();
-                recipientProfile.UpdateData(new UserProfileModel { userId = RECIPIENT_ID, name = RECIPIENT_NAME });
+            view.Received(1)
+                .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
+        });
 
-                userProfileBridge.RequestFullUserProfileAsync(RECIPIENT_ID, Arg.Any<CancellationToken>())
-                                 .Returns(UniTask.FromResult(recipientProfile));
+    [Test]
+    public void DisplayNextMessageInHistory()
+    {
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        view.OnNextChatInHistory += Raise.Event<Action>();
 
-                userProfileBridge.Get(RECIPIENT_ID).Returns(null, recipientProfile);
-
-                controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
-                {
-                    recipient = RECIPIENT_ID,
-                    isChannelMessage = false,
-                });
-
-                await UniTask.NextFrame();
-
-                userProfileBridge.Received(1).RequestFullUserProfileAsync(RECIPIENT_ID, Arg.Any<CancellationToken>());
-
-                Received.InOrder(() =>
-                {
-                    view.AddEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_ID));
-                    view.AddEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_NAME));
-                });
-            });
-
-        [UnityTest]
-        public IEnumerator FetchSenderProfileWhenMissing() =>
-            UniTask.ToCoroutine(async () =>
-            {
-                const string RECIPIENT_ID = "recipientId";
-                const string RECIPIENT_NAME = "recipientName";
-                const string SENDER_ID = "senderId";
-                const string SENDER_NAME = "senderName";
-
-                var recipientProfile = ScriptableObject.CreateInstance<UserProfile>();
-                recipientProfile.UpdateData(new UserProfileModel { userId = RECIPIENT_ID, name = RECIPIENT_NAME });
-                userProfileBridge.Get(RECIPIENT_ID).Returns(recipientProfile);
-
-                var senderProfile = ScriptableObject.CreateInstance<UserProfile>();
-                senderProfile.UpdateData(new UserProfileModel { userId = SENDER_ID, name = SENDER_NAME });
-
-                userProfileBridge.RequestFullUserProfileAsync(SENDER_ID, Arg.Any<CancellationToken>())
-                                 .Returns(UniTask.FromResult(senderProfile));
-
-                userProfileBridge.Get(SENDER_ID).Returns(null, senderProfile);
-
-                controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PUBLIC, SENDER_ID, "hey", 100)
-                {
-                    isChannelMessage = false,
-                });
-
-                await UniTask.NextFrame();
-
-                userProfileBridge.Received(1).RequestFullUserProfileAsync(SENDER_ID, Arg.Any<CancellationToken>());
-
-                Received.InOrder(() =>
-                {
-                    view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_ID));
-                    view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_NAME));
-                });
-            });
-
-        private UserProfile GivenProfile(string userId, string username, string face256)
+        Received.InOrder(() =>
         {
-            UserProfile user1 = ScriptableObject.CreateInstance<UserProfile>();
+            view.SetInputFieldText("sup");
+            view.SetInputFieldText("hey");
+        });
+    }
 
-            user1.UpdateData(new UserProfileModel
+    [Test]
+    public void DisplayPreviousMessageInHistory()
+    {
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
+        view.OnPreviousChatInHistory += Raise.Event<Action>();
+        view.OnPreviousChatInHistory += Raise.Event<Action>();
+
+        Received.InOrder(() =>
+        {
+            view.SetInputFieldText("hey");
+            view.SetInputFieldText("sup");
+        });
+    }
+
+    [Test]
+    public void DoNotDuplicateMessagesInHistory()
+    {
+        const string repeatedMessage = "hey";
+
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "bleh"));
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        view.OnNextChatInHistory += Raise.Event<Action>();
+        view.OnNextChatInHistory += Raise.Event<Action>();
+
+        Received.InOrder(() =>
+        {
+            view.SetInputFieldText("bleh");
+            view.SetInputFieldText(repeatedMessage);
+            view.SetInputFieldText("bleh");
+        });
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void ResetInputField(bool loseFocus)
+    {
+        controller.ResetInputField(loseFocus);
+
+        view.Received(1).ResetInputField(loseFocus);
+    }
+
+    [Test]
+    public void UnfocusInputField()
+    {
+        controller.UnfocusInputField();
+
+        view.Received(1).UnfocusInputField();
+    }
+
+    [TestCase("hehe")]
+    [TestCase("jojo")]
+    [TestCase("lelleolololohohoho")]
+    public void SetInputFieldText(string text)
+    {
+        controller.SetInputFieldText(text);
+
+        view.Received(1).SetInputFieldText(text);
+    }
+
+    [Test]
+    public void ClearAllEntries()
+    {
+        controller.ClearAllEntries();
+
+        view.Received(1).ClearAllEntries();
+    }
+
+    [Test]
+    public void SetChannelJoinSourceWhenJoinCommandIsWritten()
+    {
+        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "/join my-channel"));
+
+        Assert.AreEqual(ChannelJoinedSource.Command, dataStore.channels.channelJoinedSource.Get());
+    }
+
+    [TestCase("@", 1)]
+    [TestCase("@u", 2)]
+    [TestCase("hey @", 5)]
+    public void ShowMentionSuggestions(string text, int cursorPosition)
+    {
+        UserProfile user1 = GivenProfile("u1", "userName1", "faceU1");
+        UserProfile user2 = GivenProfile("u2", "userName2", "faceU2");
+
+        suggestedProfilesAction = () => new List<UserProfile>
+        {
+            user1,
+            user2,
+        };
+
+        view.OnMessageUpdated += Raise.Event<Action<string, int>>(text, cursorPosition);
+
+        view.Received(1).ShowMentionSuggestions();
+
+        view.Received(1)
+            .SetMentionSuggestions(Arg.Is<List<ChatMentionSuggestionModel>>(l =>
+                 l[0].userId == "u1" && l[0].userName == "userName1" && l[0].imageUrl == "faceU1"
+                 && l[1].userId == "u2" && l[1].userName == "userName2" && l[1].imageUrl == "faceU2"));
+    }
+
+    [TestCase("h", 1)]
+    [TestCase("how are you?", 4)]
+    [TestCase("my email is something@domain.com", 0)]
+    [TestCase("i just wrote an @ ", 18)]
+    public void DoNotShowMentionSuggestionsWhenNoPatternIsMatched(string text, int cursorPosition)
+    {
+        UserProfile user1 = GivenProfile("u1", "userName1", "faceU1");
+        UserProfile user2 = GivenProfile("u2", "userName2", "faceU2");
+
+        suggestedProfilesAction = () => new List<UserProfile>
+        {
+            user1,
+            user2,
+        };
+
+        view.OnMessageUpdated += Raise.Event<Action<string, int>>(text, cursorPosition);
+
+        view.Received(0).ShowMentionSuggestions();
+        view.Received(0).SetMentionSuggestions(Arg.Any<List<ChatMentionSuggestionModel>>());
+    }
+
+    [Test]
+    public void HideSuggestionsWhenExceptionOccurs()
+    {
+        view.ClearReceivedCalls();
+        suggestedProfilesAction = () => throw new Exception("Intended exception");
+
+        view.OnMessageUpdated += Raise.Event<Action<string, int>>("@", 1);
+
+        view.Received(1).HideMentionSuggestions();
+        view.Received(0).ShowMentionSuggestions();
+        view.Received(0).SetMentionSuggestions(Arg.Any<List<ChatMentionSuggestionModel>>());
+    }
+
+    [UnityTest]
+    public IEnumerator FetchRecipientProfileWhenMissing() =>
+        UniTask.ToCoroutine(async () =>
+        {
+            const string SENDER_ID = "senderId";
+            const string SENDER_NAME = "senderName";
+            const string RECIPIENT_ID = "recipientId";
+            const string RECIPIENT_NAME = "recipientName";
+
+            var senderProfile = ScriptableObject.CreateInstance<UserProfile>();
+            senderProfile.UpdateData(new UserProfileModel { userId = SENDER_ID, name = SENDER_NAME });
+            userProfileBridge.Get(SENDER_ID).Returns(senderProfile);
+
+            var recipientProfile = ScriptableObject.CreateInstance<UserProfile>();
+            recipientProfile.UpdateData(new UserProfileModel { userId = RECIPIENT_ID, name = RECIPIENT_NAME });
+
+            userProfileBridge.RequestFullUserProfileAsync(RECIPIENT_ID, Arg.Any<CancellationToken>())
+                             .Returns(UniTask.FromResult(recipientProfile));
+
+            userProfileBridge.Get(RECIPIENT_ID).Returns(null, recipientProfile);
+
+            controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
             {
-                userId = userId,
-                name = username,
-                snapshots = new UserProfileModel.Snapshots
-                {
-                    face256 = face256,
-                },
+                recipient = RECIPIENT_ID,
+                isChannelMessage = false,
             });
 
-            return user1;
-        }
+            await UniTask.NextFrame();
+
+            userProfileBridge.Received(1).RequestFullUserProfileAsync(RECIPIENT_ID, Arg.Any<CancellationToken>());
+
+            Received.InOrder(() =>
+            {
+                view.AddEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_ID));
+                view.AddEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_NAME));
+            });
+        });
+
+    [UnityTest]
+    public IEnumerator FetchSenderProfileWhenMissing() =>
+        UniTask.ToCoroutine(async () =>
+        {
+            const string RECIPIENT_ID = "recipientId";
+            const string RECIPIENT_NAME = "recipientName";
+            const string SENDER_ID = "senderId";
+            const string SENDER_NAME = "senderName";
+
+            var recipientProfile = ScriptableObject.CreateInstance<UserProfile>();
+            recipientProfile.UpdateData(new UserProfileModel { userId = RECIPIENT_ID, name = RECIPIENT_NAME });
+            userProfileBridge.Get(RECIPIENT_ID).Returns(recipientProfile);
+
+            var senderProfile = ScriptableObject.CreateInstance<UserProfile>();
+            senderProfile.UpdateData(new UserProfileModel { userId = SENDER_ID, name = SENDER_NAME });
+
+            userProfileBridge.RequestFullUserProfileAsync(SENDER_ID, Arg.Any<CancellationToken>())
+                             .Returns(UniTask.FromResult(senderProfile));
+
+            userProfileBridge.Get(SENDER_ID).Returns(null, senderProfile);
+
+            controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PUBLIC, SENDER_ID, "hey", 100)
+            {
+                isChannelMessage = false,
+            });
+
+            await UniTask.NextFrame();
+
+            userProfileBridge.Received(1).RequestFullUserProfileAsync(SENDER_ID, Arg.Any<CancellationToken>());
+
+            Received.InOrder(() =>
+            {
+                view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_ID));
+                view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_NAME));
+            });
+        });
+
+    private UserProfile GivenProfile(string userId, string username, string face256)
+    {
+        UserProfile user1 = ScriptableObject.CreateInstance<UserProfile>();
+
+        user1.UpdateData(new UserProfileModel
+        {
+            userId = userId,
+            name = username,
+            snapshots = new UserProfileModel.Snapshots
+            {
+                face256 = face256,
+            },
+        });
+
+        return user1;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -419,9 +419,9 @@ public class ChatHUDControllerShould
     public IEnumerator FetchRecipientProfileWhenMissing() =>
         UniTask.ToCoroutine(async () =>
         {
-            const string SENDER_ID = "senderId";
+            const string SENDER_ID = "senId";
             const string SENDER_NAME = "senderName";
-            const string RECIPIENT_ID = "recipientId";
+            const string RECIPIENT_ID = "recId";
             const string RECIPIENT_NAME = "recipientName";
 
             var senderProfile = ScriptableObject.CreateInstance<UserProfile>();
@@ -456,9 +456,9 @@ public class ChatHUDControllerShould
     public IEnumerator FetchSenderProfileWhenMissing() =>
         UniTask.ToCoroutine(async () =>
         {
-            const string RECIPIENT_ID = "recipientId";
+            const string RECIPIENT_ID = "recId";
             const string RECIPIENT_NAME = "recipientName";
-            const string SENDER_ID = "senderId";
+            const string SENDER_ID = "senId";
             const string SENDER_NAME = "senderName";
 
             var recipientProfile = ScriptableObject.CreateInstance<UserProfile>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDControllerShould.cs
@@ -1,5 +1,4 @@
 using Cysharp.Threading.Tasks;
-using DCL;
 using DCL.Chat.HUD;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
@@ -9,403 +8,502 @@ using SocialFeaturesAnalytics;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-public class ChatHUDControllerShould
+namespace DCL.Social.Chat
 {
-    private const string OWN_USER_ID = "ownUserId";
-
-    private ChatHUDController controller;
-    private IChatHUDComponentView view;
-    private DataStore dataStore;
-    private IProfanityFilter profanityFilter;
-    private Func<List<UserProfile>> suggestedProfilesAction;
-
-    [SetUp]
-    public void SetUp()
+    public class ChatHUDControllerShould
     {
-        profanityFilter = Substitute.For<IProfanityFilter>();
-        profanityFilter.Filter(Arg.Any<string>()).Returns(info => UniTask.FromResult(info[0].ToString()));
-        dataStore = new DataStore();
-        dataStore.settings.profanityChatFilteringEnabled.Set(true);
-        dataStore.featureFlags.flags.Set(new FeatureFlag { flags = { ["chat_mentions_enabled"] = true } });
-        view = Substitute.For<IChatHUDComponentView>();
-        var userProfileBridge = Substitute.For<IUserProfileBridge>();
-        var ownUserProfile = ScriptableObject.CreateInstance<UserProfile>();
-        ownUserProfile.UpdateData(new UserProfileModel {userId = OWN_USER_ID});
-        userProfileBridge.GetOwn().Returns(ownUserProfile);
-        suggestedProfilesAction = () => new List<UserProfile>();
+        private const string OWN_USER_ID = "ownUserId";
 
-        controller = new ChatHUDController(dataStore, userProfileBridge, true,
-            (name, count, token) => UniTask.FromResult(suggestedProfilesAction.Invoke()),
-            Substitute.For<ISocialAnalytics>(),
-            profanityFilter);
-        controller.Initialize(view);
-    }
+        private ChatHUDController controller;
+        private IChatHUDComponentView view;
+        private DataStore dataStore;
+        private IProfanityFilter profanityFilter;
+        private Func<List<UserProfile>> suggestedProfilesAction;
+        private IUserProfileBridge userProfileBridge;
 
-    [TearDown]
-    public void TearDown()
-    {
-        controller.Dispose();
-    }
-
-    [Test]
-    public void SubmitMessageProperly()
-    {
-        ChatMessage sentMsg = null;
-        void SendMessage(ChatMessage msg) => sentMsg = msg;
-        controller.OnSendMessage += SendMessage;
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(
-            new ChatMessage(ChatMessage.Type.PUBLIC, "idk", "test message"));
-        Assert.AreEqual("test message", sentMsg.body);
-        Assert.AreEqual(ChatMessage.Type.PUBLIC, sentMsg.messageType);
-        Assert.AreEqual(OWN_USER_ID, sentMsg.sender);
-        controller.OnSendMessage -= SendMessage;
-    }
-
-    [UnityTest]
-    public IEnumerator TrimWhenTooMuchMessagesAreInView() => UniTask.ToCoroutine(async () =>
-    {
-        view.EntryCount.Returns(ChatHUDController.MAX_CHAT_ENTRIES + 1);
-
-        var msg = new ChatEntryModel
+        [SetUp]
+        public void SetUp()
         {
-            messageType = ChatMessage.Type.PUBLIC,
-            senderName = "test",
-            bodyText = "test"
-        };
+            profanityFilter = Substitute.For<IProfanityFilter>();
 
-        await controller.AddChatMessage(msg);
+            profanityFilter.Filter(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                           .Returns(info => UniTask.FromResult(info[0].ToString()));
 
-        view.Received(1).RemoveOldestEntry();
-    });
+            dataStore = new DataStore();
+            dataStore.settings.profanityChatFilteringEnabled.Set(true);
+            dataStore.featureFlags.flags.Set(new FeatureFlag { flags = { ["chat_mentions_enabled"] = true } });
+            view = Substitute.For<IChatHUDComponentView>();
+            userProfileBridge = Substitute.For<IUserProfileBridge>();
+            var ownUserProfile = ScriptableObject.CreateInstance<UserProfile>();
+            ownUserProfile.UpdateData(new UserProfileModel { userId = OWN_USER_ID });
+            userProfileBridge.GetOwn().Returns(ownUserProfile);
+            suggestedProfilesAction = () => new List<UserProfile>();
 
-    [UnityTest]
-    public IEnumerator AddChatEntryProperly() => UniTask.ToCoroutine(async () =>
-    {
-        var msg = new ChatEntryModel
+            controller = new ChatHUDController(dataStore, userProfileBridge, true,
+                (name, count, token) => UniTask.FromResult(suggestedProfilesAction.Invoke()),
+                Substitute.For<ISocialAnalytics>(),
+                profanityFilter);
+
+            controller.Initialize(view);
+        }
+
+        [TearDown]
+        public void TearDown()
         {
-            messageType = ChatMessage.Type.PUBLIC,
-            senderName = "test",
-            bodyText = "test"
-        };
+            controller.Dispose();
+        }
 
-        await controller.AddChatMessage(msg);
-
-        view.Received(1)
-            .AddEntry(Arg.Is<ChatEntryModel>(
-                model => model.messageType == msg.messageType && model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
-    });
-
-    [TestCase("/w usr hello", "usr", "hello")]
-    [TestCase("/w usr im goku", "usr", "im goku")]
-    public void SetWhisperPropertiesWhenSendMessage(string text, string recipient, string body)
-    {
-        ChatMessage msg = null;
-        controller.OnSendMessage += m => msg = m;
-
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.NONE, "", text));
-
-        Assert.AreEqual(OWN_USER_ID, msg.sender);
-        Assert.AreEqual(ChatMessage.Type.PRIVATE, msg.messageType);
-        Assert.AreEqual(recipient, msg.recipient);
-        Assert.AreEqual(body, msg.body);
-    }
-
-    [Test]
-    public void SetSenderWhenSendingPublicMessage()
-    {
-        const string body = "how are you?";
-        ChatMessage msg = null;
-        controller.OnSendMessage += m => msg = m;
-
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.NONE, "", body));
-
-        Assert.AreEqual(OWN_USER_ID, msg.sender);
-        Assert.AreEqual(body, msg.body);
-    }
-
-    [UnityTest]
-    [TestCase("ShiT hello shithead", "**** hello shithead", ExpectedResult = (IEnumerator) null)]
-    [TestCase("ass hi grass", "*** hi grass", ExpectedResult = (IEnumerator) null)]
-    public IEnumerator FilterProfanityMessageWithExplicitWords(string body, string expected) => UniTask.ToCoroutine(
-        async () =>
+        [Test]
+        public void SubmitMessageProperly()
         {
-            profanityFilter.Filter($"<noparse>{body}</noparse>").Returns(UniTask.FromResult($"<noparse>{expected}</noparse>"));
+            ChatMessage sentMsg = null;
 
-            var msg = new ChatEntryModel
+            void SendMessage(ChatMessage msg) =>
+                sentMsg = msg;
+
+            controller.OnSendMessage += SendMessage;
+
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(
+                new ChatMessage(ChatMessage.Type.PUBLIC, "idk", "test message"));
+
+            Assert.AreEqual("test message", sentMsg.body);
+            Assert.AreEqual(ChatMessage.Type.PUBLIC, sentMsg.messageType);
+            Assert.AreEqual(OWN_USER_ID, sentMsg.sender);
+            controller.OnSendMessage -= SendMessage;
+        }
+
+        [UnityTest]
+        public IEnumerator TrimWhenTooMuchMessagesAreInView() =>
+            UniTask.ToCoroutine(async () =>
             {
-                messageType = ChatMessage.Type.PUBLIC,
-                senderName = "test",
-                bodyText = body
+                view.EntryCount.Returns(ChatHUDController.MAX_CHAT_ENTRIES + 1);
+
+                var msg = new ChatEntryModel
+                {
+                    messageType = ChatMessage.Type.PUBLIC,
+                    senderName = "test",
+                    bodyText = "test"
+                };
+
+                await controller.AddChatMessage(msg);
+
+                view.Received(1).RemoveOldestEntry();
+            });
+
+        [UnityTest]
+        public IEnumerator AddChatEntryProperly() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var msg = new ChatEntryModel
+                {
+                    messageType = ChatMessage.Type.PUBLIC,
+                    senderName = "test",
+                    bodyText = "test"
+                };
+
+                await controller.AddChatMessage(msg);
+
+                view.Received(1)
+                    .AddEntry(Arg.Is<ChatEntryModel>(
+                         model => model.messageType == msg.messageType && model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
+            });
+
+        [TestCase("/w usr hello", "usr", "hello")]
+        [TestCase("/w usr im goku", "usr", "im goku")]
+        public void SetWhisperPropertiesWhenSendMessage(string text, string recipient, string body)
+        {
+            ChatMessage msg = null;
+            controller.OnSendMessage += m => msg = m;
+
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.NONE, "", text));
+
+            Assert.AreEqual(OWN_USER_ID, msg.sender);
+            Assert.AreEqual(ChatMessage.Type.PRIVATE, msg.messageType);
+            Assert.AreEqual(recipient, msg.recipient);
+            Assert.AreEqual(body, msg.body);
+        }
+
+        [Test]
+        public void SetSenderWhenSendingPublicMessage()
+        {
+            const string body = "how are you?";
+            ChatMessage msg = null;
+            controller.OnSendMessage += m => msg = m;
+
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.NONE, "", body));
+
+            Assert.AreEqual(OWN_USER_ID, msg.sender);
+            Assert.AreEqual(body, msg.body);
+        }
+
+        [UnityTest]
+        [TestCase("ShiT hello shithead", "**** hello shithead", ExpectedResult = (IEnumerator)null)]
+        [TestCase("ass hi grass", "*** hi grass", ExpectedResult = (IEnumerator)null)]
+        public IEnumerator FilterProfanityMessageWithExplicitWords(string body, string expected) =>
+            UniTask.ToCoroutine(
+                async () =>
+                {
+                    profanityFilter.Filter($"<noparse>{body}</noparse>").Returns(UniTask.FromResult($"<noparse>{expected}</noparse>"));
+
+                    var msg = new ChatEntryModel
+                    {
+                        messageType = ChatMessage.Type.PUBLIC,
+                        senderName = "test",
+                        bodyText = body
+                    };
+
+                    await controller.AddChatMessage(msg);
+
+                    view.Received(1)
+                        .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
+                });
+
+        [UnityTest]
+        [TestCase("fuck1 heh bitch", "****1 heh *****", ExpectedResult = (IEnumerator)null)]
+        [TestCase("assfuck bitching", "ass**** *****ing", ExpectedResult = (IEnumerator)null)]
+        public IEnumerator FilterProfanityMessageWithNonExplicitWords(string body, string expected) =>
+            UniTask.ToCoroutine(
+                async () =>
+                {
+                    profanityFilter.Filter($"<noparse>{body}</noparse>").Returns(UniTask.FromResult($"<noparse>{expected}</noparse>"));
+
+                    var msg = new ChatEntryModel
+                    {
+                        messageType = ChatMessage.Type.PUBLIC,
+                        senderName = "test",
+                        bodyText = body
+                    };
+
+                    await controller.AddChatMessage(msg);
+
+                    view.Received(1)
+                        .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
+                });
+
+        [UnityTest]
+        [TestCase("fucker123", "****er123", ExpectedResult = (IEnumerator)null)]
+        [TestCase("goodname", "goodname", ExpectedResult = (IEnumerator)null)]
+        public IEnumerator FilterProfanitySenderName(string originalName, string filteredName) =>
+            UniTask.ToCoroutine(
+                async () =>
+                {
+                    profanityFilter.Filter(originalName).Returns(UniTask.FromResult(filteredName));
+
+                    var msg = new ChatEntryModel
+                    {
+                        messageType = ChatMessage.Type.PUBLIC,
+                        senderName = originalName,
+                        bodyText = "test"
+                    };
+
+                    await controller.AddChatMessage(msg);
+
+                    view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.senderName.Equals(filteredName)));
+                });
+
+        [UnityTest]
+        [TestCase("assholeeee", "*******eee", ExpectedResult = (IEnumerator)null)]
+        [TestCase("goodname", "goodname", ExpectedResult = (IEnumerator)null)]
+        public IEnumerator FilterProfanityReceiverName(string originalName, string filteredName) =>
+            UniTask.ToCoroutine(
+                async () =>
+                {
+                    profanityFilter.Filter(originalName).Returns(UniTask.FromResult(filteredName));
+
+                    var msg = new ChatEntryModel
+                    {
+                        messageType = ChatMessage.Type.PUBLIC,
+                        senderName = "test",
+                        recipientName = originalName,
+                        bodyText = "test"
+                    };
+
+                    await controller.AddChatMessage(msg);
+
+                    view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.recipientName.Equals(filteredName)));
+                });
+
+        [UnityTest]
+        public IEnumerator DoNotFilterProfanityMessageWhenFeatureFlagIsDisabled() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                dataStore.settings.profanityChatFilteringEnabled.Set(false);
+
+                var msg = new ChatEntryModel
+                {
+                    messageType = ChatMessage.Type.PUBLIC,
+                    senderName = "test",
+                    bodyText = "shit"
+                };
+
+                await controller.AddChatMessage(msg);
+
+                view.Received(1)
+                    .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
+            });
+
+        [UnityTest]
+        public IEnumerator DoNotFilterProfanityMessageWhenIsPrivate() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var msg = new ChatEntryModel
+                {
+                    messageType = ChatMessage.Type.PRIVATE,
+                    senderName = "test",
+                    bodyText = "shit"
+                };
+
+                await controller.AddChatMessage(msg);
+
+                view.Received(1)
+                    .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
+            });
+
+        [Test]
+        public void DisplayNextMessageInHistory()
+        {
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
+            view.OnNextChatInHistory += Raise.Event<Action>();
+            view.OnNextChatInHistory += Raise.Event<Action>();
+
+            Received.InOrder(() =>
+            {
+                view.SetInputFieldText("sup");
+                view.SetInputFieldText("hey");
+            });
+        }
+
+        [Test]
+        public void DisplayPreviousMessageInHistory()
+        {
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
+            view.OnPreviousChatInHistory += Raise.Event<Action>();
+            view.OnPreviousChatInHistory += Raise.Event<Action>();
+
+            Received.InOrder(() =>
+            {
+                view.SetInputFieldText("hey");
+                view.SetInputFieldText("sup");
+            });
+        }
+
+        [Test]
+        public void DoNotDuplicateMessagesInHistory()
+        {
+            const string repeatedMessage = "hey";
+
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "bleh"));
+            view.OnNextChatInHistory += Raise.Event<Action>();
+            view.OnNextChatInHistory += Raise.Event<Action>();
+            view.OnNextChatInHistory += Raise.Event<Action>();
+
+            Received.InOrder(() =>
+            {
+                view.SetInputFieldText("bleh");
+                view.SetInputFieldText(repeatedMessage);
+                view.SetInputFieldText("bleh");
+            });
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void ResetInputField(bool loseFocus)
+        {
+            controller.ResetInputField(loseFocus);
+
+            view.Received(1).ResetInputField(loseFocus);
+        }
+
+        [Test]
+        public void UnfocusInputField()
+        {
+            controller.UnfocusInputField();
+
+            view.Received(1).UnfocusInputField();
+        }
+
+        [TestCase("hehe")]
+        [TestCase("jojo")]
+        [TestCase("lelleolololohohoho")]
+        public void SetInputFieldText(string text)
+        {
+            controller.SetInputFieldText(text);
+
+            view.Received(1).SetInputFieldText(text);
+        }
+
+        [Test]
+        public void ClearAllEntries()
+        {
+            controller.ClearAllEntries();
+
+            view.Received(1).ClearAllEntries();
+        }
+
+        [Test]
+        public void SetChannelJoinSourceWhenJoinCommandIsWritten()
+        {
+            view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "/join my-channel"));
+
+            Assert.AreEqual(ChannelJoinedSource.Command, dataStore.channels.channelJoinedSource.Get());
+        }
+
+        [TestCase("@", 1)]
+        [TestCase("@u", 2)]
+        [TestCase("hey @", 5)]
+        public void ShowMentionSuggestions(string text, int cursorPosition)
+        {
+            UserProfile user1 = GivenProfile("u1", "userName1", "faceU1");
+            UserProfile user2 = GivenProfile("u2", "userName2", "faceU2");
+
+            suggestedProfilesAction = () => new List<UserProfile>
+            {
+                user1,
+                user2,
             };
 
-            await controller.AddChatMessage(msg);
+            view.OnMessageUpdated += Raise.Event<Action<string, int>>(text, cursorPosition);
+
+            view.Received(1).ShowMentionSuggestions();
 
             view.Received(1)
-                .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
-        });
+                .SetMentionSuggestions(Arg.Is<List<ChatMentionSuggestionModel>>(l =>
+                     l[0].userId == "u1" && l[0].userName == "userName1" && l[0].imageUrl == "faceU1"
+                     && l[1].userId == "u2" && l[1].userName == "userName2" && l[1].imageUrl == "faceU2"));
+        }
 
-    [UnityTest]
-    [TestCase("fuck1 heh bitch", "****1 heh *****", ExpectedResult = (IEnumerator) null)]
-    [TestCase("assfuck bitching", "ass**** *****ing", ExpectedResult = (IEnumerator) null)]
-    public IEnumerator FilterProfanityMessageWithNonExplicitWords(string body, string expected) => UniTask.ToCoroutine(
-        async () =>
+        [TestCase("h", 1)]
+        [TestCase("how are you?", 4)]
+        [TestCase("my email is something@domain.com", 0)]
+        [TestCase("i just wrote an @ ", 18)]
+        public void DoNotShowMentionSuggestionsWhenNoPatternIsMatched(string text, int cursorPosition)
         {
-            profanityFilter.Filter($"<noparse>{body}</noparse>").Returns(UniTask.FromResult($"<noparse>{expected}</noparse>"));
+            UserProfile user1 = GivenProfile("u1", "userName1", "faceU1");
+            UserProfile user2 = GivenProfile("u2", "userName2", "faceU2");
 
-            var msg = new ChatEntryModel
+            suggestedProfilesAction = () => new List<UserProfile>
             {
-                messageType = ChatMessage.Type.PUBLIC,
-                senderName = "test",
-                bodyText = body
+                user1,
+                user2,
             };
 
-            await controller.AddChatMessage(msg);
+            view.OnMessageUpdated += Raise.Event<Action<string, int>>(text, cursorPosition);
 
-            view.Received(1)
-                .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{expected}</noparse>"));
-        });
+            view.Received(0).ShowMentionSuggestions();
+            view.Received(0).SetMentionSuggestions(Arg.Any<List<ChatMentionSuggestionModel>>());
+        }
 
-    [UnityTest]
-    [TestCase("fucker123", "****er123", ExpectedResult = (IEnumerator) null)]
-    [TestCase("goodname", "goodname", ExpectedResult = (IEnumerator) null)]
-    public IEnumerator FilterProfanitySenderName(string originalName, string filteredName) => UniTask.ToCoroutine(
-        async () =>
+        [Test]
+        public void HideSuggestionsWhenExceptionOccurs()
         {
-            profanityFilter.Filter(originalName).Returns(UniTask.FromResult(filteredName));
+            view.ClearReceivedCalls();
+            suggestedProfilesAction = () => throw new Exception("Intended exception");
 
-            var msg = new ChatEntryModel
+            view.OnMessageUpdated += Raise.Event<Action<string, int>>("@", 1);
+
+            view.Received(1).HideMentionSuggestions();
+            view.Received(0).ShowMentionSuggestions();
+            view.Received(0).SetMentionSuggestions(Arg.Any<List<ChatMentionSuggestionModel>>());
+        }
+
+        [UnityTest]
+        public IEnumerator FetchRecipientProfileWhenMissing() =>
+            UniTask.ToCoroutine(async () =>
             {
-                messageType = ChatMessage.Type.PUBLIC,
-                senderName = originalName,
-                bodyText = "test"
-            };
+                const string SENDER_ID = "senderId";
+                const string SENDER_NAME = "senderName";
+                const string RECIPIENT_ID = "recipientId";
+                const string RECIPIENT_NAME = "recipientName";
 
-            await controller.AddChatMessage(msg);
+                var senderProfile = ScriptableObject.CreateInstance<UserProfile>();
+                senderProfile.UpdateData(new UserProfileModel { userId = SENDER_ID, name = SENDER_NAME });
+                userProfileBridge.Get(SENDER_ID).Returns(senderProfile);
 
-            view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.senderName.Equals(filteredName)));
-        });
+                var recipientProfile = ScriptableObject.CreateInstance<UserProfile>();
+                recipientProfile.UpdateData(new UserProfileModel { userId = RECIPIENT_ID, name = RECIPIENT_NAME });
 
-    [UnityTest]
-    [TestCase("assholeeee", "*******eee", ExpectedResult = (IEnumerator) null)]
-    [TestCase("goodname", "goodname", ExpectedResult = (IEnumerator) null)]
-    public IEnumerator FilterProfanityReceiverName(string originalName, string filteredName) => UniTask.ToCoroutine(
-        async () =>
-        {
-            profanityFilter.Filter(originalName).Returns(UniTask.FromResult(filteredName));
+                userProfileBridge.RequestFullUserProfileAsync(RECIPIENT_ID, Arg.Any<CancellationToken>())
+                                 .Returns(UniTask.FromResult(recipientProfile));
 
-            var msg = new ChatEntryModel
+                userProfileBridge.Get(RECIPIENT_ID).Returns(null, recipientProfile);
+
+                controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PRIVATE, SENDER_ID, "hey", 100)
+                {
+                    recipient = RECIPIENT_ID,
+                    isChannelMessage = false,
+                });
+
+                await UniTask.NextFrame();
+
+                userProfileBridge.Received(1).RequestFullUserProfileAsync(RECIPIENT_ID, Arg.Any<CancellationToken>());
+
+                Received.InOrder(() =>
+                {
+                    view.AddEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_ID));
+                    view.AddEntry(Arg.Is<ChatEntryModel>(c => c.recipientName == RECIPIENT_NAME));
+                });
+            });
+
+        [UnityTest]
+        public IEnumerator FetchSenderProfileWhenMissing() =>
+            UniTask.ToCoroutine(async () =>
             {
-                messageType = ChatMessage.Type.PUBLIC,
-                senderName = "test",
-                recipientName = originalName,
-                bodyText = "test"
-            };
+                const string RECIPIENT_ID = "recipientId";
+                const string RECIPIENT_NAME = "recipientName";
+                const string SENDER_ID = "senderId";
+                const string SENDER_NAME = "senderName";
 
-            await controller.AddChatMessage(msg);
+                var recipientProfile = ScriptableObject.CreateInstance<UserProfile>();
+                recipientProfile.UpdateData(new UserProfileModel { userId = RECIPIENT_ID, name = RECIPIENT_NAME });
+                userProfileBridge.Get(RECIPIENT_ID).Returns(recipientProfile);
 
-            view.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model => model.recipientName.Equals(filteredName)));
-        });
+                var senderProfile = ScriptableObject.CreateInstance<UserProfile>();
+                senderProfile.UpdateData(new UserProfileModel { userId = SENDER_ID, name = SENDER_NAME });
 
-    [UnityTest]
-    public IEnumerator DoNotFilterProfanityMessageWhenFeatureFlagIsDisabled() => UniTask.ToCoroutine(async () =>
-    {
-        dataStore.settings.profanityChatFilteringEnabled.Set(false);
+                userProfileBridge.RequestFullUserProfileAsync(SENDER_ID, Arg.Any<CancellationToken>())
+                                 .Returns(UniTask.FromResult(senderProfile));
 
-        var msg = new ChatEntryModel
+                userProfileBridge.Get(SENDER_ID).Returns(null, senderProfile);
+
+                controller.AddChatMessage(new ChatMessage("msg1", ChatMessage.Type.PUBLIC, SENDER_ID, "hey", 100)
+                {
+                    isChannelMessage = false,
+                });
+
+                await UniTask.NextFrame();
+
+                userProfileBridge.Received(1).RequestFullUserProfileAsync(SENDER_ID, Arg.Any<CancellationToken>());
+
+                Received.InOrder(() =>
+                {
+                    view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_ID));
+                    view.AddEntry(Arg.Is<ChatEntryModel>(c => c.senderName == SENDER_NAME));
+                });
+            });
+
+        private UserProfile GivenProfile(string userId, string username, string face256)
         {
-            messageType = ChatMessage.Type.PUBLIC,
-            senderName = "test",
-            bodyText = "shit"
-        };
+            UserProfile user1 = ScriptableObject.CreateInstance<UserProfile>();
 
-        await controller.AddChatMessage(msg);
-
-        view.Received(1)
-            .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
-    });
-
-    [UnityTest]
-    public IEnumerator DoNotFilterProfanityMessageWhenIsPrivate() => UniTask.ToCoroutine(async () =>
-    {
-        var msg = new ChatEntryModel
-        {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "test",
-            bodyText = "shit"
-        };
-
-        await controller.AddChatMessage(msg);
-
-        view.Received(1)
-            .AddEntry(Arg.Is<ChatEntryModel>(model => model.bodyText == $"<noparse>{msg.bodyText}</noparse>"));
-    });
-
-    [Test]
-    public void DisplayNextMessageInHistory()
-    {
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
-        view.OnNextChatInHistory += Raise.Event<Action>();
-        view.OnNextChatInHistory += Raise.Event<Action>();
-
-        Received.InOrder(() =>
-        {
-            view.SetInputFieldText("sup");
-            view.SetInputFieldText("hey");
-        });
-    }
-
-    [Test]
-    public void DisplayPreviousMessageInHistory()
-    {
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "hey"));
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "sup"));
-        view.OnPreviousChatInHistory += Raise.Event<Action>();
-        view.OnPreviousChatInHistory += Raise.Event<Action>();
-
-        Received.InOrder(() =>
-        {
-            view.SetInputFieldText("hey");
-            view.SetInputFieldText("sup");
-        });
-    }
-
-    [Test]
-    public void DoNotDuplicateMessagesInHistory()
-    {
-        const string repeatedMessage = "hey";
-
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", repeatedMessage));
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "bleh"));
-        view.OnNextChatInHistory += Raise.Event<Action>();
-        view.OnNextChatInHistory += Raise.Event<Action>();
-        view.OnNextChatInHistory += Raise.Event<Action>();
-
-        Received.InOrder(() =>
-        {
-            view.SetInputFieldText("bleh");
-            view.SetInputFieldText(repeatedMessage);
-            view.SetInputFieldText("bleh");
-        });
-    }
-
-    [TestCase(false)]
-    [TestCase(true)]
-    public void ResetInputField(bool loseFocus)
-    {
-        controller.ResetInputField(loseFocus);
-
-        view.Received(1).ResetInputField(loseFocus);
-    }
-
-    [Test]
-    public void UnfocusInputField()
-    {
-        controller.UnfocusInputField();
-
-        view.Received(1).UnfocusInputField();
-    }
-
-    [TestCase("hehe")]
-    [TestCase("jojo")]
-    [TestCase("lelleolololohohoho")]
-    public void SetInputFieldText(string text)
-    {
-        controller.SetInputFieldText(text);
-
-        view.Received(1).SetInputFieldText(text);
-    }
-
-    [Test]
-    public void ClearAllEntries()
-    {
-        controller.ClearAllEntries();
-
-        view.Received(1).ClearAllEntries();
-    }
-
-    [Test]
-    public void SetChannelJoinSourceWhenJoinCommandIsWritten()
-    {
-        view.OnSendMessage += Raise.Event<Action<ChatMessage>>(new ChatMessage(ChatMessage.Type.PUBLIC, "test", "/join my-channel"));
-
-        Assert.AreEqual(ChannelJoinedSource.Command, dataStore.channels.channelJoinedSource.Get());
-    }
-
-    [TestCase("@", 1)]
-    [TestCase("@u", 2)]
-    [TestCase("hey @", 5)]
-    public void ShowMentionSuggestions(string text, int cursorPosition)
-    {
-        UserProfile user1 = GivenProfile("u1", "userName1", "faceU1");
-        UserProfile user2 = GivenProfile("u2", "userName2", "faceU2");
-
-        suggestedProfilesAction = () => new List<UserProfile>
-        {
-            user1,
-            user2,
-        };
-
-        view.OnMessageUpdated += Raise.Event<Action<string, int>>(text, cursorPosition);
-
-        view.Received(1).ShowMentionSuggestions();
-
-        view.Received(1)
-            .SetMentionSuggestions(Arg.Is<List<ChatMentionSuggestionModel>>(l =>
-                 l[0].userId == "u1" && l[0].userName == "userName1" && l[0].imageUrl == "faceU1"
-                 && l[1].userId == "u2" && l[1].userName == "userName2" && l[1].imageUrl == "faceU2"));
-    }
-
-    [TestCase("h", 1)]
-    [TestCase("how are you?", 4)]
-    [TestCase("my email is something@domain.com", 0)]
-    [TestCase("i just wrote an @ ", 18)]
-    public void DoNotShowMentionSuggestionsWhenNoPatternIsMatched(string text, int cursorPosition)
-    {
-        UserProfile user1 = GivenProfile("u1", "userName1", "faceU1");
-        UserProfile user2 = GivenProfile("u2", "userName2", "faceU2");
-
-        suggestedProfilesAction = () => new List<UserProfile>
-        {
-            user1,
-            user2,
-        };
-
-        view.OnMessageUpdated += Raise.Event<Action<string, int>>(text, cursorPosition);
-
-        view.Received(0).ShowMentionSuggestions();
-        view.Received(0).SetMentionSuggestions(Arg.Any<List<ChatMentionSuggestionModel>>());
-    }
-
-    [Test]
-    public void HideSuggestionsWhenExceptionOccurs()
-    {
-        view.ClearReceivedCalls();
-        suggestedProfilesAction = () => throw new Exception("Intended exception");
-
-        view.OnMessageUpdated += Raise.Event<Action<string, int>>("@", 1);
-
-        view.Received(1).HideMentionSuggestions();
-        view.Received(0).ShowMentionSuggestions();
-        view.Received(0).SetMentionSuggestions(Arg.Any<List<ChatMentionSuggestionModel>>());
-    }
-
-    private UserProfile GivenProfile(string userId, string username, string face256)
-    {
-        UserProfile user1 = ScriptableObject.CreateInstance<UserProfile>();
-        user1.UpdateData(new UserProfileModel
-        {
-            userId = userId,
-            name = username,
-            snapshots = new UserProfileModel.Snapshots
+            user1.UpdateData(new UserProfileModel
             {
-                face256 = face256,
-            },
-        });
-        return user1;
+                userId = userId,
+                name = username,
+                snapshots = new UserProfileModel.Snapshots
+                {
+                    face256 = face256,
+                },
+            });
+
+            return user1;
+        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/ChatHUDViewShould.cs
@@ -138,8 +138,8 @@ namespace DCL.Social.Chat
                 subType = ChatEntryModel.SubType.RECEIVED,
             };
 
-            view.AddEntry(newMsg);
-            view.AddEntry(oldMsg);
+            view.SetEntry(newMsg);
+            view.SetEntry(oldMsg);
 
             yield return null;
 
@@ -191,9 +191,9 @@ namespace DCL.Social.Chat
                 subType = ChatEntryModel.SubType.SENT,
             };
 
-            view.AddEntry(msg1);
-            view.AddEntry(msg2);
-            view.AddEntry(msg3);
+            view.SetEntry(msg1);
+            view.SetEntry(msg2);
+            view.SetEntry(msg3);
 
             yield return null;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
@@ -1,21 +1,28 @@
 using Cysharp.Threading.Tasks;
 using DCL.Chat.HUD;
 using DCL.Interface;
+using NSubstitute;
 using NUnit.Framework;
+using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
 
 public class DefaultChatEntryShould
 {
     private DefaultChatEntry entry;
     private Canvas canvas;
+    private DefaultChatEntry.ILocalTimeConverterStrategy localTimeConverter;
 
     [SetUp]
     public void SetUp()
     {
         var canvasgo = new GameObject("canvas");
         canvas = canvasgo.AddComponent<Canvas>();
+        localTimeConverter = Substitute.For<DefaultChatEntry.ILocalTimeConverterStrategy>();
+        localTimeConverter.GetLocalTime(Arg.Any<ulong>())
+                          .Returns(info => DateTimeOffset.FromUnixTimeMilliseconds(long.Parse(info[0].ToString())).DateTime);
         ((RectTransform)canvas.transform).sizeDelta = new Vector2(500, 500);
     }
 
@@ -272,9 +279,9 @@ public class DefaultChatEntryShould
             Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
         });
 
-    [TestCase((ulong)1680013416292, "Loading name - 03/28/23 11:23:36 AM")]
-    [TestCase((ulong)1230011812000, "Loading name - 12/23/08 3:56:52 AM")]
-    [TestCase((ulong)1430092000000, "Loading name - 04/26/15 8:46:40 PM")]
+    [TestCase((ulong)1680013416292, "Loading name - 03/28/23 2:23:36 PM")]
+    [TestCase((ulong)1230011812000, "Loading name - 12/23/08 5:56:52 AM")]
+    [TestCase((ulong)1430092000000, "Loading name - 04/26/15 11:46:40 PM")]
     public void GetHoverTextWhenLoadingNames(ulong timestamp, string expectedHoverText)
     {
         GivenEntryChat("PrivateChatEntryReceived");
@@ -295,9 +302,9 @@ public class DefaultChatEntryShould
         Assert.AreEqual(expectedHoverText, entry.HoverString);
     }
 
-    [TestCase((ulong)1480072398390, "11/25/16 8:13:18 AM")]
-    [TestCase((ulong)1920396820000, "11/08/30 4:33:40 PM")]
-    [TestCase((ulong)1693000390000, "08/25/23 6:53:10 PM")]
+    [TestCase((ulong)1480072398390, "11/25/16 11:13:18 AM")]
+    [TestCase((ulong)1920396820000, "11/08/30 7:33:40 PM")]
+    [TestCase((ulong)1693000390000, "08/25/23 9:53:10 PM")]
     public void GetHoverText(ulong timestamp, string expectedHoverText)
     {
         GivenEntryChat("PrivateChatEntryReceived");
@@ -321,5 +328,6 @@ public class DefaultChatEntryShould
     {
         entry = Object.Instantiate(Resources.Load<DefaultChatEntry>($"SocialBarV1/{prefabName}"),
             canvas.transform, false);
+        entry.LocalTimeConverterStrategy = localTimeConverter;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/Tests/DefaultChatEntryShould.cs
@@ -1,23 +1,22 @@
-using System.Collections;
 using Cysharp.Threading.Tasks;
 using DCL.Chat.HUD;
 using DCL.Interface;
 using NUnit.Framework;
+using System.Collections;
 using UnityEngine;
-using UnityEngine.EventSystems;
 using UnityEngine.TestTools;
 
 public class DefaultChatEntryShould
 {
     private DefaultChatEntry entry;
     private Canvas canvas;
-    
+
     [SetUp]
     public void SetUp()
     {
         var canvasgo = new GameObject("canvas");
         canvas = canvasgo.AddComponent<Canvas>();
-        ((RectTransform) canvas.transform).sizeDelta = new Vector2(500, 500);
+        ((RectTransform)canvas.transform).sizeDelta = new Vector2(500, 500);
     }
 
     [TearDown]
@@ -28,240 +27,296 @@ public class DefaultChatEntryShould
     }
 
     [UnityTest]
-    public IEnumerator PopulateSystemChat() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("ChatEntrySystem");
-
-        var message = new ChatEntryModel
+    public IEnumerator PopulateSystemChat() =>
+        UniTask.ToCoroutine(async () =>
         {
-            messageType = ChatMessage.Type.SYSTEM,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.RECEIVED
-        };
+            GivenEntryChat("ChatEntrySystem");
 
-        entry.Populate(message);
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.SYSTEM,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.RECEIVED
+            };
 
-        await UniTask.DelayFrame(4);
+            entry.Populate(message);
 
-        Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
-    });
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("<b>user-test:</b> test message", entry.body.text);
+        });
 
     [UnityTest]
-    public IEnumerator PopulateReceivedPublicChat() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PublicChatEntryReceived");
-        
-        var message = new ChatEntryModel
+    public IEnumerator PopulateReceivedPublicChat() =>
+        UniTask.ToCoroutine(async () =>
         {
-            messageType = ChatMessage.Type.PUBLIC,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.RECEIVED
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
+            GivenEntryChat("PublicChatEntryReceived");
 
-        Assert.AreEqual("<b><link=username://user-test>user-test</link>:</b> test message", entry.body.text);
-    });
-    
-    [UnityTest]
-    public IEnumerator PopulateSentPublicChat() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PublicChatEntrySent");
-        
-        var message = new ChatEntryModel
-        {
-            messageType = ChatMessage.Type.PUBLIC,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.SENT
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PUBLIC,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.RECEIVED
+            };
 
-        Assert.AreEqual("<b>You:</b> test message", entry.body.text);
-    });
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("<b><link=username://user-test>user-test</link>:</b> test message", entry.body.text);
+        });
 
     [UnityTest]
-    public IEnumerator PopulateReceivedWhisperInPublicChannel() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PublicChatEntryReceivedWhisper");
-        
-        var message = new ChatEntryModel
+    public IEnumerator PopulateSentPublicChat() =>
+        UniTask.ToCoroutine(async () =>
         {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.RECEIVED
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
+            GivenEntryChat("PublicChatEntrySent");
 
-        Assert.AreEqual("<b><color=#5EBD3D>From <link=username://user-test>user-test</link></color>:</b> test message", entry.body.text);
-    });
-    
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PUBLIC,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.SENT
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("<b>You:</b> test message", entry.body.text);
+        });
+
     [UnityTest]
-    public IEnumerator PopulateSentWhisperInPublicChannel() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PublicChatEntrySentWhisper");
-        
-        var message = new ChatEntryModel
+    public IEnumerator PopulateReceivedWhisperInPublicChannel() =>
+        UniTask.ToCoroutine(async () =>
         {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.SENT
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
+            GivenEntryChat("PublicChatEntryReceivedWhisper");
 
-        Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
-    });
-    
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.RECEIVED
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("<b><color=#5EBD3D>From <link=username://user-test>user-test</link></color>:</b> test message", entry.body.text);
+        });
+
     [UnityTest]
-    public IEnumerator PopulateSentWhisperInPrivateChannel() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PrivateChatEntrySent");
-        
-        var message = new ChatEntryModel
+    public IEnumerator PopulateSentWhisperInPublicChannel() =>
+        UniTask.ToCoroutine(async () =>
         {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.SENT
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
+            GivenEntryChat("PublicChatEntrySentWhisper");
 
-        Assert.AreEqual("test message", entry.body.text);
-    });
-    
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.SENT
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
+        });
+
     [UnityTest]
-    public IEnumerator PopulateReceivedWhisperInPrivateChannel() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PrivateChatEntryReceived");
-        
-        var message = new ChatEntryModel
+    public IEnumerator PopulateSentWhisperInPrivateChannel() =>
+        UniTask.ToCoroutine(async () =>
         {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "test message",
-            subType = ChatEntryModel.SubType.RECEIVED
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
+            GivenEntryChat("PrivateChatEntrySent");
 
-        Assert.AreEqual("test message", entry.body.text);
-    });
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.SENT
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("test message", entry.body.text);
+        });
+
+    [UnityTest]
+    public IEnumerator PopulateReceivedWhisperInPrivateChannel() =>
+        UniTask.ToCoroutine(async () =>
+        {
+            GivenEntryChat("PrivateChatEntryReceived");
+
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.RECEIVED
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("test message", entry.body.text);
+        });
 
     [UnityTest]
     [TestCase("im at 100,100", "100,100", "im at ", ExpectedResult = null)]
     [TestCase("nah we should go to 0,-122", "0,-122", "nah we should go to ", ExpectedResult = null)]
-    public IEnumerator AddParcelCoordinates(string body, string coordinates, string bodyWithoutCoordinates) => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PublicChatEntryReceivedWhisper");
-        
-        var message = new ChatEntryModel
+    public IEnumerator AddParcelCoordinates(string body, string coordinates, string bodyWithoutCoordinates) =>
+        UniTask.ToCoroutine(async () =>
         {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = body,
-            subType = ChatEntryModel.SubType.SENT
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
+            GivenEntryChat("PublicChatEntryReceivedWhisper");
 
-        Assert.AreEqual($"<b>To receiver-test:</b> {bodyWithoutCoordinates}</noparse><link={coordinates}><color=#4886E3><u>{coordinates}</u></color></link><noparse>", entry.body.text);
-    });
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = body,
+                subType = ChatEntryModel.SubType.SENT
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual($"<b>To receiver-test:</b> {bodyWithoutCoordinates}</noparse><link={coordinates}><color=#4886E3><u>{coordinates}</u></color></link><noparse>", entry.body.text);
+        });
 
     [UnityTest]
-    public IEnumerator AddManyParcelCoordinates() => UniTask.ToCoroutine(async () =>
-    {
-        GivenEntryChat("PublicChatEntryReceivedWhisper");
-        
-        var message = new ChatEntryModel
+    public IEnumerator AddManyParcelCoordinates() =>
+        UniTask.ToCoroutine(async () =>
         {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
-            bodyText = "perhaps 73,94 then -5,42 and after -36,72",
-            subType = ChatEntryModel.SubType.SENT
-        };
-        
-        entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
+            GivenEntryChat("PublicChatEntryReceivedWhisper");
 
-        Assert.AreEqual("<b>To receiver-test:</b> perhaps </noparse><link=73,94><color=#4886E3><u>73,94</u></color></link><noparse> then </noparse><link=-5,42><color=#4886E3><u>-5,42</u></color></link><noparse> and after </noparse><link=-36,72><color=#4886E3><u>-36,72</u></color></link><noparse>", entry.body.text);
-    });
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "perhaps 73,94 then -5,42 and after -36,72",
+                subType = ChatEntryModel.SubType.SENT
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("<b>To receiver-test:</b> perhaps </noparse><link=73,94><color=#4886E3><u>73,94</u></color></link><noparse> then </noparse><link=-5,42><color=#4886E3><u>-5,42</u></color></link><noparse> and after </noparse><link=-36,72><color=#4886E3><u>-36,72</u></color></link><noparse>", entry.body.text);
+        });
 
     [UnityTest]
-    public IEnumerator DoNotShowUserName() => UniTask.ToCoroutine(async () =>
+    public IEnumerator DoNotShowUserName() =>
+        UniTask.ToCoroutine(async () =>
+        {
+            GivenEntryChat("PrivateChatEntryReceived");
+            entry.showUserName = false;
+
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.RECEIVED
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("test message", entry.body.text);
+        });
+
+    [UnityTest]
+    public IEnumerator ShowUserName() =>
+        UniTask.ToCoroutine(async () =>
+        {
+            GivenEntryChat("PrivateChatEntryReceived");
+            entry.showUserName = true;
+
+            var message = new ChatEntryModel
+            {
+                messageType = ChatMessage.Type.PRIVATE,
+                senderName = "user-test",
+                recipientName = "receiver-test",
+                bodyText = "test message",
+                subType = ChatEntryModel.SubType.SENT
+            };
+
+            entry.Populate(message);
+
+            await UniTask.DelayFrame(4);
+
+            Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
+        });
+
+    [TestCase((ulong)1680013416292, "Loading name - 03/28/23 11:23:36 AM")]
+    [TestCase((ulong)1230011812000, "Loading name - 12/23/08 3:56:52 AM")]
+    [TestCase((ulong)1430092000000, "Loading name - 04/26/15 8:46:40 PM")]
+    public void GetHoverTextWhenLoadingNames(ulong timestamp, string expectedHoverText)
     {
         GivenEntryChat("PrivateChatEntryReceived");
-        entry.showUserName = false;
 
         var message = new ChatEntryModel
         {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
+            messageType = ChatMessage.Type.PUBLIC,
+            senderName = "0xf242fad23fad32adfaf2",
+            recipientName = "0x1421f2afd124adf214df",
             bodyText = "test message",
-            subType = ChatEntryModel.SubType.RECEIVED
+            subType = ChatEntryModel.SubType.SENT,
+            isLoadingNames = true,
+            timestamp = timestamp,
         };
 
         entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
 
-        Assert.AreEqual("test message", entry.body.text);
-    });
+        Assert.AreEqual(expectedHoverText, entry.HoverString);
+    }
 
-    [UnityTest]
-    public IEnumerator ShowUserName() => UniTask.ToCoroutine(async () =>
+    [TestCase((ulong)1480072398390, "11/25/16 8:13:18 AM")]
+    [TestCase((ulong)1920396820000, "11/08/30 4:33:40 PM")]
+    [TestCase((ulong)1693000390000, "08/25/23 6:53:10 PM")]
+    public void GetHoverText(ulong timestamp, string expectedHoverText)
     {
         GivenEntryChat("PrivateChatEntryReceived");
-        entry.showUserName = true;
 
         var message = new ChatEntryModel
         {
-            messageType = ChatMessage.Type.PRIVATE,
-            senderName = "user-test",
-            recipientName = "receiver-test",
+            messageType = ChatMessage.Type.PUBLIC,
+            senderName = "0xf242fad23fad32adfaf2",
+            recipientName = "0x1421f2afd124adf214df",
             bodyText = "test message",
-            subType = ChatEntryModel.SubType.SENT
+            subType = ChatEntryModel.SubType.SENT,
+            timestamp = timestamp,
         };
 
         entry.Populate(message);
-        
-        await UniTask.DelayFrame(4);
 
-        Assert.AreEqual("<b>To receiver-test:</b> test message", entry.body.text);
-    });
-    
+        Assert.AreEqual(expectedHoverText, entry.HoverString);
+    }
+
     private void GivenEntryChat(string prefabName)
     {
         entry = Object.Instantiate(Resources.Load<DefaultChatEntry>($"SocialBarV1/{prefabName}"),

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/IPrivateChatComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/IPrivateChatComponentView.cs
@@ -1,3 +1,4 @@
+using DCL.Social.Chat;
 using DCL.Social.Friends;
 using SocialFeaturesAnalytics;
 using System;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatHUDView.cs
@@ -17,10 +17,10 @@ namespace DCL.Social.Chat
             ChatEntryFactory = chatEntryFactory;
         }
 
-        public override void AddEntry(ChatEntryModel model, bool setScrollPositionToBottom = false)
+        public override void SetEntry(ChatEntryModel model, bool setScrollPositionToBottom = false)
         {
             AddSeparatorEntryIfNeeded(model);
-            base.AddEntry(model, setScrollPositionToBottom);
+            base.SetEntry(model, setScrollPositionToBottom);
         }
 
         public override void ClearAllEntries()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
@@ -83,7 +83,8 @@ public class PrivateChatWindowController : IHUD
                     userProfileBridge.Get(conversationUserId)
                 }, ct);
             },
-          socialAnalytics);
+            socialAnalytics,
+            chatController);
 
         chatHudController.Initialize(view.ChatHUD);
         chatHudController.SortingStrategy = new ChatEntrySortingByTimestamp();
@@ -125,6 +126,7 @@ public class PrivateChatWindowController : IHUD
             if (conversationProfile != null)
             {
                 var userStatus = friendsController.GetUserStatus(conversationUserId);
+
                 View.Setup(conversationProfile,
                     userStatus.presence == PresenceStatus.ONLINE,
                     userProfileBridge.GetOwn().IsBlocked(conversationUserId));
@@ -132,6 +134,7 @@ public class PrivateChatWindowController : IHUD
                 if (shouldRequestMessages)
                 {
                     ResetPagination();
+
                     RequestPrivateMessages(
                         conversationUserId,
                         USER_PRIVATE_MESSAGES_TO_REQUEST_FOR_INITIAL_LOAD,
@@ -211,13 +214,15 @@ public class PrivateChatWindowController : IHUD
         chatController.Send(message);
     }
 
-    private void MinimizeView() => SetVisibility(false);
+    private void MinimizeView() =>
+        SetVisibility(false);
 
     private void HandleMessageReceived(ChatMessage[] messages)
     {
         var messageLogUpdated = false;
 
         var ownPlayerAlreadyMentioned = false;
+
         foreach (var message in messages)
         {
             if (!ownPlayerAlreadyMentioned)
@@ -271,7 +276,8 @@ public class PrivateChatWindowController : IHUD
         SetVisibility(true);
     }
 
-    private void HandlePressBack() => OnBack?.Invoke();
+    private void HandlePressBack() =>
+        OnBack?.Invoke();
 
     private void Unfriend(string friendId)
     {
@@ -296,6 +302,7 @@ public class PrivateChatWindowController : IHUD
     private void HandleInputFieldSelected()
     {
         Show();
+
         // The messages from 'conversationUserId' are marked as read if the player clicks on the input field of the private chat
         //MarkUserChatMessagesAsRead();
     }
@@ -312,6 +319,7 @@ public class PrivateChatWindowController : IHUD
     private void SetVisiblePanelList(bool visible)
     {
         HashSet<string> newSet = visibleTaskbarPanels.Get();
+
         if (visible)
             newSet.Add("PrivateChatChannel");
         else
@@ -357,13 +365,14 @@ public class PrivateChatWindowController : IHUD
     private void HandleMessageBlockedBySpam(ChatMessage message)
     {
         chatHudController.AddChatMessage(new ChatEntryModel
-        {
-            timestamp = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            bodyText = "You sent too many messages in a short period of time. Please wait and try again later.",
-            messageId = Guid.NewGuid().ToString(),
-            messageType = ChatMessage.Type.SYSTEM,
-            subType = ChatEntryModel.SubType.RECEIVED
-        }).Forget();
+                          {
+                              timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                              bodyText = "You sent too many messages in a short period of time. Please wait and try again later.",
+                              messageId = Guid.NewGuid().ToString(),
+                              messageType = ChatMessage.Type.SYSTEM,
+                              subType = ChatEntryModel.SubType.RECEIVED
+                          })
+                         .Forget();
     }
 
     private void ResetPagination()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowController.cs
@@ -230,7 +230,7 @@ public class PrivateChatWindowController : IHUD
 
             if (!IsMessageFomCurrentConversation(message)) continue;
 
-            chatHudController.AddChatMessage(message, limitMaxEntries: false);
+            chatHudController.SetChatMessage(message, limitMaxEntries: false);
 
             if (message.timestamp < oldestTimestamp)
             {
@@ -364,7 +364,7 @@ public class PrivateChatWindowController : IHUD
 
     private void HandleMessageBlockedBySpam(ChatMessage message)
     {
-        chatHudController.AddChatMessage(new ChatEntryModel
+        chatHudController.SetChatMessage(new ChatEntryModel
                           {
                               timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                               bodyText = "You sent too many messages in a short period of time. Please wait and try again later.",

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Tests/PrivateChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Tests/PrivateChatWindowControllerShould.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL;
 using DCL.Interface;
+using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using DCL.Social.Friends;
 using NSubstitute;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Tests/PrivateChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Tests/PrivateChatWindowControllerShould.cs
@@ -91,7 +91,7 @@ public class PrivateChatWindowControllerShould
         chatController.OnAddMessage += Raise.Event<Action<ChatMessage[]>>(new[] { msg3 });
 
         internalChatView.Received(3)
-                        .AddEntry(Arg.Is<ChatEntryModel>(model =>
+                        .SetEntry(Arg.Is<ChatEntryModel>(model =>
                              model.messageType == ChatMessage.Type.PRIVATE
                              && model.senderId == FRIEND_ID));
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ChatHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SocialBarPrefabs/Resources/SocialBarV1/ChatHUD.prefab
@@ -530,6 +530,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2411879222414548724}
+  - component: {fileID: 1044710674084031029}
+  - component: {fileID: 5939887867241173635}
   m_Layer: 5
   m_Name: MessageHoverPanel
   m_TagString: Untagged
@@ -557,8 +559,48 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 104.77, y: -193.4}
-  m_SizeDelta: {x: 154, y: 40}
+  m_SizeDelta: {x: 154.22, y: 40}
   m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1044710674084031029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2398874209708396822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 8
+    m_Right: 8
+    m_Top: 0
+    m_Bottom: 4
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &5939887867241173635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2398874209708396822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
 --- !u!1 &2825232948437699106
 GameObject:
   m_ObjectHideFlags: 0
@@ -646,6 +688,7 @@ GameObject:
   - component: {fileID: 1055481873373078086}
   - component: {fileID: 2179914846328511925}
   - component: {fileID: 770084659529766549}
+  - component: {fileID: 3344783493571960551}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -668,10 +711,10 @@ RectTransform:
   m_Father: {fileID: 2411879222414548724}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0, y: -6}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 77.11, y: -18}
+  m_SizeDelta: {x: 138.22, y: 36}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2179914846328511925
 CanvasRenderer:
@@ -771,6 +814,20 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &3344783493571960551
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3131349297428322570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
 --- !u!1 &3168199751916107564
 GameObject:
   m_ObjectHideFlags: 0
@@ -1473,7 +1530,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 5.0598, y: 0}
+  m_SizeDelta: {x: -0.0000035762787, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6704367201826075058
 CanvasRenderer:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -77,7 +77,7 @@ namespace DCL.Chat.HUD
 
             chatHudController = new ChatHUDController(dataStore, userProfileBridge, false,
                (name, count, ct) => chatMentionSuggestionProvider.GetProfilesFromChatChannelsStartingWith(name, channelId, count, ct),
-                socialAnalytics, profanityFilter);
+                socialAnalytics, chatController, profanityFilter);
 
             chatHudController.Initialize(view.ChatHUD);
             chatHudController.SortingStrategy = new ChatEntrySortingByTimestamp();
@@ -232,8 +232,6 @@ namespace DCL.Chat.HUD
                 if (!IsMessageFomCurrentChannel(message)) continue;
 
                 UpdateOldestMessage(message);
-
-                message.isChannelMessage = true;
 
                 // TODO: right now the channel history is disabled, but we must find a workaround to support history + max message limit allocation for performance reasons
                 // one approach could be to increment the max amount of messages depending on how many pages you loaded from the history

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -236,7 +236,7 @@ namespace DCL.Chat.HUD
                 // TODO: right now the channel history is disabled, but we must find a workaround to support history + max message limit allocation for performance reasons
                 // one approach could be to increment the max amount of messages depending on how many pages you loaded from the history
                 // for example: 1 page = 30 messages, 2 pages = 60 messages, and so on..
-                chatHudController.AddChatMessage(message, limitMaxEntries: true);
+                chatHudController.SetChatMessage(message, limitMaxEntries: true);
 
                 dataStore.channels.SetAvailableMemberInChannel(message.sender, channelId);
 
@@ -409,7 +409,7 @@ namespace DCL.Chat.HUD
 
         private void HandleMessageBlockedBySpam(ChatMessage message)
         {
-            chatHudController.AddChatMessage(new ChatEntryModel
+            chatHudController.SetChatMessage(new ChatEntryModel
             {
                 timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 bodyText = "You sent too many messages in a short period of time. Please wait and try again later.",

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IChatChannelWindowView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IChatChannelWindowView.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DCL.Social.Chat;
+using System;
 using UnityEngine;
 
 namespace DCL.Chat.HUD
@@ -12,7 +13,7 @@ namespace DCL.Chat.HUD
         event Action OnLeaveChannel;
         event Action OnShowMembersList;
         event Action OnHideMembersList;
-        event Action<bool> OnMuteChanged; 
+        event Action<bool> OnMuteChanged;
 
         bool IsActive { get; }
         IChatHUDComponentView ChatHUD { get; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IPublicChatWindowView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/IPublicChatWindowView.cs
@@ -1,4 +1,5 @@
 using DCL.Chat.HUD;
+using DCL.Social.Chat;
 using System;
 using UnityEngine;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
@@ -70,6 +70,7 @@ namespace DCL.Chat.HUD
                 true,
                 (name, count, ct) => chatMentionSuggestionProvider.GetNearbyProfilesStartingWith(name, count, ct),
                 socialAnalytics,
+                chatController,
                 profanityFilter);
             // dont set any message's sorting strategy, just add them sequentally
             // comms cannot calculate a server timestamp for each message

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/PublicChatWindowController.cs
@@ -230,7 +230,7 @@ namespace DCL.Chat.HUD
 
                 if (!string.IsNullOrEmpty(message.recipient)) continue;
 
-                chatHudController.AddChatMessage(message, View.IsActive);
+                chatHudController.SetChatMessage(message, View.IsActive);
                 messageLogUpdated = true;
             }
 
@@ -258,7 +258,7 @@ namespace DCL.Chat.HUD
 
         private void HandleMessageBlockedBySpam(ChatMessage message)
         {
-            chatHudController.AddChatMessage(new ChatEntryModel
+            chatHudController.SetChatMessage(new ChatEntryModel
             {
                 timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 bodyText = "You sent too many messages in a short period of time. Please wait and try again later.",

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelHUDControllerShould.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
+using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using NSubstitute;
 using NUnit.Framework;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/ChatChannelHUDControllerShould.cs
@@ -131,6 +131,15 @@ namespace DCL.Chat.HUD
         [Test]
         public void MarkMessagesAsSeenOnlyOnceWhenReceivedManyMessages()
         {
+            var senderUserProfile = ScriptableObject.CreateInstance<UserProfile>();
+            senderUserProfile.UpdateData(new UserProfileModel
+            {
+                userId = "user",
+                name = "userName",
+            });
+
+            userProfileBridge.Get("user").Returns(senderUserProfile);
+
             controller.SetVisibility(true);
             view.IsActive.Returns(true);
             chatController.ClearReceivedCalls();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChatWindowControllerShould.cs
@@ -4,6 +4,7 @@ using DCL.Chat;
 using DCL.Chat.HUD;
 using DCL.Interface;
 using DCL.ProfanityFiltering;
+using DCL.Social.Chat;
 using DCL.Social.Chat.Mentions;
 using NSubstitute;
 using NUnit.Framework;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChatWindowControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Tests/PublicChatWindowControllerShould.cs
@@ -78,7 +78,7 @@ public class PublicChatWindowControllerShould
 
         chatController.OnAddMessage += Raise.Event<Action<ChatMessage[]>>(new[] {msg});
 
-        internalChatView.Received(1).AddEntry(Arg.Is<ChatEntryModel>(model =>
+        internalChatView.Received(1).SetEntry(Arg.Is<ChatEntryModel>(model =>
             model.messageType == msg.messageType
             && model.bodyText == $"<noparse>{msg.body}</noparse>"
             && model.senderId == msg.sender));
@@ -97,7 +97,7 @@ public class PublicChatWindowControllerShould
 
         chatController.OnAddMessage += Raise.Event<Action<ChatMessage[]>>(new[] {msg});
 
-        internalChatView.DidNotReceiveWithAnyArgs().AddEntry(default);
+        internalChatView.DidNotReceiveWithAnyArgs().SetEntry(default);
     }
 
     [Test]


### PR DESCRIPTION
## What does this PR change?

Fetches the profile, if not available, when adding a chat message.
Fixes that sometimes you see the address of the user instead of the name in the message, either sender or recipient. 

## How to test the changes?

1. Launch the explorer
2. Send and receive messages in ~nearby
3. Send and receive messages in private conversations
4. Send and receive messages in #channels (recommended to use #test)
5. If at any point you see an address instead of the user name, it should change to a proper name after a small period of time

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
