### PR TITLE
Feat: add avatar equip slots animations for interactions

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/AvatarSlot/AvatarSlotComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/AvatarSlot/AvatarSlotComponentView.cs
@@ -57,7 +57,7 @@ namespace DCL.Backpack
             hiddenSlot.SetActive(isHidden);
             if (isHidden)
             {
-                nftContainer.DOShakePosition(SHAKE_ANIMATION_TIME, 4);
+                ShakeAnimation(nftContainer);
                 emptySlot.SetActive(false);
                 tooltipHiddenText.gameObject.SetActive(true);
                 tooltipHiddenText.text = $"Hidden by: {hiddenBy}";
@@ -100,8 +100,7 @@ namespace DCL.Backpack
         {
             focusedImage.enabled = true;
             tooltipContainer.SetActive(true);
-            focusedImage.transform.localScale = new Vector3(0, 0, 0);
-            focusedImage.transform.DOScale(1, ANIMATION_TIME).SetEase(Ease.OutBack);
+            ScaleUpAnimation(focusedImage.transform);
         }
 
         public override void OnLoseFocus()
@@ -117,25 +116,41 @@ namespace DCL.Backpack
             if (isSelected)
             {
                 selectedImage.enabled = true;
-                selectedImage.transform.localScale = new Vector3(0, 0, 0);
-                selectedImage.transform.DOScale(1, ANIMATION_TIME).SetEase(Ease.OutBack);
+                ScaleUpAnimation(selectedImage.transform);
             }
             else
             {
-                selectedImage.transform.DOScale(0, ANIMATION_TIME).SetEase(Ease.OutBack).OnComplete(() =>
-                {
-                    selectedImage.enabled = false;
-                    selectedImage.transform.localScale = new Vector3(1,1,1);
-                });
+                ScaleDownAndResetAnimation(selectedImage);
             }
 
             OnSelectAvatarSlot?.Invoke(model.category, isSelected);
         }
 
+
         public void OnPointerClickOnDifferentSlot()
         {
             isSelected = false;
             selectedImage.enabled = false;
+        }
+
+        private void ScaleUpAnimation(Transform targetTransform)
+        {
+            targetTransform.transform.localScale = new Vector3(0, 0, 0);
+            targetTransform.transform.DOScale(1, ANIMATION_TIME).SetEase(Ease.OutBack);
+        }
+
+        private void ScaleDownAndResetAnimation(Image targetImage)
+        {
+            targetImage.transform.DOScale(0, ANIMATION_TIME).SetEase(Ease.OutBack).OnComplete(() =>
+            {
+                targetImage.enabled = false;
+                targetImage.transform.localScale = new Vector3(1, 1, 1);
+            });
+        }
+
+        private void ShakeAnimation(Transform targetTransform)
+        {
+            targetTransform.DOShakePosition(SHAKE_ANIMATION_TIME, 4);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/AvatarSlot/AvatarSlotComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/AvatarSlot/AvatarSlotComponentView.cs
@@ -2,17 +2,21 @@ using System;
 using TMPro;
 using UIComponents.Scripts.Components;
 using UnityEngine;
-using UnityEngine.EventSystems;
+using DG.Tweening;
 using UnityEngine.UI;
 
 namespace DCL.Backpack
 {
     public class AvatarSlotComponentView : BaseComponentView<AvatarSlotComponentModel>, IAvatarSlotComponentView
     {
+        private const float ANIMATION_TIME = 0.2f;
+        private const float SHAKE_ANIMATION_TIME = 0.75f;
+
         [Header("Configuration")]
         [SerializeField] internal AvatarSlotComponentModel model;
 
         [SerializeField] internal NftTypeIconSO typeIcons;
+        [SerializeField] internal Transform nftContainer;
         [SerializeField] internal NftRarityBackgroundSO rarityBackgrounds;
         [SerializeField] internal Image typeImage;
         [SerializeField] internal ImageComponentView nftImage;
@@ -51,9 +55,9 @@ namespace DCL.Backpack
             model.isHidden = isHidden;
             model.hiddenBy = hiddenBy;
             hiddenSlot.SetActive(isHidden);
-
             if (isHidden)
             {
+                nftContainer.DOShakePosition(SHAKE_ANIMATION_TIME, 4);
                 emptySlot.SetActive(false);
                 tooltipHiddenText.gameObject.SetActive(true);
                 tooltipHiddenText.text = $"Hidden by: {hiddenBy}";
@@ -96,6 +100,8 @@ namespace DCL.Backpack
         {
             focusedImage.enabled = true;
             tooltipContainer.SetActive(true);
+            focusedImage.transform.localScale = new Vector3(0, 0, 0);
+            focusedImage.transform.DOScale(1, ANIMATION_TIME).SetEase(Ease.OutBack);
         }
 
         public override void OnLoseFocus()
@@ -107,7 +113,21 @@ namespace DCL.Backpack
         public void OnSlotClick()
         {
             isSelected = !isSelected;
-            selectedImage.enabled = isSelected;
+
+            if (isSelected)
+            {
+                selectedImage.enabled = true;
+                selectedImage.transform.localScale = new Vector3(0, 0, 0);
+                selectedImage.transform.DOScale(1, ANIMATION_TIME).SetEase(Ease.OutBack);
+            }
+            else
+            {
+                selectedImage.transform.DOScale(0, ANIMATION_TIME).SetEase(Ease.OutBack).OnComplete(() =>
+                {
+                    selectedImage.enabled = false;
+                    selectedImage.transform.localScale = new Vector3(1,1,1);
+                });
+            }
 
             OnSelectAvatarSlot?.Invoke(model.category, isSelected);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Resources/AvatarSlot.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Resources/AvatarSlot.prefab
@@ -225,6 +225,7 @@ MonoBehaviour:
     isHidden: 0
     hiddenBy: 
   typeIcons: {fileID: 11400000, guid: 9525caf9cd97d4aa1b91f145f3a604e3, type: 2}
+  nftContainer: {fileID: 2235824014885110001}
   rarityBackgrounds: {fileID: 0}
   typeImage: {fileID: 4329488436158027747}
   nftImage: {fileID: 8486726043931597902}


### PR DESCRIPTION
## What does this PR change?

Adds avatar equip slots animations, cannot be tested


https://user-images.githubusercontent.com/4254522/233325742-d3c92571-662d-45bc-9403-262ad54a9d90.mov


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1dfccf6</samp>

Added animations and a new property to the backpack editor HUD. The animations use `DOTween` to enhance the user feedback when interacting with the avatar slots. The `nftContainer` property allows the NFT image to be referenced in the code.
