### PR TITLE
feat: new wearable label

### DIFF
--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -425,6 +425,7 @@ namespace DCLServices.WearablesCatalogService
                     definition.baseUrl = string.IsNullOrEmpty(newBaseUrl) ? TEXTURES_URL_ORG : newBaseUrl;
                     definition.baseUrlBundles = ASSET_BUNDLES_URL_ORG;
                     definition.emoteDataV0 = null;
+                    definition.MostRecentTransferredDate = DateTimeOffset.FromUnixTimeSeconds(item.maxTransferredAt).DateTime;
                 }
                 catch (Exception e)
                 {

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
@@ -33,6 +33,7 @@ namespace DCLServices.WearablesCatalogService
     public class WearableDefinition
     {
         public string urn;
+        public long maxTransferredAt;
         public WearableItem definition;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
@@ -212,9 +212,7 @@ namespace DCL.Backpack
                 Rarity = rarity,
                 ImageUrl = wearable.ComposeThumbnailUrl(),
                 IsEquipped = dataStoreBackpackV2.previewEquippedWearables.Contains(wearable.id),
-
-                // TODO: make the new state work
-                IsNew = false,
+                IsNew = (DateTime.UtcNow - wearable.MostRecentTransferredDate).TotalHours < 24,
                 IsSelected = false,
             };
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -1,8 +1,8 @@
+using DCL;
+using DCL.Emotes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using DCL;
-using DCL.Emotes;
 using UnityEngine;
 
 [Serializable]
@@ -48,6 +48,8 @@ public class WearableItem
 
     public i18n[] i18n;
     public string thumbnail;
+
+    public DateTime MostRecentTransferredDate { get; set; }
 
     private string thirdPartyCollectionId;
     public string ThirdPartyCollectionId


### PR DESCRIPTION
## What does this PR change?

`Fixes #4883 `

<img width="703" alt="Screen Shot 2023-05-02 at 16 47 10" src="https://user-images.githubusercontent.com/56365551/235770021-462917f7-429d-4983-9d1d-4e54b21850ad.png">

## How to test the changes?

1. Launch the explorer
2. Check that the backpack v1 keeps working as expected
3. Add params `&ENABLE_backpack_editor_v2&DISABLE_backpack_editor_v1&`
4. If you have any wearable transferred in less than 24hs you should see the "new" label in the grid item

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e9190c</samp>

This pull request adds support for fetching and filtering third-party wearable collections from the lambdas service and displays them in the backpack editor HUD. It also improves the web request handling and the memory management of the wearables catalog service and the backpack editor HUD. It introduces a new enum `NftCollectionType` and a new UI component `BackpackFiltersComponentView` to handle the filter options. It modifies several files in the `unity-renderer/Assets/DCLServices/WearablesCatalogService` and `unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2` folders to implement these features.
