### PR TITLE
fix: the realm reconnecting mechanism iterates on all realms before c… 

### DIFF
--- a/browser-interface/packages/shared/comms/sagas.ts
+++ b/browser-interface/packages/shared/comms/sagas.ts
@@ -11,9 +11,7 @@ import type { EventChannel } from 'redux-saga'
 import { BEFORE_UNLOAD } from 'shared/meta/actions'
 import { trackEvent } from 'shared/analytics/trackEvent'
 import { notifyStatusThroughChat } from 'shared/chat'
-import { setCatalystCandidates } from 'shared/dao/actions'
 import { selectAndReconnectRealm } from 'shared/dao/sagas'
-import { getCatalystCandidates } from 'shared/dao/selectors'
 import { commsEstablished, establishingComms, FATAL_ERROR } from 'shared/loading/types'
 import { waitForMetaConfigurationInitialization } from 'shared/meta/sagas'
 import { getFeatureFlagEnabled, getMaxVisiblePeers } from 'shared/meta/selectors'
@@ -23,14 +21,13 @@ import { DEPLOY_PROFILE_SUCCESS, SEND_PROFILE_TO_RENDERER_REQUEST } from 'shared
 import { getCurrentUserProfile } from 'shared/profiles/selectors'
 import type { ConnectToCommsAction } from 'shared/realm/actions'
 import { CONNECT_TO_COMMS, setRealmAdapter, SET_REALM_ADAPTER } from 'shared/realm/actions'
-import { getFetchContentUrlPrefixFromRealmAdapter, getRealmAdapter } from 'shared/realm/selectors'
+import { getFetchContentUrlPrefixFromRealmAdapter } from 'shared/realm/selectors'
 import { waitForRealm } from 'shared/realm/waitForRealmAdapter'
 import type { IRealmAdapter } from 'shared/realm/types'
 import { USER_AUTHENTICATED } from 'shared/session/actions'
 import { measurePingTime, measurePingTimePercentages, overrideCommsProtocol } from 'shared/session/getPerformanceInfo'
 import { getCurrentIdentity, isLoginCompleted } from 'shared/session/selectors'
 import type { ExplorerIdentity } from 'shared/session/types'
-import { store } from 'shared/store/isolatedStore'
 import { lastPlayerPositionReport, positionObservable, PositionReport } from 'shared/world/positionThings'
 import type { HandleRoomDisconnection, SetRoomConnectionAction } from './actions'
 import {
@@ -213,16 +210,6 @@ function* handleConnectToComms(action: ConnectToCommsAction) {
       stack: error.stack
     })
     notifyStatusThroughChat('Error connecting to comms. Will try another realm')
-
-    const realmAdapter: IRealmAdapter | undefined = yield select(getRealmAdapter)
-    const candidates = yield select(getCatalystCandidates)
-    for (const candidate of candidates) {
-      if (candidate.domain === realmAdapter?.baseUrl) {
-        candidate.lastConnectionAttempt = Date.now()
-        break
-      }
-    }
-    store.dispatch(setCatalystCandidates(candidates))
 
     yield put(setRealmAdapter(undefined))
     yield put(setRoomConnection(undefined))

--- a/browser-interface/packages/shared/dao/actions.ts
+++ b/browser-interface/packages/shared/dao/actions.ts
@@ -17,3 +17,8 @@ export type SelectNetworkAction = ReturnType<typeof selectNetwork>
 export const CATALYST_REALMS_SCAN_REQUESTED = '[Request] Catalyst Realms scan'
 export const catalystRealmsScanRequested = () => action(CATALYST_REALMS_SCAN_REQUESTED)
 export type CatalystRealmsScanRequested = ReturnType<typeof catalystRealmsScanRequested>
+
+export const SET_LAST_CONNECTED_CANDIDATES = 'Set Last Connected Candidates'
+export const setLastConnectedCandidates = (lastConnectedCandidates: Map<string, number>) =>
+  action(SET_LAST_CONNECTED_CANDIDATES, lastConnectedCandidates)
+export type SetLastConnectedCandidates = ReturnType<typeof setLastConnectedCandidates>

--- a/browser-interface/packages/shared/dao/index.ts
+++ b/browser-interface/packages/shared/dao/index.ts
@@ -17,9 +17,9 @@ import { OFFLINE_REALM } from 'shared/realm/types'
 import { getCurrentIdentity } from 'shared/session/selectors'
 import { store } from 'shared/store/isolatedStore'
 import { checkValidRealm } from './sagas'
-import { getAllCatalystCandidates } from './selectors'
 import { Candidate, Parcel, ServerConnectionStatus } from './types'
 import { ask } from './utils/ping'
