### PR TITLE
chore: move the shader prewarm to the end of the loading screen

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenPercentageController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenPercentageController.cs
@@ -79,5 +79,8 @@ namespace DCL.LoadingScreen
 
         public void SetAvatarLoadingMessage() =>
             loadingScreenPercentageView.SetPlayerLoadingMessage();
+
+        public void SetShaderCompilingMessage() =>
+            loadingScreenPercentageView.SetShaderCompilingMessage();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenPercentageView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenPercentageView.cs
@@ -13,6 +13,7 @@ namespace DCL.LoadingScreen
         [SerializeField] internal Image loadingPercentage;
         private readonly string LOADING_AVATAR_MESSAGE = "Loading avatar...";
         private readonly string LOADING_SCENE_MESSAGE = "Loading scenes, 3D models, and sounds... {0}% complete";
+        private readonly string COMPILING_SHADERS_MESSAGE = "Compiling shaders, this might take a few seconds";
         private string currentMessage;
 
         public void SetLoadingPercentage(int percentage)
@@ -29,5 +30,12 @@ namespace DCL.LoadingScreen
 
         public void SetPlayerLoadingMessage() =>
             currentMessage = LOADING_AVATAR_MESSAGE;
+
+        public void SetShaderCompilingMessage()
+        {
+            currentMessage = COMPILING_SHADERS_MESSAGE;
+            loadingPercentage.fillAmount = 1;
+        }
+
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main/Main.cs
@@ -62,8 +62,6 @@ namespace DCL
             {
                 SetupServices();
                 performanceMetricsController = new PerformanceMetricsController();
-
-                dataStoreLoadingScreen.Ref.decoupledLoadingHUD.visible.OnChange += OnLoadingScreenVisibleStateChange;
             }
 
 #if UNITY_STANDALONE || UNITY_EDITOR
@@ -113,24 +111,6 @@ namespace DCL
 #endif
         }
 
-        private void OnLoadingScreenVisibleStateChange(bool newVisibleValue, bool previousVisibleValue)
-        {
-            if (newVisibleValue)
-            {
-                dataStoreLoadingScreen.Ref.decoupledLoadingHUD.visible.OnChange -= OnLoadingScreenVisibleStateChange;
-                PrewarmShaderVariants().Forget();
-
-                async UniTask PrewarmShaderVariants()
-                {
-                    var collection = await Environment.i.serviceLocator.Get<IAddressableResourceProvider>()
-                                                      .GetAddressable<ShaderVariantCollection>("shadervariants-selected");
-
-                    await UniTask.DelayFrame(1);
-                    collection.WarmUp();
-                }
-            }
-        }
-
         protected virtual void SetupPlugins()
         {
             pluginSystem = PluginSystemFactory.Create();
@@ -160,8 +140,6 @@ namespace DCL
 
         protected virtual void Dispose()
         {
-            dataStoreLoadingScreen.Ref.decoupledLoadingHUD.visible.OnChange -= OnLoadingScreenVisibleStateChange;
-
             DataStore.i.common.isApplicationQuitting.Set(true);
             Settings.i.SaveSettings();
 


### PR DESCRIPTION
## What does this PR change?

Moved the shader prewarm from startup to the end of the loading screen, increasing the UX. 

## How to test the changes?

This should PR should: 
- Remove the screen freeze of several seconds after selecting to start with wallet or guest
- Show a message at the end of the loading that explains that the shaders are getting prewarmed
- Ensure that the shaders are being prewarmed just once (teleporting after initial loading)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
