### PR TITLE
fix: boundaries not being in sync with the SBC

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
@@ -40,13 +40,14 @@ namespace DCL.Components
 
             if (Settings.i != null)
                 Settings.i.audioSettings.OnChanged += OnAudioSettingsChanged;
-    
+
             DataStore.i.virtualAudioMixer.sceneSFXVolume.OnChange += OnVirtualAudioMixerChangedValue;
         }
 
         public override void Initialize(IParcelScene scene, IDCLEntity entity)
         {
             base.Initialize(scene, entity);
+            isOutOfBoundaries = !entity.isInsideSceneBoundaries;
             DataStore.i.sceneBoundariesChecker.Add(entity,this);
         }
 
@@ -139,7 +140,7 @@ namespace DCL.Components
         private void UpdateAudioSourceVolume()
         {
             float newVolume = 0;
-            
+
             // isOutOfBoundaries will always be false for global scenes.
             if (!isOutOfBoundaries)
             {
@@ -181,7 +182,7 @@ namespace DCL.Components
 
             if (Settings.i != null)
                 Settings.i.audioSettings.OnChanged -= OnAudioSettingsChanged;
-            
+
             DataStore.i.virtualAudioMixer.sceneSFXVolume.OnChange -= OnVirtualAudioMixerChangedValue;
             DataStore.i.sceneBoundariesChecker.Remove(entity,this);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfo.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfo.asmdef
@@ -1,16 +1,17 @@
 {
-  "name": "MeshesInfo",
-  "rootNamespace": "",
-  "references": [
-    "GUID:6055be8ebefd69e48b49212b09b47b2f"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "MeshesInfo",
+    "rootNamespace": "",
+    "references": [
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfo.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Cysharp.Threading.Tasks;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DCL.Components;
@@ -112,7 +113,7 @@ namespace DCL.Models
             OnUpdated?.Invoke();
         }
 
-        public void RecalculateBounds()
+        public async UniTask RecalculateBounds()
         {
             if ((renderers == null || renderers.Length == 0) && colliders.Count == 0)
             {
@@ -124,6 +125,8 @@ namespace DCL.Models
             lastBoundsCalculationScale = meshRootGameObjectValue.transform.lossyScale;
             lastBoundsCalculationRotation = meshRootGameObjectValue.transform.rotation;
 
+            await UniTask.WaitForFixedUpdate();
+
             mergedBoundsValue = MeshesInfoUtils.BuildMergedBounds(renderers, colliders);
         }
 
@@ -131,7 +134,7 @@ namespace DCL.Models
         {
             OnCleanup?.Invoke();
             meshRootGameObjectValue = null;
-            animation = null; 
+            animation = null;
             currentShape = null;
             renderers = null;
             colliders.Clear();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfo.cs
@@ -121,11 +121,13 @@ namespace DCL.Models
                 return;
             }
 
+            await UniTask.WaitForFixedUpdate();
+
+            if (meshRootGameObjectValue == null) return;
+
             lastBoundsCalculationPosition = meshRootGameObjectValue.transform.position;
             lastBoundsCalculationScale = meshRootGameObjectValue.transform.lossyScale;
             lastBoundsCalculationRotation = meshRootGameObjectValue.transform.rotation;
-
-            await UniTask.WaitForFixedUpdate();
 
             mergedBoundsValue = MeshesInfoUtils.BuildMergedBounds(renderers, colliders);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfoUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MeshesInfo/MeshesInfoUtils.cs
@@ -10,35 +10,35 @@ namespace DCL.Models
         {
             Bounds bounds = new Bounds();
             bool initializedBounds = false;
-            
-            for (int i = 0; i < renderers.Length; i++)
-            {
-                if (renderers[i] == null) continue;
 
-                if (!initializedBounds)
+            if (renderers != null)
+            {
+                for (int i = 0; i < renderers.Length; i++)
                 {
-                    initializedBounds = true;
-                    bounds = GetSafeBounds(renderers[i].bounds, renderers[i].transform.position);
-                }
-                else
-                {
-                    bounds.Encapsulate(GetSafeBounds(renderers[i].bounds, renderers[i].transform.position));
+                    if (renderers[i] == null) continue;
+
+                    if (!initializedBounds)
+                    {
+                        initializedBounds = true;
+                        bounds = GetSafeBounds(renderers[i].bounds, renderers[i].transform.position);
+                    }
+                    else { bounds.Encapsulate(GetSafeBounds(renderers[i].bounds, renderers[i].transform.position)); }
                 }
             }
 
-            foreach (Collider collider in colliders)
+            if (colliders != null)
             {
-                if (collider == null) continue;
-                
-                if (!initializedBounds)
+                foreach (Collider collider in colliders)
                 {
-                    initializedBounds = true;
-                    bounds = GetSafeBounds(collider.bounds, collider.transform.position);
+                    if (collider == null) continue;
+
+                    if (!initializedBounds)
+                    {
+                        initializedBounds = true;
+                        bounds = GetSafeBounds(collider.bounds, collider.transform.position);
+                    }
+                    else { bounds.Encapsulate(GetSafeBounds(collider.bounds, collider.transform.position)); }
                 }
-                else
-                {
-                    bounds.Encapsulate(GetSafeBounds(collider.bounds, collider.transform.position));
-                }   
             }
 
             return bounds;
@@ -96,10 +96,7 @@ namespace DCL.Models
         {
             Dictionary<Mesh, int> result = new Dictionary<Mesh, int>();
 
-            foreach (var mesh in meshes)
-            {
-                result[mesh] = mesh.triangles.Length;
-            }
+            foreach (var mesh in meshes) { result[mesh] = mesh.triangles.Length; }
 
             return result;
         }
@@ -118,10 +115,7 @@ namespace DCL.Models
 
             foreach (var anim in animations)
             {
-                foreach (AnimationState state in anim)
-                {
-                    result.Add(state.clip);
-                }
+                foreach (AnimationState state in anim) { result.Add(state.clip); }
             }
 
             return result;
@@ -148,14 +142,12 @@ namespace DCL.Models
                         mat.GetTexturePropertyNameIDs(texIdsCache);
                         mat.GetTexturePropertyNames(texNameCache);
                         List<Texture> result = new List<Texture>();
+
                         for (int i = 0; i < texIdsCache.Count; i++)
                         {
                             var tex = mat.GetTexture(texIdsCache[i]);
 
-                            if (tex != null)
-                            {
-                                result.Add(tex);
-                            }
+                            if (tex != null) { result.Add(tex); }
                         }
 
                         return result;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Interfaces/ISceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Interfaces/ISceneBoundsChecker.cs
@@ -1,27 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using DCL.Models;
-using UnityEngine;
+﻿using DCL.Models;
 
 namespace DCL.Controllers
 {
     public interface ISceneBoundsChecker : IService
     {
-        event Action<IDCLEntity, bool> OnEntityBoundsCheckerStatusChanged;
-
         float timeBetweenChecks { get; set; }
         bool enabled { get; }
         int entitiesToCheckCount { get; }
         void SetFeedbackStyle(ISceneBoundsFeedbackStyle feedbackStyle);
         ISceneBoundsFeedbackStyle GetFeedbackStyle();
-        List<Material> GetOriginalMaterials(MeshesInfo meshesInfo);
-        void Start();
         void Stop();
         void AddEntityToBeChecked(IDCLEntity entity, bool isPersistent = false, bool runPreliminaryEvaluation = false);
         void RemoveEntity(IDCLEntity entity, bool removeIfPersistent = false, bool resetState = false);
         bool WasAddedAsPersistent(IDCLEntity entity);
-        void RunEntityEvaluation(IDCLEntity entity);
         void RunEntityEvaluation(IDCLEntity entity, bool onlyOuterBoundsCheck);
-        bool IsEntityMeshInsideSceneBoundaries(IDCLEntity entity);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -201,10 +201,8 @@ namespace DCL.Controllers
 
             // No need to add the entity to be checked later if we already found it outside scene outer boundaries.
             // When the correct events are triggered again, the entity will be checked again.
-            if (!isInsistent && !isPersistent && !entity.isInsideSceneOuterBoundaries)
-                return;
-
-            AddEntity(entity, isPersistent);
+            if (isInsistent || isPersistent || entity.isInsideSceneOuterBoundaries)
+                AddEntity(entity, isPersistent);
         }
 
         private void AddEntity(IDCLEntity entity, bool isPersistent)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsChecker.cs
@@ -29,7 +29,7 @@ namespace DCL.Controllers
         private bool isNerfed;
         private bool isInsistent;
         private bool isEnabled;
-        private readonly CancellationTokenSource cancellationTokenSource = new ();
+        private CancellationTokenSource cancellationTokenSource = new ();
 
         public void Initialize()
         {
@@ -59,8 +59,6 @@ namespace DCL.Controllers
 
         private async UniTask CheckEntitiesAsync(CancellationToken cancellationToken)
         {
-            isEnabled = true;
-
             try
             {
                 while (true)
@@ -140,10 +138,6 @@ namespace DCL.Controllers
                 if (e is not OperationCanceledException)
                     throw;
             }
-            finally
-            {
-                isEnabled = false;
-            }
         }
 
         private bool IsTimeBudgetDepleted(float timeBudget) =>
@@ -160,7 +154,9 @@ namespace DCL.Controllers
             if (isEnabled)
                 return;
 
+            cancellationTokenSource = new CancellationTokenSource();
             lastCheckTime = Time.realtimeSinceStartup;
+            isEnabled = true;
             CheckEntitiesAsync(cancellationTokenSource.Token).Forget();
         }
 
@@ -170,6 +166,9 @@ namespace DCL.Controllers
                 return;
 
             cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
+
+            isEnabled = false;
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsFeedbackStyle_RedBox.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsFeedbackStyle_RedBox.cs
@@ -25,6 +25,7 @@ namespace DCL.Controllers
 
                 for (int i = 0; i < count; i++)
                 {
+                    wireframeObjects[i].transform.parent = null;
                     Utils.SafeDestroy(wireframeObjects[i]);
                 }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using System;
 using DCL.Components;
 using DCL.Controllers;
@@ -12,6 +13,7 @@ using DCL;
 using DCL.Helpers.NFT;
 using NFTShape_Internal;
 using NSubstitute;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityGLTF.Loader;
 using Environment = DCL.Environment;
@@ -20,7 +22,7 @@ namespace SceneBoundariesCheckerTests
 {
     public static class SBC_Asserts
     {
-        public static IEnumerator EntitiesAreBeingCorrectlyRegistered(ParcelScene scene)
+        public static async Task EntitiesAreBeingCorrectlyRegistered(ParcelScene scene)
         {
             var boxShape1 = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(20, 2, 20));
             var boxShape2 = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(20, 2, 20));
@@ -33,7 +35,7 @@ namespace SceneBoundariesCheckerTests
             Assert.AreEqual(2, scene.entities.Count, "scene entities count can't be zero!");
             Assert.AreEqual(2, Environment.i.world.sceneBoundsChecker.entitiesToCheckCount, "entities to check can't be zero!");
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
 
             TestUtils.RemoveSceneEntity(scene, entity2.entityId);
 
@@ -42,34 +44,36 @@ namespace SceneBoundariesCheckerTests
             Assert.AreEqual(0, scene.entities.Count, "entity count should be zero");
             Assert.AreEqual(0, Environment.i.world.sceneBoundsChecker.entitiesToCheckCount, "entities to check should be zero!");
         }
-        
-        public static IEnumerator EntityIsEvaluatedOnReparenting(ParcelScene scene)
+
+        public static async Task EntityIsEvaluatedOnReparenting(ParcelScene scene)
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(8, 2, 8));
             var shapeEntity = boxShape.attachedEntities.First();
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
             AssertMeshesAndCollidersValidState(shapeEntity.meshesInfo, true);
-         
+
             var newParentEntity = TestUtils.CreateSceneEntity(scene);
             TestUtils.SetEntityTransform(scene, newParentEntity, new DCLTransform.Model { position = new Vector3(100, 1, 100) });
-            
+
             // Our entities parenting moves the child's local position to Vector3.zero by default...
             TestUtils.SetEntityParent(scene, shapeEntity, newParentEntity);
-            
-            yield return null;
+
+            await UniTask.WaitForFixedUpdate();
             AssertMeshesAndCollidersValidState(shapeEntity.meshesInfo, false);
         }
 
-        public static IEnumerator PShapeIsInvalidatedWhenStartingOutOfBounds(ParcelScene scene)
+        public static async Task PShapeIsInvalidatedWhenStartingOutOfBounds(ParcelScene scene)
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(20, 2, 20));
-            yield return null;
+
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             AssertMeshesAndCollidersValidState(boxShape.attachedEntities.First().meshesInfo, false);
         }
 
-        public static IEnumerator GLTFShapeIsInvalidatedWhenStartingOutOfBounds(ParcelScene scene)
+        public static async Task GLTFShapeIsInvalidatedWhenStartingOutOfBounds(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -81,13 +85,13 @@ namespace SceneBoundariesCheckerTests
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
-            yield return null;
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
+            await UniTask.WaitForFixedUpdate();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
-        public static IEnumerator GLTFShapeWithCollidersAndNoRenderersIsInvalidatedWhenStartingOutOfBounds(ParcelScene scene)
+        public static async Task GLTFShapeWithCollidersAndNoRenderersIsInvalidatedWhenStartingOutOfBounds(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -99,13 +103,13 @@ namespace SceneBoundariesCheckerTests
                     src = TestAssetsUtils.GetPath() + "/GLB/gltfshape-asset-bundle-colliders-no-renderers.glb"
                 }));
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
-            yield return null;
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
+            await UniTask.WaitForFixedUpdate();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
-        public static IEnumerator GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundaries(ParcelScene scene)
+        public static async Task GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundaries(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -117,28 +121,30 @@ namespace SceneBoundariesCheckerTests
                     src = TestAssetsUtils.GetPath() + "/GLB/gltfshape-asset-bundle-colliders-no-renderers.glb"
                 }));
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
-            yield return null;
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
+            await UniTask.WaitForFixedUpdate();
 
             // Force entity evaluation avoiding outer boundaries check
             Environment.i.world.sceneBoundsChecker.RunEntityEvaluation(entity, onlyOuterBoundsCheck: false);
-            
+
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
-        
-        public static IEnumerator PShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform(ParcelScene scene)
+
+        public static async Task PShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
             TestUtils.CreateAndSetShape(scene, entity.entityId, DCL.Models.CLASS_ID.BOX_SHAPE,
                 JsonConvert.SerializeObject(new BoxShape.Model { })
             );
-            
-            yield return null;
+
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
-        
-        public static IEnumerator GLTFShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform(ParcelScene scene)
+
+        public static async Task GLTFShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -148,31 +154,32 @@ namespace SceneBoundariesCheckerTests
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
-            
-            yield return null;
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
+
+            await UniTask.WaitForFixedUpdate();
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
-        
-        public static IEnumerator PShapeIsEvaluatedAfterCorrectTransformAttachment(ParcelScene scene)
+
+        public static async Task PShapeIsEvaluatedAfterCorrectTransformAttachment(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
-
             TestUtils.CreateAndSetShape(scene, entity.entityId, DCL.Models.CLASS_ID.BOX_SHAPE,
                 JsonConvert.SerializeObject(new BoxShape.Model { })
             );
-            
-            yield return null;
+
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
+
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
-            
-            yield return null;
+
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
-            
-            yield return null;
+
+            await UniTask.WaitUntil(() => entity.isInsideSceneBoundaries);
+
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
-        
-        public static IEnumerator GLTFShapeIsEvaluatedAfterCorrectTransformAttachment(ParcelScene scene)
+
+        public static async Task GLTFShapeIsEvaluatedAfterCorrectTransformAttachment(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -182,19 +189,22 @@ namespace SceneBoundariesCheckerTests
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
-            
-            yield return null;
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
+
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
-            
-            yield return null;
+
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
-            
-            yield return null;
+
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
-        
-        public static IEnumerator NFTShapeIsInvalidatedWhenStartingOutOfBounds(ParcelScene scene)
+
+        public static async Task NFTShapeIsInvalidatedWhenStartingOutOfBounds(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -206,24 +216,24 @@ namespace SceneBoundariesCheckerTests
             };
 
             NFTShape component = TestUtils.SharedComponentCreate<NFTShape, NFTShape.Model>(scene, CLASS_ID.NFT_SHAPE, componentModel);
-            yield return component.routine;
+            await UniTask.WaitUntil(() => !component.isRoutineRunning);
 
             TestUtils.SharedComponentAttach(component, entity);
 
             LoadWrapper shapeLoader = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => shapeLoader.alreadyLoaded);
+            await UniTask.WaitUntil(() => shapeLoader.alreadyLoaded);
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
-        public static IEnumerator PShapeIsInvalidatedWhenLeavingBounds(ParcelScene scene)
+        public static async Task PShapeIsInvalidatedWhenLeavingBounds(ParcelScene scene)
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(8, 1, 8));
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
             var entity = boxShape.attachedEntities.First();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
@@ -232,13 +242,13 @@ namespace SceneBoundariesCheckerTests
             var transformModel = new DCLTransform.Model { position = new Vector3(18, 1, 18) };
             TestUtils.SetEntityTransform(scene, entity, transformModel);
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
-        public static IEnumerator GLTFShapeIsInvalidatedWhenLeavingBounds(ParcelScene scene)
+        public static async Task GLTFShapeIsInvalidatedWhenLeavingBounds(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -250,20 +260,20 @@ namespace SceneBoundariesCheckerTests
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
 
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(18, 1, 18) });
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
-        public static IEnumerator NFTShapeIsInvalidatedWhenLeavingBounds(ParcelScene scene)
+        public static async Task NFTShapeIsInvalidatedWhenLeavingBounds(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -275,56 +285,57 @@ namespace SceneBoundariesCheckerTests
             };
 
             NFTShape component = TestUtils.SharedComponentCreate<NFTShape, NFTShape.Model>(scene, CLASS_ID.NFT_SHAPE, componentModel);
