### PR TITLE
feat: Physics.Bake in AB loading flow with a Feature Flag

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -185,18 +185,8 @@ namespace DCL
         {
             foreach (Mesh mesh in meshesList)
             {
-
-                if (!mesh.isReadable)
-                    continue;
-
                 asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
                 asset.meshes.Add(mesh);
-
-                bool isCollider = mesh.name.Contains("_collider", StringComparison.InvariantCultureIgnoreCase);
-
-                // colliders will fail to be created if they are not readable on WebGL
-                if (!isCollider)
-                    mesh.UploadMeshData(true);
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -196,10 +196,7 @@ namespace DCL
 
                 // colliders will fail to be created if they are not readable on WebGL
                 if (!isCollider)
-                {
-                    Physics.BakeMesh(mesh.GetInstanceID(), false);
                     mesh.UploadMeshData(true);
-                }
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -11,23 +11,16 @@ namespace DCL
 {
     public class AssetPromise_AB_GameObject : AssetPromise_WithUrl<Asset_AB_GameObject>
     {
-        public AssetPromiseSettings_Rendering settings = new AssetPromiseSettings_Rendering();
+        public AssetPromiseSettings_Rendering settings = new ();
         AssetPromise_AB subPromise;
         Coroutine loadingCoroutine;
 
         private BaseVariable<FeatureFlag> featureFlags => DataStore.i.featureFlags.flags;
-        private const string AB_LOAD_ANIMATION = "ab_load_animation";
-        private bool doTransitionAnimation;
+        private const string FEATURE_AB_MESH_GPU = "ab-mesh-gpu";
 
         public AssetPromise_AB_GameObject(string contentUrl, string hash) : base(contentUrl, hash)
         {
-            featureFlags.OnChange += OnFeatureFlagChange;
-            OnFeatureFlagChange(featureFlags.Get(), null);
-        }
 
-        private void OnFeatureFlagChange(FeatureFlag current, FeatureFlag previous)
-        {
-            doTransitionAnimation = current.IsFeatureEnabled(AB_LOAD_ANIMATION);
         }
 
         protected override void OnLoad(Action OnSuccess, Action<Exception> OnFail)
@@ -183,10 +176,26 @@ namespace DCL
 
         private void UploadMeshesToGPU(HashSet<Mesh> meshesList)
         {
+            bool uploadMesh = IsUploadMeshToGPUEnabled();
+
             foreach (Mesh mesh in meshesList)
             {
+                if (!mesh.isReadable)
+                    continue;
+
                 asset.meshToTriangleCount[mesh] = mesh.triangles.Length;
                 asset.meshes.Add(mesh);
+
+                if (!uploadMesh) continue;
+
+                bool isCollider = mesh.name.Contains("_collider", StringComparison.InvariantCultureIgnoreCase);
+
+                // colliders will fail to be created if they are not readable on WebGL
+                if (!isCollider)
+                {
+                    Physics.BakeMesh(mesh.GetInstanceID(), false);
+                    mesh.UploadMeshData(true);
+                }
             }
         }
 
@@ -198,10 +207,7 @@ namespace DCL
             return base.GetAsset(id);
         }
 
-        internal override void OnForget()
-        {
-            base.OnForget();
-            featureFlags.OnChange -= OnFeatureFlagChange;
-        }
+        private bool IsUploadMeshToGPUEnabled() =>
+            featureFlags.Get().IsFeatureEnabled(FEATURE_AB_MESH_GPU);
     }
 }


### PR DESCRIPTION
## What does this PR change?

Introduced feature flag `ab-mesh-gpu` in order to experiment with a reduction of hiccups caused by `Physics.BakeMesh` in WebGL

The flag is ON by default.

If we disable this flag, all the meshes from the asset bundles won't get baked neither get uploaded to the GPU, reducing the hiccups caused by them and increasing the memory usage up to 90mb in Genesis Plaza

Related ticket: https://github.com/decentraland/unity-renderer/issues/4820

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md