### PR TITLE
feat: wearable entity fetching

### DIFF
--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -439,7 +439,7 @@ namespace DCLServices.WearablesCatalogService
                         description = metadata.description,
                         i18n = metadata.i18n,
                         id = metadata.id,
-                        rarity = metadata.rarity,
+                        rarity = metadata.rarity ?? item.rarity,
                         thumbnail = entity.GetContentHashByFileName(metadata.thumbnail),
                         MostRecentTransferredDate = DateTimeOffset.FromUnixTimeSeconds(item.GetMostRecentTransferTimestamp())
                                                                   .DateTime,

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -20,8 +20,6 @@ namespace DCLServices.WearablesCatalogService
         public BaseDictionary<string, WearableItem> WearablesCatalog { get; }
 
         private const string ASSET_BUNDLES_URL_ORG = "https://content-assets-as-bundle.decentraland.org/";
-        // TODO: this is a specific node url and we should not hardcode-it in the client. Instead we should use catalyst.contentUrl
-        private const string TEXTURES_URL_ORG = "https://interconnected.online/content/contents/";
         private const string PAGINATED_WEARABLES_END_POINT = "users/";
         private const string NON_PAGINATED_WEARABLES_END_POINT = "collections/wearables/";
         private const string BASE_WEARABLES_COLLECTION_ID = "urn:decentraland:off-chain:base-avatars";
@@ -435,7 +433,6 @@ namespace DCLServices.WearablesCatalogService
                             replaces = metadata.data.replaces,
                             tags = metadata.data.tags,
                         },
-                        // baseUrl = TEXTURES_URL_ORG,
                         baseUrl = $"{catalyst.contentUrl}/contents/",
                         baseUrlBundles = ASSET_BUNDLES_URL_ORG,
                         emoteDataV0 = null,
@@ -483,7 +480,7 @@ namespace DCLServices.WearablesCatalogService
             return wearables;
         }
 
-        private static void MapLambdasDataIntoWearableItem(IList<WearableItem> wearablesFromLambdas)
+        private void MapLambdasDataIntoWearableItem(IList<WearableItem> wearablesFromLambdas)
         {
             var invalidWearablesIndices = ListPool<int>.Get();
 
@@ -510,7 +507,7 @@ namespace DCLServices.WearablesCatalogService
                     string newThumbnail = thumbnail[(index + 1)..];
                     string newBaseUrl = thumbnail[..(index + 1)];
                     wearable.thumbnail = newThumbnail;
-                    wearable.baseUrl = string.IsNullOrEmpty(newBaseUrl) ? TEXTURES_URL_ORG : newBaseUrl;
+                    wearable.baseUrl = string.IsNullOrEmpty(newBaseUrl) ? $"{catalyst.contentUrl}/contents/" : newBaseUrl;
                     wearable.baseUrlBundles = ASSET_BUNDLES_URL_ORG;
                     wearable.emoteDataV0 = null;
                 }

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -20,6 +20,7 @@ namespace DCLServices.WearablesCatalogService
         public BaseDictionary<string, WearableItem> WearablesCatalog { get; }
 
         private const string ASSET_BUNDLES_URL_ORG = "https://content-assets-as-bundle.decentraland.org/";
+        // TODO: this is a specific node url and we should not hardcode-it in the client. Instead we should use catalyst.contentUrl
         private const string TEXTURES_URL_ORG = "https://interconnected.online/content/contents/";
         private const string PAGINATED_WEARABLES_END_POINT = "users/";
         private const string NON_PAGINATED_WEARABLES_END_POINT = "collections/wearables/";
@@ -434,7 +435,8 @@ namespace DCLServices.WearablesCatalogService
                             replaces = metadata.data.replaces,
                             tags = metadata.data.tags,
                         },
