### PR TITLE
chore: pre-warm shader variants

### DIFF
--- a/unity-renderer/Assets/Rendering/Common/Resources/ShaderVariantCollections/shadervariants-selected.shadervariants
+++ b/unity-renderer/Assets/Rendering/Common/Resources/ShaderVariantCollections/shadervariants-selected.shadervariants
@@ -391,6 +391,12 @@ ShaderVariantCollection:
         passType: 0
       - keywords: 
         passType: 8
+  - first: {fileID: -6465566751694194690, guid: ab8c8d3251a70d541abcb13509438eea,
+      type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
   - first: {fileID: 4800000, guid: 331d3d55d3ac1604f9e758eca2b2932b, type: 3}
     second:
       variants:

--- a/unity-renderer/Assets/Rendering/Common/Resources/ShaderVariantCollections/shadervariants-selected.shadervariants
+++ b/unity-renderer/Assets/Rendering/Common/Resources/ShaderVariantCollections/shadervariants-selected.shadervariants
@@ -8,115 +8,436 @@ ShaderVariantCollection:
   m_PrefabAsset: {fileID: 0}
   m_Name: shadervariants-selected
   m_Shaders:
-  - first: {fileID: 4800000, guid: 7f7d521a5e1284f4e97bbb5c94f035aa, type: 3}
-    second:
-      variants: []
-  - first: {fileID: 4800000, guid: b38bd543f02d4b258db32c8f17759c58, type: 3}
+  - first: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
     second:
       variants:
       - keywords: 
-        passType: 13
-  - first: {fileID: 4800000, guid: 337b8b170aadf884482f684ab8372b91, type: 3}
+        passType: 0
+      - keywords: UNITY_UI_ALPHACLIP
+        passType: 0
+      - keywords: UNITY_UI_CLIP_RECT
+        passType: 0
+  - first: {fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
     second:
       variants:
       - keywords: 
-        passType: 13
-  - first: {fileID: 4800000, guid: 08f57eed8cd29db40bdfc5af4b40f41b, type: 3}
+        passType: 0
+  - first: {fileID: 15104, guid: 0000000000000000f000000000000000, type: 0}
     second:
       variants:
-      - keywords: _ALPHATEST_ON _EMISSION _NORMALMAP
+      - keywords: 
+        passType: 0
+  - first: {fileID: 15105, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 66, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: SHADOWS_DEPTH
+        passType: 8
+  - first: {fileID: 6, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: SHADOWS_DEPTH
+        passType: 8
+  - first: {fileID: 108, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 200, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: FOG_LINEAR
+        passType: 0
+  - first: {fileID: 9000, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 9001, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 9002, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: 65df88701913c224d95fc554db28381a, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: e6e9a19c3678ded42a3bc431ebef7dbd, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: 0849e84e3d62649e8882e9d6f056a017, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+      - keywords: _RECONSTRUCT_NORMAL_HIGH _SOURCE_DEPTH
+        passType: 0
+      - keywords: _RECONSTRUCT_NORMAL_HIGH _SOURCE_DEPTH_NORMALS
+        passType: 0
+      - keywords: _RECONSTRUCT_NORMAL_LOW _SOURCE_DEPTH
+        passType: 0
+      - keywords: _RECONSTRUCT_NORMAL_LOW _SOURCE_DEPTH_NORMALS
+        passType: 0
+      - keywords: _SOURCE_DEPTH
+        passType: 0
+      - keywords: _SOURCE_DEPTH_NORMALS
+        passType: 0
+  - first: {fileID: 4800000, guid: 5f1864addb451f54bae8c86d230f736e, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: 84b0f0f6534d12f408714410ae176b61, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+      - keywords: _BLOOM_LQ _TONEMAP_ACES
+        passType: 0
+      - keywords: _TONEMAP_ACES
+        passType: 0
+  - first: {fileID: 4800000, guid: 8d2bb70cbf9db8d4da26e15b26e74248, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: INSTANCING_ON
+        passType: 8
+      - keywords: INSTANCING_ON _GLOSSINESS_FROM_BASE_ALPHA
+        passType: 8
+      - keywords: _GLOSSINESS_FROM_BASE_ALPHA
+        passType: 8
+      - keywords: 
         passType: 13
-      - keywords: _ALPHATEST_ON _EMISSION _NORMALMAP _GPU_SKINNING
+      - keywords: FOG_LINEAR _GLOSSINESS_FROM_BASE_ALPHA _MAIN_LIGHT_SHADOWS _SCREEN_SPACE_OCCLUSION
+          _SHADOWS_SOFT _SPECULAR_COLOR
         passType: 13
-      - keywords: _ALPHATEST_ON _EMISSION _NORMALMAP _SSAO_OFF
+      - keywords: FOG_LINEAR _GLOSSINESS_FROM_BASE_ALPHA _MAIN_LIGHT_SHADOWS _SCREEN_SPACE_OCCLUSION
+          _SPECULAR_COLOR
         passType: 13
-      - keywords: _ALPHATEST_ON _EMISSION _NORMALMAP _SSAO_OFF _GPU_SKINNING
+      - keywords: FOG_LINEAR _GLOSSINESS_FROM_BASE_ALPHA _MAIN_LIGHT_SHADOWS _SHADOWS_SOFT
+          _SPECULAR_COLOR
+        passType: 13
+      - keywords: FOG_LINEAR _GLOSSINESS_FROM_BASE_ALPHA _MAIN_LIGHT_SHADOWS _SPECULAR_COLOR
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS
+        passType: 13
+      - keywords: _GLOSSINESS_FROM_BASE_ALPHA
+        passType: 13
+      - keywords: _GLOSSINESS_FROM_BASE_ALPHA _MAIN_LIGHT_SHADOWS_CASCADE
+        passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS
+        passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS_CASCADE
         passType: 13
   - first: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
     second:
       variants:
       - keywords: 
         passType: 8
-      - keywords: INSTANCING_ON
-        passType: 8
       - keywords: _ALPHATEST_ON
         passType: 8
       - keywords: 
         passType: 13
-      - keywords: FOG_LINEAR _ALPHATEST_ON _MAIN_LIGHT_SHADOWS _SHADOWS_SOFT
+      - keywords: FOG_LINEAR _ALPHATEST_ON _MAIN_LIGHT_SHADOWS _SCREEN_SPACE_OCCLUSION
+        passType: 13
+      - keywords: FOG_LINEAR _ALPHATEST_ON _MAIN_LIGHT_SHADOWS _SCREEN_SPACE_OCCLUSION
+          _SHADOWS_SOFT
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _SCREEN_SPACE_OCCLUSION
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _SCREEN_SPACE_OCCLUSION _SHADOWS_SOFT
+        passType: 13
+      - keywords: _ALPHATEST_ON
+        passType: 13
+      - keywords: _ALPHATEST_ON _MAIN_LIGHT_SHADOWS_CASCADE
+        passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS
+        passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS_CASCADE
         passType: 13
   - first: {fileID: 4800000, guid: 3b75227de96217540aae9be81fbd99f6, type: 3}
     second:
       variants:
       - keywords: 
+        passType: 8
+      - keywords: _ALPHATEST_ON
+        passType: 8
+      - keywords: 
         passType: 13
-      - keywords: FOG_LINEAR INSTANCING_ON _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+      - keywords: FOG_LINEAR _ALPHATEST_ON _EMISSION _MAIN_LIGHT_SHADOWS _METALLICSPECGLOSSMAP
           _NORMALMAP
         passType: 13
-      - keywords: FOG_LINEAR _DETAIL_MULX2 _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
-          _NORMALMAP
+      - keywords: FOG_LINEAR _ALPHATEST_ON _EMISSION _MAIN_LIGHT_SHADOWS _METALLICSPECGLOSSMAP
+          _NORMALMAP _SCREEN_SPACE_OCCLUSION
         passType: 13
-      - keywords: FOG_LINEAR _DETAIL_MULX2 _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
-          _NORMALMAP _PARALLAXMAP
+      - keywords: FOG_LINEAR _ALPHATEST_ON _EMISSION _MAIN_LIGHT_SHADOWS _METALLICSPECGLOSSMAP
+          _NORMALMAP _SCREEN_SPACE_OCCLUSION _SHADOWS_SOFT
         passType: 13
-      - keywords: FOG_LINEAR _DETAIL_MULX2 _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
-          _NORMALMAP _PARALLAXMAP _RECEIVE_SHADOWS_OFF
+      - keywords: FOG_LINEAR _ALPHATEST_ON _EMISSION _MAIN_LIGHT_SHADOWS _METALLICSPECGLOSSMAP
+          _NORMALMAP _SHADOWS_SOFT
         passType: 13
-      - keywords: FOG_LINEAR _DETAIL_MULX2 _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
-          _NORMALMAP _RECEIVE_SHADOWS_OFF
+      - keywords: FOG_LINEAR _ALPHATEST_ON _EMISSION _MAIN_LIGHT_SHADOWS _NORMALMAP
         passType: 13
-      - keywords: FOG_LINEAR _DETAIL_SCALED _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
-          _NORMALMAP
+      - keywords: FOG_LINEAR _ALPHATEST_ON _EMISSION _MAIN_LIGHT_SHADOWS _NORMALMAP
+          _SCREEN_SPACE_OCCLUSION
         passType: 13
-      - keywords: FOG_LINEAR _DETAIL_SCALED _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
-          _NORMALMAP _PARALLAXMAP
+      - keywords: FOG_LINEAR _ALPHATEST_ON _EMISSION _MAIN_LIGHT_SHADOWS _NORMALMAP
+          _SCREEN_SPACE_OCCLUSION _SHADOWS_SOFT
         passType: 13
-      - keywords: FOG_LINEAR _DETAIL_SCALED _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
-          _NORMALMAP _RECEIVE_SHADOWS_OFF
+      - keywords: FOG_LINEAR _ALPHATEST_ON _EMISSION _MAIN_LIGHT_SHADOWS _NORMALMAP
+          _SHADOWS_SOFT
         passType: 13
-      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _NORMALMAP
+      - keywords: FOG_LINEAR _EMISSION _MAIN_LIGHT_SHADOWS _NORMALMAP
         passType: 13
-      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _NORMALMAP
-          _PARALLAXMAP
+      - keywords: FOG_LINEAR _EMISSION _MAIN_LIGHT_SHADOWS _NORMALMAP _SCREEN_SPACE_OCCLUSION
         passType: 13
-      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _NORMALMAP
-          _PARALLAXMAP _RECEIVE_SHADOWS_OFF
+      - keywords: FOG_LINEAR _EMISSION _MAIN_LIGHT_SHADOWS _NORMALMAP _SCREEN_SPACE_OCCLUSION
+          _SHADOWS_SOFT
         passType: 13
-      - keywords: _ALPHATEST_ON _EMISSION _METALLICSPECGLOSSMAP _NORMALMAP
+      - keywords: FOG_LINEAR _EMISSION _MAIN_LIGHT_SHADOWS _NORMALMAP _SHADOWS_SOFT
         passType: 13
-      - keywords: _ALPHATEST_ON _EMISSION _NORMALMAP
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _NORMALMAP
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _NORMALMAP _SHADOWS_SOFT
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _SCREEN_SPACE_OCCLUSION
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _SCREEN_SPACE_OCCLUSION _SHADOWS_SOFT
+        passType: 13
+      - keywords: FOG_LINEAR _MAIN_LIGHT_SHADOWS _SHADOWS_SOFT
+        passType: 13
+      - keywords: _ALPHATEST_ON
+        passType: 13
+      - keywords: _ALPHATEST_ON _MAIN_LIGHT_SHADOWS_CASCADE
+        passType: 13
+      - keywords: _ALPHATEST_ON _MAIN_LIGHT_SHADOWS_CASCADE _NORMALMAP
+        passType: 13
+      - keywords: _ALPHATEST_ON _NORMALMAP
+        passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS
         passType: 13
       - keywords: _MAIN_LIGHT_SHADOWS _NORMALMAP
         passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS_CASCADE
+        passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS_CASCADE _NORMALMAP
+        passType: 13
       - keywords: _NORMALMAP
         passType: 13
+  - first: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+      - keywords: UNDERLAY_ON
+        passType: 0
+      - keywords: UNITY_UI_CLIP_RECT
+        passType: 0
+  - first: {fileID: 4800000, guid: 537b3c029e4916749868ad462dca58c5, type: 3}
+    second:
+      variants:
+      - keywords: ENUM_173FCA8E617C4725B6502C6FBE756CEC_ROUNDED
+        passType: 13
+  - first: {fileID: 4800000, guid: 4375464fae6230e48abab9e9669b9614, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
   - first: {fileID: 4800000, guid: 861f58cc229a5f449b2494095122257f, type: 3}
     second:
       variants:
       - keywords: FOG_LINEAR
         passType: 0
-      - keywords: FOG_LINEAR INSTANCING_ON
-        passType: 0
-      - keywords: FOG_LINEAR INSTANCING_ON _ALPHAPREMULTIPLY_ON _ALPHATEST_ON
-        passType: 0
-      - keywords: FOG_LINEAR INSTANCING_ON _ALPHATEST_ON
-        passType: 0
-      - keywords: FOG_LINEAR _ALPHAPREMULTIPLY_ON _ALPHATEST_ON
-        passType: 0
       - keywords: FOG_LINEAR _ALPHATEST_ON
         passType: 0
-      - keywords: INSTANCING_ON
-        passType: 13
-      - keywords: INSTANCING_ON _ALPHATEST_ON
+      - keywords: 
         passType: 13
       - keywords: _ALPHATEST_ON
         passType: 13
-      - keywords: _ALPHATEST_ON _EMISSION _NORMALMAP
+  - first: {fileID: 4800000, guid: 08f57eed8cd29db40bdfc5af4b40f41b, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: _GPU_SKINNING
+        passType: 8
+      - keywords: _GPU_SKINNING _SSAO_OFF
+        passType: 8
+      - keywords: _SSAO_OFF
+        passType: 8
+      - keywords: FOG_LINEAR _GPU_SKINNING _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+        passType: 13
+      - keywords: FOG_LINEAR _GPU_SKINNING _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SCREEN_SPACE_OCCLUSION
+        passType: 13
+      - keywords: FOG_LINEAR _GPU_SKINNING _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SCREEN_SPACE_OCCLUSION _SHADOWS_SOFT
+        passType: 13
+      - keywords: FOG_LINEAR _GPU_SKINNING _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SCREEN_SPACE_OCCLUSION _SHADOWS_SOFT _SSAO_OFF
+        passType: 13
+      - keywords: FOG_LINEAR _GPU_SKINNING _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SCREEN_SPACE_OCCLUSION _SSAO_OFF
+        passType: 13
+      - keywords: FOG_LINEAR _GPU_SKINNING _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SHADOWS_SOFT
+        passType: 13
+      - keywords: FOG_LINEAR _GPU_SKINNING _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SHADOWS_SOFT _SSAO_OFF
+        passType: 13
+      - keywords: FOG_LINEAR _GPU_SKINNING _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SSAO_OFF
+        passType: 13
+      - keywords: _GPU_SKINNING
+        passType: 13
+      - keywords: _GPU_SKINNING _MAIN_LIGHT_SHADOWS_CASCADE
+        passType: 13
+      - keywords: _GPU_SKINNING _MAIN_LIGHT_SHADOWS_CASCADE _SHADOWS_SOFT
+        passType: 13
+      - keywords: _GPU_SKINNING _MAIN_LIGHT_SHADOWS_CASCADE _SHADOWS_SOFT _SSAO_OFF
+        passType: 13
+      - keywords: _GPU_SKINNING _MAIN_LIGHT_SHADOWS_CASCADE _SSAO_OFF
+        passType: 13
+      - keywords: _GPU_SKINNING _SSAO_OFF
+        passType: 13
+  - first: {fileID: 4800000, guid: 0406db5a14f94604a8c57ccfbc9f3b46, type: 3}
+    second:
+      variants:
+      - keywords: FOG_LINEAR
+        passType: 0
+      - keywords: FOG_LINEAR _SCREEN_SPACE_OCCLUSION _SURFACE_TYPE_TRANSPARENT
+        passType: 0
+      - keywords: FOG_LINEAR _SURFACE_TYPE_TRANSPARENT
+        passType: 0
+  - first: {fileID: 4800000, guid: d540ea39c5edb8e44b3119aa7ed2d662, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: 39aceaab833d6664ca7d7e7b5da5e5de, type: 3}
+    second:
+      variants:
+      - keywords: FOG_LINEAR
+        passType: 0
+      - keywords: 
+        passType: 8
+      - keywords: 
         passType: 13
   - first: {fileID: 4800000, guid: acd491c64cf95fb43828192802060ca0, type: 3}
     second:
       variants:
+      - keywords: FOG_LINEAR
+        passType: 13
+  - first: {fileID: 4800000, guid: fe393ace9b354375a9cb14cdbbc28be4, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+      - keywords: OUTLINE_ON
+        passType: 0
+      - keywords: UNDERLAY_ON
+        passType: 0
+      - keywords: UNITY_UI_CLIP_RECT
+        passType: 0
+  - first: {fileID: 4800000, guid: c8f1036d047721a43a74331d59080020, type: 3}
+    second:
+      variants:
+      - keywords: FOG_LINEAR
+        passType: 0
+  - first: {fileID: -6465566751694194690, guid: bf4000fbd9b31784cab1d27368431336,
+      type: 3}
+    second:
+      variants:
+      - keywords: FOG_LINEAR
+        passType: 0
+      - keywords: 
+        passType: 8
+  - first: {fileID: 4800000, guid: 48ab4630448d99f40b8df0f1d6076f87, type: 3}
+    second:
+      variants:
+      - keywords: FOG_LINEAR
+        passType: 0
+      - keywords: 
+        passType: 8
+  - first: {fileID: 4800000, guid: 331d3d55d3ac1604f9e758eca2b2932b, type: 3}
+    second:
+      variants:
+      - keywords: FOG_LINEAR
+        passType: 0
+      - keywords: 
+        passType: 8
       - keywords: 
         passType: 13
-      - keywords: FOG_LINEAR
+  - first: {fileID: 4800000, guid: 7bc4930422bfadd4593b1cbf453a2a2d, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: 
+        passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS
+        passType: 13
+      - keywords: _MAIN_LIGHT_SHADOWS_CASCADE
+        passType: 13
+  - first: {fileID: 4800000, guid: d5df9882eb4ac420cb9650be25a83b62, type: 3}
+    second:
+      variants:
+      - keywords: SNOISE
+        passType: 0
+  - first: {fileID: 4800000, guid: e3aa1a34ff3944f9cb36479e4b6b9e43, type: 3}
+    second:
+      variants:
+      - keywords: DUMMY
+        passType: 0
+  - first: {fileID: 4800000, guid: da07703fcc09f8d4799221050659bd55, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: 36e335017ad71d54fbb10842863188ae, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: 7f7d521a5e1284f4e97bbb5c94f035aa, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0
+  - first: {fileID: 4800000, guid: 337b8b170aadf884482f684ab8372b91, type: 3}
+    second:
+      variants:
+      - keywords: 
         passType: 13

--- a/unity-renderer/Assets/Rendering/Common/Resources/ShaderVariantCollections/shadervariants-selected.shadervariants.meta
+++ b/unity-renderer/Assets/Rendering/Common/Resources/ShaderVariantCollections/shadervariants-selected.shadervariants.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 095cb0e1c8bff4c09977d5a28310f763
+guid: 8d996c673bb3a10489e844b3bc3141c9
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/unity-renderer/ProjectSettings/GraphicsSettings.asset
+++ b/unity-renderer/ProjectSettings/GraphicsSettings.asset
@@ -41,7 +41,7 @@ GraphicsSettings:
   - {fileID: 4800000, guid: 337b8b170aadf884482f684ab8372b91, type: 3}
   - {fileID: 4800000, guid: 08f57eed8cd29db40bdfc5af4b40f41b, type: 3}
   m_PreloadedShaders:
-  - {fileID: 20000000, guid: 095cb0e1c8bff4c09977d5a28310f763, type: 2}
+  - {fileID: 20000000, guid: 8d996c673bb3a10489e844b3bc3141c9, type: 2}
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
## What does this PR change?

Closes #4822 

Replaced our shader variant collection, by one exported from Project Auditor with Compiled filter

## How to test the changes?

1. Enable Log Shaders Compilation in the Graphics settings (under Preload variants)
2. Make a PC Build
3. Run this build and go through several scenes with a lot of people, switch wearables, enable/disable all UI, play with graphic settings and repeat.
4. Exit
5. Check Player.Log - 98% of "Compiled shader:" phrases should be packed in one place

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 45202d6</samp>

Updated the guid and reference of the `shadervariants-selected.shadervariants` asset file, which contains the optimized shader variants for the project. This change avoids asset conflicts and improves build size.
