### PR TITLE
fix: sign up call

### DIFF
--- a/browser-interface/packages/shared/session/sagas.ts
+++ b/browser-interface/packages/shared/session/sagas.ts
@@ -270,7 +270,10 @@ function* logout() {
 }
 
 function* redirectToSignUp() {
-  window.location.search += '&show_wallet=1'
+
+  const q = new URLSearchParams(globalThis.location.search)
+  q.set('show_wallet', '1')
+  globalThis.history.replaceState({ show_wallet: '1' }, 'show_wallet', `?${q.toString()}`)
   window.location.reload()
 }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDViewV2.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDViewV2.cs
@@ -138,10 +138,6 @@ public class ProfileHUDViewV2 : BaseComponentView, IProfileHUDView
             NameSubmitted?.Invoke(this, newName);
         });
 
-        buttonClaimName.onClick.AddListener(() => ClaimNamePressed?.Invoke(this, EventArgs.Empty));
-        buttonLogOut.onClick.AddListener(() => LogedOutPressed?.Invoke(this, EventArgs.Empty));
-        buttonSignUp.onClick.AddListener(() => SignedUpPressed?.Invoke(this, EventArgs.Empty));
-
         descriptionStartEditingButton.onClick.AddListener(descriptionInputText.Select);
         descriptionIsEditingButton.onClick.AddListener(() => descriptionInputText.OnDeselect(null));
         descriptionInputText.onTextSelection.AddListener((description, x, y) =>


### PR DESCRIPTION
Sign up button in the client was not relaunching with show_wallet url param. Also the button was subscribed twice.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Test
Use this link
https://explorer-artifacts.decentraland.org/@dcl/explorer-website/branch/feat/seamless-login/?explorer-branch=fix/sign-up-call

Go as a guest, open the explore Menu and in the upper right corner, press on your profile and click "Sign In". Decentraland should be relaunched prompting you to sign with a wallet.
![image](https://user-images.githubusercontent.com/50231608/235465950-509dce7d-bd65-4683-83d1-e9410b390f88.png)

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0225d99</samp>

This pull request refactors the code for the profile HUD, improving the communication between the browser and the Unity renderer. It changes how the sign up page is opened from the `Get a name` button, and how the button logic is handled in the `ProfileHUDViewV2` and `ProfileHUDController` classes.
