### PR TITLE
hotfix: report disconnected from realm error as error and not fatal error

### DIFF
--- a/browser-interface/packages/shared/comms/handlers.ts
+++ b/browser-interface/packages/shared/comms/handlers.ts
@@ -31,7 +31,7 @@ import {
 } from './peers'
 import { scenesSubscribedToCommsEvents } from './sceneSubscriptions'
 import { globalObservable } from 'shared/observables'
-import { BringDownClientAndReportFatalError, ErrorContext } from 'shared/loading/ReportFatalError'
+import { BringDownClientAndShowError } from 'shared/loading/ReportFatalError'
 
 type PingRequest = {
   alias: number
@@ -96,10 +96,10 @@ function handleDisconnectionEvent(data: AdapterDisconnectedEvent, room: RoomConn
 
   // when we are kicked, the explorer should re-load, or maybe go to offline~offline realm
   if (data.kicked) {
-    const error = new Error(
-      'Disconnected from realm as the user id is already taken. Please make sure you are not logged into the world through another tab'
+    BringDownClientAndShowError(
+      'Disconnected from realm as the user id is already taken.' +
+      'Please make sure you are not logged into the world through another tab'
     )
-    BringDownClientAndReportFatalError(error, ErrorContext.COMMS_INIT)
   }
 }
 

--- a/browser-interface/packages/shared/loading/ReportFatalError.ts
+++ b/browser-interface/packages/shared/loading/ReportFatalError.ts
@@ -23,6 +23,8 @@ export function BringDownClientAndShowError(event: ExecutionLifecycleEvent | str
     event === COMMS_COULD_NOT_BE_ESTABLISHED ? 'comms' : event === NETWORK_MISMATCH ? 'networkmismatch' : 'fatal'
 
   store.dispatch(fatalError(targetError))
+  store.dispatch(setRealmAdapter(undefined))
+  store.dispatch(setRoomConnection(undefined))
 
   globalObservable.emit('error', {
     error: new Error(event),

--- a/browser-interface/packages/shared/realm/connections/BFFConnection.ts
+++ b/browser-interface/packages/shared/realm/connections/BFFConnection.ts
@@ -14,7 +14,7 @@ import { RealmConnectionEvents, BffServices, IRealmAdapter } from '../types'
 import mitt from 'mitt'
 import { legacyServices } from '../local-services/legacy'
 import { AboutResponse } from 'shared/protocol/decentraland/bff/http_endpoints.gen'
-import { BringDownClientAndReportFatalError, ErrorContext } from 'shared/loading/ReportFatalError'
+import { BringDownClientAndShowError } from 'shared/loading/ReportFatalError'
 
 export type TopicData = {
   peerId: string
@@ -43,10 +43,10 @@ async function authenticatePort(port: RpcClientPort, identity: ExplorerIdentity)
   auth
     .getDisconnectionMessage({})
     .then(() => {
-      const error = new Error(
-        'Disconnected from realm as the user id is already taken. Please make sure you are not logged into the world through another tab'
+      BringDownClientAndShowError(
+        'Disconnected from realm as the user id is already taken.' +
+        'Please make sure you are not logged into the world through another tab'
       )
-      BringDownClientAndReportFatalError(error, ErrorContext.COMMS_INIT)
     })
     .catch(console.error)
   return authResponse.peerId


### PR DESCRIPTION
## Test

1. Open two tabs
2. The first opened tab should show an error

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e86616</samp>

Improved the error handling for the case when the user id is already taken by another connection in the comms module. Replaced fatal errors with user-friendly messages and cleared the comms state when the client is brought down. Modified `handlers.ts`, `BFFConnection.ts`, and `ReportFatalError.ts`.
