### PR TITLE
chore: added better error handling for gltf importing

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Textures/Tests/TexturesTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Textures/Tests/TexturesTests.cs
@@ -226,6 +226,7 @@ namespace Tests
             // so we just try to guess the number of frames to skip
             yield return null;
             yield return null;
+            yield return null;
 
             // texture should have being disposed
             Assert.IsFalse(imageTexture);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
@@ -196,10 +196,7 @@ namespace DCL
                 cancellationToken.ThrowIfCancellationRequested();
                 CleanPromise(promise);
 
-                if (promise.isForgotten)
-                {
-                    promise.Unload();
-                }
+                if (promise.isForgotten) { promise.Unload(); }
 
                 await SkipFrameIfOverBudgetAsync();
             }
@@ -268,10 +265,7 @@ namespace DCL
 
                     blockedPromises.Remove(blockedPromise);
 
-                    if (blockedPromise != null && !blockedPromise.isForgotten)
-                    {
-                        blockedPromisesToLoadAux.Add(blockedPromise);
-                    }
+                    if (blockedPromise != null && !blockedPromise.isForgotten) { blockedPromisesToLoadAux.Add(blockedPromise); }
                 }
             }
 
@@ -289,7 +283,7 @@ namespace DCL
                 if (promise.isForgotten)
                     continue;
 
-                promise.ForceFail(new Exception("Promise is forgotten"));
+                promise.ForceFail(new PromiseForgottenException("Promise is forgotten"));
                 Forget(promise);
                 CleanPromise(promise);
 
@@ -329,16 +323,10 @@ namespace DCL
 
             if (masterToBlockedPromises.ContainsKey(id))
             {
-                if (masterToBlockedPromises[id].Contains(finalPromise))
-                {
-                    masterToBlockedPromises[id].Remove(finalPromise);
-                }
+                if (masterToBlockedPromises[id].Contains(finalPromise)) { masterToBlockedPromises[id].Remove(finalPromise); }
             }
 
-            if (masterPromiseById.ContainsKey(id) && masterPromiseById[id] == promise)
-            {
-                masterPromiseById.Remove(id);
-            }
+            if (masterPromiseById.ContainsKey(id) && masterPromiseById[id] == promise) { masterPromiseById.Remove(id); }
 
             if (blockedPromises.Contains(finalPromise))
                 blockedPromises.Remove(finalPromise);
@@ -365,10 +353,7 @@ namespace DCL
                     e.Current?.Cleanup();
             }
 
-            foreach (var kvp in masterPromiseById)
-            {
-                kvp.Value.Cleanup();
-            }
+            foreach (var kvp in masterPromiseById) { kvp.Value.Cleanup(); }
 
             masterPromiseById = new Dictionary<object, AssetPromiseType>();
             waitingPromises = new HashSet<AssetPromiseType>();
@@ -376,5 +361,10 @@ namespace DCL
         }
 
         protected virtual void OnSilentForget(AssetPromiseType promise) { }
+    }
+
+    public class PromiseForgottenException : Exception
+    {
+        public PromiseForgottenException(string message) : base(message) { }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/BlockedAndMasterPromisesShould.cs
@@ -69,7 +69,7 @@ namespace AssetPromiseKeeper_GLTF_Tests
             Assert.IsTrue(keeper.library.Contains(asset));
             Assert.AreEqual(1, keeper.library.masterAssets.Count);
         }
