### PR TITLE
fix: realm-picking algorithm to always filter out nodes that do not a…

### DIFF
--- a/browser-interface/packages/shared/dao/index.ts
+++ b/browser-interface/packages/shared/dao/index.ts
@@ -69,7 +69,8 @@ export async function fetchCatalystStatus(
     result.configurations &&
     result.bff &&
     result.content &&
-    result.lambdas
+    result.lambdas &&
+    result.acceptingUsers
   ) {
     const { comms, configurations, bff } = result
 
@@ -94,10 +95,15 @@ export async function fetchCatalystStatus(
       catalystName: configurations.realmName,
       domain: domain,
       status: aboutResponse.status,
-      version: { bff: result.bff.version, content: result.content.version, lambdas: result.lambdas.version, comms: result.comms.protocol },
+      version: {
+        bff: result.bff.version,
+        content: result.content.version,
+        lambdas: result.lambdas.version,
+        comms: result.comms.protocol
+      },
       elapsed: aboutResponse.elapsed!,
       usersCount: bff.userCount || comms.usersCount || 0,
-      acceptingUsers: bff.acceptingUsers,
+      acceptingUsers: result.acceptingUsers,
       maxUsers: 2000,
       usersParcels
     }

--- a/browser-interface/test/dao/fetchCatalystStatuses.test.ts
+++ b/browser-interface/test/dao/fetchCatalystStatuses.test.ts
@@ -44,15 +44,15 @@ describe('Fetch catalyst server status', () => {
             },
             bff: {
               userCount: EXPECTED.usersCount,
-              version: '1.0.0',
-              acceptingUsers: true
+              version: '1.0.0'
             },
             content: {
               version: '1.0.0'
             },
             lambdas: {
               version: '1.0.0'
-            }
+            },
+            acceptingUsers: true
           }
         }
       } else {


### PR DESCRIPTION
## What does this PR change?

This PR filters out the nodes that are at max user capacity before triggering the realm-picking algorithm. Since after selecting a node there is a double-check seeing if a server is at max capacity, we should prevent returning nodes at max capacity from the realm-picking algorithm, this is what this PR does.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1dfb775</samp>

Improve server selection and version formatting for DAO. The pull request enhances the `browser-interface` package by using the user capacity of catalyst servers to choose the best one, and by making the version object more readable in `dao/index.ts`.
