### PR TITLE
fix: `onEnter` and `onLeave` events

### DIFF
--- a/browser-interface/packages/shared/world/parcelSceneManager.ts
+++ b/browser-interface/packages/shared/world/parcelSceneManager.ts
@@ -68,7 +68,11 @@ export function forceStopScene(sceneId: string) {
 // finds a parcel scene by parcel position (that is not a portable experience)
 export function getLoadedParcelSceneByParcel(parcelPosition: string) {
   for (const [, w] of loadedSceneWorkers) {
-    if (!w.rpcContext.sceneData.isPortableExperience && w.metadata.scene?.parcels?.includes(parcelPosition)) {
+    if (
+      !w.rpcContext.sceneData.isPortableExperience &&
+      !w.rpcContext.sceneData.isGlobalScene &&
+      w.metadata.scene?.parcels?.includes(parcelPosition)
+    ) {
       return w
     }
   }


### PR DESCRIPTION
## What does this PR change?
global scenes were not filtered out while getting current scene
so avatars global scene was always being returned while trying to get scene at `0,0`
and `onEnter` `onLeave` events were sent to avatars scene instead of to the desired scene at `0,0`

## How to test the changes?
scene should receive events correctly
```
import { onEnterSceneObservable, onLeaveSceneObservable} from '@dcl/sdk/observables'

onEnterSceneObservable.add((player) => {
    console.log("player entered scene: ", player.userId) 
  })
  
  onLeaveSceneObservable.add((player) => {
    console.log("player left scene: ", player.userId)
  })
```

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 525b050</samp>

Updated parcel scene loading logic to support global scenes. Fixed a bug where global scenes could be incorrectly matched by parcel position in `parcelSceneManager.ts`.
