### PR TITLE
Chore: updating User Profile with null model or null avatar 

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDViewV2.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDViewV2.cs
@@ -304,9 +304,9 @@ public class ProfileHUDViewV2 : BaseComponentView, IProfileHUDView
     {
         textName.text = string.IsNullOrEmpty(userProfile.userName) || userProfile.userName.Length <= NAME_POSTFIX_LENGTH
             ? userProfile.userName
-            : userProfile.userName.Substring(0, userProfile.userName.Length - NAME_POSTFIX_LENGTH - 1);
+            : userProfile.userName[..(userProfile.userName.Length - NAME_POSTFIX_LENGTH - 1)];
 
-        textPostfix.text = $"#{userProfile.userId.Substring(userProfile.userId.Length - NAME_POSTFIX_LENGTH)}";
+        textPostfix.text = $"#{userProfile.userId[^NAME_POSTFIX_LENGTH..]}";
         SetActiveUnverifiedNameGOs(true);
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
@@ -19,13 +19,14 @@ public class AvatarModel : BaseModel
     public string id;
     public string name;
     public string bodyShape;
+
     public Color skinColor;
     public Color hairColor;
     public Color eyeColor;
-    public List<string> wearables = new List<string>();
-    public HashSet<string> forceRender = new HashSet<string>();
 
-    public List<AvatarEmoteEntry> emotes = new List<AvatarEmoteEntry>();
+    public List<string> wearables = new ();
+    public HashSet<string> forceRender = new ();
+    public List<AvatarEmoteEntry> emotes = new ();
 
     public string expressionTriggerId = null;
     public long expressionTriggerTimestamp = -1;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarModel/AvatarModel.cs
@@ -32,6 +32,18 @@ public class AvatarModel : BaseModel
     public long expressionTriggerTimestamp = -1;
     public bool talking = false;
 
+    public static AvatarModel FallbackModel(string name, int id) =>
+        new()
+        {
+            id = $"{name}_{id}",
+            name = name,
+            bodyShape = "urn:decentraland:off-chain:base-avatars:BaseMale",
+
+            skinColor = new Color(0.800f, 0.608f, 0.467f),
+            hairColor = new Color(0.596f, 0.373f, 0.216f),
+            eyeColor = new Color(0.373f, 0.224f, 0.196f),
+        };
+
     public override BaseModel GetDataFromPb(ComponentBodyPayload pbModel)
     {
         if (pbModel.PayloadCase != ComponentBodyPayload.PayloadOneofCase.AvatarShape)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.asmdef
@@ -22,7 +22,8 @@
       "GUID:fbcc413e192ef9048811d47ab0aca0c0",
       "GUID:5db7e9d450464b96bfddf316690db751",
       "GUID:3b80b0b562b1cbc489513f09fc1b8f69",
-      "GUID:c8ea72e806cd2ab47b539b37895b86b7"
+      "GUID:c8ea72e806cd2ab47b539b37895b86b7",
+      "GUID:2995626b54c60644988f134a69a77450"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -73,12 +73,16 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     {
         if (newModel == null)
         {
-            Debug.LogError("Model is null! Using fallback or previous model instead.");
+            if (DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("user_profile_null_model_exception"))
+                Debug.LogException(new Exception("Model is null! Using fallback or previous model instead."));
+
             newModel = !model.userId.IsNullOrEmpty() ? model : ModelFallback();
         }
         else if (newModel.avatar == null)
         {
-            Debug.LogError("Avatar is null! Using fallback or previous avatar instead.");
+            if (DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("user_profile_null_model_exception"))
+                Debug.LogException(new Exception("Avatar is null! Using fallback or previous avatar instead."));
+
             newModel.avatar = !model.userId.IsNullOrEmpty() ? model.avatar : AvatarFallback();
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -63,9 +63,6 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     {
         if (newModel == null)
         {
-            model =  new () { avatar = new AvatarModel() };
-            return;
-
             if (DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("user_profile_null_model_exception"))
                 Debug.LogError("Model is null when updating UserProfile! Using fallback or previous model instead.");
 
@@ -73,16 +70,16 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
             newModel = string.IsNullOrEmpty(model.userId) ? ModelFallback() : model;
         }
 
-        // if (newModel.avatar == null)
-        // {
-        //     model.avatar = new AvatarModel();
-        //
-        //     if (DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("user_profile_null_model_exception"))
-        //         Debug.LogError("Avatar is null when updating UserProfile! Using fallback or previous avatar instead.");
-        //
-        //     // Check if there is a previous avatar to fallback to.
-        //     newModel.avatar = string.IsNullOrEmpty(model.userId) ? AvatarFallback() : model.avatar;
-        // }
+        if (newModel.avatar == null)
+        {
+            model.avatar = new AvatarModel();
+
+            if (DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("user_profile_null_model_exception"))
+                Debug.LogError("Avatar is null when updating UserProfile! Using fallback or previous avatar instead.");
+
+            // Check if there is a previous avatar to fallback to.
+            newModel.avatar = string.IsNullOrEmpty(model.userId) ? AvatarFallback() : model.avatar;
+        }
 
         bool faceSnapshotDirty = model.snapshots.face256 != newModel.snapshots.face256;
         bool bodySnapshotDirty = model.snapshots.body != newModel.snapshots.body;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -1,4 +1,3 @@
-using Castle.Core.Internal;
 using DCL;
 using DCL.Helpers;
 using Decentraland.Renderer.KernelServices;
@@ -100,7 +99,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
                 Debug.LogError("Model is null when updating UserProfile! Using fallback or previous model instead.");
 
             // Check if there is a previous model to fallback to. Because default model has everything empty or null.
-            newModel = !model.userId.IsNullOrEmpty() ? model : ModelFallback();
+            newModel = string.IsNullOrEmpty(model.userId) ? ModelFallback() : model;
         }
 
         if (newModel.avatar == null)
@@ -109,7 +108,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
                 Debug.LogError("Avatar is null when updating UserProfile! Using fallback or previous avatar instead.");
 
             // Check if there is a previous avatar to fallback to.
-            newModel.avatar = !model.userId.IsNullOrEmpty() ? model.avatar : AvatarFallback();
+            newModel.avatar = string.IsNullOrEmpty(model.userId) ? AvatarFallback() : model.avatar;
         }
 
         bool faceSnapshotDirty = model.snapshots.face256 != newModel.snapshots.face256;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -39,15 +39,15 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     public AvatarModel avatar => model.avatar;
     public int tutorialStep => model.tutorialStep;
 
-    internal Dictionary<string, int> inventory = new Dictionary<string, int>();
+    internal Dictionary<string, int> inventory = new ();
 
     public ILazyTextureObserver snapshotObserver = new LazyTextureObserver();
     public ILazyTextureObserver bodySnapshotObserver = new LazyTextureObserver();
 
     // Empty initialization to avoid null-checks
-    internal UserProfileModel model = new () { avatar = new AvatarModel() };
+    internal readonly UserProfileModel model = new () { avatar = new AvatarModel() };
 
-    private UserProfileModel CreateFallbackModel()
+    private UserProfileModel ModelFallback()
     {
         string fallbackStringField = "fallback_" + this.GetInstanceID();
 
@@ -57,27 +57,28 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
                 name = fallbackStringField,
                 description = fallbackStringField,
 
-                avatar = CreateFallbackAvatarModel(),
+                avatar = AvatarFallback(),
             };
 
         return fallback;
     }
 
-    private static AvatarModel CreateFallbackAvatarModel() =>
+    private static AvatarModel AvatarFallback() =>
         new() { bodyShape = "urn:decentraland:off-chain:base-avatars:BaseMale"};
 
     private int emoteLamportTimestamp = 1;
 
     public void UpdateData(UserProfileModel newModel)
     {
-        newModel = null;
-
         if (newModel == null)
         {
             Debug.LogError("Model is null! Using fallback model instead.");
-            model = CreateFallbackModel();
-            OnUpdate?.Invoke(this);
-            return;
+            newModel = ModelFallback();
+        }
+        else if (newModel.avatar == null)
+        {
+            Debug.LogError("Avatar is null! Using fallback avatar instead.");
+            newModel.avatar = AvatarFallback();
         }
 
         bool isModelDirty = !newModel.Equals(model);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -99,6 +99,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
             if (DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("user_profile_null_model_exception"))
                 Debug.LogError("Model is null when updating UserProfile! Using fallback or previous model instead.");
 
+            // Check if there is a previous model to fallback to. Because default model has everything empty or null.
             newModel = !model.userId.IsNullOrEmpty() ? model : ModelFallback();
         }
 
@@ -107,6 +108,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
             if (DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("user_profile_null_model_exception"))
                 Debug.LogError("Avatar is null when updating UserProfile! Using fallback or previous avatar instead.");
 
+            // Check if there is a previous avatar to fallback to.
             newModel.avatar = !model.userId.IsNullOrEmpty() ? model.avatar : AvatarFallback();
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -44,18 +44,39 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     public ILazyTextureObserver snapshotObserver = new LazyTextureObserver();
     public ILazyTextureObserver bodySnapshotObserver = new LazyTextureObserver();
 
-    internal UserProfileModel model = new UserProfileModel() //Empty initialization to avoid nullchecks
+    // Empty initialization to avoid null-checks
+    internal UserProfileModel model = new () { avatar = new AvatarModel() };
+
+    private UserProfileModel CreateFallbackModel()
     {
-        avatar = new AvatarModel()
-    };
+        string fallbackStringField = "fallback_" + this.GetInstanceID();
+
+        UserProfileModel fallback = new UserProfileModel
+            {
+                userId = fallbackStringField,
+                name = fallbackStringField,
+                description = fallbackStringField,
+
+                avatar = CreateFallbackAvatarModel(),
+            };
+
+        return fallback;
+    }
+
+    private static AvatarModel CreateFallbackAvatarModel() =>
+        new() { bodyShape = "urn:decentraland:off-chain:base-avatars:BaseMale"};
 
     private int emoteLamportTimestamp = 1;
 
     public void UpdateData(UserProfileModel newModel)
     {
+        newModel = null;
+
         if (newModel == null)
         {
-            model = new UserProfileModel();
+            Debug.LogError("Model is null! Using fallback model instead.");
+            model = CreateFallbackModel();
+            OnUpdate?.Invoke(this);
             return;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
@@ -69,6 +69,7 @@ public class UserProfileController : MonoBehaviour
             return;
 
         var model = JsonUtility.FromJson<UserProfileModelDTO>(payload).ToUserProfileModel();
+
         ownUserProfile.UpdateData(model);
         userProfilesCatalog.Add(model.userId, ownUserProfile);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileModel.cs
@@ -65,6 +65,26 @@ public class UserProfileModel
     public int tutorialStep;
     public bool hasClaimedName = false;
 
+    public static UserProfileModel FallbackModel(string name, int id)
+    {
+        var fallbackId = $"{name}_{id}";
+
+        return new UserProfileModel
+        {
+            // Required fields (otherwise exceptions will be thrown by UserProfile.OnUpdate subscribers)
+            userId = fallbackId,
+            name = name,
+            description = "There was a problem with loading this profile. This is a fallback profile",
+
+            avatar = AvatarModel.FallbackModel(name, id),
+
+            // Optional (exceptions-free) fields
+            ethAddress = fallbackId,
+            email = fallbackId,
+            baseUrl = fallbackId,
+        };
+    }
+
     public bool Equals(UserProfileModel model)
     {
         if (model == null) return false;
@@ -127,6 +147,4 @@ public class UserProfileModel
 
         return baseUrl + url;
     }
-
-
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileModel.cs
@@ -54,14 +54,14 @@ public class UserProfileModel
     public ulong updated_at;
     public int version;
     public AvatarModel avatar;
-    public Snapshots snapshots = new Snapshots();
+    public Snapshots snapshots = new ();
     public UserProfileModel Clone() => (UserProfileModel)MemberwiseClone();
 
     public bool hasConnectedWeb3 = true;
 
     public int tutorialFlagsMask;
-    public List<string> blocked;
-    public List<string> muted;
+    public List<string> blocked = new ();
+    public List<string> muted = new ();
     public int tutorialStep;
     public bool hasClaimedName = false;
 


### PR DESCRIPTION
## What does this PR change?
Closes #4755

- add fallback or recovering UserProfile in the case it was failing from payload parsing

## How to test the changes?

Since it was an edge-case, I am not sure it can be tested by QA. 
However, I expect it to fix issue #5058 (if it still present). In case it is reproducible, you should see a guy in just black pants with normal skin color (instead of black in world and transparent in AvatarEditor)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9724acc</samp>

This pull request enhances the `UserProfile` feature by using new C# features, adding error handling, and removing unused code. It also updates the `ProfileHUDViewV2` and `AvatarModel` classes to use new C# syntax for readability and consistency. Finally, it adds a new assembly reference to the `UserProfile.asmdef` file to enable feature flagging.
