### PR TITLE
fix: map showing in worlds

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/RealmsPlugin/Utils/JumpToHomeController.cs
+++ b/unity-renderer/Assets/DCLPlugins/RealmsPlugin/Utils/JumpToHomeController.cs
@@ -1,9 +1,7 @@
 using DCL;
 using DCL.Interface;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
-using Variables.RealmsInfo;
 
 namespace DCLPlugins.RealmPlugin
 {
@@ -18,7 +16,6 @@ namespace DCLPlugins.RealmPlugin
         [SerializeField] private RectTransform positionWithMiniMap;
         [SerializeField] private RectTransform positionWithoutMiniMap;
 
-        private BaseCollection<RealmModel> realms => DataStore.i.realm.realmsInfo;
         private BaseVariable<bool> jumpHomeButtonVisible => DataStore.i.HUDs.jumpHomeButtonVisible;
         private BaseVariable<bool> minimapVisible => DataStore.i.HUDs.minimapVisible;
         private BaseVariable<bool> exitedThroughButton => DataStore.i.common.exitedWorldThroughGoBackButton;
@@ -58,15 +55,7 @@ namespace DCLPlugins.RealmPlugin
             });
         }
 
-        private string GetMostPopulatedRealm()
-        {
-            var currentRealms = realms.Get().ToList();
-            return currentRealms.OrderByDescending(e => e.usersCount).FirstOrDefault()?.serverName;
-        }
-
-        private void OnDestroy()
-        {
+        private void OnDestroy() =>
             jumpButton.onClick.RemoveListener(GoHome);
-        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/HUDCommon.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/HUDCommon.asmdef
@@ -7,7 +7,8 @@
       "GUID:99cea83ca76dcd846abed7e61a8c90bd",
       "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
       "GUID:e74765a8cb92146848e566f7913d4c58",
-      "GUID:f92ef779fd645be45832a91c16125784"
+      "GUID:f92ef779fd645be45832a91c16125784",
+      "GUID:28f74c468a54948bfa9f625c5d428f56"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTrigger.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTrigger.cs
@@ -23,7 +23,7 @@ public class ShowHideUIByTrigger : MonoBehaviour
 
     private void AllUIVisible_OnChange(bool current, bool previous) { SetUIVisibility(!current); }
 
-    private void SetUIVisibility(bool isVisible)
+    protected virtual void SetUIVisibility(bool isVisible)
     {
         if (showHideAnimator != null)
             showHideAnimator.enabled = isVisible;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerJumpToHome.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerJumpToHome.cs
@@ -1,0 +1,14 @@
+using DCL;
+using UnityEngine;
+
+[RequireComponent(typeof(CanvasGroup))]
+public class ShowHideUIByTriggerJumpToHome : ShowHideUIByTrigger
+{
+
+    protected override void SetUIVisibility(bool isVisible)
+    {
+        if (!DataStore.i.HUDs.jumpHomeButtonVisible.Get())
+            return;
+        base.SetUIVisibility(isVisible);
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerJumpToHome.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerJumpToHome.cs
@@ -7,11 +7,6 @@ public class ShowHideUIByTriggerJumpToHome : ShowHideUIByTrigger
 
     protected override void SetUIVisibility(bool isVisible)
     {
-        if (!DataStore.i.HUDs.jumpHomeButtonVisible.Get())
-        {
-            base.SetUIVisibility(false);
-            return;
-        }
-        base.SetUIVisibility(isVisible);
+        base.SetUIVisibility(isVisible && DataStore.i.HUDs.jumpHomeButtonVisible.Get());
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerJumpToHome.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerJumpToHome.cs
@@ -8,7 +8,10 @@ public class ShowHideUIByTriggerJumpToHome : ShowHideUIByTrigger
     protected override void SetUIVisibility(bool isVisible)
     {
         if (!DataStore.i.HUDs.jumpHomeButtonVisible.Get())
+        {
+            base.SetUIVisibility(false);
             return;
+        }
         base.SetUIVisibility(isVisible);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerJumpToHome.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerJumpToHome.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e65e98ed8afc84e40a25ba6348480134
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerMinimap.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerMinimap.cs
@@ -1,0 +1,14 @@
+using DCL;
+using UnityEngine;
+
+[RequireComponent(typeof(CanvasGroup))]
+public class ShowHideUIByTriggerMinimap : ShowHideUIByTrigger
+{
+
+    protected override void SetUIVisibility(bool isVisible)
+    {
+        if (!DataStore.i.HUDs.minimapVisible.Get())
+            return;
+        base.SetUIVisibility(isVisible);
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerMinimap.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerMinimap.cs
@@ -7,11 +7,6 @@ public class ShowHideUIByTriggerMinimap : ShowHideUIByTrigger
 
     protected override void SetUIVisibility(bool isVisible)
     {
-        if (!DataStore.i.HUDs.minimapVisible.Get())
-        {
-            base.SetUIVisibility(false);
-            return;
-        }
-        base.SetUIVisibility(isVisible);
+        base.SetUIVisibility(isVisible && DataStore.i.HUDs.minimapVisible.Get());
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerMinimap.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerMinimap.cs
@@ -8,7 +8,10 @@ public class ShowHideUIByTriggerMinimap : ShowHideUIByTrigger
     protected override void SetUIVisibility(bool isVisible)
     {
         if (!DataStore.i.HUDs.minimapVisible.Get())
+        {
+            base.SetUIVisibility(false);
             return;
+        }
         base.SetUIVisibility(isVisible);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerMinimap.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Common/ShowHideUIByTriggerMinimap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f9ddafbc04829b41af264f12ac82a27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/Resources/MinimapHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/Resources/MinimapHUD.prefab
@@ -1967,8 +1967,8 @@ GameObject:
   - component: {fileID: 2859839270417482854}
   - component: {fileID: 269540385008896160}
   - component: {fileID: 2940456320096999484}
-  - component: {fileID: 5339787396754724817}
   - component: {fileID: 4227713636645781401}
+  - component: {fileID: 7292131858360462501}
   m_Layer: 5
   m_Name: MinimapHUD
   m_TagString: Untagged
@@ -2108,18 +2108,6 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!114 &5339787396754724817
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4525154057530514719}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30cedd7c5f8c0064e98640b29b2156a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &4227713636645781401
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2136,6 +2124,18 @@ MonoBehaviour:
   animSpeedFactor: 1
   disableAfterFadeOut: 0
   canvasGroup: {fileID: 0}
+--- !u!114 &7292131858360462501
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4525154057530514719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f9ddafbc04829b41af264f12ac82a27, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4663711089530102657
 GameObject:
   m_ObjectHideFlags: 0
@@ -2665,6 +2665,7 @@ GameObject:
   - component: {fileID: 223458749653844719}
   - component: {fileID: 64377760550986365}
   - component: {fileID: 5015472051642357042}
+  - component: {fileID: 8719467018810224531}
   m_Layer: 5
   m_Name: JumpToHomeButton
   m_TagString: Untagged
@@ -2784,9 +2785,9 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6684377303349115013}
   m_Enabled: 1
-  m_Alpha: 1
+  m_Alpha: 0
   m_Interactable: 1
-  m_BlocksRaycasts: 1
+  m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
 --- !u!114 &8345580414719424793
 MonoBehaviour:
@@ -2800,7 +2801,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d8b939b5bedb9494b806609faeda7d8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hideOnEnable: 1
+  hideOnEnable: 0
   animSpeedFactor: 1
   disableAfterFadeOut: 0
   canvasGroup: {fileID: 7179560460713622161}
@@ -2895,6 +2896,18 @@ MonoBehaviour:
   iconToChange: {fileID: 0}
   onFocusColor: {r: 1, g: 1, b: 1, a: 1}
   onLoseFocusColor: {r: 0.027450982, g: 0.7803922, b: 0.7176471, a: 1}
+--- !u!114 &8719467018810224531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6684377303349115013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e65e98ed8afc84e40a25ba6348480134, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7015908234902076449
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?

Fixes #4842

Adds a condition to the ShowHideUIByTrigger class and does a refactor to the MinimapHUD.

A further and more clean refactor would be to move the responsibility of showing/hiding the canvas group from the `ShowUIByTrigger` class into the respective view, which could work through the `BaseComponentView` abstract class. Therefore, leaving only the listener in the `ShowUIByTrigger` class. 

This can take a little bit more time (given that there are many views, and not all of them inherit from `BaseComponentView`, ie `MinimapHudView`). IMHO, its an overkill for just this issue, so Im creating a new ticket to track it as a possible enhacement. 

If we continue creating UIs that are specific for scenarios (like more worlds UI, or maybe quests?) then it makes sense to take full on the refactor 

## How to test the changes?

1. Launch the explorer in a catalyst realm. Minimap should be there
2. Press ad unpress U to see that the minimap toggles correctly
3. Use `/changerealm redeemer.dcl.eth` and check that the minimap dissapeared and the "Go to Genesis City" button is there
4. Press ad unpress U to see that the button toggles correctly

Repeat the process but starting directly from a realm


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23a2bb1</samp>

Refactored the logic for showing or hiding the minimap and the jump to home button based on the `DataStore` values. Created new subclasses of `ShowHideUIByTrigger` to handle the specific UI behaviors for each HUD element. Updated the `MinimapHUD.prefab` and the `HUDCommon.asmdef` files to reflect the changes.