-            yield return component.routine;
+            await UniTask.WaitUntil(() => !component.isRoutineRunning);
 
             TestUtils.SharedComponentAttach(component, entity);
 
             LoadWrapper shapeLoader = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => shapeLoader.alreadyLoaded);
+            await UniTask.WaitUntil(() => shapeLoader.alreadyLoaded);
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
 
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(18, 1, 18) });
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
-        public static IEnumerator HeightIsEvaluated(ParcelScene scene)
+        public static async Task HeightIsEvaluated(ParcelScene scene)
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(8, 5, 8));
             var entity = boxShape.attachedEntities.First();
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
 
             // Move object to surpass the scene height boundaries
             var transformModel = new DCLTransform.Model { position = new Vector3(8, 30, 8) };
             TestUtils.SetEntityTransform(scene, entity, transformModel);
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
-        public static IEnumerator ChildShapeIsEvaluated(ParcelScene scene)
+        public static async Task ChildShapeIsEvaluated(ParcelScene scene)
         {
             long entityId = 11;
             TestUtils.InstantiateEntityWithShape(scene, entityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(8, 1, 8));
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
             AssertMeshesAndCollidersValidState(scene.entities[entityId].meshesInfo, true);
 
             // Attach child
             long childEntityId = 20;
             TestUtils.InstantiateEntityWithShape(scene, childEntityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(8, 1, 8));
-            
-            yield return null;
-            yield return null;
+
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
             AssertMeshesAndCollidersValidState(scene.entities[childEntityId].meshesInfo, true);
 
             TestUtils.SetEntityParent(scene, childEntityId, entityId);
@@ -333,47 +344,51 @@ namespace SceneBoundariesCheckerTests
             var transformModel = new DCLTransform.Model { position = new Vector3(18, 1, 18) };
             TestUtils.SetEntityTransform(scene, scene.entities[entityId], transformModel);
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
             AssertMeshesAndCollidersValidState(scene.entities[childEntityId].meshesInfo, false);
         }
 
