### PR TITLE
hotfix: ensure the lambdas url value in case it is not initialized

### DIFF
--- a/unity-renderer/Assets/DCLServices/Lambdas/LambdasService.cs
+++ b/unity-renderer/Assets/DCLServices/Lambdas/LambdasService.cs
@@ -12,6 +12,8 @@ namespace DCLServices.Lambdas
 {
     public class LambdasService : ILambdasService
     {
+        private const string DEFAULT_LAMBDAS_URL = "https://interconnected.online/lambdas/";
+
         private ICatalyst catalyst;
 
         private Service<IWebRequestController> webRequestController;
@@ -126,7 +128,7 @@ namespace DCLServices.Lambdas
         }
 
         internal string GetLambdasUrl() =>
-            catalyst.lambdasUrl;
+            string.IsNullOrEmpty(catalyst.lambdasUrl) ? DEFAULT_LAMBDAS_URL : catalyst.lambdasUrl;
 
         private static void PrintError<TResponse>(string endPoint, string message)
         {


### PR DESCRIPTION
## What does this PR change?
Ensure the lambdas url value in case it is not initialized when we're going to order a request to a lambdas.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
copilot:summary