### PR TITLE
fix: null chat notification entries in rare occasions

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs
@@ -3,7 +3,6 @@ using DCL.Helpers;
 using DG.Tweening;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using TMPro;
 using UnityEngine;
@@ -21,8 +20,8 @@ namespace DCL.Chat.Notifications
         [SerializeField] private ShowHideAnimator panelAnimator;
         [SerializeField] private ShowHideAnimator scrollbarAnimator;
 
-        private const string NOTIFICATION_POOL_NAME_PREFIX = "NotificationEntriesPool_";
-        private const string FRINED_REQUEST_NOTIFICATION_POOL_NAME_PREFIX = "FriendRequestNotificationEntriesPool_";
+        private const string CHAT_NOTIFICATION_POOL_NAME_PREFIX = "ChatNotificationEntriesPool_";
+        private const string FRIEND_REQUEST_NOTIFICATION_POOL_NAME_PREFIX = "FriendRequestNotificationEntriesPool_";
         private const int MAX_NOTIFICATION_ENTRIES = 30;
 
         public event Action<string> OnClickedChatMessage;
@@ -35,19 +34,16 @@ namespace DCL.Chat.Notifications
 
         private readonly Vector2 notificationOffset = new (0, -56);
 
-        private Pool entryPool;
         private bool isOverMessage;
         private bool isOverPanel;
         private int notificationCount = 1;
         private TMP_Text notificationMessage;
         private CancellationTokenSource animationCancellationToken = new ();
 
-        public static MainChatNotificationsComponentView Create()
-        {
-            return Instantiate(Resources.Load<MainChatNotificationsComponentView>("SocialBarV1/ChatNotificationHUD"));
-        }
+        public static MainChatNotificationsComponentView Create() =>
+            Instantiate(Resources.Load<MainChatNotificationsComponentView>("SocialBarV1/ChatNotificationHUD"));
 
-        public void Awake()
+        public override void Awake()
         {
             onFocused += FocusedOnPanel;
             notificationMessage = notificationButton.GetComponentInChildren<TMP_Text>();
@@ -56,10 +52,8 @@ namespace DCL.Chat.Notifications
             scrollRectangle.onValueChanged.AddListener(ResetNotificationButtonFromScroll);
         }
 
-        public override void Show(bool instant = false)
-        {
+        public override void Show(bool instant = false) =>
             gameObject.SetActive(true);
-        }
 
         public override void Hide(bool instant = false)
         {
@@ -67,17 +61,12 @@ namespace DCL.Chat.Notifications
             gameObject.SetActive(false);
         }
 
-        public Transform GetPanelTransform()
-        {
-            return gameObject.transform;
-        }
+        public Transform GetPanelTransform() =>
+            gameObject.transform;
 
         private void ResetNotificationButtonFromScroll(Vector2 newValue)
         {
-            if (newValue.y <= 0.0)
-            {
-                ResetNotificationButton();
-            }
+            if (newValue.y <= 0.0) { ResetNotificationButton(); }
         }
 
         public void ShowPanel()
