### PR TITLE
chore: disable ssao in all settings presets

### DIFF
--- a/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
+++ b/unity-renderer/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
     shadowDistance: 50
     enableDetailObjectCulling: 1
     detailObjectCullingLimit: 50
-    ssaoQuality: 1
+    ssaoQuality: 0
     maxHQAvatars: 40
     reflectionResolution: 1
     shaderQuality: 0
@@ -61,7 +61,7 @@ MonoBehaviour:
     shadowDistance: 70
     enableDetailObjectCulling: 1
     detailObjectCullingLimit: 50
-    ssaoQuality: 2
+    ssaoQuality: 0
     maxHQAvatars: 60
     reflectionResolution: 2
     shaderQuality: 1
@@ -78,7 +78,7 @@ MonoBehaviour:
     shadowDistance: 100
     enableDetailObjectCulling: 0
     detailObjectCullingLimit: 0
-    ssaoQuality: 3
+    ssaoQuality: 0
     maxHQAvatars: 100
     reflectionResolution: 3
     shaderQuality: 2


### PR DESCRIPTION
## What does this PR change?

We are disabling SSAO by default in all settings to check for perfomance improvements in web.

User are still able to enable SSAO through the settings menu. 

## How to test the changes?

1. Launch the web client
2. Check that the 'Ambient Occlusion' setting in the 'Graphics' tab is disabled for every preset. 
3. Check that manually enabling it enables the ambient oclussion
4. Launch the desktop client
5. Check that the 'Ambient Occlusion' is at least 'Low' for any given setting

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