+import { getCatalystCandidates } from './selectors'
 
 async function fetchCatalystNodes(endpoint: string | undefined): Promise<CatalystNode[]> {
   if (endpoint) {
@@ -139,8 +139,8 @@ export async function resolveRealmAboutFromBaseUrl(
   realmString: string
 ): Promise<{ about: AboutResponse; baseUrl: string } | undefined> {
   // load candidates if necessary
-  const allCandidates: Candidate[] = getAllCatalystCandidates(store.getState())
-  const realmBaseUrl = resolveRealmBaseUrlFromRealmQueryParameter(realmString, allCandidates).replace(/\/+$/, '')
+  const candidates: Candidate[] = getCatalystCandidates(store.getState())
+  const realmBaseUrl = resolveRealmBaseUrlFromRealmQueryParameter(realmString, candidates).replace(/\/+$/, '')
 
   if (!realmBaseUrl) {
     throw new Error(`Can't resolve realm ${realmString}`)
@@ -243,11 +243,11 @@ export async function changeRealm(realmString: string, forceChange: boolean = fa
 // TODO: unify this function with the one implementing the realm selection algorithm
 export async function changeToMostPopulatedRealm(): Promise<void> {
   const realmAdapter = getRealmAdapter(store.getState())
-  const allCandidates: Candidate[] = getAllCatalystCandidates(store.getState())
+  const candidates: Candidate[] = getCatalystCandidates(store.getState())
   let isDAORealm: boolean = false
 
-  for (let i = 0; i < allCandidates.length; i++) {
-    if (allCandidates[i].catalystName === realmAdapter?.about.configurations?.realmName) {
+  for (let i = 0; i < candidates.length; i++) {
+    if (candidates[i].catalystName === realmAdapter?.about.configurations?.realmName) {
       isDAORealm = true
     }
   }
@@ -257,7 +257,7 @@ export async function changeToMostPopulatedRealm(): Promise<void> {
     return
   }
 
-  const sortedArray: Candidate[] = allCandidates.sort((n1, n2) => {
+  const sortedArray: Candidate[] = candidates.sort((n1, n2) => {
     if (n1.usersCount < n2.usersCount) {
       return 1
     }

--- a/browser-interface/packages/shared/dao/reducer.ts
+++ b/browser-interface/packages/shared/dao/reducer.ts
@@ -1,5 +1,5 @@
 import { AnyAction } from 'redux'
-import { SET_CATALYST_CANDIDATES, SELECT_NETWORK, SelectNetworkAction } from './actions'
+import { SET_CATALYST_CANDIDATES, SELECT_NETWORK, SelectNetworkAction, SET_LAST_CONNECTED_CANDIDATES } from './actions'
 import { DaoState } from './types'
 
 export function daoReducer(state?: DaoState, action?: AnyAction): DaoState {
@@ -7,7 +7,8 @@ export function daoReducer(state?: DaoState, action?: AnyAction): DaoState {
     return {
       network: null,
       candidates: [],
-      catalystCandidatesReceived: false
+      catalystCandidatesReceived: false,
+      lastConnectedCandidates: new Map()
     }
   }
   if (!action) {
@@ -24,6 +25,11 @@ export function daoReducer(state?: DaoState, action?: AnyAction): DaoState {
         ...state,
         catalystCandidatesReceived: true,
         candidates: action.payload
+      }
+    case SET_LAST_CONNECTED_CANDIDATES:
+      return {
+        ...state,
+        lastConnectedCandidates: action.payload
       }
   }
   return state

--- a/browser-interface/packages/shared/dao/sagas.ts
+++ b/browser-interface/packages/shared/dao/sagas.ts
@@ -127,13 +127,14 @@ function* tryConnectRealm(realm: string) {
  * 4- Best pick from candidate scan (implies sync candidate initialization)
  */
 export function* selectAndReconnectRealm() {
-  while (true) { // we're going to try connect realm until we don't have more realms to try
+  while (true) {
+    // we're going to try connect realm until we don't have more realms to try
     const realm: string | undefined = yield call(selectRealm)
 
     if (realm) {
       try {
         yield call(tryConnectRealm, realm)
-        // if no realm was selected, then do the whole initialization dance
+        break
       } catch (e: any) {
         // if it failed, try changing the queryString
         clearQsRealm()

--- a/browser-interface/packages/shared/dao/sagas.ts
+++ b/browser-interface/packages/shared/dao/sagas.ts
@@ -1,9 +1,4 @@
-import {
-  ETHEREUM_NETWORK,
-  PIN_CATALYST,
-  PREVIEW,
-  rootURLPreviewMode
-} from 'config'
+import { ETHEREUM_NETWORK, PIN_CATALYST, PREVIEW, rootURLPreviewMode } from 'config'
 import { getFromPersistentStorage, saveToPersistentStorage } from 'lib/browser/persistentStorage'
 import defaultLogger from 'lib/logger'
 import { waitFor } from 'lib/redux'
@@ -31,17 +26,18 @@ import { USER_AUTHENTICATED } from 'shared/session/actions'
 import { getCurrentIdentity } from 'shared/session/selectors'
 import { RootState } from 'shared/store/rootTypes'
 import { CatalystNode } from 'lib/web3/fetchCatalystNodesFromContract'
-import { changeRealm, fetchCatalystRealms, fetchCatalystStatuses } from '.'
+import { changeRealm, fetchCatalystRealms, fetchCatalystStatuses, resolveRealmConfigFromString } from '.'
 import { waitForMetaConfigurationInitialization, waitForNetworkSelected } from '../meta/sagas'
 import {
   catalystRealmsScanRequested,
   setCatalystCandidates,
   SetCatalystCandidates,
-  SET_CATALYST_CANDIDATES
+  SET_CATALYST_CANDIDATES,
+  setLastConnectedCandidates
 } from './actions'
 import { defaultChainConfig } from './pick-realm-algorithm/defaults'
 import { createAlgorithm } from './pick-realm-algorithm/index'
-import { getAllCatalystCandidates, getCatalystCandidatesReceived } from './selectors'
+import { getCatalystCandidates, getCatalystCandidatesReceived, getLastConnectedCandidates } from './selectors'
 import { Candidate, PingResult, Realm, ServerConnectionStatus } from './types'
 import { ask, ping } from './utils/ping'
 import { saveProfileDelta } from '../profiles/actions'
@@ -61,16 +57,30 @@ export function* daoSaga(): any {
 }
 
 function* pickCatalystRealm() {
-  const { candidates, currentUserParcel, config } = (yield select(getInformationForCatalystPicker)) as ReturnType<
+  const { currentUserParcel, config } = (yield select(getInformationForCatalystPicker)) as ReturnType<
     typeof getInformationForCatalystPicker
   >
+
+  const candidates: Candidate[] = yield select(getCatalystCandidates)
+  const lastConnectedCandidates = (yield select(getLastConnectedCandidates)) as ReturnType<
+    typeof getLastConnectedCandidates
+  >
+
   if (candidates.length === 0) return undefined
+
+  const filteredCandidates = candidates.filter((candidate: Candidate) => {
+    const lastConnected = lastConnectedCandidates.get(candidate.domain)
+    if (lastConnected && Date.now() - lastConnected < 60 * 1000) {
+      return false
+    }
+    return true
+  })
 
   const algorithm = createAlgorithm(config)
 
   const realm: Realm = yield call(
     candidateToRealm,
-    algorithm.pickCandidate(candidates, [currentUserParcel.x, currentUserParcel.y])
+    algorithm.pickCandidate(filteredCandidates, [currentUserParcel.x, currentUserParcel.y])
   )
 
   return urlWithProtocol(realm.hostname)
@@ -79,7 +89,7 @@ function* pickCatalystRealm() {
 function getInformationForCatalystPicker(state: RootState) {
   const config = getPickRealmsAlgorithmConfig(state)
   return {
-    candidates: getAllCatalystCandidates(state),
+    candidates: getCatalystCandidates(state),
     currentUserParcel: getParcelPosition(state),
     config: !config || !config.length ? defaultChainConfig : config
   }
@@ -96,15 +106,15 @@ function clearQsRealm() {
   globalThis.history.replaceState({}, 'realm', `?${q.toString()}`)
 }
 
-function* tryConnectRealm() {
-  const realm: string | undefined = yield call(selectRealm)
+function* tryConnectRealm(realm: string) {
+  const realmConfig = yield call(resolveRealmConfigFromString, realm)
 
-  if (realm) {
-    yield call(waitForExplorerIdentity)
-    yield call(changeRealm, realm, true)
-  } else {
-    throw new Error("Couldn't select a suitable realm to join.")
-  }
+  const lastConnectedCandidates = yield select(getLastConnectedCandidates)
+  lastConnectedCandidates.set(realmConfig.baseUrl, Date.now())
+  yield put(setLastConnectedCandidates(lastConnectedCandidates))
+
+  yield call(waitForExplorerIdentity)
+  yield call(changeRealm, realm, true)
 }
 
 /**
@@ -117,19 +127,19 @@ function* tryConnectRealm() {
  * 4- Best pick from candidate scan (implies sync candidate initialization)
  */
 export function* selectAndReconnectRealm() {
-  try {
-    yield call(tryConnectRealm)
-    // if no realm was selected, then do the whole initialization dance
-  } catch (e: any) {
-    // if it failed, try changing the queryString
-    clearQsRealm()
-    try {
-      // and try again
-      yield call(tryConnectRealm)
-    } catch (e: any) {
-      debugger
-      BringDownClientAndReportFatalError(e, 'comms#init')
-      throw e
+  while (true) { // we're going to try connect realm until we don't have more realms to try
+    const realm: string | undefined = yield call(selectRealm)
+
+    if (realm) {
+      try {
+        yield call(tryConnectRealm, realm)
+        // if no realm was selected, then do the whole initialization dance
+      } catch (e: any) {
+        // if it failed, try changing the queryString
+        clearQsRealm()
+      }
+    } else {
+      throw new Error("Couldn't select a suitable realm to join.")
     }
   }
 }
@@ -256,9 +266,9 @@ function* cacheCatalystRealm() {
 }
 
 function* cacheCatalystCandidates(_action: SetCatalystCandidates) {
-  const allCandidates: Candidate[] = yield select(getAllCatalystCandidates)
+  const candidates: Candidate[] = yield select(getCatalystCandidates)
   const network: ETHEREUM_NETWORK = yield call(waitForNetworkSelected)
-  yield call(saveToPersistentStorage, getLastRealmCandidatesCacheKey(network), allCandidates)
+  yield call(saveToPersistentStorage, getLastRealmCandidatesCacheKey(network), candidates)
 }
 
 export const waitForRoomConnection = waitFor(getCommsRoom, SET_ROOM_CONNECTION)

--- a/browser-interface/packages/shared/dao/selectors.ts
+++ b/browser-interface/packages/shared/dao/selectors.ts
@@ -1,25 +1,12 @@
-import { RootDaoState } from './types'
+import { Candidate, RootDaoState } from './types'
 import { HOTSCENES_SERVICE, POI_SERVICE } from 'config'
 import { urlWithProtocol } from 'shared/realm/resolver'
 import { RootRealmState } from 'shared/realm/types'
-import { getFeatureFlagEnabled } from 'shared/meta/selectors'
-import { RootMetaState } from 'shared/meta/types'
 
-export const getCatalystCandidates = (store: RootDaoState) => store.dao.candidates
+export const getCatalystCandidates = (store: RootDaoState): Candidate[] => [...store.dao.candidates]
 export const getCatalystCandidatesReceived = (store: RootDaoState) => store.dao.catalystCandidatesReceived
 
-export const getAllCatalystCandidates = (store: RootDaoState & RootMetaState) => {
-  const candidates = getCatalystCandidates(store).filter((it) => !!it)
-  const enableLegacyComms: boolean = getFeatureFlagEnabled(store, 'enable_legacy_comms_v2')
-
-  return candidates.filter(($) => {
-    if ($.lastConnectionAttempt && Date.now() - $.lastConnectionAttempt < 60 * 1000) {
-      return false
-    }
-    if ($.protocol === 'v3') return true
-    return enableLegacyComms
-  })
-}
+export const getLastConnectedCandidates = (store: RootDaoState) => store.dao.lastConnectedCandidates
 
 export const getHotScenesService = (state: RootRealmState) => {
   if (HOTSCENES_SERVICE) {

--- a/browser-interface/packages/shared/dao/types.ts
+++ b/browser-interface/packages/shared/dao/types.ts
@@ -22,7 +22,6 @@ type BaseCandidate = {
   version: { bff: string; comms: string; lambdas: string; content: string }
   elapsed: number
   status: ServerConnectionStatus
-  lastConnectionAttempt?: number
 }
 
 export type Candidate = {
@@ -51,6 +50,7 @@ export type DaoState = {
   network: ETHEREUM_NETWORK | null
   candidates: Candidate[]
   catalystCandidatesReceived: boolean
+  lastConnectedCandidates: Map<string, number>
 }
 
 export type RootDaoState = {


### PR DESCRIPTION
…rashing (even when fails with comms)

## What does this PR change?

Fix https://github.com/decentraland/unity-renderer/issues/5281

## How to test the changes?

1. Test /changerealm
2. Test teleporting and checking if you don't change the realm

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91a9fe6</samp>

The pull request improves the logic of connecting to a realm by using a new data structure to store and filter the catalyst candidates based on their last connection attempts. It also refactors some code and removes unused imports and properties. The main files affected are `comms/sagas.ts`, `dao/sagas.ts`, `dao/reducer.ts`, and `dao/types.ts`.
