### PR TITLE
fix: exception caused by fetching the scene ID from the new urn format

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -2,6 +2,7 @@
 using DCL;
 using DCL.Helpers;
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
 
@@ -34,7 +35,10 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
         {
             // This case happens when loading worlds
             if (sceneId.StartsWith(URN_PREFIX))
+            {
                 sceneId = sceneId.Replace(URN_PREFIX, "");
+                sceneId = Regex.Replace(sceneId, "\\?.+", ""); // from "?" char onwards we delete everything
+            }
 
             return sceneId;
         }
@@ -57,6 +61,12 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
             {
                 id = hash,
             };
+
+            if (string.IsNullOrEmpty(contentUrl))
+            {
+                onSuccess();
+                return;
+            }
 
             var finalUrl = $"{contentUrl}manifest/{hash}.json";
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -34,10 +34,7 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
         {
             // This case happens when loading worlds
             if (sceneId.StartsWith(URN_PREFIX))
-            {
-                int prefixLength = URN_PREFIX.Length;
-                return sceneId.Substring(prefixLength, sceneId.IndexOf("?", StringComparison.Ordinal) - prefixLength);
-            }
+                sceneId = sceneId.Replace(URN_PREFIX, "");
 
             return sceneId;
         }


### PR DESCRIPTION
## What does this PR change?

Fixes exception caused by new URN format.

## How to test the changes?

New Asset bundles should load for worlds, check them with `/detectabs`

- Enter `dclonboarding.dcl.eth` realm in `.zone` ([link](https://play.decentraland.zone/?explorer-branch=fix/ab-urn-format&realm=dclonboarding.dcl.eth))
- Enter `dclonboarding.dcl.eth` realm in `.org` by adding `ENABLE_AB-NEW-CDN` flag ([link](https://play.decentraland.org/?explorer-branch=fix/ab-urn-format&realm=dclonboarding.dcl.eth&ENABLE_AB-NEW-CDN))

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md