-                        baseUrl = TEXTURES_URL_ORG,
+                        // baseUrl = TEXTURES_URL_ORG,
+                        baseUrl = $"{catalyst.contentUrl}/contents/",
                         baseUrlBundles = ASSET_BUNDLES_URL_ORG,
                         emoteDataV0 = null,
                         description = metadata.description,

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -423,55 +423,8 @@ namespace DCLServices.WearablesCatalogService
 
                 try
                 {
-                    WearableItem wearable = new WearableItem
-                    {
-                        data = new WearableItem.Data
-                        {
-                            representations = new WearableItem.Representation[metadata.data.representations.Length],
-                            category = metadata.data.category,
-                            hides = metadata.data.hides,
-                            replaces = metadata.data.replaces,
-                            tags = metadata.data.tags,
-                        },
-                        baseUrl = $"{catalyst.contentUrl}/contents/",
-                        baseUrlBundles = ASSET_BUNDLES_URL_ORG,
-                        emoteDataV0 = null,
-                        description = metadata.description,
-                        i18n = metadata.i18n,
-                        id = metadata.id,
-                        rarity = metadata.rarity ?? item.rarity,
-                        thumbnail = entity.GetContentHashByFileName(metadata.thumbnail),
-                        MostRecentTransferredDate = DateTimeOffset.FromUnixTimeSeconds(item.GetMostRecentTransferTimestamp())
-                                                                  .DateTime,
-                    };
-
-                    for (var i = 0; i < metadata.data.representations.Length; i++)
-                    {
-                        WearableWithEntityResponseDto.ElementDto.EntityDto.MetadataDto.Representation representation = metadata.data.representations[i];
-
-                        wearable.data.representations[i] = new WearableItem.Representation
-                        {
-                            bodyShapes = representation.bodyShapes,
-                            mainFile = representation.mainFile,
-                            overrideHides = representation.overrideHides,
-                            overrideReplaces = representation.overrideReplaces,
-                            contents = new WearableItem.MappingPair[representation.contents.Length],
-                        };
-
-                        for (var z = 0; z < representation.contents.Length; z++)
-                        {
-                            string fileName = representation.contents[z];
-                            string hash = entity.GetContentHashByFileName(fileName);
-
-                            wearable.data.representations[i].contents[z] = new WearableItem.MappingPair
-                            {
-                                url = $"{catalyst.contentUrl}/contents/{hash}",
-                                hash = hash,
-                                key = fileName,
-                            };
-                        }
-                    }
-
+                    WearableItem wearable = item.ToWearableItem($"{catalyst.contentUrl}/contents/",
+                        ASSET_BUNDLES_URL_ORG);
                     wearables.Add(wearable);
                 }
                 catch (Exception e) { Debug.LogException(e); }

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
@@ -17,7 +17,9 @@ namespace DCLServices.WearablesCatalogService
         private const string WEARABLE_WITHOUT_THUMBNAIL = "wearableWithoutThumbnail";
         private const string BASE_WEARABLES_COLLECTION = "urn:decentraland:off-chain:base-avatars";
         private const string TPW_COLLECTION_ID = "tpwCollection";
-        private const string CONTENT_URL = "http://content.url";
+        private const string CONTENT_URL = "http://catalyst.url/content/";
+        private const string LAMBDAS_URL = "http://catalyst.url/lambdas/";
+        private const string EXPLORER_URL = "http://catalyst.url/explorer/";
 
         private LambdasWearablesCatalogService service;
         private ILambdasService lambdasService;
@@ -59,6 +61,7 @@ namespace DCLServices.WearablesCatalogService
             serviceProviders = Substitute.For<IServiceProviders>();
             ICatalyst catalyst = Substitute.For<ICatalyst>();
             catalyst.contentUrl.Returns(CONTENT_URL);
+            catalyst.lambdasUrl.Returns(LAMBDAS_URL);
             serviceProviders.catalyst.Returns(catalyst);
 
             service = new LambdasWearablesCatalogService(initialCatalog, lambdasService, serviceProviders);
