### PR TITLE
Chore: initial pools prewarming optimization

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShapeRegister.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShapeRegister.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using DCL.ECSRuntime;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace DCL.ECSComponents
 {
@@ -39,15 +40,11 @@ namespace DCL.ECSComponents
         internal void ConfigurePool(GameObject prefab)
         {
             pool = PoolManager.i.GetPool(AVATAR_POOL_NAME);
-            if (pool != null)
-                return;
+            if (pool != null) return;
 
-            pool = PoolManager.i.AddPool(
-                AVATAR_POOL_NAME,
-                GameObject.Instantiate(prefab).gameObject,
-                isPersistent: true);
+            pool = PoolManager.i.AddPool(AVATAR_POOL_NAME, Object.Instantiate(prefab).gameObject, isPersistent: true);
 
-            pool.ForcePrewarm();
+            pool.ForcePrewarm(forceActive: false);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentView.cs
@@ -193,7 +193,7 @@ namespace DCL.EmotesCustomization
                     maxPrewarmCount: EMOTE_CARDS_POOL_PREWARM,
                     isPersistent: true);
 
-                emoteCardsPool.ForcePrewarm();
+                emoteCardsPool.ForcePrewarm(forceActive: false);
             }
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentView.cs
@@ -475,34 +475,24 @@ namespace DCL.Social.Passports
             nftLandsPagesEntryPool.ReleaseAll();
         }
 
-        private Pool GetNftIconEntryPool()
-        {
-            var pool = PoolManager.i.GetPool(NFT_ICON_POOL_NAME_PREFIX + name + GetInstanceID());
-            if (pool != null) return pool;
+        private Pool GetNftIconEntryPool() =>
+            GetNftEntryPool(NFT_ICON_POOL_NAME_PREFIX + name + GetInstanceID(), wearableUIReferenceObject, MAX_NFT_ICON_ENTRIES);
 
-            pool = PoolManager.i.AddPool(
-                NFT_ICON_POOL_NAME_PREFIX + name + GetInstanceID(),
-                Instantiate(wearableUIReferenceObject).gameObject,
-                maxPrewarmCount: MAX_NFT_ICON_ENTRIES,
-                isPersistent: true);
+        private Pool GetNftPagesEntryPool(string poolId) =>
+            GetNftEntryPool(poolId, nftPageUIReferenceObject, MAX_NFT_PAGES_ENTRIES);
 
-            pool.ForcePrewarm();
-
-            return pool;
-        }
-
-        private Pool GetNftPagesEntryPool(string poolId)
+        private static Pool GetNftEntryPool(string poolId, GameObject referenceObject, int maxPrewarmCount)
         {
             var pool = PoolManager.i.GetPool(poolId);
             if (pool != null) return pool;
 
             pool = PoolManager.i.AddPool(
                 poolId,
-                Instantiate(nftPageUIReferenceObject).gameObject,
-                maxPrewarmCount: MAX_NFT_PAGES_ENTRIES,
+                Instantiate(referenceObject).gameObject,
+                maxPrewarmCount: maxPrewarmCount,
                 isPersistent: true);
 
-            pool.ForcePrewarm();
+            pool.ForcePrewarm(forceActive: false);
 
             return pool;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
@@ -4,7 +4,6 @@ using Cysharp.Threading.Tasks;
 using DCL.Configuration;
 using UnityEngine;
 using DCL.Helpers;
-using Unity.Profiling;
 using UnityEngine.Assertions;
 
 namespace DCL
@@ -65,21 +64,18 @@ namespace DCL
             this.maxPrewarmCount = maxPrewarmCount;
         }
 
-        ProfilerMarker m_prewarmMarker = new ("Pool.Prewarm");
         public void ForcePrewarm(bool forceActive = true)
         {
-            using (m_prewarmMarker.Auto())
-            {
-                if (maxPrewarmCount <= objectsCount)
-                    return;
+            if (maxPrewarmCount <= objectsCount)
+                return;
 
-                Assert.IsTrue(original != null, $"Original should never be null here ({id})");
-                var parent= PoolManager.USE_POOL_CONTAINERS && container != null ? container.transform : null;
+            Assert.IsTrue(original != null, $"Original should never be null here ({id})");
+            var parent = PoolManager.USE_POOL_CONTAINERS && container != null ? container.transform : null;
 
-                int objectsToInstantiate = Mathf.Max(0, maxPrewarmCount - objectsCount);
-                for (var i = 0; i < objectsToInstantiate; i++)
-                    InstantiateOnPrewarm(parent, forceActive);
-            }
+            int objectsToInstantiate = Mathf.Max(0, maxPrewarmCount - objectsCount);
+
+            for (var i = 0; i < objectsToInstantiate; i++)
+                InstantiateOnPrewarm(parent, forceActive);
         }
 
         /// <summary>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PoolManager/Pool.cs
@@ -78,17 +78,14 @@ namespace DCL
 
                 int objectsToInstantiate = Mathf.Max(0, maxPrewarmCount - objectsCount);
                 for (var i = 0; i < objectsToInstantiate; i++)
-                    if(forceActive)
-                        Instantiate();
-                    else
-                        InstantiateOnPrewarm(parent);
+                    InstantiateOnPrewarm(parent, forceActive);
             }
         }
 
         /// <summary>
         /// Lightweight version of Instantiate() that doesn't activate/deactivate the gameObject and parent it straight away.
         /// </summary>
-        private void InstantiateOnPrewarm(Transform parent)
+        private void InstantiateOnPrewarm(Transform parent, bool forceActive = true)
         {
             GameObject gameObject = Object.Instantiate(original, parent);
 
@@ -98,6 +95,11 @@ namespace DCL
 
             poolable.node = unusedObjects.AddFirst(poolable);
 
+            if (forceActive)
+            {
+                gameObject.SetActive(true);
+                gameObject.SetActive(false);
+            }
 #if UNITY_EDITOR
             RefreshName();
 #endif

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/RuntimeComponentFactory/PoolableComponentFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/RuntimeComponentFactory/PoolableComponentFactory.cs
@@ -75,7 +75,7 @@ namespace DCL
                 if (item.usePool)
                 {
                     EnsurePoolForItem(item);
-                    GetPoolForItem(item).ForcePrewarm();
+                    GetPoolForItem(item).ForcePrewarm(forceActive: false);
                 }
             }
         }


### PR DESCRIPTION
## What does this PR change?
Closes #5186

- simplified logic for initial Instantiation of the objects on Prewarming
- removed actrivate/deactivate for some pools used by heavy initial loading systems

This should give us around 0.5-1 sec boost on loading times.

## How to test the changes?

1. Launch the explorer
2. Check that things works as previously and there are no glitches on their first appearance - Places/Events/Highlights, Emotes customization, Passport icons/pages

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8a4683</samp>

This pull request optimizes the performance and consistency of various pooling systems in the unity-renderer project. It replaces `GameObject.Instantiate` with `Object.Instantiate` where possible, and adds a new parameter and a new method to the `Pool` class to avoid unnecessary activation and deactivation of pooled objects during prewarming. It also adds profiler markers and refactors some pool creation logic in different classes.
