### PR TITLE
fix: BFF /about endpoint response mapping for realm-picking algorithm

### DIFF
--- a/browser-interface/packages/shared/dao/index.ts
+++ b/browser-interface/packages/shared/dao/index.ts
@@ -97,7 +97,7 @@ export async function fetchCatalystStatus(
       version: { bff: result.bff.version, content: result.content.version, lambdas: result.lambdas.version, comms: result.comms.protocol },
       elapsed: aboutResponse.elapsed!,
       usersCount: bff.userCount || comms.usersCount || 0,
-      acceptingUsers: bff.acceptingUsers,
+      acceptingUsers: result.acceptingUsers,
       maxUsers: 2000,
       usersParcels
     }


### PR DESCRIPTION
## What does this PR change?

It fixes the mapping of the BFF /about endpoint. Currently it is expecting the `acceptingUsers` property to come within `bff` property but instead is arriving at root level. You can verify this by hitting this [endpoint](https://peer-ue-2.decentraland.zone/about).

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2656ae7</samp>

Fixed a bug in `fetchCatalystStatus` function that caused an error when `bff` was undefined. Used `result` instead of `bff` to get `acceptingUsers` property from the catalyst status API.