@@ -282,8 +285,8 @@ namespace DCLServices.WearablesCatalogService
 
                 lambdasService.Received(1)
                               .GetFromSpecificUrl<WearableWithEntityResponseDto>(
-                                   "https://peer-testing-2.decentraland.org/explorer/:userId/wearables",
-                                   $"https://peer-testing-2.decentraland.org/explorer/{USER_ID}/wearables",
+                                   $"{EXPLORER_URL}/:userId/wearables",
+                                   $"{EXPLORER_URL}/{USER_ID}/wearables",
                                    30, 3,
                                    Arg.Any<CancellationToken>(),
                                    Arg.Is<(string paramName, string paramValue)[]>(args =>
@@ -325,8 +328,8 @@ namespace DCLServices.WearablesCatalogService
 
                 lambdasService.Received(1)
                               .GetFromSpecificUrl<WearableWithEntityResponseDto>(
-                                   "https://peer-testing-2.decentraland.org/explorer/:userId/wearables",
-                                   $"https://peer-testing-2.decentraland.org/explorer/{USER_ID}/wearables",
+                                   $"{EXPLORER_URL}/:userId/wearables",
+                                   $"{EXPLORER_URL}/{USER_ID}/wearables",
                                    30, 3,
                                    Arg.Any<CancellationToken>(),
                                    Arg.Is<(string paramName, string paramValue)[]>(args =>
@@ -355,8 +358,8 @@ namespace DCLServices.WearablesCatalogService
 
                 lambdasService.Received(1)
                               .GetFromSpecificUrl<WearableWithEntityResponseDto>(
-                                   "https://peer-testing-2.decentraland.org/explorer/:userId/wearables",
-                                   $"https://peer-testing-2.decentraland.org/explorer/{USER_ID}/wearables",
+                                   $"{EXPLORER_URL}/:userId/wearables",
+                                   $"{EXPLORER_URL}/{USER_ID}/wearables",
                                    30, 3,
                                    Arg.Any<CancellationToken>(),
                                    Arg.Is<(string paramName, string paramValue)[]>(args =>

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
@@ -267,7 +267,7 @@ namespace DCLServices.WearablesCatalogService
         public IEnumerator ValidateParamsWhenRequestingOwnedWearablesWithFilters() =>
             UniTask.ToCoroutine(async () =>
             {
-                GivenWearableWithSpecificLambdasUrl(GivenValidWearableItem(VALID_WEARABLE_ID, ""));
+                GivenWearableEntityWithSpecificLambdasUrl(GivenValidWearableEntity(VALID_WEARABLE_ID));
 
                 (IReadOnlyList<WearableItem> wearables, int totalAmount) =
                     await service.RequestOwnedWearablesAsync(USER_ID, 0, 10, default(CancellationToken),
@@ -277,9 +277,9 @@ namespace DCLServices.WearablesCatalogService
                         orderBy: (NftOrderByOperation.Date, true));
 
                 lambdasService.Received(1)
-                              .GetFromSpecificUrl<WearableWithDefinitionResponse>(
-                                   "https://peer-testing.decentraland.org/explorer/:userId/wearables",
-                                   $"https://peer-testing.decentraland.org/explorer/{USER_ID}/wearables",
+                              .GetFromSpecificUrl<WearableWithEntityResponseDto>(
+                                   "https://peer-testing-2.decentraland.org/explorer/:userId/wearables",
+                                   $"https://peer-testing-2.decentraland.org/explorer/{USER_ID}/wearables",
                                    30, 3,
                                    Arg.Any<CancellationToken>(),
                                    Arg.Is<(string paramName, string paramValue)[]>(args =>
@@ -287,22 +287,24 @@ namespace DCLServices.WearablesCatalogService
                                        && args[0].paramValue == "0"
                                        && args[1].paramName == "pageSize"
                                        && args[1].paramValue == "10"
-                                       && args[2].paramName == "rarity"
-                                       && args[2].paramValue == "epic"
-                                       && args[3].paramName == "category"
-                                       && args[3].paramValue == "upper_body"
-                                       && args[4].paramName == "name"
-                                       && args[4].paramValue == "woah"
-                                       && args[5].paramName == "orderBy"
-                                       && args[5].paramValue == "date"
-                                       && args[6].paramName == "direction"
-                                       && args[6].paramValue == "ASC"
-                                       && args[7].paramName == "collectionType"
-                                       && args[7].paramValue == "base-wearable"
+                                       && args[2].paramName == "includeEntities"
+                                       && args[2].paramValue == "true"
+                                       && args[3].paramName == "rarity"
+                                       && args[3].paramValue == "epic"
+                                       && args[4].paramName == "category"
+                                       && args[4].paramValue == "upper_body"
+                                       && args[5].paramName == "name"
+                                       && args[5].paramValue == "woah"
+                                       && args[6].paramName == "orderBy"
+                                       && args[6].paramValue == "date"
+                                       && args[7].paramName == "direction"
+                                       && args[7].paramValue == "ASC"
                                        && args[8].paramName == "collectionType"
-                                       && args[8].paramValue == "on-chain"
+                                       && args[8].paramValue == "base-wearable"
                                        && args[9].paramName == "collectionType"
-                                       && args[9].paramValue == "third-party"));
+                                       && args[9].paramValue == "on-chain"
+                                       && args[10].paramName == "collectionType"
+                                       && args[10].paramValue == "third-party"));
             });
 
         [UnityTest]
@@ -311,16 +313,16 @@ namespace DCLServices.WearablesCatalogService
         public IEnumerator ValidateCollectionIdParamsWhenRequestingOwnedWearablesWithoutThirdPartyFilters(NftCollectionType collectionType) =>
             UniTask.ToCoroutine(async () =>
             {
-                GivenWearableWithSpecificLambdasUrl(GivenValidWearableItem(VALID_WEARABLE_ID, ""));
+                GivenWearableEntityWithSpecificLambdasUrl(GivenValidWearableEntity(VALID_WEARABLE_ID));
 
                 (IReadOnlyList<WearableItem> wearables, int totalAmount) =
                     await service.RequestOwnedWearablesAsync(USER_ID, 0, 10, default(CancellationToken),
                         collectionTypeMask: collectionType);
 
                 lambdasService.Received(1)
-                              .GetFromSpecificUrl<WearableWithDefinitionResponse>(
-                                   "https://peer-testing.decentraland.org/explorer/:userId/wearables",
-                                   $"https://peer-testing.decentraland.org/explorer/{USER_ID}/wearables",
+                              .GetFromSpecificUrl<WearableWithEntityResponseDto>(
+                                   "https://peer-testing-2.decentraland.org/explorer/:userId/wearables",
+                                   $"https://peer-testing-2.decentraland.org/explorer/{USER_ID}/wearables",
                                    30, 3,
                                    Arg.Any<CancellationToken>(),
                                    Arg.Is<(string paramName, string paramValue)[]>(args =>
@@ -328,28 +330,29 @@ namespace DCLServices.WearablesCatalogService
                                        && args[0].paramValue == "0"
                                        && args[1].paramName == "pageSize"
                                        && args[1].paramValue == "10"
-                                       && args[2].paramName == "collectionType"
-                                       && args[2].paramValue == (collectionType == NftCollectionType.Base ? "base-wearable" : "on-chain")));
+                                       && args[2].paramName == "includeEntities"
+                                       && args[2].paramValue == "true"
+                                       && args[3].paramName == "collectionType"
+                                       && args[3].paramValue == (collectionType == NftCollectionType.Base ? "base-wearable" : "on-chain")));
             });
 
         [UnityTest]
         public IEnumerator ValidateCollectionIdParamsWhenRequestingOwnedWearablesWithThirdPartyFilters() =>
             UniTask.ToCoroutine(async () =>
             {
-                NftCollectionType collectionType = NftCollectionType.ThirdParty;
                 var thirdPartyCollectionId = "testThirdPartyCollectionId";
 
-                GivenWearableWithSpecificLambdasUrl(GivenValidWearableItem(VALID_WEARABLE_ID, ""));
+                GivenWearableEntityWithSpecificLambdasUrl(GivenValidWearableEntity(VALID_WEARABLE_ID));
 
                 (IReadOnlyList<WearableItem> wearables, int totalAmount) =
                     await service.RequestOwnedWearablesAsync(USER_ID, 0, 10, default(CancellationToken),
-                        thirdPartyCollectionIds: thirdPartyCollectionId != null ? new List<string> { thirdPartyCollectionId } : null,
-                        collectionTypeMask: collectionType);
+                        thirdPartyCollectionIds: new List<string> { thirdPartyCollectionId },
+                        collectionTypeMask: NftCollectionType.ThirdParty);
 
                 lambdasService.Received(1)
-                              .GetFromSpecificUrl<WearableWithDefinitionResponse>(
-                                   "https://peer-testing.decentraland.org/explorer/:userId/wearables",
-                                   $"https://peer-testing.decentraland.org/explorer/{USER_ID}/wearables",
+                              .GetFromSpecificUrl<WearableWithEntityResponseDto>(
+                                   "https://peer-testing-2.decentraland.org/explorer/:userId/wearables",
+                                   $"https://peer-testing-2.decentraland.org/explorer/{USER_ID}/wearables",
                                    30, 3,
                                    Arg.Any<CancellationToken>(),
                                    Arg.Is<(string paramName, string paramValue)[]>(args =>
@@ -357,10 +360,12 @@ namespace DCLServices.WearablesCatalogService
                                        && args[0].paramValue == "0"
                                        && args[1].paramName == "pageSize"
                                        && args[1].paramValue == "10"
-                                       && args[2].paramName == "collectionType"
-                                       && args[2].paramValue == "third-party"
-                                       && args[3].paramName == "thirdPartyCollectionId"
-                                       && args[3].paramValue == thirdPartyCollectionId));
+                                       && args[2].paramName == "includeEntities"
+                                       && args[2].paramValue == "true"
+                                       && args[3].paramName == "collectionType"
+                                       && args[3].paramValue == "third-party"
+                                       && args[4].paramName == "thirdPartyCollectionId"
+                                       && args[4].paramValue == thirdPartyCollectionId));
             });
 
         [Test]
@@ -389,7 +394,7 @@ namespace DCLServices.WearablesCatalogService
             Assert.IsFalse(service.IsValidWearable(WEARABLE_WITHOUT_THUMBNAIL));
         }
 
-        private void GivenWearableWithSpecificLambdasUrl(WearableItem wearable)
+        private void GivenWearableDefinitionWithSpecificLambdasUrl(WearableItem wearable)
         {
             lambdasService.GetFromSpecificUrl<WearableWithDefinitionResponse>(
                                Arg.Any<string>(),
@@ -404,6 +409,25 @@ namespace DCLServices.WearablesCatalogService
                                    new ()
                                    {
                                        definition = wearable
+                                   },
+                               }, 0, 10, 1), true)));
+        }
+
+        private void GivenWearableEntityWithSpecificLambdasUrl(WearableWithEntityResponseDto.ElementDto.EntityDto entity)
+        {
+            lambdasService.GetFromSpecificUrl<WearableWithEntityResponseDto>(
+                               Arg.Any<string>(),
+                               Arg.Any<string>(),
+                               Arg.Any<int>(),
+                               Arg.Any<int>(),
+                               Arg.Any<CancellationToken>(),
+                               Arg.Any<(string paramName, string paramValue)[]>())
+                          .Returns(UniTask.FromResult<(WearableWithEntityResponseDto response, bool success)>(
+                               (new WearableWithEntityResponseDto(new List<WearableWithEntityResponseDto.ElementDto>
+                               {
+                                   new ()
+                                   {
+                                       entity = entity,
                                    },
                                }, 0, 10, 1), true)));
         }