-        public static IEnumerator ChildShapeIsEvaluatedOnShapelessParent(ParcelScene scene)
+        public static async Task ChildShapeIsEvaluatedOnShapelessParent(ParcelScene scene)
         {
             // create shapeless parent entity
             long entityId = 11;
             TestUtils.CreateSceneEntity(scene, entityId);
             TestUtils.SetEntityTransform(scene, scene.entities[entityId], new Vector3(18, 1, 18), Quaternion.identity, Vector3.one);
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
 
             AssertMeshesAndCollidersValidState(scene.entities[entityId].meshesInfo, true);
 
             // Attach child
             long childEntityId = 20;
             TestUtils.InstantiateEntityWithShape(scene, childEntityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(0, 0, 0));
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
 
             TestUtils.SetEntityParent(scene, childEntityId, entityId);
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
 
-            AssertMeshesAndCollidersValidState(scene.entities[childEntityId].meshesInfo, false);
+            IDCLEntity child = scene.entities[childEntityId];
+
+            AssertMeshesAndCollidersValidState(child.meshesInfo, false);
 
             // Move parent object to re-enter the scene boundaries
             TestUtils.SetEntityTransform(scene, scene.entities[entityId], new Vector3(8, 1, 8), Quaternion.identity, Vector3.one);
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitUntil(() => child.isInsideSceneBoundaries);
 
-            AssertMeshesAndCollidersValidState(scene.entities[childEntityId].meshesInfo, true);
+            AssertMeshesAndCollidersValidState(child.meshesInfo, true);
         }
 
-        public static IEnumerator PShapeIsResetWhenReenteringBounds(ParcelScene scene)
+        public static async Task PShapeIsResetWhenReenteringBounds(ParcelScene scene)
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(18, 1, 18));
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
 
             var entity = boxShape.attachedEntities.First();
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
 
@@ -381,19 +396,19 @@ namespace SceneBoundariesCheckerTests
             var transformModel = new DCLTransform.Model { position = new Vector3(8, 1, 8) };
             TestUtils.SetEntityTransform(scene, entity, transformModel);
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
-        
-        public static IEnumerator OnPointerEventCollidersAreResetWhenReenteringBounds(ParcelScene scene)
+
+        public static async Task OnPointerEventCollidersAreResetWhenReenteringBounds(ParcelScene scene)
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(18, 1, 18));
-            yield return boxShape.routine;
-            
+            await UniTask.WaitUntil(() => !boxShape.isRoutineRunning);
+
             var entity = boxShape.attachedEntities.First();
-            
+
             // Attach onpointer event component
             string onPointerId = "pointerevent-1";
             var OnPointerDownModel = new OnPointerDown.Model()
