### PR TITLE
chore: add gltfast fail metric

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/GenericAnalytics/GenericAnalytics.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/GenericAnalytics/GenericAnalytics.cs
@@ -4,13 +4,10 @@ public static class GenericAnalytics
 {
     public static void SendAnalytic(string eventName, Dictionary<string, string> data)
     {
-        FillGenericData(data);
-
         IAnalytics analytics = DCL.Environment.i.platform.serviceProviders.analytics;
-        analytics.SendAnalytic(eventName, data);
+        analytics?.SendAnalytic(eventName, data);
     }
 
     public static void SendAnalytic(string eventName) { SendAnalytic(eventName, new Dictionary<string, string>()); }
 
-    internal static void FillGenericData(Dictionary<string, string> data) { }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.asmdef
@@ -10,7 +10,8 @@
         "GUID:18ee28afad71091499d9ebad494c995e",
         "GUID:2995626b54c60644988f134a69a77450",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
+        "GUID:2fe81fa47ac9ca345860b544ce917241"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?

Adds a gltfast fail metric so we can analyze if GLTFast is failling and with which `targetUrl`. 

Im not completely happy to access the static context of the analytics, but there is no simple way to inject the IAnalytics dependency into `RendearableAssetLoadHelper`. I refactored and added a nullcheck to the static context just to clear from any possible errors of calling the static method with a null Analytics environment.

## How to test the changes?



## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