@@ -496,6 +520,54 @@ namespace DCLServices.WearablesCatalogService
                 thumbnail = thumbnail,
                 description = "description",
                 rarity = "rare",
+            };
+        }
+
+        private WearableWithEntityResponseDto.ElementDto.EntityDto GivenValidWearableEntity(string id)
+        {
+            return new WearableWithEntityResponseDto.ElementDto.EntityDto
+            {
+                content = new WearableWithEntityResponseDto.ElementDto.EntityDto.ContentDto[]
+                {
+                    new()
+                    {
+                        file = "thumbnail.png",
+                        hash = "thumbnailhash",
+                    },
+                    new()
+                    {
+                        file = "model.glb",
+                        hash = "modelhash",
+                    },
+                },
+                metadata = new WearableWithEntityResponseDto.ElementDto.EntityDto.MetadataDto
+                {
+                    thumbnail = "thumbnail.png",
+                    id = id,
+                    data = new WearableWithEntityResponseDto.ElementDto.EntityDto.MetadataDto.DataDto
+                    {
+                        representations = new WearableWithEntityResponseDto.ElementDto.EntityDto.MetadataDto.Representation[]
+                        {
+                            new()
+                            {
+                                contents = new[]
+                                {
+                                    "model.glb",
+                                },
+                                mainFile = "model.glb",
+                            },
+                        },
+                    },
+                    rarity = "rare",
+                    i18n = new i18n[]
+                    {
+                        new()
+                        {
+                            code = "en",
+                            text = id,
+                        }
+                    }
+                },
             };
         }
     }

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL;
 using DCLServices.Lambdas;
 using NSubstitute;
 using NUnit.Framework;
