### PR TITLE
hotfix: remove shader variants from Graphics settings

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -131,6 +131,8 @@ namespace DCL
                 {
                     var collection = await Environment.i.serviceLocator.Get<IAddressableResourceProvider>()
                                                       .GetAddressable<ShaderVariantCollection>("shadervariants-selected");
+
+                    await UniTask.DelayFrame(1);
                     collection.WarmUp();
                 }
             }

--- a/unity-renderer/ProjectSettings/GraphicsSettings.asset
+++ b/unity-renderer/ProjectSettings/GraphicsSettings.asset
@@ -40,8 +40,7 @@ GraphicsSettings:
   - {fileID: 4800000, guid: b38bd543f02d4b258db32c8f17759c58, type: 3}
   - {fileID: 4800000, guid: 337b8b170aadf884482f684ab8372b91, type: 3}
   - {fileID: 4800000, guid: 08f57eed8cd29db40bdfc5af4b40f41b, type: 3}
-  m_PreloadedShaders:
-  - {fileID: 20000000, guid: 8d996c673bb3a10489e844b3bc3141c9, type: 2}
+  m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
## What does this PR change?
Closes #5111 

- removed shader variants from Graphics settings
- add delay before shader prewarming, so the loading screen shows first image


## How to test the changes?

1. Launch the explorer in Firefox
2. Record profiling on launch
3. Stop recording when GPlaza is loaded
4. Choose JavaScript and Invert Call Stack
5. Click on the first long red bar - it should be ShaderVariantsCollection.Warmup 
6. Validate that this red bar is around 20 s and not 33 s
![image](https://user-images.githubusercontent.com/35366872/236179782-d846da15-8fea-4d5a-9a21-6fa062afd369.png)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
