### PR TITLE
fix: skybox editor on pause

### DIFF
--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/Editor/Procedural Skybox/SkyboxEditor.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/Editor/Procedural Skybox/SkyboxEditor.cs
@@ -205,7 +205,7 @@ namespace DCL.Skybox
 
                 if (selectedConfiguration != configurations[selectedConfigurationIndex])
                 {
-                    UpdateConfigurationsList();
+                    configurations[selectedConfigurationIndex] = selectedConfiguration;
 
                     if (Application.isPlaying && SkyboxController.i != null && overridingController)
                     {


### PR DESCRIPTION
## What does this PR change?

Fixes an issue generated by using addressables in the skybox editor. The selected configuration was not being changed correctly

## How to test the changes?

ONLY IN EDITOR

Pull the branch, and change the skybox configurations in the Skybox Editor (Window->SkyboxEditor). Press Play and check that the skybox flows through time correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 268b2d2</samp>

Fix bug in `SkyboxEditor.cs` that prevented updating the selected configuration. Enhance procedural skybox tool usability and functionality.
