### PR TITLE
Fix: fixed placement of event started UI text

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/EventsSubSection/EventCard_Long.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/EventsSubSection/EventCard_Long.prefab
@@ -1175,8 +1175,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.000015258789}
-  m_SizeDelta: {x: 0, y: 20}
+  m_AnchoredPosition: {x: 75.83435, y: -0.000015258789}
+  m_SizeDelta: {x: -75.8344, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &8768943608833477585
 CanvasRenderer:


### PR DESCRIPTION
## What does this PR change?

Fix https://github.com/decentraland/growth/issues/127
Fixes issue in which the "Started x days ago" text in the long events card was overlapping

...

## How to test the changes?

1. Launch the explorer
2. Verify that the highlighted events section has the correct ui placement for all texts
3. Verify that live events in the highlighted section have the correct UI placements for the "Started x days ago" text

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc2e1df</samp>

Adjusted the position and width of the `EventCard_Long` component in the events section of ExploreV2. This is part of a pull request to improve the layout and responsiveness of the ExploreV2 feature.
