### PR TITLE
fix: fix items alignment in the backpack's (v2) wearables grid

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Prefabs/WearablesSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Prefabs/WearablesSection.prefab
@@ -8087,10 +8087,10 @@ RectTransform:
   m_Father: {fileID: 8122654311339567853}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -80, y: -132}
-  m_SizeDelta: {x: -981, y: -1009}
+  m_SizeDelta: {x: 824, y: 136}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &216720716380197272
 MonoBehaviour:
@@ -8109,7 +8109,7 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 2
+  m_ChildAlignment: 0
   m_StartCorner: 0
   m_StartAxis: 0
   m_CellSize: {x: 136, y: 136}
@@ -8555,7 +8555,7 @@ PrefabInstance:
     - target: {fileID: 3576930520628333720, guid: f5f14a07355bcff46ac345f4d95ec24a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 40.55
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3576930520628333720, guid: f5f14a07355bcff46ac345f4d95ec24a,
         type: 3}
@@ -8586,6 +8586,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: PageSelector
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213288149590170572, guid: f5f14a07355bcff46ac345f4d95ec24a,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5955730194940385775, guid: f5f14a07355bcff46ac345f4d95ec24a,
         type: 3}


### PR DESCRIPTION
## What does this PR change?
Fix items alignment in the backpack's (v2) wearables grid.

## How to test the changes?
1. Launch the explorer (using `&DISABLE_backpack_editor_v1&ENABLE_backpack_editor_v2`)
2. Open the new backpack.
3. Check that all elements in the grid appears aligned correctly.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36eba64</samp>

Improve the UI and UX of the `WearablesSection` prefab in the backpack editor HUD. Fix layout and animation bugs in the wearables list and details panels.