### PR TITLE
support px for skd7

### DIFF
--- a/browser-interface/package-lock.json
+++ b/browser-interface/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/legacy-ecs": "^6.11.11",
         "@dcl/protocol": "^1.0.0-4863715547.commit-286ee57",
         "@dcl/rpc": "^1.1.1",
-        "@dcl/scene-runtime": "^7.0.5",
+        "@dcl/scene-runtime": "^7.0.6-20230510181717.commit-7f2a0c9",
         "@dcl/schemas": "^6.11.1",
         "@dcl/urn-resolver": "^2.0.3",
         "@types/mocha": "^10.0.1",
@@ -553,8 +553,9 @@
       }
     },
     "node_modules/@dcl/scene-runtime": {
-      "version": "7.0.5",
-      "license": "Apache-2.0"
+      "version": "7.0.6-20230510181717.commit-7f2a0c9",
+      "resolved": "https://registry.npmjs.org/@dcl/scene-runtime/-/scene-runtime-7.0.6-20230510181717.commit-7f2a0c9.tgz",
+      "integrity": "sha512-WHmIh7JiGDxesSxISzSOP1IJGWX7nrD5rRFVV9F7nzm95k8LXslKHzGHjhz9iy5713egyMmKCpsLKhki7ZRnxA=="
     },
     "node_modules/@dcl/schemas": {
       "version": "6.12.0",
@@ -9006,7 +9007,9 @@
       }
     },
     "@dcl/scene-runtime": {
-      "version": "7.0.5"
+      "version": "7.0.6-20230510181717.commit-7f2a0c9",
+      "resolved": "https://registry.npmjs.org/@dcl/scene-runtime/-/scene-runtime-7.0.6-20230510181717.commit-7f2a0c9.tgz",
+      "integrity": "sha512-WHmIh7JiGDxesSxISzSOP1IJGWX7nrD5rRFVV9F7nzm95k8LXslKHzGHjhz9iy5713egyMmKCpsLKhki7ZRnxA=="
     },
     "@dcl/schemas": {
       "version": "6.12.0",

--- a/browser-interface/package.json
+++ b/browser-interface/package.json
@@ -63,7 +63,7 @@
     "@dcl/legacy-ecs": "^6.11.11",
     "@dcl/protocol": "^1.0.0-4863715547.commit-286ee57",
     "@dcl/rpc": "^1.1.1",
-    "@dcl/scene-runtime": "^7.0.5",
+    "@dcl/scene-runtime": "^7.0.6-20230510181717.commit-7f2a0c9",
     "@dcl/schemas": "^6.11.1",
     "@dcl/urn-resolver": "^2.0.3",
     "@types/mocha": "^10.0.1",


### PR DESCRIPTION
## What does this PR change?

Fix typo https://github.com/decentraland/scene-runtime/compare/7.0.5...main

## How to test the changes?

Explorer should work in https://play.decentraland.org/?realm=shibu.dcl.eth

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 51b4aa3</samp>

This pull request updates the `browser-interface` project to use the latest version of the `@dcl/scene-runtime` package, which provides the core functionality of the unity renderer in the browser. This is part of the ongoing development and maintenance of the browser interface.