-        
+
         [UnityTest]
         public IEnumerator SucceedWhenMastersParentIsDeactivated()
         {
@@ -91,11 +91,11 @@ namespace AssetPromiseKeeper_GLTF_Tests
             prom3.OnFailEvent += (x, error) => { failEventCalled3 = true; };
 
             keeper.Keep(prom);
-            
+
             // This is what happens when a scene is unloaded while a master promise is loading from that scene
             // (blocking other promises).
             parent.SetActive(false);
-            
+
             keeper.Keep(prom2);
             keeper.Keep(prom3);
 
@@ -130,11 +130,9 @@ namespace AssetPromiseKeeper_GLTF_Tests
             var keeper = new AssetPromiseKeeper_GLTF();
             keeper.throttlingCounter.enabled = false;
 
-            //NOTE(Brian): Expect the 404 error
-            LogAssert.Expect(LogType.Log, new Regex("^.*?404"));
-            LogAssert.Expect(LogType.Exception, new Regex("^.*?Failed to Load Json Stream"));
-
             string url = TestAssetsUtils.GetPath() + "/non_existing_url.glb";
+
+            LogAssert.Expect(LogType.Error, new Regex("^.*?404"));
 
             AssetPromise_GLTF prom = new AssetPromise_GLTF(scene.contentProvider, url);
             Asset_GLTF asset = null;
@@ -178,7 +176,6 @@ namespace AssetPromiseKeeper_GLTF_Tests
 
             Assert.IsFalse(keeper.library.Contains(asset));
             Assert.AreNotEqual(1, keeper.library.masterAssets.Count);
-            
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/AssetPromise_GLTFast_Loader.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/AssetPromise_GLTFast_Loader.cs
@@ -101,7 +101,7 @@ namespace DCL
                     NodeNameMethod = NameImportMethod.OriginalUnique
                 };
 
-                bool success = await gltfImport.Load(url, gltFastSettings, cancellationSourceToken).AsUniTask().AttachExternalCancellation(cancellationSourceToken);
+                bool success = await gltfImport.Load(url, gltFastSettings, cancellationSourceToken);
 
                 if (cancellationSourceToken.IsCancellationRequested)
                 {
@@ -110,7 +110,7 @@ namespace DCL
                 }
 
                 if (!success)
-                    onFail?.Invoke(new Exception($"[GLTFast] Failed to load asset {url}"));
+                    onFail?.Invoke(new GltFastLoadException($"[GLTFast] Load failed: {consoleLogger.LastErrorCode}"));
                 else
                 {
                     asset.Setup(gltfImport);
@@ -122,12 +122,17 @@ namespace DCL
                 if (e is OperationCanceledException)
                     return;
 
-                Debug.LogException(e);
+                Debug.LogError("[GltFast] Failed to load: " + e);
                 onFail?.Invoke(e);
             }
         }
 
         private bool FileToUrl(string fileName, out string fileHash) =>
             contentProvider.TryGetContentsUrl(assetDirectoryPath + fileName, out fileHash);
