### PR TITLE
fix: refactor signup hud into plugin

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
@@ -1,6 +1,6 @@
 import type { Avatar } from '@dcl/schemas'
 import { FETCH_REMOTE_PROFILE_RETRIES } from 'config'
-import { generateRandomUserProfile } from 'shared/profiles/sagas'
+import { generateRandomUserProfile } from 'lib/decentraland/profiles/generateRandomUserProfile'
 import { ensureAvatarCompatibilityFormat } from 'lib/decentraland/profiles/transformations/profileToServerFormat'
 import defaultLogger from 'lib/logger'
 import { call, CallEffect, put, race, select } from 'redux-saga/effects'
@@ -95,7 +95,7 @@ function* fetchWithBestStrategy(
   }
 
   // If no other choice is available, generate a random user profile
-  return generateRandomUserProfile(userId, 'guest flow')
+  return generateRandomUserProfile(userId)
 }
 
 function* fetchFromComms(roomConnection: RoomConnection, userId: string, version: number) {

--- a/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
@@ -1,6 +1,6 @@
 import type { Avatar } from '@dcl/schemas'
 import { FETCH_REMOTE_PROFILE_RETRIES } from 'config'
-import { generateRandomUserProfile } from 'lib/decentraland/profiles/generateRandomUserProfile'
+import { generateRandomUserProfile } from 'shared/profiles/sagas'
 import { ensureAvatarCompatibilityFormat } from 'lib/decentraland/profiles/transformations/profileToServerFormat'
 import defaultLogger from 'lib/logger'
 import { call, CallEffect, put, race, select } from 'redux-saga/effects'
@@ -95,7 +95,7 @@ function* fetchWithBestStrategy(
   }
 
   // If no other choice is available, generate a random user profile
-  return generateRandomUserProfile(userId)
+  return generateRandomUserProfile(userId, 'guest flow')
 }
 
 function* fetchFromComms(roomConnection: RoomConnection, userId: string, version: number) {

--- a/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin.meta
+++ b/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 840b782d1e550c4479872367da67f132
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "SignupHUDPlugin",
+    "rootNamespace": "",
+    "references": [
+        "GUID:fd3745cf152e6934d99eadd24f220eba",
+        "GUID:7fe146b43e76fe745aeaf2020feb54b7",
+        "GUID:a3ceb534947fac14da25035bc5c24788",
+        "GUID:fbcc413e192ef9048811d47ab0aca0c0",
+        "GUID:dffbb581f2650ea4990781f603ac258a",
+        "GUID:0663fad624d836944b40ae27c3414652",
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:3b80b0b562b1cbc489513f09fc1b8f69"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.asmdef.meta
+++ b/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 271e70bea5d0ea2488ee97efd025cb8f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.cs
@@ -1,0 +1,36 @@
+﻿using Cysharp.Threading.Tasks;
+using DCL;
+using DCL.Providers;
+using SignupHUD;
+
+namespace DCLPlugins.SignupHUDPlugin
+{
+    public class SignupHUDPlugin : IPlugin
+    {
+        private const string SIGNUP_HUD = "SignupHUD";
+
+        private SignupHUDController controller;
+
+        public SignupHUDPlugin()
+        {
+            Initialize().Forget();
+        }
+
+        private async UniTaskVoid Initialize()
+        {
+            var assetsProvider = DCL.Environment.i.platform.serviceLocator.Get<IAddressableResourceProvider>();
+            var analytics = DCL.Environment.i.platform.serviceProviders.analytics;
+            var loadingScreenDataStore = DataStore.i.Get<DataStore_LoadingScreen>();
+            var hudsDataStore = DataStore.i.HUDs;
+
+            var view = await assetsProvider.Instantiate<ISignupHUDView>(SIGNUP_HUD, $"_{SIGNUP_HUD}");
+            controller = new SignupHUDController(analytics, view, loadingScreenDataStore, hudsDataStore);
+            controller.Initialize();
+        }
+
+        public void Dispose()
+        {
+            controller?.Dispose();
+        }
+    }
+}

--- a/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.cs.meta
+++ b/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 631ea3a32de54b538b0543e7ce8f3494
+timeCreated: 1682929402

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDBridge.cs
@@ -75,10 +75,7 @@ public class HUDBridge : MonoBehaviour
 
     public void ShowAvatarEditorInSignUp()
     {
-        Debug.unityLogger.logEnabled = true;
         DataStore.i.common.isSignUpFlow.Set(true);
-        Debug.Log($"Alex : \n {DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("seamless_login")}");
-        Debug.Log($"Alex : \n {DataStore.i.featureFlags.flags.Get().ToString()}");
         if(DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("seamless_login"))
             DataStore.i.HUDs.signupVisible.Set(true, true);
         else

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDBridge.cs
@@ -75,8 +75,14 @@ public class HUDBridge : MonoBehaviour
 
     public void ShowAvatarEditorInSignUp()
     {
+        Debug.unityLogger.logEnabled = true;
         DataStore.i.common.isSignUpFlow.Set(true);
-        DataStore.i.HUDs.avatarEditorVisible.Set(true, true);
+        Debug.Log($"Alex : \n {DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("seamless_login")}");
+        Debug.Log($"Alex : \n {DataStore.i.featureFlags.flags.Get().ToString()}");
+        if(DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("seamless_login"))
+            DataStore.i.HUDs.signupVisible.Set(true, true);
+        else
+            DataStore.i.HUDs.avatarEditorVisible.Set(true, true);
     }
 
     #endregion

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -115,8 +115,6 @@ public class HUDController : IHUDController
     public QuestsTrackerHUDController questsTrackerHUD =>
         GetHUDElement(HUDElementID.QUESTS_TRACKER) as QuestsTrackerHUDController;
 
-    public SignupHUDController signupHUD => GetHUDElement(HUDElementID.SIGNUP) as SignupHUDController;
-
     public Dictionary<HUDElementID, IHUD> hudElements { get; private set; } = new Dictionary<HUDElementID, IHUD>();
 
     private UserProfile ownUserProfile => UserProfile.GetOwnUserProfile();
@@ -372,11 +370,6 @@ public class HUDController : IHUDController
                 await CreateHudElement(configuration, hudElementId, cancellationToken);
                 if (configuration.active)
                     questsTrackerHUD.Initialize(QuestsController.i);
-                break;
-            case HUDElementID.SIGNUP:
-                await CreateHudElement(configuration, hudElementId, cancellationToken);
-                if (configuration.active)
-                    signupHUD.Initialize();
                 break;
             case HUDElementID.AVATAR_NAMES:
                 // TODO Remove the HUDElementId once kernel stops sending the Configure HUD message

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDFactory.cs
@@ -164,17 +164,10 @@ public class HUDFactory : IHUDFactory
                 return new QuestsPanelHUDController();
             case HUDElementID.QUESTS_TRACKER:
                 return new QuestsTrackerHUDController(await CreateHUDView<IQuestsTrackerHUDView>(QUESTS_TRACKER_HUD, cancellationToken));
-            case HUDElementID.SIGNUP:
-                return new SignupHUDController(Environment.i.platform.serviceProviders.analytics, await CreateSignupHUDView(cancellationToken),
-                    dataStoreLoadingScreen.Ref,
-                    DataStore.i.HUDs);
         }
 
         return null;
     }
-
-    public async UniTask<ISignupHUDView> CreateSignupHUDView(CancellationToken cancellationToken = default) =>
-        await CreateHUDView<ISignupHUDView>(SIGNUP_HUD, cancellationToken);
 
     protected async UniTask<T> CreateHUDView<T>(string assetAddress, CancellationToken cancellationToken = default) where T:IDisposable
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Interfaces/IHUDFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Interfaces/IHUDFactory.cs
@@ -40,7 +40,7 @@ namespace DCL
         QUESTS_PANEL = 26,
         QUESTS_TRACKER = 27,
 
-        [Obsolete("Deprecated HUD Element")]
+        [Obsolete("Deprecated HUD Element, ported to Plugin System")]
         SIGNUP = 29,
         [Obsolete("Deprecated HUD Element")]
         LOADING = 30,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
@@ -1,5 +1,6 @@
 using DCL;
 using DCL.Interface;
+using UnityEngine;
 
 namespace SignupHUD
 {
@@ -30,7 +31,6 @@ namespace SignupHUD
                 return;
 
             signupVisible.OnChange += OnSignupVisibleChanged;
-            signupVisible.Set(false);
 
             view.OnNameScreenNext += OnNameScreenNext;
             view.OnEditAvatar += OnEditAvatar;
@@ -38,6 +38,7 @@ namespace SignupHUD
             view.OnTermsOfServiceBack += OnTermsOfServiceBack;
 
             CommonScriptableObjects.isLoadingHUDOpen.OnChange += OnLoadingScreenAppear;
+            signupVisible.Set(signupVisible.Get(), true);
         }
         private void OnLoadingScreenAppear(bool current, bool previous)
         {
@@ -45,7 +46,10 @@ namespace SignupHUD
                 signupVisible.Set(false);
         }
 
-        private void OnSignupVisibleChanged(bool current, bool previous) { SetVisibility(current); }
+        private void OnSignupVisibleChanged(bool current, bool previous)
+        {
+            SetVisibility(current);
+        }
 
         internal void StartSignupProcess()
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Tests/SignupHUDViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Tests/SignupHUDViewShould.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using DCL.Providers;
 using NUnit.Framework;
 using SignupHUD;
@@ -8,20 +9,27 @@ namespace Tests.SignupHUD
 {
     public class SignupHUDViewShould
     {
+        private const string SIGNUP_HUD = "SignupHUD";
+
         private SignupHUDView hudView;
-        private HUDFactory factory;
+        private AddressableResourceProvider assetsProvider;
 
         [SetUp]
         public async Task SetUp()
         {
-            factory = new HUDFactory(new AddressableResourceProvider());
-            hudView = (SignupHUDView)await factory.CreateSignupHUDView();
+            assetsProvider = new AddressableResourceProvider();
+            hudView = await GetView();
+        }
+
+        private async UniTask<SignupHUDView> GetView()
+        {
+            return (SignupHUDView) await assetsProvider.Instantiate<ISignupHUDView>(SIGNUP_HUD, $"_{SIGNUP_HUD}");
         }
 
         [TearDown]
         public void TearDown()
         {
-            factory.Dispose();
+            assetsProvider.Dispose();
 
             if (hudView != null)
                 Object.Destroy(hudView.gameObject);
@@ -33,7 +41,7 @@ namespace Tests.SignupHUD
         public async Task SetVisibilityProperly(bool visibility)
         {
             if(hudView == null)
-                hudView = (SignupHUDView)await factory.CreateSignupHUDView();
+                hudView = await GetView();
 
             hudView.SetVisibility(visibility);
             Assert.AreEqual(visibility, hudView.gameObject.activeSelf);
@@ -43,7 +51,7 @@ namespace Tests.SignupHUD
         public async Task ShowNameScreenProperly()
         {
             if(hudView == null)
-                hudView = (SignupHUDView)await factory.CreateSignupHUDView();
+                hudView = await GetView();
 
             hudView.nameAndEmailPanel.gameObject.SetActive(false);
             hudView.termsOfServicePanel.gameObject.SetActive(true);
@@ -58,7 +66,7 @@ namespace Tests.SignupHUD
         public async Task ShowTermsOfServiceScreenProperly()
         {
             if(hudView == null)
-                hudView = (SignupHUDView)await factory.CreateSignupHUDView();
+                hudView = await GetView();
 
             hudView.nameAndEmailPanel.gameObject.SetActive(true);
             hudView.termsOfServicePanel.gameObject.SetActive(false);
@@ -73,7 +81,7 @@ namespace Tests.SignupHUD
         public async Task DisableNextButtonWithShortName()
         {
             if(hudView == null)
-                hudView = (SignupHUDView)await factory.CreateSignupHUDView();
+                hudView = await GetView();
 
             hudView.nameAndEmailNextButton.interactable = true;
             hudView.nameInputField.text = "";
@@ -88,7 +96,7 @@ namespace Tests.SignupHUD
         public async Task EnableNextButtonWithValidName()
         {
             if(hudView == null)
-                hudView = (SignupHUDView)await factory.CreateSignupHUDView();
+                hudView = await GetView();
 
             hudView.nameAndEmailNextButton.interactable = false;
             hudView.nameInputField.text = "ValidName";
@@ -103,7 +111,7 @@ namespace Tests.SignupHUD
         public async Task DisableNextButtonWithInvalidEmail()
         {
             if(hudView == null)
-                hudView = (SignupHUDView)await factory.CreateSignupHUDView();
+                hudView = await GetView();
 
             hudView.nameAndEmailNextButton.interactable = true;
             hudView.nameInputField.text = "ValidName";
@@ -118,7 +126,7 @@ namespace Tests.SignupHUD
         public async Task EnableNextButtonWithValidEmail()
         {
             if(hudView == null)
-                hudView = (SignupHUDView)await factory.CreateSignupHUDView();
+                hudView = await GetView();
 
             hudView.nameAndEmailNextButton.interactable = true;
             hudView.nameInputField.text = "ValidName";

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystem.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystem.asmdef
@@ -63,7 +63,8 @@
         "GUID:4c9ae00fd9ea408f9557b9d7b174c501",
         "GUID:a3ceb534947fac14da25035bc5c24788",
         "GUID:d39b964a85ed9470095c13aaf673b25c",
-        "GUID:0c692b52b8dc4a8e9802ddcb8e10f231"
+        "GUID:0c692b52b8dc4a8e9802ddcb8e10f231",
+        "GUID:271e70bea5d0ea2488ee97efd025cb8f"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
@@ -18,6 +18,7 @@ using DCLPlugins.FallbackFontsLoader;
 using DCLPlugins.LoadingScreenPlugin;
 using DCLPlugins.RealmPlugin;
 using DCLPlugins.SentryPlugin;
+using DCLPlugins.SignupHUDPlugin;
 using DCLPlugins.UIRefresherPlugin;
 
 namespace DCL
@@ -60,6 +61,7 @@ namespace DCL
             pluginSystem.Register<FallbackFontsLoaderPlugin>(() => new FallbackFontsLoaderPlugin());
             pluginSystem.Register<SentryPlugin>(() => new SentryPlugin());
             pluginSystem.Register<LoadingScreenPlugin>(() => new LoadingScreenPlugin());
+            pluginSystem.Register<SignupHUDPlugin>(() => new SignupHUDPlugin());
 
             pluginSystem.RegisterWithFlag<FriendRequestHUDPlugin>(() => new FriendRequestHUDPlugin(), "new_friend_requests");
             pluginSystem.RegisterWithFlag<RealmPlugin>(() => new RealmPlugin(DataStore.i), "realms_modifier_plugin");


### PR DESCRIPTION
## How to test the changes?
If you login in a new session with `ENABLE_SEAMLESS_LOGIN` the avatar editor shouldnt appear. Additionally, check that without the feature flag the behaviour is the same as production.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86749db</samp>

This pull request migrates the signup HUD from a HUD element to a plugin, which is a system that allows modular and independent features to be added to the project. The pull request removes the signup HUD logic from the `HUDController`, `HUDFactory`, and `HUDBridge` scripts, and creates a new plugin folder with the `SignupHUDPlugin` class and its related files. The pull request also updates the `SignupHUDController` script to improve its compatibility and functionality with the plugin system, and adds the signup HUD plugin as a reference and a dependency to the plugin system assembly.