@@ -401,10 +416,13 @@ namespace SceneBoundariesCheckerTests
                 type = "pointerUp",
                 uuid = onPointerId
             };
-            
+
             // Grab onpointer event collider
             var component = TestUtils.EntityComponentCreate<OnPointerDown, OnPointerDown.Model>(scene, entity,
                 OnPointerDownModel, CLASS_ID_COMPONENT.UUID_CALLBACK);
+
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             var meshFilter = entity.gameObject.GetComponentInChildren<MeshFilter>();
             var onPointerEventCollider = meshFilter.transform.Find(OnPointerEventColliders.COLLIDER_NAME).GetComponent<MeshCollider>();
@@ -419,15 +437,15 @@ namespace SceneBoundariesCheckerTests
             var transformModel = new DCLTransform.Model { position = new Vector3(8, 1, 8) };
             TestUtils.SetEntityTransform(scene, entity, transformModel);
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             // Check onpointer event collider got enabled
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
             Assert.IsTrue(onPointerEventCollider.enabled);
         }
 
-        public static IEnumerator GLTFShapeIsResetWhenReenteringBounds(ParcelScene scene)
+        public static async Task GLTFShapeIsResetWhenReenteringBounds(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -439,21 +457,21 @@ namespace SceneBoundariesCheckerTests
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
-            yield return null;
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
+            await UniTask.WaitForFixedUpdate();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
 
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
 
-        public static IEnumerator NFTShapeIsResetWhenReenteringBounds(ParcelScene scene)
+        public static async Task NFTShapeIsResetWhenReenteringBounds(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -465,19 +483,20 @@ namespace SceneBoundariesCheckerTests
             };
 
             NFTShape component = TestUtils.SharedComponentCreate<NFTShape, NFTShape.Model>(scene, CLASS_ID.NFT_SHAPE, componentModel);
-            yield return component.routine;
+            await UniTask.WaitUntil(() => !component.isRoutineRunning);
 
             TestUtils.SharedComponentAttach(component, entity);
 
             LoadWrapper shapeLoader = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => shapeLoader.alreadyLoaded);
+            await UniTask.WaitUntil(() => shapeLoader.alreadyLoaded);
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
 
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SBC_Asserts.cs
@@ -67,8 +67,7 @@ namespace SceneBoundariesCheckerTests
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(20, 2, 20));
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(boxShape.attachedEntities.First().meshesInfo, false);
         }
@@ -84,9 +83,10 @@ namespace SceneBoundariesCheckerTests
                 {
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
+
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
             await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
@@ -102,9 +102,10 @@ namespace SceneBoundariesCheckerTests
                 {
                     src = TestAssetsUtils.GetPath() + "/GLB/gltfshape-asset-bundle-colliders-no-renderers.glb"
                 }));
+
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
             await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
@@ -120,9 +121,10 @@ namespace SceneBoundariesCheckerTests
                 {
                     src = TestAssetsUtils.GetPath() + "/GLB/gltfshape-asset-bundle-colliders-no-renderers.glb"
                 }));
+
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
             await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
 
             // Force entity evaluation avoiding outer boundaries check
             Environment.i.world.sceneBoundsChecker.RunEntityEvaluation(entity, onlyOuterBoundsCheck: false);
@@ -138,8 +140,7 @@ namespace SceneBoundariesCheckerTests
                 JsonConvert.SerializeObject(new BoxShape.Model { })
             );
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
@@ -153,22 +154,23 @@ namespace SceneBoundariesCheckerTests
                 {
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
+
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
             await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
 
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
         public static async Task PShapeIsEvaluatedAfterCorrectTransformAttachment(ParcelScene scene)
         {
             var entity = TestUtils.CreateSceneEntity(scene);
+
             TestUtils.CreateAndSetShape(scene, entity.entityId, DCL.Models.CLASS_ID.BOX_SHAPE,
                 JsonConvert.SerializeObject(new BoxShape.Model { })
             );
 
-            await UniTask.WaitForFixedUpdate();
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
 
@@ -188,18 +190,17 @@ namespace SceneBoundariesCheckerTests
                 {
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
+
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
             await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
 
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
@@ -232,8 +233,7 @@ namespace SceneBoundariesCheckerTests
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(8, 1, 8));
 
-            await UniTask.WaitForFixedUpdate();
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
             var entity = boxShape.attachedEntities.First();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
@@ -242,8 +242,7 @@ namespace SceneBoundariesCheckerTests
             var transformModel = new DCLTransform.Model { position = new Vector3(18, 1, 18) };
             TestUtils.SetEntityTransform(scene, entity, transformModel);
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
@@ -259,6 +258,7 @@ namespace SceneBoundariesCheckerTests
                 {
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
+
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
             await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
 
@@ -267,8 +267,7 @@ namespace SceneBoundariesCheckerTests
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(18, 1, 18) });
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
@@ -297,8 +296,7 @@ namespace SceneBoundariesCheckerTests
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(18, 1, 18) });
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
@@ -308,16 +306,14 @@ namespace SceneBoundariesCheckerTests
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(8, 5, 8));
             var entity = boxShape.attachedEntities.First();
 
-            await UniTask.WaitForFixedUpdate();
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
 
             // Move object to surpass the scene height boundaries
             var transformModel = new DCLTransform.Model { position = new Vector3(8, 30, 8) };
             TestUtils.SetEntityTransform(scene, entity, transformModel);
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
             AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
         }
 
@@ -326,16 +322,14 @@ namespace SceneBoundariesCheckerTests
             long entityId = 11;
             TestUtils.InstantiateEntityWithShape(scene, entityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(8, 1, 8));
 
-            await UniTask.WaitForFixedUpdate();
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
             AssertMeshesAndCollidersValidState(scene.entities[entityId].meshesInfo, true);
 
             // Attach child
             long childEntityId = 20;
             TestUtils.InstantiateEntityWithShape(scene, childEntityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(8, 1, 8));
 
-            await UniTask.WaitForFixedUpdate();
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
             AssertMeshesAndCollidersValidState(scene.entities[childEntityId].meshesInfo, true);
 
             TestUtils.SetEntityParent(scene, childEntityId, entityId);
@@ -344,8 +338,7 @@ namespace SceneBoundariesCheckerTests
             var transformModel = new DCLTransform.Model { position = new Vector3(18, 1, 18) };
             TestUtils.SetEntityTransform(scene, scene.entities[entityId], transformModel);
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
             AssertMeshesAndCollidersValidState(scene.entities[childEntityId].meshesInfo, false);
         }
 
@@ -355,21 +348,17 @@ namespace SceneBoundariesCheckerTests
             long entityId = 11;
             TestUtils.CreateSceneEntity(scene, entityId);
             TestUtils.SetEntityTransform(scene, scene.entities[entityId], new Vector3(18, 1, 18), Quaternion.identity, Vector3.one);
-            await UniTask.WaitForFixedUpdate();
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(scene.entities[entityId].meshesInfo, true);
 
             // Attach child
             long childEntityId = 20;
             TestUtils.InstantiateEntityWithShape(scene, childEntityId, DCL.Models.CLASS_ID.BOX_SHAPE, new Vector3(0, 0, 0));
-            await UniTask.WaitForFixedUpdate();
-            await UniTask.WaitForFixedUpdate();
+            await WaitForFixedUpdates();
 
             TestUtils.SetEntityParent(scene, childEntityId, entityId);
-            await UniTask.WaitForFixedUpdate();
-            await UniTask.WaitForFixedUpdate();
-
+            await WaitForFixedUpdates();
             IDCLEntity child = scene.entities[childEntityId];
 
             AssertMeshesAndCollidersValidState(child.meshesInfo, false);
