### PR TITLE
fix: equipping and unequipping body shapes

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/WearableItemResolver.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/WearableItemResolver.cs
@@ -87,7 +87,8 @@ namespace AvatarSystem
                 // either we have the wearable and we have to add it to forget it later
                 // or it's null and we just return it
                 if (wearable != null)
-                    wearablesRetrieved.Add(wearableId, wearable);
+                    // TODO: dispose replaced wearable if exists
+                    wearablesRetrieved[wearableId] = wearable;
 
                 // return promise.value;
                 return wearable;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -163,6 +163,7 @@ namespace DCL.Backpack
 
             previewEquippedWearables.Set(userProfile.avatar.wearables);
 
+            UnEquipCurrentBodyShape();
             EquipBodyShape(bodyShape);
 
             model.skinColor = userProfile.avatar.skinColor;
@@ -221,6 +222,8 @@ namespace DCL.Backpack
             backpackEmotesSectionController.SetEquippedBodyShape(bodyShape.id);
             wearableGridController.Equip(bodyShape.id);
             previewEquippedWearables.Add(bodyShape.id);
+
+            avatarIsDirty = true;
         }
 
         private void TakeSnapshots(IBackpackEditorHUDView.OnSnapshotsReady onSuccess, Action onFailed)
@@ -324,6 +327,8 @@ namespace DCL.Backpack
 
         private void UnEquipCurrentBodyShape()
         {
+            if (model.bodyShape.id == "NOT_LOADED") return;
+
             if (!wearablesCatalogService.WearablesCatalog.TryGetValue(model.bodyShape.id, out WearableItem wearable))
             {
                 Debug.LogError($"Cannot unequip body shape {model.bodyShape.id}");


### PR DESCRIPTION
## What does this PR change?

Fixes cases when you equip and unequip a body shape in the backpack v2.
They were getting in the wearable list and not refreshing the UI correctly.

## How to test the changes?

1. Launch the explorer
2. Add `&ENABLE_backpack_editor_v2=&DISABLE_backpack_editor_v1` to url
3. Open the backpack
4. Check that the body shape slot is correctly set
5. Equip other body shapes. Check that the equipped state is correct with the avatar slot aswell
6. Save the avatar by closing the backpack
7. Open again
8. Try to unequip and equip multiple times
9. The UI and the avatar should be always correct

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0c5174</samp>

This pull request enhances the backpack editor HUD and fixes a wearable resolver bug. It adds a field to track the equipped wearables in the `BackpackEditorHUDController`, synchronizes the state of the wearable grid with the profile and the preview, and handles body shapes. It also prevents duplicate wearables from being added to the `wearablesRetrieved` dictionary in the `WearableItemResolver` and adds a TODO comment to dispose the replaced wearable.
