### PR TITLE
fix: plugins creation exception handling

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginInfo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginInfo.cs
@@ -13,8 +13,15 @@
             if ( isEnabled )
                 return;
 
-            instance = builder.Invoke();
-            enableOnInit = false;
+            try
+            {
+                instance = builder.Invoke();
+                enableOnInit = false;
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
         }
 
         public void Disable()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginInfo.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginInfo.cs
@@ -1,4 +1,7 @@
-﻿namespace DCL
+using System;
+using UnityEngine;
+
+namespace DCL
 {
     public class PluginInfo
     {


### PR DESCRIPTION
## What does this PR change?
an exception while instancing a plugin can break the instantiation of other plugins.
so we encapsulate the instantiation in a `try/catch`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 07ccead</samp>

Improve error handling and code quality of `PluginInfo` class. This class is responsible for creating and managing plugins in the unity-renderer.
