### PR TITLE
feat: rename explore section to discovery

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
@@ -2355,7 +2355,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6196565778153578672
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2376,10 +2376,10 @@ RectTransform:
   m_Father: {fileID: 5737986593011763845}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 424, y: -23}
+  m_SizeDelta: {x: 104, y: 46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5854303832268976974
 MonoBehaviour:
@@ -2812,7 +2812,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: EXPLORE <color=#43404Aff>[X]</color>
+  m_text: DISCOVERY <color=#43404Aff>[X]</color>
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -3156,7 +3156,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: EXPLORE <color=#A09BA8ff>[X]</color>
+  m_text: DISCOVERY <color=#A09BA8ff>[X]</color>
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -4737,7 +4737,7 @@ PrefabInstance:
     - target: {fileID: 8731583579770001316, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
         type: 3}
       propertyPath: model.sections.Array.data[0].selectedTitle
-      value: EXPLORE <color=#A09BA8ff>[X]</color>
+      value: DISCOVERY <color=#A09BA8ff>[X]</color>
       objectReference: {fileID: 0}
     - target: {fileID: 8731583579770001316, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
         type: 3}
@@ -4803,7 +4803,7 @@ PrefabInstance:
     - target: {fileID: 8731583579770001316, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
         type: 3}
       propertyPath: model.sections.Array.data[0].unselectedTitle
-      value: EXPLORE <color=#43404Aff>[X]</color>
+      value: DISCOVERY <color=#43404Aff>[X]</color>
       objectReference: {fileID: 0}
     - target: {fileID: 8731583579770001316, guid: 47888b63c7dcb7f4a9fbda4bd22c7894,
         type: 3}


### PR DESCRIPTION
## What does this PR change?

Fix #3452
Rename Explore to Discovery in the explorer menu

...

## How to test the changes?

1. Launch the explorer
2. Open the menu
3. Verify that the first section is correctly called "Discover" instead of "Explore"

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
