### PR TITLE
fix: duplicated key exception when resolving avatar wearables

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/WearableItemResolver.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/WearableItemResolver.cs
@@ -87,7 +87,8 @@ namespace AvatarSystem
                 // either we have the wearable and we have to add it to forget it later
                 // or it's null and we just return it
                 if (wearable != null)
-                    wearablesRetrieved.Add(wearableId, wearable);
+                    // TODO: dispose replaced wearable if exists
+                    wearablesRetrieved[wearableId] = wearable;
 
                 // return promise.value;
                 return wearable;


### PR DESCRIPTION
## What does this PR change?

Solves a duplicated key exception when solving wearables.

## How to test the changes?

1. Launch the explorer
2. Navigate through populated scenes
3. Avatars should load as expected
4. Open the backpack and change your wearables
5. The profile and the avatar should be updated correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b98ecab</samp>

Fix a bug in `WearableItemResolver.cs` that could cause an exception when adding duplicate wearableIds. Add a TODO comment to handle potential memory leaks.
