### PR TITLE
chore: disable physcs 2D auto simulation

### DIFF
--- a/unity-renderer/ProjectSettings/Physics2DSettings.asset
+++ b/unity-renderer/ProjectSettings/Physics2DSettings.asset
@@ -3,7 +3,7 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 4
+  serializedVersion: 5
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
@@ -38,7 +38,7 @@ Physics2DSettings:
     m_IslandSolverJointCostScale: 10
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
-  m_AutoSimulation: 0
+  m_SimulationMode: 2
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1


### PR DESCRIPTION
## What does this PR change?

Closes #4821 

As per Unity recommendation,

Both 3D and 2D physics simulations are currently being run in the game, even though the game only uses
3D physics. Those updates cause unnecessary overhead, which can add up when multiple updates are
scheduled during the same frame.
We recommend that the team disables the 2D physics auto simulation in the Project Settings. The
relevant setting is Project Settings -> Physics 2D-> Simulation Mode -> Script.

We are changing the Simulation Mode from Fixed Update to Script

## How to test the changes?


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