@@ -98,23 +87,19 @@ namespace DCL.Chat.Notifications
         public void ShowNotifications()
         {
             foreach (BaseComponentView notification in notificationQueue)
-                // For an unknown reason, sometimes we get an invalid notification
-                if (notification)
-                    notification.Show();
+                notification.Show();
         }
 
         public void HideNotifications()
         {
             foreach (BaseComponentView notification in notificationQueue)
-                // For an unknown reason, sometimes we get an invalid notification
-                if (notification)
-                    notification.Hide();
+                notification.Hide();
         }
 
         public void AddNewChatNotification(PrivateChatMessageNotificationModel model)
         {
-            entryPool = GetNotificationEntryPool();
-            var newNotification = entryPool.Get();
+            Pool entryPool = GetChatNotificationEntryPool();
+            PoolableObject newNotification = entryPool.Get();
 
             var entry = newNotification.gameObject.GetComponent<ChatNotificationMessageComponentView>();
             poolableQueue.Enqueue(newNotification);
@@ -134,6 +119,7 @@ namespace DCL.Chat.Notifications
             entry.showHideAnimator.OnWillFinishHide += SetScrollToEnd;
 
             chatEntriesContainer.anchoredPosition += notificationOffset;
+
             if (isOverPanel)
             {
                 notificationButton.gameObject.SetActive(true);
@@ -153,8 +139,8 @@ namespace DCL.Chat.Notifications
 
         public void AddNewChatNotification(PublicChannelMessageNotificationModel model)
         {
-            entryPool = GetNotificationEntryPool();
-            var newNotification = entryPool.Get();
+            Pool entryPool = GetChatNotificationEntryPool();
+            PoolableObject newNotification = entryPool.Get();
 
             var entry = newNotification.gameObject.GetComponent<ChatNotificationMessageComponentView>();
             poolableQueue.Enqueue(newNotification);
@@ -174,6 +160,7 @@ namespace DCL.Chat.Notifications
             entry.showHideAnimator.OnWillFinishHide += SetScrollToEnd;
 
             chatEntriesContainer.anchoredPosition += notificationOffset;
+
             if (isOverPanel)
             {
                 notificationButton.gameObject.SetActive(true);
@@ -196,8 +183,8 @@ namespace DCL.Chat.Notifications
 
         public void AddNewFriendRequestNotification(FriendRequestNotificationModel model)
         {
-            entryPool = GetFriendRequestNotificationEntryPool();
-            var newNotification = entryPool.Get();
+            Pool entryPool = GetFriendRequestNotificationEntryPool();
+            PoolableObject newNotification = entryPool.Get();
 
             var entry = newNotification.gameObject.GetComponent<FriendRequestNotificationComponentView>();
             poolableQueue.Enqueue(newNotification);
@@ -216,6 +203,7 @@ namespace DCL.Chat.Notifications
             entry.showHideAnimator.OnWillFinishHide += SetScrollToEnd;
 
             chatEntriesContainer.anchoredPosition += notificationOffset;
+
             if (isOverPanel)
             {
                 notificationButton.gameObject.SetActive(true);
@@ -239,14 +227,18 @@ namespace DCL.Chat.Notifications
         private async UniTaskVoid AnimateNewEntry(Transform notification, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            Sequence mySequence = DOTween.Sequence().AppendInterval(0.2f)
-                .Append(notification.DOScale(1, 0.3f).SetEase(Ease.OutBack));
+
+            Sequence mySequence = DOTween.Sequence()
+                                         .AppendInterval(0.2f)
+                                         .Append(notification.DOScale(1, 0.3f).SetEase(Ease.OutBack));
+
             try
             {
                 Vector2 endPosition = new Vector2(0, 0);
                 Vector2 currentPosition = chatEntriesContainer.anchoredPosition;
                 notification.localScale = Vector3.zero;
                 DOTween.To(() => currentPosition, x => currentPosition = x, endPosition, 0.8f).SetEase(Ease.OutCubic);
+
                 while (chatEntriesContainer.anchoredPosition.y < 0)
                 {
                     chatEntriesContainer.anchoredPosition = currentPosition;
@@ -274,6 +266,7 @@ namespace DCL.Chat.Notifications
         private void IncreaseNotificationCount()
         {
             notificationCount++;
+
             if (notificationMessage != null)
                 notificationMessage.text = notificationCount <= 9 ? notificationCount.ToString() : "9+";
         }
@@ -366,23 +359,35 @@ namespace DCL.Chat.Notifications
             if (poolableQueue.Count < MAX_NOTIFICATION_ENTRIES) return;
 
             BaseComponentView notificationToDequeue = notificationQueue.Dequeue();
+            notificationToDequeue.onFocused -= FocusedOnNotification;
 
-            if (notificationToDequeue)
-                notificationToDequeue.onFocused -= FocusedOnNotification;
+            PoolableObject pooledObj = poolableQueue.Dequeue();
 
-            entryPool.Release(poolableQueue.Dequeue());
+            switch (notificationToDequeue)
+            {
+                case FriendRequestNotificationComponentView:
+                    GetFriendRequestNotificationEntryPool().Release(pooledObj);
+                    break;
+                case ChatNotificationMessageComponentView:
+                    GetChatNotificationEntryPool().Release(pooledObj);
+                    break;
+                default:
+                    Debug.LogError($"Failed to release notification of type {notificationToDequeue.GetType()}. No object pool found.");
+                    break;
+            }
         }
 
-        private Pool GetNotificationEntryPool()
+        private Pool GetChatNotificationEntryPool()
         {
-            var entryPool = PoolManager.i.GetPool(NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID());
+            var entryPool = PoolManager.i.GetPool(CHAT_NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID());
             if (entryPool != null) return entryPool;
 
             entryPool = PoolManager.i.AddPool(
-                NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID(),
+                CHAT_NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID(),
                 Instantiate(chatNotification),
                 maxPrewarmCount: MAX_NOTIFICATION_ENTRIES,
                 isPersistent: true);
+
             entryPool.ForcePrewarm();
 
             return entryPool;
@@ -390,22 +395,22 @@ namespace DCL.Chat.Notifications
 
         private Pool GetFriendRequestNotificationEntryPool()
         {
-            var entryPool = PoolManager.i.GetPool(FRINED_REQUEST_NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID());
+            var entryPool = PoolManager.i.GetPool(FRIEND_REQUEST_NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID());
+
             if (entryPool != null)
                 return entryPool;
 
             entryPool = PoolManager.i.AddPool(
-                FRINED_REQUEST_NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID(),
+                FRIEND_REQUEST_NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID(),
                 Instantiate(friendRequestNotification),
                 maxPrewarmCount: MAX_NOTIFICATION_ENTRIES,
                 isPersistent: true);
+
             entryPool.ForcePrewarm();
 
             return entryPool;
         }
 
-        public override void RefreshControl()
-        {
-        }
+        public override void RefreshControl() { }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs
@@ -380,7 +380,7 @@ namespace DCL.Chat.Notifications
 
             entryPool = PoolManager.i.AddPool(
                 NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID(),
-                chatNotification,
+                Instantiate(chatNotification),
                 maxPrewarmCount: MAX_NOTIFICATION_ENTRIES,
                 isPersistent: true);
             entryPool.ForcePrewarm();
@@ -396,7 +396,7 @@ namespace DCL.Chat.Notifications
 
             entryPool = PoolManager.i.AddPool(
                 FRINED_REQUEST_NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID(),
-                Instantiate(friendRequestNotification).gameObject,
+                Instantiate(friendRequestNotification),
                 maxPrewarmCount: MAX_NOTIFICATION_ENTRIES,
                 isPersistent: true);
             entryPool.ForcePrewarm();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs
@@ -380,7 +380,7 @@ namespace DCL.Chat.Notifications
 
             entryPool = PoolManager.i.AddPool(
                 NOTIFICATION_POOL_NAME_PREFIX + name + GetInstanceID(),
-                Instantiate(chatNotification).gameObject,
+                chatNotification,
                 maxPrewarmCount: MAX_NOTIFICATION_ENTRIES,
                 isPersistent: true);
             entryPool.ForcePrewarm();


### PR DESCRIPTION
## What does this PR change?

Fixes that sometimes we get an exception on the notification panel due the notification entry being null.
The problem was due objects in the pool getting messed up between friend requests and chat messages. There was only one `entryPool` field for both kind of pools. When an entry was getting released, the internal object pool's linked list was nesting two different type of objects in the same pool.
The fix consists on referring to the correct pool depending on the type of notification.

```
NullReferenceException: Object reference not set to an instance of an object
DCL.Chat.Notifications.MainChatNotificationsComponentView.AddNewChatNotification (DCL.Chat.Notifications.PublicChannelMessageNotificationModel model) (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/MainChatNotificationsComponentView.cs:163)
DCL.Chat.Notifications.ChatNotificationController.AddNotificationAsync (DCL.Interface.ChatMessage message, DCL.Chat.Channels.Channel channel, System.Threading.CancellationToken cancellationToken) (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs:207)
UnityEngine.Debug:LogException(Exception)
Cysharp.Threading.Tasks.UniTaskScheduler:PublishUnobservedTaskException(Exception) (at Library/PackageCache/com.cysharp.unitask@c7eedf85c7/Runtime/UniTaskScheduler.cs:90)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskVoidMethodBuilder:SetException(Exception) (at Library/PackageCache/com.cysharp.unitask@c7eedf85c7/Runtime/CompilerServices/AsyncUniTaskVoidMethodBuilder.cs:53)
DCL.Chat.Notifications.<AddNotificationAsync>d__33:MoveNext() (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs:213)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskVoidMethodBuilder:Start(<AddNotificationAsync>d__33&) (at Library/PackageCache/com.cysharp.unitask@c7eedf85c7/Runtime/CompilerServices/AsyncUniTaskVoidMethodBuilder.cs:110)
DCL.Chat.Notifications.ChatNotificationController:AddNotificationAsync(ChatMessage, Channel, CancellationToken)
DCL.Chat.Notifications.ChatNotificationController:HandleMessageAdded(ChatMessage[]) (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationMessagesHUD/ChatNotificationController.cs:145)
DCL.Social.Chat.ChatController:AddMessages(ChatMessage[]) (at Assets/Scripts/MainScripts/DCL/Controllers/ChatController/ChatController.cs:429)
DCL.Social.Chat.WebInterfaceChatBridge:AddMessageToChatWindow(String) (at Assets/Scripts/MainScripts/DCL/Controllers/ChatController/WebInterfaceChatBridge.cs:50)
UnityEngine.GameObject:SendMessage(String, Object)
<ProcessMessages>d__19:MoveNext() (at Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/WebSocketCommunication/WebSocketCommunication.cs:292)
UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)
```

## How to test the changes?

1. Launch the explorer
2. Use the chat by sending and receiving messages
3. Receive friend requests so they are added in the notification panel
4. Keep using the chat until you get more than 30 notifications (preferrable 60+)
5. You should always see the chat notifications in the panel as expected without exceptions
6. Use the taskbar, should open the windows as expected when clicking the buttons

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
