### PR TITLE
hotfix: bring down client on id duplicated

### DIFF
--- a/browser-interface/packages/shared/comms/adapters/LivekitAdapter.ts
+++ b/browser-interface/packages/shared/comms/adapters/LivekitAdapter.ts
@@ -47,7 +47,8 @@ export class LivekitAdapter implements MinimumCommunicationsAdapter {
           message: `Got RoomEvent.Disconnected. Reason: ${_reason}`,
           stack: ""
         })
-        this.disconnect().catch((err) => {
+        const kicked = _reason === DisconnectReason.DUPLICATE_IDENTITY
+        this.do_disconnect(kicked).catch((err) => {
           this.config.logger.error(`error during disconnection ${err.toString()}`)
         })
       })
@@ -100,6 +101,10 @@ export class LivekitAdapter implements MinimumCommunicationsAdapter {
   }
 
   async disconnect() {
+    return this.do_disconnect(false)
+  }
+
+  async do_disconnect(kicked: boolean) {
     if (this.disconnected) {
       return
     }
@@ -108,7 +113,7 @@ export class LivekitAdapter implements MinimumCommunicationsAdapter {
 
     this.disconnected = true
     this.room.disconnect().catch(commsLogger.error)
-    this.events.emit('DISCONNECTION', { kicked: false })
+    this.events.emit('DISCONNECTION', { kicked })
   }
 
   handleMessage(address: string, data: Uint8Array) {

--- a/browser-interface/packages/shared/comms/handlers.ts
+++ b/browser-interface/packages/shared/comms/handlers.ts
@@ -31,6 +31,7 @@ import {
 } from './peers'
 import { scenesSubscribedToCommsEvents } from './sceneSubscriptions'
 import { globalObservable } from 'shared/observables'
+import { BringDownClientAndReportFatalError, ErrorContext } from 'shared/loading/ReportFatalError'
 
 type PingRequest = {
   alias: number
@@ -92,12 +93,13 @@ export async function requestProfileFromPeers(
 
 function handleDisconnectionEvent(data: AdapterDisconnectedEvent, room: RoomConnection) {
   store.dispatch(handleRoomDisconnection(room))
+
   // when we are kicked, the explorer should re-load, or maybe go to offline~offline realm
   if (data.kicked) {
-    const url = new URL(document.location.toString())
-    url.search = ''
-    url.searchParams.set('disconnection-reason', 'logged-in-somewhere-else')
-    document.location = url.toString()
+    const error = new Error(
+      'Disconnected from realm as the user id is already taken. Please make sure you are not logged into the world through another tab'
+    )
+    BringDownClientAndReportFatalError(error, ErrorContext.COMMS_INIT)
   }
 }
 

--- a/browser-interface/packages/shared/loading/ReportFatalError.ts
+++ b/browser-interface/packages/shared/loading/ReportFatalError.ts
@@ -87,6 +87,8 @@ export function BringDownClientAndReportFatalError(
 ) {
   let sagaStack: string | undefined = payload['sagaStack']
 
+  debugger
+
   if (sagaStack) {
     // first stringify
     sagaStack = '' + sagaStack

--- a/browser-interface/packages/shared/loading/ReportFatalError.ts
+++ b/browser-interface/packages/shared/loading/ReportFatalError.ts
@@ -87,8 +87,6 @@ export function BringDownClientAndReportFatalError(
 ) {
   let sagaStack: string | undefined = payload['sagaStack']
 
-  debugger
-
   if (sagaStack) {
     // first stringify
     sagaStack = '' + sagaStack
@@ -105,6 +103,8 @@ export function BringDownClientAndReportFatalError(
     stack: getStack(error).slice(0, 10000),
     saga_stack: sagaStack
   })
+
+  store.dispatch(fatalError(error.message || 'fatal error'))
 
   globalObservable.emit('error', {
     error,


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

The current PR partially addresses #4513 bringing down the client and removing disabling comms from retrying to connect to the realm when it was initially kicked due to a duplicated id error (i.e. two tabs open with the same wallet address).

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer on one tab with a given wallet
2. Launch the explorer on another tab with the same wallet
3. At least one of the two should get an error explaining the issue, bringing down the client and disconnecting from comms
4. The tab with no issue or a new tab if the previous two erred should be available to connect successfully with no realm issues

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