@@ -396,8 +385,7 @@ namespace SceneBoundariesCheckerTests
             var transformModel = new DCLTransform.Model { position = new Vector3(8, 1, 8) };
             TestUtils.SetEntityTransform(scene, entity, transformModel);
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
@@ -411,6 +399,7 @@ namespace SceneBoundariesCheckerTests
 
             // Attach onpointer event component
             string onPointerId = "pointerevent-1";
+
             var OnPointerDownModel = new OnPointerDown.Model()
             {
                 type = "pointerUp",
@@ -421,8 +410,7 @@ namespace SceneBoundariesCheckerTests
             var component = TestUtils.EntityComponentCreate<OnPointerDown, OnPointerDown.Model>(scene, entity,
                 OnPointerDownModel, CLASS_ID_COMPONENT.UUID_CALLBACK);
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             var meshFilter = entity.gameObject.GetComponentInChildren<MeshFilter>();
             var onPointerEventCollider = meshFilter.transform.Find(OnPointerEventColliders.COLLIDER_NAME).GetComponent<MeshCollider>();
@@ -437,8 +425,7 @@ namespace SceneBoundariesCheckerTests
             var transformModel = new DCLTransform.Model { position = new Vector3(8, 1, 8) };
             TestUtils.SetEntityTransform(scene, entity, transformModel);
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             // Check onpointer event collider got enabled
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
@@ -456,6 +443,7 @@ namespace SceneBoundariesCheckerTests
                 {
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
+
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
             await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
             await UniTask.WaitForFixedUpdate();
@@ -465,8 +453,7 @@ namespace SceneBoundariesCheckerTests
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
@@ -495,8 +482,7 @@ namespace SceneBoundariesCheckerTests
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
 
-            await UniTask.WaitForFixedUpdate(); // preliminary check
-            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+            await WaitForFixedUpdates();
 
             AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
         }
@@ -508,10 +494,7 @@ namespace SceneBoundariesCheckerTests
                 if (meshesInfo.meshRootGameObject == null)
                     return; // It's valid if there's no mesh
             }
-            else
-            {
-                Assert.IsTrue(meshesInfo.meshRootGameObject != null, "MeshRootGameObject is null. The object is valid when it shouldn't.");
-            }
+            else { Assert.IsTrue(meshesInfo.meshRootGameObject != null, "MeshRootGameObject is null. The object is valid when it shouldn't."); }
 
             if (Environment.i.world.sceneBoundsChecker.GetFeedbackStyle() is SceneBoundsFeedbackStyle_RedBox)
             {
@@ -530,16 +513,16 @@ namespace SceneBoundariesCheckerTests
             }
             else
             {
-                for (int i = 0; i < meshesInfo.renderers.Length; i++)
-                {
-                    Assert.That(meshesInfo.renderers[i].enabled == expectedValidState);
-                }
+                for (int i = 0; i < meshesInfo.renderers.Length; i++) { Assert.That(meshesInfo.renderers[i].enabled == expectedValidState); }
 
-                foreach (Collider collider in meshesInfo.colliders)
-                {
-                    Assert.That(collider.enabled == expectedValidState);
-                }
+                foreach (Collider collider in meshesInfo.colliders) { Assert.That(collider.enabled == expectedValidState); }
             }
+        }
+
+        private static async Task WaitForFixedUpdates()
+        {
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.asmdef
@@ -54,7 +54,8 @@
         "GUID:be0e3042b7c1c6e41ae8221ae6470d80",
         "GUID:44002c75b9995c34d97b8afc551d32eb",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
-        "GUID:44a9db8f655ab05409802e5476cf9dd3"
+        "GUID:44a9db8f655ab05409802e5476cf9dd3",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using System.Collections;
 using DCL;
@@ -6,6 +7,7 @@ using DCL.Controllers;
 using DCL.Helpers;
 using DCL.Helpers.NFT.Markets;
 using NSubstitute;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Environment = DCL.Environment;
@@ -29,7 +31,6 @@ namespace SceneBoundariesCheckerTests
             scene.isPersistent = false;
             Environment.i.world.sceneBoundsChecker.timeBetweenChecks = 0f;
             TestUtils_NFT.RegisterMockedNFTShape(Environment.i.world.componentFactory);
-            
         }
 
         protected override IEnumerator TearDown()
@@ -38,7 +39,7 @@ namespace SceneBoundariesCheckerTests
             coreComponentsPlugin.Dispose();
             yield return base.TearDown();
         }
-        
+
         protected override ServiceLocator InitializeServiceLocator()
         {
             ServiceLocator result = base.InitializeServiceLocator();
@@ -55,109 +56,113 @@ namespace SceneBoundariesCheckerTests
             return result;
         }
 
-        [UnityTest]
-        public IEnumerator EntitiesAreBeingCorrectlyRegistered() { yield return SBC_Asserts.EntitiesAreBeingCorrectlyRegistered(scene); }
-        
-        [UnityTest]
-        public IEnumerator EntityIsEvaluatedOnReparenting() { yield return SBC_Asserts.EntityIsEvaluatedOnReparenting(scene); }
+        [Test]
+        public async Task EntitiesAreBeingCorrectlyRegistered() { await SBC_Asserts.EntitiesAreBeingCorrectlyRegistered(scene); }
 
