### PR TITLE
fix: sdk7 AvatarShape

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/Resources/NewAvatarShape.prefab
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/Resources/NewAvatarShape.prefab
@@ -1,548 +1,146 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &1616179327777916617
-GameObject:
+--- !u!1001 &4205392024585164535
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2140587817739381742}
-  m_Layer: 23
-  m_Name: ImpostorContainer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2140587817739381742
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1616179327777916617}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8210819811968446249}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2168919188079980899
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1612428930952922234}
-  - component: {fileID: 3201016372773453961}
-  - component: {fileID: 3504616517296556492}
-  m_Layer: 23
-  m_Name: NewAvatarShape
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1612428930952922234
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2168919188079980899}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 940233138722625532}
-  - {fileID: 7377730628817763273}
-  - {fileID: 8210819811968446249}
-  - {fileID: 18568410159500416}
-  - {fileID: 6690809206991169106}
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3201016372773453961
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2168919188079980899}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 528eb0c5369dcaa41bb5b814c2e9ca74, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  avatarContainer: {fileID: 8963989720318013202}
-  avatarCollider: {fileID: 6534765647599015563}
-  onPointerDown: {fileID: 338606394308916673}
-  outlineOnHover: {fileID: 4900985733649484496}
-  playerNameContainer: {fileID: 6128202859544868951}
-  baseAvatarContainer: {fileID: 762005512886389656}
-  baseAvatarReferencesPrefab: {fileID: 4766333532709993497, guid: 7bf2abf753051c34c9e0a568a90fc0f0,
-    type: 3}
---- !u!114 &3504616517296556492
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2168919188079980899}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8b2e184f0ec373f4e807d927e1f8aef3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &5622968589254119458
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7377730628817763273}
-  - component: {fileID: 6534765647599015563}
-  m_Layer: 21
-  m_Name: AvatarCollider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &7377730628817763273
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5622968589254119458}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.8, z: 0}
-  m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1612428930952922234}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &6534765647599015563
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5622968589254119458}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!1 &6128202859544868951
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6690809206991169106}
-  m_Layer: 23
-  m_Name: PlayerNameContainer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6690809206991169106
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2842120016485600253, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3389185268529299172, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+        type: 3}
+      propertyPath: m_Name
+      value: AvatarShapeN
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 5523974814614327640, guid: 2f03e6cf1b102864995f93ecfe4f09e1, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 2f03e6cf1b102864995f93ecfe4f09e1, type: 3}
+--- !u!4 &134792089655743208 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4288110136316019743, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 4205392024585164535}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6128202859544868951}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 635177030720891857}
-  m_Father: {fileID: 1612428930952922234}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6930828014457569972
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 940233138722625532}
-  - component: {fileID: 338606394308916673}
-  - component: {fileID: 2534857999325092631}
-  - component: {fileID: 4900985733649484496}
-  m_Layer: 9
-  m_Name: PointerEventCollider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &940233138722625532
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6930828014457569972}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.8, z: 0}
-  m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1612428930952922234}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &338606394308916673
+--- !u!114 &1152701543451487409 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 3865137627712764486, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 4205392024585164535}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6930828014457569972}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c895124a3dad9421bbeaf89ace0a198c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  collider: {fileID: 2534857999325092631}
---- !u!65 &2534857999325092631
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+--- !u!1 &1536927900958468115 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3389185268529299172, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 4205392024585164535}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6930828014457569972}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &4900985733649484496
+--- !u!114 &2646687146671961169
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6930828014457569972}
+  m_GameObject: {fileID: 1536927900958468115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 528eb0c5369dcaa41bb5b814c2e9ca74, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  avatarContainer: {fileID: 8587153251705812578}
+  avatarCollider: {fileID: 5908135508241649659}
+  onPointerDown: {fileID: 1152701543451487409}
+  outlineOnHover: {fileID: 2506262489978194212}
+  playerNameContainer: {fileID: 6793133867511931175}
+  baseAvatarContainer: {fileID: 134792089655743208}
+  baseAvatarReferencesPrefab: {fileID: 4766333532709993497, guid: 7bf2abf753051c34c9e0a568a90fc0f0,
+    type: 3}
+--- !u!114 &2506262489978194212 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1771187575892058067, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 4205392024585164535}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fb6cb20447764382a9a277c8a9bc31b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &7524742732015396865
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 762005512886389656}
-  m_Layer: 23
-  m_Name: LoadingAvatarContainer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &762005512886389656
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7524742732015396865}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.755, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8210819811968446249}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8963989720318013202
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8210819811968446249}
-  - component: {fileID: 8010905555894327181}
-  - component: {fileID: 2077461904248848557}
-  m_Layer: 23
-  m_Name: AvatarRenderer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8210819811968446249
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8963989720318013202}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 762005512886389656}
-  - {fileID: 3462401327801288064}
-  - {fileID: 2140587817739381742}
-  m_Father: {fileID: 1612428930952922234}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8010905555894327181
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8963989720318013202}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 703a54a14152d5746a40188f469a0c8f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  femaleLocomotions:
-    idle: {fileID: 7400000, guid: 62d81b2041d701b4381d66d17f7e246e, type: 2}
-    walk: {fileID: 7400000, guid: db8c33ed0888f7b44af0b2acde9bd2b5, type: 2}
-    run: {fileID: 7400000, guid: 1e3081b9c1f466743bc7602362784e93, type: 2}
-    jump: {fileID: 7400000, guid: ec6a6c2a81a2b984f986fd6cbc8279d3, type: 2}
-    fall: {fileID: 7400000, guid: 5e5b5c340739da142b767937144ef10b, type: 2}
-  maleLocomotions:
-    idle: {fileID: 7400000, guid: 4fef0b7f5be12aa48a2e9d8facaaa42b, type: 2}
-    walk: {fileID: 7400000, guid: c91199fcab8eef54d8045d809d671896, type: 2}
-    run: {fileID: 7400000, guid: 916369dcf45c5944e9f2409e0be10181, type: 2}
-    jump: {fileID: 7400000, guid: b51f09eb09017384a8ff4b3b88b00c00, type: 2}
-    fall: {fileID: 7400000, guid: cd48d8cde6039fa4fac548ddab2ff277, type: 2}
-  animation: {fileID: 0}
-  blackboard:
-    walkSpeedFactor: 0.5
-    runSpeedFactor: 0.25
-    movementSpeed: 0
-    verticalSpeed: 0
-    isGrounded: 1
-    expressionTriggerId: 
-    expressionTriggerTimestamp: 0
-    deltaTime: 0
-    shouldLoop: 0
-  target: {fileID: 1612428930952922234}
---- !u!114 &2077461904248848557
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8963989720318013202}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4efd5242010312149afedadae5a61e12, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &9098911786849325134
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 18568410159500416}
-  m_Layer: 23
-  m_Name: Particles
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &18568410159500416
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9098911786849325134}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1612428930952922234}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &7007480161813772401
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8210819811968446249}
-    m_Modifications:
-    - target: {fileID: 1933068967218137769, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_Name
-      value: AvatarAudioHandlerRemote
-      objectReference: {fileID: 0}
-    - target: {fileID: 1933068967218137769, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_Layer
-      value: 23
-      objectReference: {fileID: 0}
-    - target: {fileID: 3728983229202958758, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: stickersController
-      value: 
-      objectReference: {fileID: 2077461904248848557}
-    - target: {fileID: 3728983229202958758, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: avatarAnimatorLegacy
-      value: 
-      objectReference: {fileID: 8010905555894327181}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 256ca49022c0ba84abc2a941931ee350, type: 3}
---- !u!4 &3462401327801288064 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5851154196944813553, guid: 256ca49022c0ba84abc2a941931ee350,
+--- !u!65 &5908135508241649659 stripped
+BoxCollider:
+  m_CorrespondingSourceObject: {fileID: 7755590202629118220, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
     type: 3}
-  m_PrefabInstance: {fileID: 7007480161813772401}
+  m_PrefabInstance: {fileID: 4205392024585164535}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &7878348618944592465
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 6690809206991169106}
-    m_Modifications:
-    - target: {fileID: 3778843143832927354, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_Name
-      value: PlayerName
-      objectReference: {fileID: 0}
-    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8559866741916390979, guid: c53ec74589327644bba45b4054fb78dc,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c53ec74589327644bba45b4054fb78dc, type: 3}
---- !u!4 &635177030720891857 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7315286666275099008, guid: c53ec74589327644bba45b4054fb78dc,
+--- !u!1 &6793133867511931175 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7213221244455466960, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
     type: 3}
-  m_PrefabInstance: {fileID: 7878348618944592465}
+  m_PrefabInstance: {fileID: 4205392024585164535}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8587153251705812578 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5582000225371496597, guid: 2f03e6cf1b102864995f93ecfe4f09e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 4205392024585164535}
   m_PrefabAsset: {fileID: 0}

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/Resources/NewAvatarShape.prefab.meta
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/Resources/NewAvatarShape.prefab.meta
@@ -1,3 +1,7 @@
 fileFormatVersion: 2
-guid: 69f62fd92c7144c6bdd5a94b41ec5fff
-timeCreated: 1657187863
+guid: 9ae044a947c79412682ba17e9300d307
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?
temporally fix `AvatarShape` for sdk7.
this component needs to be refactored, since it was copy without any kind of criteria from sdk6's component.
to reduce the possibility of changes on sdk6's `AvatarShape` breaking sdk7's `AvatarShape` 
I've replaced the prefab used for sdk7 for a "prefab variant" of sdk6's prefab

fixes https://github.com/decentraland/sdk/issues/660

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
