### PR TITLE
fix: disable SpriteGenerator.TraceMesh

### DIFF
--- a/unity-renderer/Assets/UIComponents/Scripts/Components/Image/ImageComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/Image/ImageComponentView.cs
@@ -50,7 +50,7 @@ public interface IImageComponentView
 
 public class ImageComponentView : BaseComponentView, IImageComponentView, IComponentModelConfig<ImageComponentModel>
 {
-    private readonly Vector2 vector2oneHalf = new Vector2(0.5f, 0.5f);
+    private readonly Vector2 vector2oneHalf = new (0.5f, 0.5f);
 
     [Header("Prefab References")]
     [SerializeField] internal Image image;


### PR DESCRIPTION
## What does this PR change?
Closes #5184 

main fix was to include additional parameters into  `Sprite.Create` to not generate Polygonal Mesh

#### Before
![image](https://github.com/decentraland/unity-renderer/assets/35366872/1fb02872-ece9-41bf-aa92-2f812e79244b)

#### After
![image](https://github.com/decentraland/unity-renderer/assets/35366872/4c884e48-6a3b-45c9-9bba-4e641e336f2e)


## How to test the changes?

1. Launch the explorer
2. Test the map - all sprites there should work fine (chunks, POI)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4168a77</samp>

This pull request refactors and updates the code for creating and rendering sprites from textures in the map and the UI. It improves performance, quality, and readability by using constant fields, helper methods, and target-typed new expressions in `ChunkController.cs` and `ImageComponentView.cs`.