+    }
+
+    public class GltFastLoadException : Exception
+    {
+        public GltFastLoadException(string message) : base(message) { }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFTextureDownloaderWrapper.cs
@@ -48,7 +48,7 @@ namespace DCL.GLTFast.Wrappers
 
         private void OnFail(Asset_Texture arg1, Exception arg2)
         {
-            Error = arg2.Message;
+            Error = arg2.ToString();
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -13,6 +13,7 @@ namespace DCL.Components
     {
         private const string NEW_CDN_FF = "ab-new-cdn";
         private const string FAILED_GLTFAST_LOAD_EVENT = "failed_GLTFast_load";
+        private const string STARTED_GLTFAST_LOAD_EVENT = "started_GLTFast_load";
         private const string SUCESS_GLTF_LOAD_AFTER_GLTFAST_FAIL_EVENT = "success_GLTF_load_after_GLTFast_fail";
         private const string FAIL_GLTF_LOAD_AFTER_GLTFAST_FAIL_EVENT = "failed_GLTF_load_after_GLTFast_fail";
 
@@ -310,6 +311,7 @@ namespace DCL.Components
 
         private void LoadGLTFast(string targetUrl, Action<Rendereable> OnSuccess, Action<Exception> OnFail, bool hasFallback)
         {
+            SendMetric(STARTED_GLTFAST_LOAD_EVENT, targetUrl, "");
             currentLoadingSystem = GLTFAST_GO_NAME_PREFIX;
 
             if (gltfastPromise != null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -52,6 +52,7 @@ namespace DCL.Components
         private AssetPromise_AB_GameObject abPromise;
         private string currentLoadingSystem;
         private FeatureFlag featureFlags => DataStore.i.featureFlags.flags.Get();
+        private string targetUrl;
 
         public bool isFinished
         {
@@ -88,7 +89,6 @@ namespace DCL.Components
 
         float loadStartTime = 0;
         float loadFinishTime = float.MaxValue;
-        private string targetUrl;
 #endif
 
         public RendereableAssetLoadHelper(ContentProvider contentProvider, string bundlesContentUrl, Func<bool> isGltFastEnabled)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -87,6 +87,7 @@ namespace DCL.Components
 
         float loadStartTime = 0;
         float loadFinishTime = float.MaxValue;
+        private string targetUrl;
 #endif
 
         public RendereableAssetLoadHelper(ContentProvider contentProvider, string bundlesContentUrl, Func<bool> isGltFastEnabled)
@@ -98,6 +99,7 @@ namespace DCL.Components
 
         public void Load(string targetUrl, LoadingType forcedLoadingType = LoadingType.DEFAULT)
         {
+            this.targetUrl = targetUrl;
             Assert.IsFalse(string.IsNullOrEmpty(targetUrl), "url is null!!");
 #if UNITY_EDITOR
             loadStartTime = Time.realtimeSinceStartup;
@@ -355,10 +357,10 @@ namespace DCL.Components
             if (exception != null)
             {
                 if (!hasFallback)
-                    Debug.LogException(exception);
+                    Debug.LogWarning("All fallbacks failed for " + targetUrl);
                 else if (VERBOSE)
                 {
-                    Debug.Log($"Load Fail Detected, trying to use a fallback, " +
+                    Debug.LogWarning($"Load Fail Detected, trying to use a fallback, " +
                               $"loading type was: {currentLoadingSystem} and error was: {exception.Message}");
                 }
             }

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -276,7 +276,7 @@ namespace UnityGLTF
                         return;
 #endif
 
-                    Debug.LogException(e);
+                    Debug.LogError("[Old GltfImporter] Failed to load: " + e);
                 }
                 finally
                 {

--- a/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -276,7 +276,7 @@ namespace UnityGLTF
                         return;
 #endif
 
-                    Debug.LogError("[Old GltfImporter] Failed to load: " + e);
+                    Debug.LogError("[Old GltfImporter] Failed to load: " + e.Message);
                 }
                 finally
                 {

--- a/unity-renderer/Assets/UnityGLTF/Scripts/Loader/WebRequestLoader.cs
+++ b/unity-renderer/Assets/UnityGLTF/Scripts/Loader/WebRequestLoader.cs
@@ -73,7 +73,7 @@ namespace UnityGLTF.Loader
             {
                 finalUrl = Path.Combine(rootUri, httpRequestPath);
             }
-            
+
             token.ThrowIfCancellationRequested();
 
             WebRequestAsyncOperation asyncOp = (WebRequestAsyncOperation)webRequestController.Get(
@@ -84,33 +84,32 @@ namespace UnityGLTF.Loader
                 requestAttemps: 3);
 
             Assert.IsNotNull(asyncOp, "asyncOp == null ... Maybe you are using a mocked WebRequestController?");
-            
+
             token.ThrowIfCancellationRequested();
-            
+
             await UniTask.WaitUntil( () => asyncOp.isDone || asyncOp.isDisposed || asyncOp.isSucceeded, cancellationToken: token);
 
 #if UNITY_STANDALONE || UNITY_EDITOR
             if (DataStore.i.common.isApplicationQuitting.Get())
                 return;
 #endif
-            
+
             token.ThrowIfCancellationRequested();
-            
+
             bool error = false;
             string errorMessage = null;
 
             if (!asyncOp.isSucceeded)
             {
-                Debug.Log($"{asyncOp.webRequest.error} - {finalUrl} - responseCode: {asyncOp.webRequest.responseCode}");
-                errorMessage = $"{asyncOp.webRequest.error} {asyncOp.webRequest.downloadHandler.text}";
-                error = true;
+                errorMessage = $"{asyncOp.webRequest.error} {asyncOp.webRequest.downloadHandler.text} {finalUrl}";
+                throw new Exception(errorMessage);
             }
 
             if (!error && asyncOp.webRequest.downloadedBytes > int.MaxValue)
             {
                 Debug.Log("Stream is too big for a byte array");
                 errorMessage = "Stream is too big for a byte array";
-                error = true;
+                throw new Exception(errorMessage);
             }
 
             if (!error)


### PR DESCRIPTION
## What does this PR change?

- Old Gltf importer will now fail to load completely if an image is missing
- Added better error messages

Closes #5048

## How to test the changes?

- Go to -60,38
- Both importers fail, scene must be almost empty

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
