### PR TITLE
fix: report `UserError` just as warnings to the analytics

### DIFF
--- a/browser-interface/packages/entryPoints/index.ts
+++ b/browser-interface/packages/entryPoints/index.ts
@@ -55,10 +55,7 @@ globalThis.DecentralandKernel = {
 
         await Promise.all([initializeUnity(options.rendererOptions), loadWebsiteSystems(options.kernelOptions)])
       } catch (err: any) {
-        if (err instanceof UserError)
-          BringDownClientAndShowError(err.message)
-        else
-          BringDownClientAndReportFatalError(err, ErrorContext.WEBSITE_INIT)
+        BringDownClientAndReportFatalError(err, ErrorContext.WEBSITE_INIT)
       }
     }, 0)
 


### PR DESCRIPTION
Some errors were being reported as `fatal`, but they were just warnings.

Every `UserError` error type, must be reported as a warning to the analytics.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1942871</samp>

This pull request improves the error handling and reporting logic in the `browser-interface` package. It adds a new `UserError` class to distinguish user-related errors from website errors, and modifies the `BringDownClientAndReportFatalError` function and the `index.ts` file to handle them accordingly.
