### PR TITLE
fix: guest login on desktop spawns in empty world

### DIFF
--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxController.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxController.cs
@@ -619,14 +619,13 @@ namespace DCL.Skybox
 
         public void ApplyAvatarColor(float normalizedDayTime)
         {
+            if (configuration == null)
+                return;
+
             if (dataStore.skyboxConfig.avatarMatProfile.Get() == AvatarMaterialProfile.InWorld)
-            {
                 configuration.ApplyInWorldAvatarColor(normalizedDayTime, directionalLight.gameObject);
-            }
             else
-            {
                 configuration.ApplyEditorAvatarColor();
-            }
         }
 
         private void OnAvatarMatProfileOnChange(AvatarMaterialProfile current, AvatarMaterialProfile previous) =>


### PR DESCRIPTION
## What does this PR change?
Guest login on desktop spawned in empty world due to a **NullRef** exception.

## How to test the changes?
1. Delete Local Storage inside %appdata%
2. Launch desktop client using the link https://renderer-artifacts.decentraland.org/desktop/index.html?dcl://DESKTOP-BRANCH=fix/guest-login-on-desktop-spawns-in-empty-world&DESKTOP-DEVELOPER-MODE
3. Choose Guest login

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 272581f</samp>

Fix skybox controller exception when switching to avatar editor. Add null check for `configuration` field in `SkyboxController.cs`.