### PR TITLE
fix: restore LiveKit VoiceChat code, that was incorrectly commented

### DIFF
--- a/browser-interface/packages/shared/comms/adapters/voice/liveKitVoiceHandler.ts
+++ b/browser-interface/packages/shared/comms/adapters/voice/liveKitVoiceHandler.ts
@@ -248,17 +248,17 @@ export const createLiveKitVoiceHandler = async (room: Room): Promise<VoiceHandle
     .on(RoomEvent.TrackSubscribed, handleTrackSubscribed)
     .on(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed)
     .on(RoomEvent.MediaDevicesError, handleMediaDevicesError)
-  //.on(RoomEvent.ParticipantConnected, addParticipant)
-  //.on(RoomEvent.ParticipantDisconnected, removeParticipant)
-  //.on(RoomEvent.Reconnected, function (..._args) {
-  //  reconnectAllParticipants()
-  //})
+    .on(RoomEvent.ParticipantConnected, addParticipant)
+    .on(RoomEvent.ParticipantDisconnected, removeParticipant)
+    .on(RoomEvent.Reconnected, function (..._args) {
+      reconnectAllParticipants()
+    })
 
   if (audioContext.state !== 'running') await audioContext.resume()
 
   logger.log('initialized')
 
-  //reconnectAllParticipants()
+  reconnectAllParticipants()
 
   return {
     setRecording(recording) {


### PR DESCRIPTION
This code was removed by accident (it was just a test) and merged in `dev`.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab12d89</samp>

Enable and fix voice communication with LiveKit. The pull request restores the functionality of `liveKitVoiceHandler.ts` to handle voice events and streams from other users in the scene.