@@ -20,6 +21,7 @@ namespace DCLServices.WearablesCatalogService
         private LambdasWearablesCatalogService service;
         private ILambdasService lambdasService;
         private BaseDictionary<string, WearableItem> initialCatalog;
+        private IServiceProviders serviceProviders;
 
         [SetUp]
         public void SetUp()
@@ -40,21 +42,22 @@ namespace DCLServices.WearablesCatalogService
                 });
 
             GivenPaginatedCollectionInLambdas(TPW_COLLECTION_ID,
-                new List<WearableDefinition>
+                new List<WearableElementV1Dto>
                 {
                     new () { definition = GivenValidWearableItem(VALID_WEARABLE_ID, "baseurl/thumbnail"), },
                     new () { definition = GivenValidWearableItem(WEARABLE_WITHOUT_THUMBNAIL, null) },
                 });
 
-            GivenPaginatedWearableInLambdas(new List<WearableDefinition>
+            GivenPaginatedWearableInLambdas(new List<WearableElementV1Dto>
             {
                 new () { definition = GivenValidWearableItem(VALID_WEARABLE_ID, "baseurl/thumbnail") },
                 new () { definition = GivenValidWearableItem(WEARABLE_WITHOUT_THUMBNAIL, null) },
             });
 
             initialCatalog = new BaseDictionary<string, WearableItem>();
+            serviceProviders = Substitute.For<IServiceProviders>();
 
-            service = new LambdasWearablesCatalogService(initialCatalog, lambdasService);
+            service = new LambdasWearablesCatalogService(initialCatalog, lambdasService, serviceProviders);
             service.Initialize();
         }
 
@@ -396,7 +399,7 @@ namespace DCLServices.WearablesCatalogService
                                Arg.Any<CancellationToken>(),
                                Arg.Any<(string paramName, string paramValue)[]>())
                           .Returns(UniTask.FromResult<(WearableWithDefinitionResponse response, bool success)>(
-                               (new WearableWithDefinitionResponse(new List<WearableDefinition>
+                               (new WearableWithDefinitionResponse(new List<WearableElementV1Dto>
                                {
                                    new ()
                                    {
@@ -435,7 +438,7 @@ namespace DCLServices.WearablesCatalogService
                                }, true)));
         }
 
-        private void GivenPaginatedCollectionInLambdas(string collectionId, List<WearableDefinition> wearables)
+        private void GivenPaginatedCollectionInLambdas(string collectionId, List<WearableElementV1Dto> wearables)
         {
             lambdasService.Get<WearableWithDefinitionResponse>(Arg.Any<string>(),
                                $"users/{USER_ID}/third-party-wearables/{collectionId}",
@@ -452,7 +455,7 @@ namespace DCLServices.WearablesCatalogService
                                }, true)));
         }
 
