### PR TITLE
fix: avoid logging `OperationCanceledException` exceptions from backpack

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackFiltersController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackFiltersController.cs
@@ -71,10 +71,8 @@ namespace DCL.Backpack
                     view.LoadCollectionDropdown(collections, defaultCollection);
                     collectionsAlreadyLoaded = true;
                 }
-                catch (Exception e)
-                {
-                    Debug.LogException(e);
-                }
+                catch (OperationCanceledException) { }
+                catch (Exception e) { Debug.LogException(e); }
             }
 
             loadThirdPartyCollectionsCancellationToken = loadThirdPartyCollectionsCancellationToken.SafeRestart();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
@@ -262,6 +262,7 @@ namespace DCL.Backpack
 
                 return totalAmount;
             }
+            catch (OperationCanceledException) { }
             catch (Exception e) { Debug.LogException(e); }
 
             return 0;


### PR DESCRIPTION
## What does this PR change?
Avoid logging `OperationCanceledException` exceptions from Backpack.

## How to test the changes?
1. Launch the explorer.
2. Open the backpack.
3. Change of page very quickly in the wearables grid.
4. Notice any exception is logged in the console.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f31435</samp>

Added catch blocks for `OperationCanceledException` in `BackpackFiltersController.cs` and `WearableGridController.cs`. This prevents logging errors when the user cancels the wearable requests.