### PR TITLE
feat: ability of pre-visualize wearables before equipping

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -1,7 +1,6 @@
 using DCLServices.WearablesCatalogService;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace DCL.Backpack
@@ -272,10 +271,14 @@ namespace DCL.Backpack
 
             preEquipModel.Update(model);
 
-            WearableItem wearableToBeReplaced = preEquipModel.wearables.Values.FirstOrDefault(item => item.data.category == wearable.data.category);
+            foreach (var w in preEquipModel.wearables.Values)
+            {
+                if (w.data.category != wearable.data.category)
+                    continue;
 
-            if (wearableToBeReplaced != null)
-                preEquipModel.wearables.Remove(wearableToBeReplaced.id);
+                preEquipModel.wearables.Remove(w.id);
+                break;
+            }
 
             preEquipModel.wearables.Add(wearableId, wearable);
 
@@ -290,10 +293,14 @@ namespace DCL.Backpack
                 return;
             }
 
-            WearableItem wearableToBeReplaced = model.wearables.Values.FirstOrDefault(item => item.data.category == wearable.data.category);
+            foreach (var w in model.wearables.Values)
+            {
+                if (w.data.category != wearable.data.category)
+                    continue;
 
-            if (wearableToBeReplaced != null)
-                UnEquipWearable(wearableToBeReplaced.id);
+                UnEquipWearable(w.id);
+                break;
+            }
 
             model.wearables.Add(wearableId, wearable);
             previewEquippedWearables.Add(wearableId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -101,7 +101,7 @@ namespace DCL.Backpack
         }
 
         private void OnBackpackVisibleChanged(bool current, bool _) =>
-            SetVisibility(current, avatarIsDirty);
+            SetVisibility(current, saveAvatar: avatarIsDirty);
 
         private void SetVisibility(bool visible, bool saveAvatar = true)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -75,7 +75,7 @@ namespace DCL.Backpack
             view.SetColorPickerVisibility(false);
             view.OnColorChanged += OnWearableColorChanged;
 
-            SetVisibility(dataStore.HUDs.avatarEditorVisible.Get(), false);
+            SetVisibility(dataStore.HUDs.avatarEditorVisible.Get(), saveAvatar: false);
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDModel.cs
@@ -23,5 +23,17 @@ namespace DCL.Backpack
                 eyeColor = eyesColor
             };
         }
+
+        public void Update(BackpackEditorHUDModel newModel)
+        {
+            wearables.Clear();
+            foreach (var wearable in newModel.wearables)
+                wearables.Add(wearable.Key, wearable.Value);
+
+            bodyShape = newModel.bodyShape;
+            hairColor = newModel.hairColor;
+            skinColor = newModel.skinColor;
+            eyesColor = newModel.eyesColor;
+        }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/BackpackEditorHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/BackpackEditorHUDControllerShould.cs
@@ -1,4 +1,5 @@
-﻿using DCL.Browser;
+﻿using Cysharp.Threading.Tasks;
+using DCL.Browser;
 using DCLServices.WearablesCatalogService;
 using MainScripts.DCL.Models.AvatarAssets.Tests.Helpers;
 using NSubstitute;
@@ -156,6 +157,20 @@ namespace DCL.Backpack
 
             // Assert
             Assert.IsTrue(userProfile.avatar.wearables.Count == 0);
+        }
+
+        [Test]
+        public void SelectAndPreVisualizeWearableCorrectly()
+        {
+            // Arrange
+            EquipAndSaveCorrectly();
+
+            // Act
+            wearableGridView.OnWearableSelected += Raise.Event<Action<WearableGridItemModel>>(new WearableGridItemModel { WearableId = "urn:decentraland:off-chain:base-avatars:f_african_leggins" });
+
+            // Assert
+            view.Received(1).UpdateAvatarPreview(Arg.Is<AvatarModel>(avatarModel =>
+                avatarModel.wearables.Contains("urn:decentraland:off-chain:base-avatars:f_african_leggins")));
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/WearableGridControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/WearableGridControllerShould.cs
@@ -493,6 +493,9 @@ namespace DCL.Backpack
 
             dataStore.previewEquippedWearables.Add("w1");
 
+            string wearableSelectedId = null;
+            controller.OnWearableSelected += wearableId => wearableSelectedId = wearableId;
+
             view.OnWearableSelected += Raise.Event<Action<WearableGridItemModel>>(new WearableGridItemModel
             {
                 WearableId = "w1",
@@ -516,6 +519,8 @@ namespace DCL.Backpack
                      && i.hiddenBy == null
                      && i.hideList[0] == "lower_body"
                      && i.removeList[0] == "eyes"));
+
+            Assert.AreEqual("w1", wearableSelectedId);
         }
 
         [UnityTest]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
@@ -36,6 +36,7 @@ namespace DCL.Backpack
         private (NftOrderByOperation type, bool directionAscendent)? wearableSorting;
         private NftCollectionType collectionTypeMask = NftCollectionType.Base | NftCollectionType.OnChain;
 
+        public event Action<string> OnWearableSelected;
         public event Action<string> OnWearableEquipped;
         public event Action<string> OnWearableUnequipped;
 
@@ -259,6 +260,8 @@ namespace DCL.Backpack
                 removeList = wearable.data.replaces != null ? wearable.data.replaces.ToList() : new List<string>(),
                 wearableId = wearableId,
             });
+
+            OnWearableSelected?.Invoke(wearableId);
         }
 
         private void HandleWearableUnequipped(WearableGridItemModel wearableGridItem) =>


### PR DESCRIPTION
## What does this PR change?
It lets the user to pre-visualize the wearables in the avatar preview each time he click on them (before equipping).

## How to test the changes?
1. Launch the explorer (using `&DISABLE_backpack_editor_v1&ENABLE_backpack_editor_v2`).
2. Open the new backpack.
3. Select a wearable in the grid.
4. Notice the wearable is previsualized in the avatar preview.
5. Select another one.
6. Notice the avatar preview is reset to the original configuration and the new selected wearable is previsualized.
7. If you close and open the backpack without equipping any wearable (using the EQUIP action), your avatar will appear with the original wearables.
8. If you select several wearables without equipping them and several ones equipping them, if you close the backpack, only the equipped ones will be applied in the avatar.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86f023a</samp>

This pull request adds a new feature to the backpack editor HUD that allows users to preview wearables on their avatar before equipping them. It also improves the test coverage and the model update logic for the HUD. The main files affected are `BackpackEditorHUDController.cs`, `BackpackEditorHUDModel.cs`, and `WearableGridController.cs`.