### PR TITLE
fix: Avoid onboarding if realm is present as param

### DIFF
--- a/browser-interface/packages/config/index.ts
+++ b/browser-interface/packages/config/index.ts
@@ -61,6 +61,7 @@ export const ENGINE_DEBUG_PANEL = location.search.includes('ENGINE_DEBUG_PANEL')
 export const SCENE_DEBUG_PANEL = location.search.includes('SCENE_DEBUG_PANEL') && !ENGINE_DEBUG_PANEL
 export const SHOW_FPS_COUNTER = location.search.includes('SHOW_FPS_COUNTER') || location.search.includes('DEBUG_MODE')
 export const HAS_INITIAL_POSITION_MARK = location.search.includes('position')
+export const HAS_INITIAL_REALM_MARK = location.search.includes('realm')
 export const WSS_ENABLED = !!ensureSingleString(qs.get('ws'))
 export const FORCE_SEND_MESSAGE = location.search.includes('FORCE_SEND_MESSAGE')
 export const ALLOW_SWIFT_SHADER = location.search.includes('ALLOW_SWIFT_SHADER')

--- a/browser-interface/packages/shared/session/sagas.ts
+++ b/browser-interface/packages/shared/session/sagas.ts
@@ -1,6 +1,13 @@
 import { Authenticator } from '@dcl/crypto'
 import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
-import { DEBUG_KERNEL_LOG, ETHEREUM_NETWORK, HAS_INITIAL_POSITION_MARK, PREVIEW, RESET_TUTORIAL } from 'config'
+import {
+  DEBUG_KERNEL_LOG,
+  ETHEREUM_NETWORK,
+  HAS_INITIAL_POSITION_MARK,
+  HAS_INITIAL_REALM_MARK,
+  PREVIEW,
+  RESET_TUTORIAL
+} from 'config'
 import { RequestManager } from 'eth-connect'
 import { DecentralandIdentity, LoginState } from '@dcl/kernel-interface'
 import { getFromPersistentStorage, saveToPersistentStorage } from 'lib/browser/persistentStorage'
@@ -149,7 +156,7 @@ function* SetupTutorial() {
   // from the renderer
   const onboardingRealmName: string | undefined = yield select(getFeatureFlagVariantName, 'new_tutorial_variant')
   const isNewTutorialDisabled =
-    onboardingRealmName === 'disabled' || onboardingRealmName === 'undefined' || HAS_INITIAL_POSITION_MARK
+    onboardingRealmName === 'disabled' || onboardingRealmName === 'undefined' || HAS_INITIAL_POSITION_MARK || HAS_INITIAL_REALM_MARK
   if (!isNewTutorialDisabled) {
     try {
       const realm: string | undefined = yield select(getFeatureFlagVariantValue, 'new_tutorial_variant')


### PR DESCRIPTION
## What does this PR change?

If a realm is present in the url, this PR avoids sending you to the onboarding realm

## How to test the changes?

1. Launch the explorer as a new user with a realm (world or not) in the url
Check that:
[play.decentraland.org/?realm=catalystRealm](http://play.decentraland.org/?realm=catalystRealm) => fires old tutorial
[play.decentraland.org/?realm=catalystRealm&position=100,100](http://play.decentraland.org/?realm=catalystRealm&position=100,100) => fires old tutorial
[play.decentraland.org/?position=100,100](http://play.decentraland.org/?position=100,100) => fires old tutorial
[play.decentraland.org/?realm=world](http://play.decentraland.org/?realm=world) => does not fire tutorial

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b4586a</samp>

Disable the new tutorial feature for users with pre-selected realms. Add a constant `HAS_INITIAL_REALM_MARK` to check for `realm` query parameter in the URL.
