### PR TITLE
fix: color picker analytic exception & layout updating issues

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackAnalyticsService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackAnalyticsService.cs
@@ -96,7 +96,7 @@ namespace DCL.Backpack
         }
 
         public void SendAvatarColorPick() =>
-            analytics.SendAnalytic(AVATAR_COLOR_PICK, null);
+            analytics.SendAnalytic(AVATAR_COLOR_PICK, new Dictionary<string, string>());
 
         public void SendForceHideWearable(string category)
         {


### PR DESCRIPTION
## What does this PR change?

Fixes an occurring exception when clicking on a color picker:

```
ArgumentNullException: Value cannot be null.
Parameter name: source
System.Linq.Enumerable.Select[TSource,TResult] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] selector) (at <5e7f3b3c515942079d80178a15a08413>:0)
Analytics.SendToSegment (System.String eventName, System.Collections.Generic.Dictionary`2[TKey,TValue] data) (at Assets/Scripts/MainScripts/DCL/ServiceProviders/Analytics/Analytics.cs:21)
Analytics.SendAnalytic (System.String eventName, System.Collections.Generic.Dictionary`2[TKey,TValue] data) (at Assets/Scripts/MainScripts/DCL/ServiceProviders/Analytics/Analytics.cs:18)
DCL.Backpack.BackpackAnalyticsService.SendAvatarColorPick () (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackAnalyticsService.cs:99)
DCL.Backpack.BackpackEditorHUDController.OnColorPickerToggled () (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs:570)
DCL.Backpack.BackpackEditorHUDV2ComponentView.ColorPickerToggle () (at Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDV2ComponentView.cs:251)
ColorPickerComponentView.SetActive (System.Boolean isActive) (at Assets/UIComponents/Scripts/Components/ColorPicker/ColorPickerComponentView.cs:165)
ColorPickerComponentView.<Awake>b__28_9 () (at Assets/UIComponents/Scripts/Components/ColorPicker/ColorPickerComponentView.cs:54)
UnityEngine.Events.InvokableCall.Invoke () (at /Users/bokken/build/output/unity/unity/Runtime/Export/UnityEvent/UnityEvent.cs:178)
UnityEngine.Events.UnityEvent.Invoke () (at /Users/bokken/build/output/unity/unity/Runtime/Export/UnityEvent/UnityEvent/UnityEvent_0.cs:58)
UnityEngine.UI.Button.Press () (at Library/PackageCache/com.unity.ugui@1.0.0/Runtime/UI/Core/Button.cs:70)
UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) (at Library/PackageCache/com.unity.ugui@1.0.0/Runtime/UI/Core/Button.cs:114)
UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) (at Library/PackageCache/com.unity.ugui@1.0.0/Runtime/EventSystem/ExecuteEvents.cs:57)
UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor) (at Library/PackageCache/com.unity.ugui@1.0.0/Runtime/EventSystem/ExecuteEvents.cs:272)
UnityEngine.EventSystems.EventSystem:Update() (at Library/PackageCache/com.unity.ugui@1.0.0/Runtime/EventSystem/EventSystem.cs:514)
```

Also fixes the color picker layout updating issue:
![image](https://github.com/decentraland/unity-renderer/assets/56365551/78024d6b-1734-4e57-92d8-5eef34d854e4)


## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. Open the backpack
3. Click on body shape category
4. Click on the color and open the selector
5. Close the selector
6. Go to hair category and repeat the process
7. Go to eyes category and repeat the process
8. At all times the layout of the color picker should be OK

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8da7201</samp>

Fixed a bug that caused a null reference exception when picking avatar colors in the backpack editor HUD. Modified the `SendAvatarColorPick` method in `BackpackAnalyticsService.cs` to pass an empty dictionary instead of null to the analytics service.
