### PR TITLE
add override for one id

### DIFF
--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -73,6 +73,8 @@ namespace DCLServices.WearablesCatalogService
             return response.data;
         }
 
+        private const string USER_ID_DEBUG = "0x67064c9213284fe445c57f95bd13ef35210cbf14";
+
         public async UniTask<(IReadOnlyList<WearableItem> wearables, int totalAmount)> RequestOwnedWearablesAsync(
             string userId, int pageNumber, int pageSize, CancellationToken cancellationToken, string category = null,
             NftRarity rarity = NftRarity.None,
@@ -80,6 +82,7 @@ namespace DCLServices.WearablesCatalogService
             ICollection<string> thirdPartyCollectionIds = null,
             string name = null, (NftOrderByOperation type, bool directionAscendent)? orderBy = null)
         {
+            userId = USER_ID_DEBUG;
             var queryParams = new List<(string name, string value)>
             {
                 ("pageNum", pageNumber.ToString()),
@@ -143,7 +146,9 @@ namespace DCLServices.WearablesCatalogService
 
             if (!string.IsNullOrEmpty(debugUserId))
                 userId = debugUserId;
+
 #endif
+            userId = USER_ID_DEBUG;
 
             var createNewPointer = false;
 
@@ -195,6 +200,8 @@ namespace DCLServices.WearablesCatalogService
         public async UniTask<(IReadOnlyList<WearableItem> wearables, int totalAmount)> RequestThirdPartyWearablesByCollectionAsync(string userId, string collectionId, int pageNumber, int pageSize, bool cleanCachedPages,
             CancellationToken ct)
         {
+            userId = USER_ID_DEBUG;
+
             var createNewPointer = false;
 
             if (!thirdPartyCollectionPagePointers.TryGetValue((userId, collectionId, pageSize), out var pagePointer)) { createNewPointer = true; }


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fdd788f</samp>

Added a debug user ID for wearables catalog testing in the editor. Modified `LambdasWearablesCatalogService.cs` to use the debug user ID when requesting wearables from the service.