-        private void GivenPaginatedWearableInLambdas(List<WearableDefinition> wearables)
+        private void GivenPaginatedWearableInLambdas(List<WearableElementV1Dto> wearables)
         {
             lambdasService.Get<WearableWithDefinitionResponse>(Arg.Any<string>(),
                                $"users/{USER_ID}/wearables",

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
@@ -17,6 +17,7 @@ namespace DCLServices.WearablesCatalogService
         private const string WEARABLE_WITHOUT_THUMBNAIL = "wearableWithoutThumbnail";
         private const string BASE_WEARABLES_COLLECTION = "urn:decentraland:off-chain:base-avatars";
         private const string TPW_COLLECTION_ID = "tpwCollection";
+        private const string CONTENT_URL = "http://content.url";
 
         private LambdasWearablesCatalogService service;
         private ILambdasService lambdasService;
@@ -56,6 +57,9 @@ namespace DCLServices.WearablesCatalogService
 
             initialCatalog = new BaseDictionary<string, WearableItem>();
             serviceProviders = Substitute.For<IServiceProviders>();
+            ICatalyst catalyst = Substitute.For<ICatalyst>();
+            catalyst.contentUrl.Returns(CONTENT_URL);
+            serviceProviders.catalyst.Returns(catalyst);
 
             service = new LambdasWearablesCatalogService(initialCatalog, lambdasService, serviceProviders);
             service.Initialize();
@@ -127,7 +131,7 @@ namespace DCLServices.WearablesCatalogService
                                    cancellationToken: Arg.Any<CancellationToken>());
 
                 WearableItem resultantWearable = service.WearablesCatalog[WEARABLE_WITHOUT_THUMBNAIL];
-                Assert.AreEqual("https://interconnected.online/content/contents/", resultantWearable.baseUrl);
+                Assert.AreEqual($"{CONTENT_URL}/contents/", resultantWearable.baseUrl);
             });
 
         [Test]
@@ -178,7 +182,7 @@ namespace DCLServices.WearablesCatalogService
                 Assert.AreEqual("rare", secondWearable.rarity);
                 Assert.AreEqual("hash", secondWearable.data.representations[0].contents[0].hash);
                 Assert.AreEqual(string.Empty, secondWearable.thumbnail);
-                Assert.AreEqual("https://interconnected.online/content/contents/", secondWearable.baseUrl);
+                Assert.AreEqual($"{CONTENT_URL}/contents/", secondWearable.baseUrl);
                 Assert.AreEqual("https://content-assets-as-bundle.decentraland.org/", secondWearable.baseUrlBundles);
                 Assert.IsNull(secondWearable.emoteDataV0);
                 Assert.AreEqual(secondWearable, service.WearablesCatalog[WEARABLE_WITHOUT_THUMBNAIL]);
@@ -218,7 +222,7 @@ namespace DCLServices.WearablesCatalogService
                 Assert.AreEqual("rare", secondWearable.rarity);
                 Assert.AreEqual("hash", secondWearable.data.representations[0].contents[0].hash);
                 Assert.AreEqual(string.Empty, secondWearable.thumbnail);
-                Assert.AreEqual("https://interconnected.online/content/contents/", secondWearable.baseUrl);
+                Assert.AreEqual($"{CONTENT_URL}/contents/", secondWearable.baseUrl);
                 Assert.AreEqual("https://content-assets-as-bundle.decentraland.org/", secondWearable.baseUrlBundles);
                 Assert.IsNull(secondWearable.emoteDataV0);
                 Assert.AreEqual(secondWearable, service.WearablesCatalog[WEARABLE_WITHOUT_THUMBNAIL]);
@@ -257,7 +261,7 @@ namespace DCLServices.WearablesCatalogService
                 Assert.AreEqual("rare", secondWearable.rarity);
                 Assert.AreEqual("hash", secondWearable.data.representations[0].contents[0].hash);
                 Assert.AreEqual(string.Empty, secondWearable.thumbnail);
-                Assert.AreEqual("https://interconnected.online/content/contents/", secondWearable.baseUrl);
+                Assert.AreEqual($"{CONTENT_URL}/contents/", secondWearable.baseUrl);
                 Assert.AreEqual("https://content-assets-as-bundle.decentraland.org/", secondWearable.baseUrlBundles);
                 Assert.IsNull(secondWearable.emoteDataV0);
                 Assert.AreEqual(secondWearable, service.WearablesCatalog[WEARABLE_WITHOUT_THUMBNAIL]);

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/WarablesCatalogServiceTests.asmdef
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/WarablesCatalogServiceTests.asmdef
@@ -10,7 +10,8 @@
         "LambdasService",
         "UniTask",
         "IService",
