### PR TITLE
fix: added cancellation handling on rendereable asset fallback

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -303,6 +303,7 @@ namespace DCL.Components
             {
                 if (sendMetric)
                     SendMetric(FAIL_GLTF_LOAD_AFTER_GLTFAST_FAIL_EVENT, targetUrl, exception.Message);
+
                 OnFailWrapper(OnFail, exception, hasFallback);
             };
 
@@ -355,16 +356,20 @@ namespace DCL.Components
             loadFinishTime = Time.realtimeSinceStartup;
 #endif
 
+            if (exception is PromiseForgottenException or OperationCanceledException)
+            {
+                ClearEvents();
+                return;
+            }
+
             // If the entity is destroyed while loading, the exception is expected to be null and no error should be thrown
             if (exception != null)
             {
                 if (!hasFallback)
                     Debug.LogWarning("All fallbacks failed for " + targetUrl);
                 else if (VERBOSE)
-                {
                     Debug.LogWarning($"Load Fail Detected, trying to use a fallback, " +
-                              $"loading type was: {currentLoadingSystem} and error was: {exception.Message}");
-                }
+                                     $"loading type was: {currentLoadingSystem} and error was: {exception.Message}");
             }
 
             OnFail?.Invoke(exception);


### PR DESCRIPTION
## What does this PR change?

On some code paths, we still have flow exceptions leaking through this system, causing canceled asset requests to be loaded anyways by using the fallback path.

Fixes https://github.com/decentraland/unity-renderer/issues/5171

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
