### PR TITLE
fix: close searchbox close icon when thext is empty

### DIFF
--- a/unity-renderer/Assets/UIComponents/Scripts/Components/SearchBar/SearchBarComponentView.cs
+++ b/unity-renderer/Assets/UIComponents/Scripts/Components/SearchBar/SearchBarComponentView.cs
@@ -197,7 +197,7 @@ public class SearchBarComponentView : BaseComponentView, ISearchBarComponentView
 
     internal void SetSearchMode()
     {
-        clearSearchButton.gameObject.SetActive(true);
+        clearSearchButton.gameObject.SetActive(!string.IsNullOrEmpty(inputField.text));
         searchSpinner.SetActive(false);
     }
 

--- a/unity-renderer/Assets/UIComponents/Tests/SearchBarComponentViewTests.cs
+++ b/unity-renderer/Assets/UIComponents/Tests/SearchBarComponentViewTests.cs
@@ -119,9 +119,12 @@ public class SearchBarComponentViewTests
     }
 
     [Test]
-    public void SetSearchModeCorrectly()
+    [TestCase("Any text")]
+    [TestCase("")]
+    public void SetSearchModeCorrectly(string text)
     {
         // Arrange
+        searchBarComponent.inputField.text = text;
         searchBarComponent.clearSearchButton.gameObject.SetActive(false);
         searchBarComponent.searchSpinner.SetActive(true);
 
@@ -129,7 +132,7 @@ public class SearchBarComponentViewTests
         searchBarComponent.SetSearchMode();
 
         // Assert
-        Assert.IsTrue(searchBarComponent.clearSearchButton.gameObject.activeSelf);
+        Assert.AreEqual(!string.IsNullOrEmpty(text), searchBarComponent.clearSearchButton.gameObject.activeSelf);
         Assert.IsFalse(searchBarComponent.searchSpinner.activeSelf);
     }
 


### PR DESCRIPTION
## What does this PR change?
The close icon button in our searchbox UI component should be hidden when the input text is empty.

![image](https://github.com/decentraland/unity-renderer/assets/64659061/de16dfb7-f907-4a36-84d3-1485587b1121)

## How to test the changes?
1. Launch the explorer.
2. Open the backpack.
3. Notice the searchbox component (in the top right side of the screen) is not showing the close icon.
4. Input some text in the searchbox.
5. Notice the close icon appears after the search.
6. Clean the searchbox text.
7. Notice the close icon is hidden.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 576fc6d</samp>

This pull request improves the UI and testing of the `SearchBarComponentView` class. It fixes a bug with the clear search button visibility and adds a new test case for different input field states.