-        "ServiceProvidersInterfaces"
+        "ServiceProvidersInterfaces",
+        "CatalystInterfaces"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/WarablesCatalogServiceTests.asmdef
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/WarablesCatalogServiceTests.asmdef
@@ -9,7 +9,8 @@
         "BaseVariable",
         "LambdasService",
         "UniTask",
-        "IService"
+        "IService",
+        "ServiceProvidersInterfaces"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
@@ -36,4 +36,61 @@ namespace DCLServices.WearablesCatalogService
         public long maxTransferredAt;
         public WearableItem definition;
     }
+
+    [Serializable]
+    public class WearableElementDto
+    {
+        public string urn;
+        public WearableIndividualDataDto[] individualData;
+        public WearableEntityDto entity;
+
+        public long GetMostRecentTransferTimestamp()
+        {
+            long max = 0;
+
+            foreach (WearableIndividualDataDto dto in individualData)
+            {
+                var transferredAt = long.Parse(dto.transferredAt);
+
+                if (transferredAt > max)
+                    max = transferredAt;
+            }
+
+            return max;
+        }
+    }
+
+    [Serializable]
+    public class WearableEntityDto
+    {
+        public WearableItem metadata;
+    }
+
+    [Serializable]
+    public class WearableIndividualDataDto
+    {
+        public string id;
+        public string tokenId;
+        public string transferredAt;
+        public string price;
+    }
+
+    [Serializable]
+    public class WearableWithEntityResponseDto : PaginatedResponse
+    {
+        public List<WearableElementDto> elements;
+
+        public WearableWithEntityResponseDto(List<WearableElementDto> elements,
+            int pageNum, int pageSize, int totalAmount)
+        {
+            this.elements = elements;
+            this.pageNum = pageNum;
+            this.pageSize = pageSize;
+            this.totalAmount = totalAmount;
+        }
+
+        public WearableWithEntityResponseDto()
+        {
+        }
+    }
 }

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
@@ -109,6 +109,7 @@ namespace DCLServices.WearablesCatalogService
             public string urn;
             public IndividualDataDto[] individualData;
             public EntityDto entity;
