### PR TITLE
fix: Add fov control in desktop

### DIFF
--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GraphicsWidgetDesktop.asset
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GraphicsWidgetDesktop.asset
@@ -40,3 +40,4 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 4d4176072656e0b42b9d61a473892dbe, type: 2}
         - {fileID: 11400000, guid: 20b1fa10251202a47ab25a3d5aa34414, type: 2}
         - {fileID: 11400000, guid: aa7fb5fbe49c3414da9be3fae9a523f9, type: 2}
+        - {fileID: 11400000, guid: c23658fb02f70492aa38b97db6beafe0, type: 2}


### PR DESCRIPTION
## What does this PR change?

Closes #4940 

Adds fov control in desktop

## How to test the changes?

1. Launch the desktop client
2. Check that you have fov control on the graphics settings and that it works correctly in first person

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 657b453</samp>

Add graphics quality switcher to settings panel. This feature lets the user choose from predefined graphics settings that affect the rendering performance and quality.