-        [UnityTest]
-        public IEnumerator PShapeIsInvalidatedWhenStartingOutOfBounds() { yield return SBC_Asserts.PShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
+        [Test]
+        public async Task EntityIsEvaluatedOnReparenting() { await SBC_Asserts.EntityIsEvaluatedOnReparenting(scene); }
 
-        [UnityTest]
-        public IEnumerator GLTFShapeIsInvalidatedWhenStartingOutOfBounds() { yield return SBC_Asserts.GLTFShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
+        [Test]
+        public async Task PShapeIsInvalidatedWhenStartingOutOfBounds() { await SBC_Asserts.PShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
 
-        [UnityTest]
-        public IEnumerator GLTFShapeWithCollidersAndNoRenderersIsInvalidatedWhenStartingOutOfBounds() { yield return SBC_Asserts.GLTFShapeWithCollidersAndNoRenderersIsInvalidatedWhenStartingOutOfBounds(scene); }
-        
-        [UnityTest]
-        public IEnumerator GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundaries() { yield return SBC_Asserts.GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundaries(scene); }
+        [Test]
+        public async Task GLTFShapeIsInvalidatedWhenStartingOutOfBounds() { await SBC_Asserts.GLTFShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
 
-        [UnityTest]
-        public IEnumerator PShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform() { yield return SBC_Asserts.PShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform(scene); }
-        
-        [UnityTest]
-        public IEnumerator GLTFShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform() { yield return SBC_Asserts.GLTFShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform(scene); }
-        
-        [UnityTest]
-        public IEnumerator PShapeIsEvaluatedAfterCorrectTransformAttachment() { yield return SBC_Asserts.PShapeIsEvaluatedAfterCorrectTransformAttachment(scene); }
-        
-        [UnityTest]
-        public IEnumerator GLTFShapeIsEvaluatedAfterCorrectTransformAttachment() { yield return SBC_Asserts.GLTFShapeIsEvaluatedAfterCorrectTransformAttachment(scene); }
-        
-        [UnityTest]
-        public IEnumerator PShapeIsInvalidatedWhenLeavingBounds() { yield return SBC_Asserts.PShapeIsInvalidatedWhenLeavingBounds(scene); }
+        [Test]
+        public async Task GLTFShapeWithCollidersAndNoRenderersIsInvalidatedWhenStartingOutOfBounds() { await SBC_Asserts.GLTFShapeWithCollidersAndNoRenderersIsInvalidatedWhenStartingOutOfBounds(scene); }
 
-        [UnityTest]
-        public IEnumerator GLTFShapeIsInvalidatedWhenLeavingBounds() { yield return SBC_Asserts.GLTFShapeIsInvalidatedWhenLeavingBounds(scene); }
+        [Test]
+        public async Task GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundaries() { await SBC_Asserts.GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundaries(scene); }
 
-        [UnityTest]
-        public IEnumerator PShapeIsResetWhenReenteringBounds() { yield return SBC_Asserts.PShapeIsResetWhenReenteringBounds(scene); }
-        
-        [UnityTest]
-        public IEnumerator OnPointerEventCollidersAreResetWhenReenteringBounds() { yield return SBC_Asserts.OnPointerEventCollidersAreResetWhenReenteringBounds(scene); }
+        [Test]
+        public async Task PShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform() { await SBC_Asserts.PShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform(scene); }
 
-        [UnityTest]
-        public IEnumerator NFTShapeIsInvalidatedWhenStartingOutOfBounds() { yield return SBC_Asserts.NFTShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
+        [Test]
+        public async Task GLTFShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform() { await SBC_Asserts.GLTFShapeIsInvalidatedWhenStartingOutOfBoundsWithoutTransform(scene); }
 
-        [UnityTest]
-        public IEnumerator NFTShapeIsInvalidatedWhenLeavingBounds() { yield return SBC_Asserts.NFTShapeIsInvalidatedWhenLeavingBounds(scene); }
+        [Test]
+        public async Task PShapeIsEvaluatedAfterCorrectTransformAttachment() { await SBC_Asserts.PShapeIsEvaluatedAfterCorrectTransformAttachment(scene); }
 
-        [UnityTest]
+        [Test]
+        public async Task GLTFShapeIsEvaluatedAfterCorrectTransformAttachment() { await SBC_Asserts.GLTFShapeIsEvaluatedAfterCorrectTransformAttachment(scene); }
+
+        [Test]
+        public async Task PShapeIsInvalidatedWhenLeavingBounds() { await SBC_Asserts.PShapeIsInvalidatedWhenLeavingBounds(scene); }
+
+        [Test]
+        public async Task GLTFShapeIsInvalidatedWhenLeavingBounds() { await SBC_Asserts.GLTFShapeIsInvalidatedWhenLeavingBounds(scene); }
+
+        [Test]
+        public async Task PShapeIsResetWhenReenteringBounds() { await SBC_Asserts.PShapeIsResetWhenReenteringBounds(scene); }
+
+        [Test]
+        public async Task OnPointerEventCollidersAreResetWhenReenteringBounds() { await SBC_Asserts.OnPointerEventCollidersAreResetWhenReenteringBounds(scene); }
+
+        [Test]
+        public async Task NFTShapeIsInvalidatedWhenStartingOutOfBounds() { await SBC_Asserts.NFTShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
+
+        [Test]
+        public async Task NFTShapeIsInvalidatedWhenLeavingBounds() { await SBC_Asserts.NFTShapeIsInvalidatedWhenLeavingBounds(scene); }
+
+        [Test]
         [Explicit]
         [Category("Explicit")]
-        public IEnumerator NFTShapeIsResetWhenReenteringBounds() { yield return SBC_Asserts.NFTShapeIsResetWhenReenteringBounds(scene); }
+        public async Task NFTShapeIsResetWhenReenteringBounds() { await SBC_Asserts.NFTShapeIsResetWhenReenteringBounds(scene); }
 
-        [UnityTest]
-        public IEnumerator GLTFShapeIsResetWhenReenteringBounds() { yield return SBC_Asserts.GLTFShapeIsResetWhenReenteringBounds(scene); }
+        [Test]
+        public async Task GLTFShapeIsResetWhenReenteringBounds() { await SBC_Asserts.GLTFShapeIsResetWhenReenteringBounds(scene); }
 
-        [UnityTest]
-        public IEnumerator ChildShapeIsEvaluated() { yield return SBC_Asserts.ChildShapeIsEvaluated(scene); }
+        [Test]
+        public async Task ChildShapeIsEvaluated() { await SBC_Asserts.ChildShapeIsEvaluated(scene); }
 
-        [UnityTest]
-        public IEnumerator ChildShapeIsEvaluatedOnShapelessParent() { yield return SBC_Asserts.ChildShapeIsEvaluatedOnShapelessParent(scene); }
+        [Test]
+        public async Task ChildShapeIsEvaluatedOnShapelessParent() { await SBC_Asserts.ChildShapeIsEvaluatedOnShapelessParent(scene); }
 
-        [UnityTest]
-        public IEnumerator HeightIsEvaluated() { yield return SBC_Asserts.HeightIsEvaluated(scene); }
+        [Test]
+        public async Task HeightIsEvaluated() { await SBC_Asserts.HeightIsEvaluated(scene); }
 
-        [UnityTest]
-        public IEnumerator AudioSourceIsMuted()
+        [Test]
+        public async Task AudioSourceIsMuted()
         {
             var entity = TestUtils.CreateSceneEntity(scene);
             scene.isPersistent = false;
 
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(-28, 1, 8) });
-            yield return TestUtils.CreateAudioSourceWithClipForEntity(entity);
+            await TestUtils.CreateAudioSourceWithClipForEntity(entity).ToUniTask();
 
+            await UniTask.Yield();
             AudioSource dclAudioSource = entity.gameObject.GetComponentInChildren<AudioSource>();
             Assert.AreEqual(0, dclAudioSource.volume);
         }
 
-        [UnityTest]
-        public IEnumerator AudioSourceWithMeshIsDisabled()
+        [Test]
+        public async Task AudioSourceWithMeshIsDisabled()
         {
             scene.isPersistent = false;
 
             TestUtils.CreateEntityWithGLTFShape(scene, new Vector3(8, 1, 8), TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb", out var entity);
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
+            await new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(-28, 1, 8) });
-            yield return TestUtils.CreateAudioSourceWithClipForEntity(entity);
+            await TestUtils.CreateAudioSourceWithClipForEntity(entity);
 
+            await UniTask.Yield();
             AudioSource dclAudioSource = entity.gameObject.GetComponentInChildren<AudioSource>();
             Assert.AreEqual(0, dclAudioSource.volume);
         }
 
-        [UnityTest]
-        public IEnumerator AudioSourcePlaysBackOnReentering()
+        [Test]
+        public async Task AudioSourcePlaysBackOnReentering()
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(-28, 1, 8) });
-            yield return TestUtils.CreateAudioSourceWithClipForEntity(entity);
-            TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(2, 1, 2) });
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
 
+            await TestUtils.CreateAudioSourceWithClipForEntity(entity);
+            TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(2, 1, 2) });
+
+            await UniTask.Yield();
             AudioSource dclAudioSource = entity.gameObject.GetComponentInChildren<AudioSource>();
             Assert.IsTrue(dclAudioSource.enabled);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests_DebugMode.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/Tests/SceneBoundariesCheckerTests_DebugMode.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using System.Collections;
 using System.Linq;
 using DCL;
@@ -7,6 +8,7 @@ using DCL.Helpers;
 using DCL.Models;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -23,13 +25,14 @@ namespace SceneBoundariesCheckerTests
             scene = TestUtils.CreateTestScene() as ParcelScene;
             scene.isPersistent = false;
             coreComponentsPlugin = new CoreComponentsPlugin();
-            
+
             DataStore.i.debugConfig.isDebugMode.Set(true);
 
             Environment.i.world.sceneBoundsChecker.SetFeedbackStyle(new SceneBoundsFeedbackStyle_RedBox());
             Environment.i.world.sceneBoundsChecker.timeBetweenChecks = 0f;
 
             UnityEngine.Assertions.Assert.IsTrue(Environment.i.world.sceneBoundsChecker.enabled);
