### PR TITLE
hotfix: avoid showing tos popup to users with wallets

### DIFF
--- a/browser-interface/packages/shared/session/sagas.ts
+++ b/browser-interface/packages/shared/session/sagas.ts
@@ -144,7 +144,7 @@ function* authenticate(action: AuthenticateAction) {
   if (getFeatureFlagVariantName(store.getState(), 'seamless_login_variant') === 'enabled') {
 
     const tosAccepted: boolean = !!((yield call(getFromPersistentStorage, 'tos_popup_accepted')) as boolean)
-    isSignUp = !tosAccepted && !PREVIEW
+    isSignUp = avatar.version <= 0 && !tosAccepted && !PREVIEW
   }
 
   if (isSignUp) {


### PR DESCRIPTION
Fix an issue with the A/B test for wallet users

## Test 

Go with ENABLE_SEAMLESS_LOGIN and a wallet that already has been in DCL, you shouldnt see a popup and your name shouldnt be randomized.

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