+            public string rarity;
 
             public long GetMostRecentTransferTimestamp()
             {
@@ -118,7 +119,8 @@ namespace DCLServices.WearablesCatalogService
 
                 foreach (IndividualDataDto dto in individualData)
                 {
-                    var transferredAt = long.Parse(dto.transferredAt);
+                    if (!long.TryParse(dto.transferredAt, out long transferredAt))
+                        continue;
 
                     if (transferredAt > max)
                         max = transferredAt;

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
@@ -112,6 +112,8 @@ namespace DCLServices.WearablesCatalogService
 
             public long GetMostRecentTransferTimestamp()
             {
+                if (individualData == null) return 0;
+
                 long max = 0;
 
                 foreach (IndividualDataDto dto in individualData)

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
@@ -13,9 +13,9 @@ namespace DCLServices.WearablesCatalogService
     [Serializable]
     public class WearableWithDefinitionResponse : PaginatedResponse
     {
-        public List<WearableDefinition> elements;
+        public List<WearableElementV1Dto> elements;
 
-        public WearableWithDefinitionResponse(List<WearableDefinition> elements,
+        public WearableWithDefinitionResponse(List<WearableElementV1Dto> elements,
             int pageNum, int pageSize, int totalAmount)
         {
             this.elements = elements;
@@ -24,13 +24,12 @@ namespace DCLServices.WearablesCatalogService
             this.totalAmount = totalAmount;
         }
 
-        public WearableWithDefinitionResponse()
-        {
-        }
+        public WearableWithDefinitionResponse() { }
     }
 
     [Serializable]
-    public class WearableDefinition
+    [Obsolete("Deprecated. Use WearableElementV2Dto instead")]
+    public class WearableElementV1Dto
     {
         public string urn;
         public long maxTransferredAt;
@@ -38,49 +37,98 @@ namespace DCLServices.WearablesCatalogService
     }
 
     [Serializable]
-    public class WearableElementDto
-    {
-        public string urn;
-        public WearableIndividualDataDto[] individualData;
-        public WearableEntityDto entity;
-
-        public long GetMostRecentTransferTimestamp()
-        {
-            long max = 0;
-
-            foreach (WearableIndividualDataDto dto in individualData)
-            {
-                var transferredAt = long.Parse(dto.transferredAt);
-
-                if (transferredAt > max)
-                    max = transferredAt;
-            }
-
-            return max;
-        }
-    }
-
-    [Serializable]
-    public class WearableEntityDto
-    {
-        public WearableItem metadata;
-    }
-
-    [Serializable]
-    public class WearableIndividualDataDto
-    {
-        public string id;
-        public string tokenId;
-        public string transferredAt;
-        public string price;
-    }
-
-    [Serializable]
     public class WearableWithEntityResponseDto : PaginatedResponse
     {
-        public List<WearableElementDto> elements;
+        [Serializable]
+        public class ElementDto
+        {
+            [Serializable]
+            public class IndividualDataDto
+            {
+                public string id;
+                public string tokenId;
+                public string transferredAt;
+                public string price;
+            }
 
-        public WearableWithEntityResponseDto(List<WearableElementDto> elements,
+            [Serializable]
+            public class EntityDto
+            {
+                [Serializable]
+                public class ContentDto
+                {
+                    public string file;
+                    public string hash;
+                }
+
+                [Serializable]
+                public class MetadataDto
+                {
+                    [Serializable]
+                    public class Representation
+                    {
+                        public string[] bodyShapes;
+                        public string mainFile;
+                        public string[] contents;
+                        public string[] overrideHides;
+                        public string[] overrideReplaces;
+                    }
+
+                    [Serializable]
+                    public class DataDto
+                    {
+                        public Representation[] representations;
+                        public string category;
+                        public string[] tags;
+                        public string[] replaces;
+                        public string[] hides;
+                    }
+
+                    public DataDto data;
+                    public string id;
+
+                    public i18n[] i18n;
+                    public string thumbnail;
+
+                    public string rarity;
+                    public string description;
+                }
+
+                public MetadataDto metadata;
+                public ContentDto[] content;
+
+                public string GetContentHashByFileName(string fileName)
+                {
+                    foreach (ContentDto dto in content)
+                        if (dto.file == fileName)
+                            return dto.hash;
+                    return null;
+                }
+            }
+
+            public string urn;
+            public IndividualDataDto[] individualData;
+            public EntityDto entity;
+
+            public long GetMostRecentTransferTimestamp()
+            {
+                long max = 0;
+
+                foreach (IndividualDataDto dto in individualData)
+                {
+                    var transferredAt = long.Parse(dto.transferredAt);
+
+                    if (transferredAt > max)
+                        max = transferredAt;
+                }
+
+                return max;
+            }
+        }
+
+        public List<ElementDto> elements;
+
+        public WearableWithEntityResponseDto(List<ElementDto> elements,
             int pageNum, int pageSize, int totalAmount)
         {
             this.elements = elements;
@@ -89,8 +137,6 @@ namespace DCLServices.WearablesCatalogService
             this.totalAmount = totalAmount;
         }
 
-        public WearableWithEntityResponseDto()
-        {
-        }
+        public WearableWithEntityResponseDto() { }
     }
 }

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearablesCatalogService.asmdef
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearablesCatalogService.asmdef
@@ -15,7 +15,9 @@
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:2995626b54c60644988f134a69a77450",
-        "GUID:1a3c68bc9839144538e7a9a75285fb44"
+        "GUID:1a3c68bc9839144538e7a9a75285fb44",
+        "GUID:dffbb581f2650ea4990781f603ac258a",
+        "GUID:a4bf61c057a098f4ca05b539a6d8c0fe"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.cs
@@ -118,7 +118,9 @@ namespace DCL
             result.Register<IBillboardsController>(BillboardsController.Create);
 
             result.Register<IWearablesCatalogService>(() => new WearablesCatalogServiceProxy(
-                new LambdasWearablesCatalogService(DataStore.i.common.wearables, result.Get<ILambdasService>()),
+                new LambdasWearablesCatalogService(DataStore.i.common.wearables,
+                    result.Get<ILambdasService>(),
+                    result.Get<IServiceProviders>()),
                 WebInterfaceWearablesCatalogService.Instance,
                 DataStore.i.common.wearables,
                 KernelConfig.i,


### PR DESCRIPTION
## What does this PR change?

Implements the new json format to retrieve owned wearables which simplifies catalyst overload into entities & metadata.
Also fixes an incorrect hardcoded content server.

## How to test the changes?

1. Launch the explorer
2. Add `&ENABLE_backpack_editor_v2=&DISABLE_backpack_editor_v1` params into the url
3. Open the backpack
4. Check that all your wearables are correctly listed in the grid
5. Try previewing and equipping wearables
6. Switch between pages
7. **Check that you can see: on-chain, base & third-party wearables (by using the collection dropdown)**
8. Go to a crowded place, check that all the wearables are being loaded correctly. Also open passports of other users and check that the wearables are being listed correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7204e7</samp>

This pull request updates the wearables catalog service to use a new endpoint that provides more information about each wearable. It also introduces new classes to model the response data and simplifies the logic of parsing and validating the wearables. The main files affected are `LambdasWearablesCatalogService.cs` and `WearableResponse.cs`.