+
             UnityEngine.Assertions.Assert.IsTrue(
                 Environment.i.world.sceneBoundsChecker.GetFeedbackStyle() is SceneBoundsFeedbackStyle_RedBox);
 
@@ -43,12 +46,12 @@ namespace SceneBoundariesCheckerTests
             DataStore.i.debugConfig.isDebugMode.Set(false);
         }
 
-
-        [UnityTest]
-        public IEnumerator ResetMaterialCorrectlyWhenInvalidEntitiesAreRemoved()
+        [Test]
+        public async Task ResetMaterialCorrectlyWhenInvalidEntitiesAreRemoved()
         {
             var entity = TestUtils.CreateSceneEntity(scene);
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
+
             TestUtils.CreateAndSetShape(scene, entity.entityId, DCL.Models.CLASS_ID.GLTF_SHAPE, JsonConvert.SerializeObject(
                 new
                 {
@@ -56,15 +59,17 @@ namespace SceneBoundariesCheckerTests
                 }));
 
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
 
             SBC_Asserts.AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
+
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(18, 1, 18) });
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
 
             SBC_Asserts.AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
 
@@ -72,11 +77,13 @@ namespace SceneBoundariesCheckerTests
 
             Environment.i.platform.parcelScenesCleaner.CleanMarkedEntities();
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
 
             var entity2 = TestUtils.CreateSceneEntity(scene);
 
             TestUtils.SetEntityTransform(scene, entity2, new DCLTransform.Model { position = new Vector3(8, 1, 8) });
+
             TestUtils.CreateAndSetShape(scene, entity2.entityId, DCL.Models.CLASS_ID.GLTF_SHAPE, JsonConvert.SerializeObject(
                 new
                 {
@@ -85,59 +92,101 @@ namespace SceneBoundariesCheckerTests
 
             LoadWrapper gltfShape2 = Environment.i.world.state.GetLoaderForEntity(entity2);
 
-            yield return new UnityEngine.WaitUntil(() => gltfShape2.alreadyLoaded);
-            yield return null;
+            await UniTask.WaitUntil(() => gltfShape2.alreadyLoaded);
+            await UniTask.WaitForFixedUpdate();
 
             SBC_Asserts.AssertMeshesAndCollidersValidState(entity2.meshesInfo, true);
         }
 
-        [UnityTest]
-        public IEnumerator PShapeIsInvalidatedWhenStartingOutOfBoundsDebugMode() { yield return SBC_Asserts.PShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
+        [Test]
+        public async Task PShapeIsInvalidatedWhenStartingOutOfBoundsDebugMode()
+        {
+            await SBC_Asserts.PShapeIsInvalidatedWhenStartingOutOfBounds(scene);
+        }
 
-        [UnityTest]
-        public IEnumerator GLTFShapeIsInvalidatedWhenStartingOutOfBoundsDebugMode() { yield return SBC_Asserts.GLTFShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
+        [Test]
+        public async Task GLTFShapeIsInvalidatedWhenStartingOutOfBoundsDebugMode()
+        {
+            await SBC_Asserts.GLTFShapeIsInvalidatedWhenStartingOutOfBounds(scene);
+        }
 
-        [UnityTest]
-        public IEnumerator GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundariesDebugMode() { yield return SBC_Asserts.GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundaries(scene); }
-        
-        [UnityTest]
-        public IEnumerator NFTShapeIsInvalidatedWhenStartingOutOfBoundsDebugMode() { yield return SBC_Asserts.NFTShapeIsInvalidatedWhenStartingOutOfBounds(scene); }
+        [Test]
+        public async Task GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundariesDebugMode()
+        {
+            await SBC_Asserts.GLTFShapeCollidersCheckedWhenEvaluatingSceneInnerBoundaries(scene);
+        }
 
-        [UnityTest]
-        public IEnumerator PShapeIsInvalidatedWhenLeavingBoundsDebugMode() { yield return SBC_Asserts.PShapeIsInvalidatedWhenLeavingBounds(scene); }
+        [Test]
+        public async Task NFTShapeIsInvalidatedWhenStartingOutOfBoundsDebugMode()
+        {
+            await SBC_Asserts.NFTShapeIsInvalidatedWhenStartingOutOfBounds(scene);
+        }
 
-        [UnityTest]
-        public IEnumerator GLTFShapeIsInvalidatedWhenLeavingBoundsDebugMode() { yield return SBC_Asserts.GLTFShapeIsInvalidatedWhenLeavingBounds(scene); }
+        [Test]
+        public async Task PShapeIsInvalidatedWhenLeavingBoundsDebugMode()
+        {
+            await SBC_Asserts.PShapeIsInvalidatedWhenLeavingBounds(scene);
+        }
 
-        [UnityTest]
-        public IEnumerator NFTShapeIsInvalidatedWhenLeavingBoundsDebugMode() { yield return SBC_Asserts.NFTShapeIsInvalidatedWhenLeavingBounds(scene); }
+        [Test]
+        public async Task GLTFShapeIsInvalidatedWhenLeavingBoundsDebugMode()
+        {
+            await SBC_Asserts.GLTFShapeIsInvalidatedWhenLeavingBounds(scene);
+        }
 
-        [UnityTest]
-        public IEnumerator PShapeIsResetWhenReenteringBoundsDebugMode() { yield return SBC_Asserts.PShapeIsResetWhenReenteringBounds(scene); }
+        [Test]
+        public async Task NFTShapeIsInvalidatedWhenLeavingBoundsDebugMode()
+        {
+            await SBC_Asserts.NFTShapeIsInvalidatedWhenLeavingBounds(scene);
+        }
 
-        [UnityTest]
+        [Test]
+        public async Task PShapeIsResetWhenReenteringBoundsDebugMode()
+        {
+            await SBC_Asserts.PShapeIsResetWhenReenteringBounds(scene);
+        }
+
+        [Test]
         [Explicit]
         [Category("Explicit")]
-        public IEnumerator NFTShapeIsResetWhenReenteringBoundsDebugMode() { yield return SBC_Asserts.NFTShapeIsResetWhenReenteringBounds(scene); }
-
-        [UnityTest]
-        public IEnumerator ChildShapeIsEvaluatedDebugMode() { yield return SBC_Asserts.ChildShapeIsEvaluated(scene); }
-
-        [UnityTest]
-        public IEnumerator ChildShapeIsEvaluatedOnShapelessParentDebugMode() { yield return SBC_Asserts.ChildShapeIsEvaluatedOnShapelessParent(scene); }
-
-        [UnityTest]
-        public IEnumerator HeightIsEvaluatedDebugMode() { yield return SBC_Asserts.HeightIsEvaluated(scene); }
-
-        [UnityTest]
-        public IEnumerator GLTFShapeIsResetWhenReenteringBoundsDebugMode() { yield return SBC_Asserts.GLTFShapeIsResetWhenReenteringBounds(scene); }
-        
-        [UnityTest]
-        public IEnumerator GLTFShapeRendererIsNotDisabledWhenInvalidatedInDebugMode()
+        public async Task NFTShapeIsResetWhenReenteringBoundsDebugMode()
         {
-            var entity = TestUtils.CreateSceneEntity(scene);
+            await SBC_Asserts.NFTShapeIsResetWhenReenteringBounds(scene);
+        }
 
+        [Test]
+        public async Task ChildShapeIsEvaluatedDebugMode()
+        {
+            await SBC_Asserts.ChildShapeIsEvaluated(scene);
+        }
+
+        [Test]
+        public async Task ChildShapeIsEvaluatedOnShapelessParentDebugMode()
+        {
+            await SBC_Asserts.ChildShapeIsEvaluatedOnShapelessParent(scene);
+        }
+
+        [Test]
+        public async Task HeightIsEvaluatedDebugMode()
+        {
+            await SBC_Asserts.HeightIsEvaluated(scene);
+        }
+
+        [Test]
+        public async Task GLTFShapeIsResetWhenReenteringBoundsDebugMode()
+        {
+            await SBC_Asserts.GLTFShapeIsResetWhenReenteringBounds(scene);
+        }
+
+        [Test]
+        public async Task GLTFShapeRendererIsNotDisabledWhenInvalidatedInDebugMode()
+        {
+            scene.isPersistent = true;
+            var entity = TestUtils.CreateSceneEntity(scene);
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(50, 1, 50) });
+
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
 
             TestUtils.CreateAndSetShape(scene, entity.entityId, DCL.Models.CLASS_ID.GLTF_SHAPE, JsonConvert.SerializeObject(
                 new
@@ -145,30 +194,33 @@ namespace SceneBoundariesCheckerTests
                     src = TestAssetsUtils.GetPath() + "/GLB/PalmTree_01.glb"
                 }));
             LoadWrapper gltfShape = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => gltfShape.alreadyLoaded);
-            yield return null;
 
-            SBC_Asserts.AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
-            
+            await UniTask.WaitUntil(() => gltfShape.alreadyLoaded);
+            await UniTask.WaitForFixedUpdate(); // preliminary check
+            await UniTask.WaitForFixedUpdate(); // immortal process catches up
+
+            SBC_Asserts.AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
+
             Assert.IsTrue(entity.meshesInfo.renderers[0].enabled);
         }
