### PR TITLE
hotfix: ghost material generating glitches in FPV

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/BaseAvatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/BaseAvatar.cs
@@ -77,16 +77,21 @@ namespace AvatarSystem
                                .ToUniTaskInstantCancelation(true, cancellationToken: linkedCts.Token);
             }
 
-            baseAvatarReferences.ParticlesContainer.SetActive(true);
-            List<UniTask> tasks = new List<UniTask>();
-            tasks.Add(GetRevealTask(ghostMaterial, avatarHeight, completionHeight));
-
-            for (var index = 0; index < cachedMaterials.Count; index++)
+            try
             {
-                tasks.Add(GetRevealTask(cachedMaterials[index], -avatarHeight, -completionHeight));
-            }
+                baseAvatarReferences.ParticlesContainer.SetActive(true);
+                List<UniTask> tasks = new List<UniTask>();
+                tasks.Add(GetRevealTask(ghostMaterial, avatarHeight, completionHeight));
 
-            await UniTask.WhenAll(tasks);
+                for (var index = 0; index < cachedMaterials.Count; index++) { tasks.Add(GetRevealTask(cachedMaterials[index], -avatarHeight, -completionHeight)); }
+
+                await UniTask.WhenAll(tasks);
+            }
+            finally
+            {
+                baseAvatarReferences.ParticlesContainer.SetActive(false);
+                FadeOutGhostMaterial();
+            }
         }
 
         public void RevealInstantly(Renderer targetRenderer, float avatarHeight)
@@ -105,6 +110,15 @@ namespace AvatarSystem
                 cachedMaterials[i].SetVector(REVEAL_NORMAL_ID, Vector3.up * -1);
                 SetRevealPosition(cachedMaterials[i], -avatarHeight);
             }
+            baseAvatarReferences.ParticlesContainer.SetActive(false);
+            FadeOutGhostMaterial();
+        }
+
+        private void FadeOutGhostMaterial()
+        {
+            Color color = ghostMaterial.GetColor(COLOR_ID);
+            color.a = 0;
+            ghostMaterial.color = color;
         }
 
         internal static void SetRevealPosition(Material material, float height)


### PR DESCRIPTION
## What does this PR change?

Ghost view was generating weird visual glitches in FPV because it was not completely faded out

## How to test the changes?



## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f4fba1</samp>

This pull request fixes some bugs in the avatar system related to the reveal animation. It ensures that `BaseAvatar` disposes of the `revealEffect` and `ghostMaterial` correctly in all cases.
