### PR TITLE
Chore: remove duplicated assets in Addressable Groups and in Scene

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Addressables/Tests/AddressablesValidationTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Addressables/Tests/AddressablesValidationTests.cs
@@ -58,7 +58,7 @@ public class AddressablesValidationTests
             message: ComposeAssertMessage(msg, analyzeRule: "Check Resources to Addressable Duplicate Dependencies"));
     }
 
-    [Test][Category("ToFix")]
+    [Test][Category("EditModeCI")]
     public void ValidateScenesToAddressableDuplicateDependencies()
     {
         CheckSceneDupeDependencies rule = new CheckSceneDupeDependencies();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Addressables/Tests/AddressablesValidationTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Addressables/Tests/AddressablesValidationTests.cs
@@ -39,23 +39,7 @@ public class AddressablesValidationTests
         string msg = CreateDuplicatesMessage(bundlesByAsset, EXCLUDED_FILE_TYPES);
 
         Assert.That(msg, Is.Empty,
-            message: ComposeAssertMessage(msg, analyzeRule: "Check Duplicate Bundle Dependencies"));
-    }
-
-    [Test][Category("ToFix")]
-    public void ValidateResourcesToAddressableDuplicateDependencies()
-    {
-        CheckResourcesDupeDependencies rule = new CheckResourcesDupeDependencies();
-        List<AnalyzeRule.AnalyzeResult> duplicates = rule.RefreshAnalysis(AddressableAssetSettingsDefaultObject.Settings);
-
-        if (duplicates[0].resultName == NO_ISSUES_FOUND)
-            return;
-
-        Dictionary<string, List<string>> bundlesByResource = GroupBundlesByDuplicatedAssets(duplicates);
-        string msg = CreateDuplicatesMessage(bundlesByResource, EXCLUDED_FILE_TYPES);
-
-        Assert.That(msg, Is.Empty,
-            message: ComposeAssertMessage(msg, analyzeRule: "Check Resources to Addressable Duplicate Dependencies"));
+            message: ComposeAssertMessage(msg, analyzeRule: "Check Duplicate Bundle Dependencies in Addressables->Analyze tool")); 
     }
 
     [Test][Category("EditModeCI")]
@@ -64,14 +48,29 @@ public class AddressablesValidationTests
         CheckSceneDupeDependencies rule = new CheckSceneDupeDependencies();
         List<AnalyzeRule.AnalyzeResult> duplicates = rule.RefreshAnalysis(AddressableAssetSettingsDefaultObject.Settings);
 
-        if (duplicates[0].resultName == NO_ISSUES_FOUND)
+        if (duplicates[0].resultName.Contains(NO_ISSUES_FOUND)) 
             return;
 
         Dictionary<string, (List<string> Scenes, List<string> Bundles)> scenesAndBundlesByAsset = GroupScenesAndBundlesByDuplicatedAsset(duplicates);
         string msg = CreateScenesDuplicatesMessage(scenesAndBundlesByAsset, EXCLUDED_FILE_TYPES);
 
         Assert.That(msg, Is.Empty,
-            message: ComposeAssertMessage(msg, analyzeRule: "Check Scene to Addressable Duplicate Dependencies"));
+            message: ComposeAssertMessage(msg, analyzeRule: "Check Scene to Addressable Duplicate Dependencies in Addressables->Analyze tool"));
+    }
+
+    [Test][Category("ToFix")]
+    public void ValidateResourcesToAddressableDuplicateDependencies()
+    {
+        var rule = new CheckResourcesDupeDependencies();
+        var duplicates = rule.RefreshAnalysis(AddressableAssetSettingsDefaultObject.Settings);
+
+        if (duplicates.Count == 0 || duplicates[0].resultName == NO_ISSUES_FOUND) return;
+
+        var bundlesByResource = GroupBundlesByDuplicatedAssets(duplicates);
+        var msg = CreateDuplicatesMessage(bundlesByResource, EXCLUDED_FILE_TYPES);
+
+        Assert.That(msg, Is.Empty,
+            message: ComposeAssertMessage(msg, analyzeRule: "Check Resources to Addressable Duplicate Dependencies in Addressables->Analyze tool"));
     }
 
     private static Dictionary<string, List<string>> GroupBundlesByDuplicatedAssets(List<AnalyzeRule.AnalyzeResult> duplicates, bool isCustomGroupsRule = false)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -27,7 +27,6 @@ namespace DCL
 
         private HotScenesController hotScenesController;
 
-        public PoolableComponentFactory componentFactory;
         private readonly DataStoreRef<DataStore_LoadingScreen> dataStoreLoadingScreen;
         protected IKernelCommunication kernelCommunication;
 


### PR DESCRIPTION
## What does this PR change?
Closes #5081 

- removed un-used reference in scene prefabs
- included in the CI related test for checking Scene-vs-Addressables 

## How to test the changes?

1. Launch the explorer
2. Check that related content works as previous:  - UI callbacks, Billboards, Avatar shapes, Text shapes, Audio, Animations 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 92ccee6</samp>

Removed unused `componentFactory` field from `Main` class. This improves code clarity and reduces unnecessary dependencies.
