### PR TITLE
fix: hiccup when loading objects with huge hierarchies

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsFeedbackStyle_Simple.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneBoundariesController/SceneBoundsFeedbackStyle_Simple.cs
@@ -6,7 +6,7 @@ namespace DCL.Controllers
 {
     public class SceneBoundsFeedbackStyle_Simple : ISceneBoundsFeedbackStyle
     {
-        private readonly List<Renderer> disabledRenderers = new List<Renderer>();
+        private readonly HashSet<Renderer> disabledRenderers = new ();
 
         public void ApplyFeedback(MeshesInfo meshesInfo, bool isInsideBoundaries)
         {
@@ -28,7 +28,7 @@ namespace DCL.Controllers
 
                 if (isInsideBoundaries && disabledRenderers.Contains(meshesInfo.renderers[i]))
                     disabledRenderers.Remove( meshesInfo.renderers[i]);
-                else if (!isInsideBoundaries && !disabledRenderers.Contains(meshesInfo.renderers[i]))
+                else if (!isInsideBoundaries)
                     disabledRenderers.Add( meshesInfo.renderers[i]);
             }
         }


### PR DESCRIPTION
## What does this PR change?

Fixed a hiccup caused when loading objects with huge hierarchies.

The most notable hiccup when loading genesis plaza went from +100ms to ~0.1ms

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

