### PR TITLE
chore: clean upload artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
       - run:
           name: upload code coverage
           command: |
-            aws s3 sync /tmp/workspace/unity-renderer/unity-renderer/CodeCoverage/Report "s3://${S3_BUCKET}/desktop-coverage/${CIRCLE_BRANCH}" --acl public-read
+            aws s3 sync --delete /tmp/workspace/unity-renderer/unity-renderer/CodeCoverage/Report "s3://${S3_BUCKET}/desktop-coverage/${CIRCLE_BRANCH}" --acl public-read
       - store_test_results:
           path: ./unity-renderer/test-results
       - store_artifacts:

--- a/browser-interface/scripts/publish-preview.sh
+++ b/browser-interface/scripts/publish-preview.sh
@@ -19,6 +19,8 @@ npx @dcl/cdn-uploader@next \
   --bucket-folder "branch/${CIRCLE_BRANCH}" \
   --concurrency 10 \
   --config scripts/cdn-uploader-config.yml
+# TODO: Create a --delete flag for cdn-uploader and remove this line
+#       --delete will delete all files in the bucket-folder that are not in the local-folder
 
 
 set +u # unbound variables

--- a/ci-benchmark-upload-report.sh
+++ b/ci-benchmark-upload-report.sh
@@ -25,4 +25,4 @@ mkdir -p output
 cp "$PROJECT_PATH/benchmark-results.xml" output/UnityPerformanceBenchmark/
 cd output/UnityPerformanceBenchmark/
 mv UnityPerformanceBenchmark*.html index.html
-aws s3 sync ./ "s3://${S3_BUCKET}/branch-benchmark/${CIRCLE_BRANCH}" --acl public-read
+aws s3 sync --delete ./ "s3://${S3_BUCKET}/branch-benchmark/${CIRCLE_BRANCH}" --acl public-read

--- a/ci-publish-preview-artifacts.sh
+++ b/ci-publish-preview-artifacts.sh
@@ -21,7 +21,7 @@ ARTIFACTS_PATH=/tmp/workspace/unity-renderer/unity-artifacts/
 echo "{\"version\":\"${VERSION}\"}" > ${ARTIFACTS_PATH}/version.json
 
 # Upload artifacts for preview
-aws s3 sync ${ARTIFACTS_PATH} "s3://${S3_BUCKET}/desktop/${CIRCLE_BRANCH}" --acl public-read
+aws s3 sync --delete ${ARTIFACTS_PATH} "s3://${S3_BUCKET}/desktop/${CIRCLE_BRANCH}" --acl public-read
 
 # Invalidate cache
 aws configure set preview.cloudfront true
@@ -30,5 +30,5 @@ aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_DISTRIBUTION}
 
 # Upload artifacts to prod
 if [ "${CIRCLE_BRANCH}" == "main" ] || [ "${CIRCLE_BRANCH}" == "dev" ]; then
-  aws s3 sync ${ARTIFACTS_PATH} "s3://${S3_BUCKET}/release-desktop/${VERSION}" --acl public-read
+  aws s3 sync --delete ${ARTIFACTS_PATH} "s3://${S3_BUCKET}/release-desktop/${VERSION}" --acl public-read
 fi


### PR DESCRIPTION
## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 301e4db</samp>

Added `--delete` flag to `aws s3 sync` commands in various scripts to keep S3 artifacts in sync with source branch. This improves the accuracy and relevance of code coverage and performance benchmark reports.
