### PR TITLE
fix: onboarding flow for wallets

### DIFF
--- a/browser-interface/packages/shared/comms/sagas.ts
+++ b/browser-interface/packages/shared/comms/sagas.ts
@@ -416,9 +416,9 @@ function* handleCommsReconnectionInterval() {
     // TODO: Why are we not doing `if (reason === undefined) continue`?
     // The timeout makes no sense, except to avoid a logical error
     // in the saga flow that leads to some race condition.
-    const { commsConnection, realmAdapter, hasFatalError, identity } = yield select(reconnectionState)
+    const { commsConnection, realmAdapter, hasFatalError, identity, profile } = yield select(reconnectionState)
 
-    const shouldReconnect = !commsConnection && !hasFatalError && identity?.address && !realmAdapter
+    const shouldReconnect = !commsConnection && !hasFatalError && identity?.address && !realmAdapter && profile
 
     if (shouldReconnect) {
       // reconnect

--- a/browser-interface/packages/shared/comms/selectors.ts
+++ b/browser-interface/packages/shared/comms/selectors.ts
@@ -6,6 +6,8 @@ import { ExplorerIdentity } from 'shared/session/types'
 import { RootState } from 'shared/store/rootTypes'
 import { RoomConnection } from './interface'
 import { RootCommsState } from './types'
+import { getCurrentUserProfile } from 'shared/profiles/selectors'
+import { Avatar } from '@dcl/schemas'
 
 export const getCommsIsland = (store: RootCommsState): string | undefined => store.comms.island
 export const getCommsRoom = (state: RootCommsState): RoomConnection | undefined => state.comms.context
@@ -15,11 +17,13 @@ export function reconnectionState(state: RootState): {
   realmAdapter: IRealmAdapter | undefined
   hasFatalError: string | null
   identity: ExplorerIdentity | undefined
+  profile: Avatar | null
 } {
   return {
     commsConnection: getCommsRoom(state),
     realmAdapter: getRealmAdapter(state),
     hasFatalError: getFatalError(state),
-    identity: getCurrentIdentity(state)
+    identity: getCurrentIdentity(state),
+    profile: getCurrentUserProfile(state)
   }
 }

--- a/browser-interface/packages/shared/dao/sagas.ts
+++ b/browser-interface/packages/shared/dao/sagas.ts
@@ -183,28 +183,27 @@ function* selectRealm() {
 
 function* onboardingTutorialRealm() {
   const profile = yield select(getCurrentUserProfile)
-  if (profile) {
-    const needsTutorial = RESET_TUTORIAL || !profile.tutorialStep
-    const onboardingRealmName = yield select(getFeatureFlagVariantName, 'new_tutorial_variant')
-    const isNewTutorialDisabled =
-      onboardingRealmName === 'disabled' || onboardingRealmName === 'undefined' || HAS_INITIAL_POSITION_MARK
-    if (needsTutorial && !isNewTutorialDisabled) {
-      try {
-        const realm: string | undefined = yield select(getFeatureFlagVariantValue, 'new_tutorial_variant')
-        if (realm) {
-          trackEvent('onboarding_started', { onboardingRealm: realm })
-          //We are using the previous tutorial flow. 256 meant complete in the previous tutorial.
-          //Also, with just going to the onboarding, we are assuming completion. If not, the onboarding will be shown on every login
-          //So, we start an async function that just waits for a SET_REALM_ADAPTER. Meaning that we left the onboarding realm
-          //TODO: This should be added organically in the onboarding or replaced when we dont use the old tutorial anymore
-          yield put(setOnboardingState({ isInOnboarding: true, onboardingRealm: realm }))
-          return realm
-        } else {
-          logger.warn('No realm was provided for the onboarding experience.')
-        }
-      } catch (err) {
-        console.error(err)
+  const tutorialStep = profile ? !profile.tutorialStep : true
+  const needsTutorial = RESET_TUTORIAL || tutorialStep
+  const onboardingRealmName = yield select(getFeatureFlagVariantName, 'new_tutorial_variant')
+  const isNewTutorialDisabled =
+    onboardingRealmName === 'disabled' || onboardingRealmName === 'undefined' || HAS_INITIAL_POSITION_MARK
+  if (needsTutorial && !isNewTutorialDisabled) {
+    try {
+      const realm: string | undefined = yield select(getFeatureFlagVariantValue, 'new_tutorial_variant')
+      if (realm) {
+        trackEvent('onboarding_started', { onboardingRealm: realm })
+        //We are using the previous tutorial flow. 256 meant complete in the previous tutorial.
+        //Also, with just going to the onboarding, we are assuming completion. If not, the onboarding will be shown on every login
+        //So, we start an async function that just waits for a SET_REALM_ADAPTER. Meaning that we left the onboarding realm
+        //TODO: This should be added organically in the onboarding or replaced when we dont use the old tutorial anymore
+        yield put(setOnboardingState({ isInOnboarding: true, onboardingRealm: realm }))
+        return realm
+      } else {
+        logger.warn('No realm was provided for the onboarding experience.')
       }
+    } catch (err) {
+      console.error(err)
     }
   }
 }

--- a/browser-interface/packages/shared/profiles/sagas/content/requestProfile.ts
+++ b/browser-interface/packages/shared/profiles/sagas/content/requestProfile.ts
@@ -1,11 +1,10 @@
 import defaultLogger from 'lib/logger'
 import type { RemoteProfile } from 'shared/profiles/types'
-import { ensureRealmAdapter } from 'shared/realm/ensureRealmAdapter'
 
 export async function requestProfile(userId: string, version?: number): Promise<RemoteProfile | null> {
-  const backendConfiguration = await ensureRealmAdapter()
+  const lambdasServer = 'https://peer.decentraland.org/lambdas'
   try {
-    let url = `${backendConfiguration.services.lambdasServer}/profiles/${userId}`
+    let url = `${lambdasServer}/profiles/${userId}`
     if (version) {
       url = url + `?version=${version}`
     } else if (!userId.startsWith('default')) {

--- a/browser-interface/packages/shared/session/sagas.ts
+++ b/browser-interface/packages/shared/session/sagas.ts
@@ -117,8 +117,8 @@ function* authenticate(action: AuthenticateAction) {
   // 1. authenticate our user
   yield put(userAuthenticated(identity, net, isGuest))
   // 2. then ask for our profile when we selected a catalyst
-  yield call(waitForRealm)
   const avatar = yield call(initialRemoteProfileLoad)
+  yield call(waitForRealm)
 
   // 3. continue with signin/signup (only not in preview)
   const isSignUp = avatar.version <= 0 && !PREVIEW

--- a/browser-interface/runTestServer.js
+++ b/browser-interface/runTestServer.js
@@ -73,6 +73,7 @@ const server = http.createServer(app)
   server.listen(port, function () {
     console.info('==>     Listening on port %s. Open up http://localhost:%s/test to run tests', port, port)
     console.info('                              Open up http://localhost:%s/ to test the client.', port)
+    console.info('                              Open up http://localhost:%s/?ENABLE_WEB3 to test the client with your wallet.', port)
 
     if (!singleRun) {
       titere


### PR DESCRIPTION
## What does this PR change?

The onboarding flow is not working for any wallet, new or old.

- The Realm connection is delayed until we load the user wallet profile
- We load the Profile by fetching it directly from a catalyst
- We decide which realm to connect to right after we fetch a Profile

Fixes #5011

## How to test the changes?

### First case
1. Inside Metamask create a new wallet.
2. Go to https://play.decentraland.zone/?explorer-branch=fix/onboarding-flow and choose the Wallet login.
3. Proceed through the login flow by creating a new character.
4. You should enter the onboarding world

### Second case
1. Inside Metamask switch to an existing wallet that has completed the onboarding
2. Go to https://play.decentraland.zone/?explorer-branch=fix/onboarding-flow and choose the Wallet login.
3. You should spawn in genesis plaza

### Third case
1. Go to https://play.decentraland.zone/?explorer-branch=fix/onboarding-flow and login as guest
2. You should enter the onboarding world

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
