### PR TITLE
test: separated downloading and creation in map chunk loading

### DIFF
--- a/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/MapRendererChunkComponentsFactory.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/MapRendererChunkComponentsFactory.cs
@@ -109,7 +109,7 @@ namespace DCLServices.MapRendererV2.ComponentsFactory
                 {
                     var chunk = new ChunkController(atlasChunkPrefab, chunkLocalPosition, coordsCenter, parent);
                     chunk.SetDrawOrder(MapRendererDrawOrder.ATLAS);
-                    await chunk.LoadImage(atlasChunkSize, parcelSize, coordsCenter, ct);
+                    await chunk.DownloadImage(atlasChunkSize, parcelSize, coordsCenter, ct);
                     return chunk;
                 }
 

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/ChunkAtlasController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/ChunkAtlasController.cs
@@ -72,6 +72,9 @@ namespace DCLServices.MapRendererV2.MapLayers.Atlas
                 chunks.AddRange(await UniTask.WhenAll(chunksCreating));
                 chunksCreating.Clear();
             }
+
+            foreach (IChunkController chunk in chunks)
+                chunk.Initialize();
         }
 
         private void ClearCurrentChunks()

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/ChunkAtlasController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/ChunkAtlasController.cs
@@ -14,7 +14,7 @@ namespace DCLServices.MapRendererV2.MapLayers.Atlas
             Transform parent,
             CancellationToken ct);
 
-        public const int CHUNKS_CREATED_PER_BATCH = 10;
+        public const int CHUNKS_CREATED_PER_BATCH = 50;
 
         private readonly SpriteRenderer prefab;
         private readonly int chunkSize;

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/IChunkController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/IChunkController.cs
@@ -2,5 +2,8 @@
 
 namespace DCLServices.MapRendererV2.MapLayers.Atlas
 {
-    public interface IChunkController : IDisposable { }
+    public interface IChunkController : IDisposable
+    {
+        void Initialize();
+    }
 }


### PR DESCRIPTION
## What does this PR change?

Separated the logic that downloads the map chunks and creates the sprite, to avoid halting the requests too much.

Fixes #5188

## How to test the changes?

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md