### PR TITLE
fix: re-enable NPS-Delight

### DIFF
--- a/browser-interface/packages/shared/dao/sagas.ts
+++ b/browser-interface/packages/shared/dao/sagas.ts
@@ -45,6 +45,7 @@ import { getAllCatalystCandidates, getCatalystCandidatesReceived } from './selec
 import { Candidate, PingResult, Realm, ServerConnectionStatus } from './types'
 import { ask, ping } from './utils/ping'
 import { saveProfileDelta } from '../profiles/actions'
+import { setDelightedSurveyEnabled } from 'unity-interface/delightedSurvey'
 
 const waitForExplorerIdentity = waitFor(getCurrentIdentity, USER_AUTHENTICATED)
 
@@ -237,6 +238,7 @@ function* cacheCatalystRealm() {
   ) {
     yield put(saveProfileDelta({ tutorialStep: 256 }))
     yield put(setOnboardingState({ isInOnboarding: false }))
+    setDelightedSurveyEnabled(true)
   }
 
   if (realmAdapter) {

--- a/browser-interface/packages/shared/session/sagas.ts
+++ b/browser-interface/packages/shared/session/sagas.ts
@@ -51,6 +51,7 @@ import { changeRealm } from '../dao'
 import { SET_SCENE_LOADER } from '../scene-loader/actions'
 import { WorldConfig } from '../meta/types'
 import { getUnityInstance } from '../../unity-interface/IUnityInterface'
+import { setDelightedSurveyEnabled } from 'unity-interface/delightedSurvey'
 
 const TOS_KEY = 'tos'
 const logger = DEBUG_KERNEL_LOG ? createLogger('session: ') : createDummyLogger()
@@ -163,6 +164,7 @@ function* SetupTutorial() {
         yield call(changeRealm, realm, true)
         //The scene loader change is not instant, so we wait for it to be done using a take of the SET_SCENE_LOADER action
         yield take(SET_SCENE_LOADER)
+        setDelightedSurveyEnabled(true)
       } else {
         logger.warn('No realm was provided for the onboarding experience.')
       }

--- a/browser-interface/packages/shared/session/sagas.ts
+++ b/browser-interface/packages/shared/session/sagas.ts
@@ -51,7 +51,6 @@ import { changeRealm } from '../dao'
 import { SET_SCENE_LOADER } from '../scene-loader/actions'
 import { WorldConfig } from '../meta/types'
 import { getUnityInstance } from '../../unity-interface/IUnityInterface'
-import { setDelightedSurveyEnabled } from 'unity-interface/delightedSurvey'
 
 const TOS_KEY = 'tos'
 const logger = DEBUG_KERNEL_LOG ? createLogger('session: ') : createDummyLogger()
@@ -164,7 +163,6 @@ function* SetupTutorial() {
         yield call(changeRealm, realm, true)
         //The scene loader change is not instant, so we wait for it to be done using a take of the SET_SCENE_LOADER action
         yield take(SET_SCENE_LOADER)
-        setDelightedSurveyEnabled(true)
       } else {
         logger.warn('No realm was provided for the onboarding experience.')
       }

--- a/browser-interface/packages/unity-interface/delightedSurvey.ts
+++ b/browser-interface/packages/unity-interface/delightedSurvey.ts
@@ -8,7 +8,7 @@ declare const globalThis: { analytics: any; delighted: any }
 
 let timer: ReturnType<typeof setTimeout> | null = null
 
-;(globalThis as any).setDelightedSurveyEnabled = setDelightedSurveyEnabled
+;(globalThis as any).delightedSurvey = delightedSurvey
 
 export function setDelightedSurveyEnabled(enabled: boolean) {
   if (enabled && !timer) {

--- a/browser-interface/packages/unity-interface/delightedSurvey.ts
+++ b/browser-interface/packages/unity-interface/delightedSurvey.ts
@@ -8,6 +8,8 @@ declare const globalThis: { analytics: any; delighted: any }
 
 let timer: ReturnType<typeof setTimeout> | null = null
 
+;(globalThis as any).setDelightedSurveyEnabled = setDelightedSurveyEnabled
+
 export function setDelightedSurveyEnabled(enabled: boolean) {
   if (enabled && !timer) {
     timer = setTimeout(delightedSurvey, TIMEOUT_MS)


### PR DESCRIPTION
## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e06ced8</samp>

This pull request implements a feature to show a Delighted survey to the user after they enter the Decentraland world. It modifies the `sessionSuccess` saga and the `delightedSurvey` module in the `browser-interface` package.