-        
-        [UnityTest]
-        public IEnumerator PShapeRendererIsNotDisabledWhenInvalidatedInDebugMode()
+
+        [Test]
+        public async Task PShapeRendererIsNotDisabledWhenInvalidatedInDebugMode()
         {
             var boxShape = TestUtils.CreateEntityWithBoxShape(scene, new Vector3(50, 1, 50));
 
-            yield return null;
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
+
             var entity = boxShape.attachedEntities.First();
-            
+
             SBC_Asserts.AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
-            
+
             Assert.IsTrue(entity.meshesInfo.renderers[0].enabled);
         }
-        
-        [UnityTest]
-        public IEnumerator NFTShapeRendererIsNotDisabledWhenInvalidatedInDebugMode()
+
+        [Test]
+        public async Task NFTShapeRendererIsNotDisabledWhenInvalidatedInDebugMode()
         {
             var entity = TestUtils.CreateSceneEntity(scene);
 
@@ -180,22 +232,25 @@ namespace SceneBoundariesCheckerTests
             };
 
             NFTShape component = TestUtils.SharedComponentCreate<NFTShape, NFTShape.Model>(scene, CLASS_ID.NFT_SHAPE, componentModel);
-            yield return component.routine;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
 
             TestUtils.SharedComponentAttach(component, entity);
 
             LoadWrapper shapeLoader = Environment.i.world.state.GetLoaderForEntity(entity);
-            yield return new UnityEngine.WaitUntil(() => shapeLoader.alreadyLoaded);
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
 
             SBC_Asserts.AssertMeshesAndCollidersValidState(entity.meshesInfo, true);
 
             // Move object to surpass the scene boundaries
             TestUtils.SetEntityTransform(scene, entity, new DCLTransform.Model { position = new Vector3(18, 1, 18) });
 
-            yield return null;
+            await UniTask.WaitForFixedUpdate();
+            await UniTask.WaitForFixedUpdate();
 
             SBC_Asserts.AssertMeshesAndCollidersValidState(entity.meshesInfo, false);
-            
+
             Assert.IsTrue(entity.meshesInfo.renderers[0].enabled);
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.asmdef
@@ -57,7 +57,8 @@
         "GUID:44a9db8f655ab05409802e5476cf9dd3",
         "GUID:3509dee42d344efa97defa29ec7c351b",
         "GUID:a871c50d0a774d2b8594d36cb4766e5e",
-        "GUID:fd239a454d9a4039b164f90867ea3216"
+        "GUID:fd239a454d9a4039b164f90867ea3216",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Tests/SceneTests.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using System;
 using DCL;
 using DCL.Components;
@@ -14,6 +15,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NSubstitute;
 using RPC.Context;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -380,7 +382,7 @@ public class SceneTests : IntegrationTestSuite_Legacy
     }
 
     [Test]
-    public void ParcelScene_SetEntityParent()
+    public async Task ParcelScene_SetEntityParent()
     {
         var entityId = 1134;
         var entityId2 = 3124;
@@ -389,26 +391,34 @@ public class SceneTests : IntegrationTestSuite_Legacy
 
         // Make sure that it doesn't have a parent
         Assert.IsNull(entity.parent);
+        await UniTask.WaitForFixedUpdate();
         Assert.IsFalse(Environment.i.world.sceneBoundsChecker.WasAddedAsPersistent(entity));
 
         // Set player reference as parent
         TestUtils.SetEntityParent(scene, entityId, (long) SpecialEntityId.FIRST_PERSON_CAMERA_ENTITY_REFERENCE);
         Assert.AreEqual(entity.gameObject.transform.parent,
             DCLCharacterController.i.firstPersonCameraGameObject.transform);
+        await UniTask.WaitForFixedUpdate();
         Assert.IsTrue(Environment.i.world.sceneBoundsChecker.WasAddedAsPersistent(entity));
 
         // Set another entity as parent and ensure is not added as persistent
         TestUtils.SetEntityParent(scene, entityId, entityId2);
+
+        await UniTask.WaitForFixedUpdate();
         Assert.IsFalse(Environment.i.world.sceneBoundsChecker.WasAddedAsPersistent(entity));
 
         // Set avatar position reference as parent
         TestUtils.SetEntityParent(scene, entityId, (long) SpecialEntityId.AVATAR_ENTITY_REFERENCE);
         Assert.AreEqual(entity.gameObject.transform.parent, DCLCharacterController.i.avatarGameObject.transform);
+
+        await UniTask.WaitForFixedUpdate();
         Assert.IsTrue(Environment.i.world.sceneBoundsChecker.WasAddedAsPersistent(entity));
 
         // Remove all parents
         TestUtils.SetEntityParent(scene, entityId, (long) SpecialEntityId.SCENE_ROOT_ENTITY);
         Assert.IsNull(entity.parent);
+
+        await UniTask.WaitForFixedUpdate();
         Assert.IsFalse(Environment.i.world.sceneBoundsChecker.WasAddedAsPersistent(entity));
     }
 


### PR DESCRIPTION
## What does this PR change?

### Unity updates the boundaries of colliders in the `FixedUpdate`, so we **always had incorrect values** on all collider boundaries for half a frame since the SBC worked on the Update loop.

- The `SceneBoundsChecker` immortal task now waits for the next `FixedUpdate` to re-check all entities
- The preliminary check of the `SceneBoundsChecker` now also waits for the next `FixedUpdate`
- `MeshesInfo.RecalculateBounds` is now async and waits for `FixedUpdate`
- All `SceneBoundsChecker` routines and tests are now Tasks

Fixes #5113
Fixes #4866 

## How to test the changes?

For these coordinates `-109,-7` `23,78` do:
- Set the Scene load radius to 2
- Wait for the scene to load correctly
- Move somewhere else until the target scene is unloaded
- Move back until the scene loads correctly
- Those scenes shouldn't have invisible objects compared to the initial loading. 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
