### PR TITLE
fix: removed a55 from badwords due unwanted address filtering

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ProfanityFiltering/Resources/Profanity/badwords.json
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/ProfanityFiltering/Resources/Profanity/badwords.json
@@ -28,7 +28,6 @@
     "4r5e",
     "5h1t",
     "5hit",
-    "a55",
     "ar5e",
     "acrotomophilia",
     "alabamahotpocket",


### PR DESCRIPTION
## What does this PR change?

If you write in the chat an address which contains `a55` its considered a profanity word and then filtered, making impossible to read the full address.

## How to test the changes?

1. Launch the explorer
2. Activate profanity filtering from the settings
3. Write in the chat an address that contains `a55`, for example: `0x3a55404f3b6B40876512fE612711e76d3714F49B`
4. It should not be filtered

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
