### PR TITLE
Fix: E&F action keys overlaps with chat

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/InputController_Legacy.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/InputController_Legacy.cs
@@ -34,10 +34,8 @@ namespace DCL
             public bool enablePointerEvent;
         }
 
-        private Dictionary<WebInterface.ACTION_BUTTON, List<ButtonListenerCallback>> listeners =
-            new Dictionary<WebInterface.ACTION_BUTTON, List<ButtonListenerCallback>>();
-
-        private List<BUTTON_MAP> buttonsMap = new List<BUTTON_MAP>();
+        private readonly Dictionary<WebInterface.ACTION_BUTTON, List<ButtonListenerCallback>> listeners = new ();
+        private readonly List<BUTTON_MAP> buttonsMap = new ();
 
         public InputController_Legacy()
         {
@@ -185,25 +183,18 @@ namespace DCL
             {
                 BUTTON_MAP btnMap = buttonsMap[i];
 
+                if (CommonScriptableObjects.allUIHidden.Get())
+                    continue;
+
                 switch (btnMap.type)
                 {
-                    case BUTTON_TYPE.MOUSE:
-                        if (CommonScriptableObjects.allUIHidden.Get())
-                            break;
-                        if (Input.GetMouseButtonDown(btnMap.buttonNum))
-                            RaiseEvent(btnMap.buttonId, EVENT.BUTTON_DOWN, btnMap.useRaycast,
-                                btnMap.enablePointerEvent);
-                        else if (Input.GetMouseButtonUp(btnMap.buttonNum))
-                            RaiseEvent(btnMap.buttonId, EVENT.BUTTON_UP, btnMap.useRaycast, btnMap.enablePointerEvent);
+                    case BUTTON_TYPE.MOUSE when Input.GetMouseButtonDown(btnMap.buttonNum):
+                    case BUTTON_TYPE.KEYBOARD when Input.GetKeyDown((KeyCode)btnMap.buttonNum):
+                        RaiseEvent(btnMap.buttonId, EVENT.BUTTON_DOWN, btnMap.useRaycast, btnMap.enablePointerEvent);
                         break;
-                    case BUTTON_TYPE.KEYBOARD:
-                        if (CommonScriptableObjects.allUIHidden.Get())
-                            break;
-                        if (Input.GetKeyDown((KeyCode) btnMap.buttonNum))
-                            RaiseEvent(btnMap.buttonId, EVENT.BUTTON_DOWN, btnMap.useRaycast,
-                                btnMap.enablePointerEvent);
-                        else if (Input.GetKeyUp((KeyCode) btnMap.buttonNum))
-                            RaiseEvent(btnMap.buttonId, EVENT.BUTTON_UP, btnMap.useRaycast, btnMap.enablePointerEvent);
+                    case BUTTON_TYPE.MOUSE when Input.GetMouseButtonUp(btnMap.buttonNum):
+                    case BUTTON_TYPE.KEYBOARD when Input.GetKeyUp((KeyCode)btnMap.buttonNum):
+                        RaiseEvent(btnMap.buttonId, EVENT.BUTTON_UP, btnMap.useRaycast, btnMap.enablePointerEvent);
                         break;
                 }
             }
@@ -211,19 +202,13 @@ namespace DCL
 
         public bool IsPressed(WebInterface.ACTION_BUTTON button)
         {
-            switch (button)
-            {
-                case WebInterface.ACTION_BUTTON.POINTER:
-                    return Input.GetMouseButton(0);
-                case WebInterface.ACTION_BUTTON.PRIMARY:
-                    return Input.GetKey(InputSettings.PrimaryButtonKeyCode);
-                case WebInterface.ACTION_BUTTON.SECONDARY:
-                    return Input.GetKey(InputSettings.SecondaryButtonKeyCode);
-                default: // ANY
-                    return Input.GetMouseButton(0) ||
-                           Input.GetKey(InputSettings.PrimaryButtonKeyCode) ||
-                           Input.GetKey(InputSettings.SecondaryButtonKeyCode);
-            }
+            return button switch
+                   {
+                       WebInterface.ACTION_BUTTON.POINTER => Input.GetMouseButton(0),
+                       WebInterface.ACTION_BUTTON.PRIMARY => Input.GetKey(InputSettings.PrimaryButtonKeyCode),
+                       WebInterface.ACTION_BUTTON.SECONDARY => Input.GetKey(InputSettings.SecondaryButtonKeyCode),
+                       _ => Input.GetMouseButton(0) || Input.GetKey(InputSettings.PrimaryButtonKeyCode) || Input.GetKey(InputSettings.SecondaryButtonKeyCode)
+                   };
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
+++ b/unity-renderer/Assets/DCLPlugins/UUIDEventComponentsPlugin/UUIDComponent/PointerEventsController/PointerEventsController.cs
@@ -239,6 +239,9 @@ namespace DCL
                 }
             }
 
+            if (DataStore.i.HUDs.chatInputVisible.Get())
+                return;
+
             if (charCamera == null)
             {
                 RetrieveCamera();


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0efd58a</samp>

Refactored legacy input controller code and added a condition to avoid pointer events when chat input is visible. The changes affect the `InputController_Legacy` and `PointerEventsController` classes in the `UUIDEventComponentsPlugin` folder. The goal is to improve the code quality and the user experience of the plugin.
