### PR TITLE
fix: add livekit session ids for disconnection causes

### DIFF
--- a/browser-interface/packages/shared/analytics/types.ts
+++ b/browser-interface/packages/shared/analytics/types.ts
@@ -85,5 +85,5 @@ export type TrackEvents = PositionTrackEvents & {
   ['invalid_denied_catalyst_url']: { url: string }
   ['invalid_comms_message_too_big']: { message: string }
   ['onboarding_started']: { onboardingRealm: string }
-  ['disconnection_cause']: { context: string; message: string; }
+  ['disconnection_cause']: { context: string; message: string; liveKitRoomSid: string ; liveKitParticipantSid: string }
 }

--- a/browser-interface/packages/shared/comms/adapters/LivekitAdapter.ts
+++ b/browser-interface/packages/shared/comms/adapters/LivekitAdapter.ts
@@ -41,11 +41,16 @@ export class LivekitAdapter implements MinimumCommunicationsAdapter {
         this.config.logger.log('remote participant left', _.identity)
       })
       .on(RoomEvent.Disconnected, (reason: DisconnectReason | undefined) => {
-        this.config.logger.log('disconnected from room', reason)
+        this.config.logger.log('disconnected from room', reason, {
+          liveKitParticipantSid: this.room.localParticipant.sid,
+          liveKitRoomSid: this.room.sid
+        })
         if (!this.disconnected) {
           trackEvent('disconnection_cause', {
             context: 'livekit-adapter',
             message: `Got RoomEvent.Disconnected. Reason: ${reason}`,
+            liveKitParticipantSid: this.room.localParticipant.sid,
+            liveKitRoomSid: this.room.sid
           })
         }
         const kicked = reason === DisconnectReason.DUPLICATE_IDENTITY
@@ -94,7 +99,8 @@ export class LivekitAdapter implements MinimumCommunicationsAdapter {
       trackEvent('error', {
         context: 'livekit-adapter',
         message: `Error trying to send data. Reason: ${err.message}`,
-        stack: err.stack
+        stack: err.stack,
+        saga_stack: `room session id: ${this.room.sid}, participant id: ${this.room.localParticipant.sid}`
       })
       // this fails in some cases, catch is needed
       this.config.logger.error(err)


### PR DESCRIPTION
## What does this PR change?
Add LiveKit session ids when logging disconnection causes