### PR TITLE
fix: failing requests because of json conversion incompatibility

### DIFF
--- a/unity-renderer/Assets/DCLServices/Lambdas/LandsService/LandsResponse.cs
+++ b/unity-renderer/Assets/DCLServices/Lambdas/LandsService/LandsResponse.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -10,13 +11,13 @@ namespace DCLServices.Lambdas.LandsService
         [Serializable]
         public class LandEntry
         {
-            [SerializeField] private string name;
-            [SerializeField] private string contractAddress;
-            [SerializeField] private string category;
-            [SerializeField] private string x;
-            [SerializeField] private string y;
-            [SerializeField] private string price;
-            [SerializeField] private string image;
+            [JsonProperty] private string name;
+            [JsonProperty] private string contractAddress;
+            [JsonProperty] private string category;
+            [JsonProperty] private string x;
+            [JsonProperty] private string y;
+            [JsonProperty] private string price;
+            [JsonProperty] private string image;
 
             public string Name => name;
             public string ContractAddress => contractAddress;
@@ -34,7 +35,7 @@ namespace DCLServices.Lambdas.LandsService
                 };
         }
 
-        [SerializeField] private List<LandEntry> elements;
+        [JsonProperty] private List<LandEntry> elements;
 
         public IReadOnlyList<LandEntry> Elements => elements;
     }

--- a/unity-renderer/Assets/DCLServices/Lambdas/NamesService/NamesResponse.cs
+++ b/unity-renderer/Assets/DCLServices/Lambdas/NamesService/NamesResponse.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -10,9 +11,9 @@ namespace DCLServices.Lambdas.NamesService
         [Serializable]
         public class NameEntry
         {
-            [SerializeField] private string name;
-            [SerializeField] private string contractAddress;
-            [SerializeField] private string price;
+            [JsonProperty] private string name;
+            [JsonProperty] private string contractAddress;
+            [JsonProperty] private string price;
 
             public string Name => name;
             public string ContractAddress => contractAddress;
@@ -26,7 +27,7 @@ namespace DCLServices.Lambdas.NamesService
                 };
         }
 
-        [SerializeField] private List<NameEntry> elements;
+        [JsonProperty] private List<NameEntry> elements;
 
         public IReadOnlyList<NameEntry> Elements => elements;
     }

--- a/unity-renderer/Assets/DCLServices/Lambdas/PaginatedResponse.cs
+++ b/unity-renderer/Assets/DCLServices/Lambdas/PaginatedResponse.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using UnityEngine;
+﻿using Newtonsoft.Json;
+using System;
 
 namespace DCLServices.Lambdas
 {
     [Serializable]
     public abstract class PaginatedResponse
     {
-        [SerializeField] protected internal int pageNum;
-        [SerializeField] protected internal int pageSize;
-        [SerializeField] protected internal int totalAmount;
+        [JsonProperty] protected internal int pageNum;
+        [JsonProperty] protected internal int pageSize;
+        [JsonProperty] protected internal int totalAmount;
 
         public int PageNum => pageNum;
         public int PageSize => pageSize;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentController.cs
@@ -218,7 +218,7 @@ namespace DCL.Social.Passports
                 showViewAllButton = names.totalAmount > MAX_NFT_COUNT;
             }
             catch (OperationCanceledException) { }
-            catch (Exception e) { Debug.LogError(e.Message); }
+            catch (Exception e) { Debug.LogException(e); }
             finally
             {
                 view.SetCollectibleNames(namesResult);


### PR DESCRIPTION
## What does this PR change?

We changed the default Json deserializer for the one from Newtonsoft.

We had to fix a few DTO objects that used unity attributes

## How to test the changes?

https://play.decentraland.org/?explorer-branch=fix/json-req

Names and Lands should appear correctly in the player's passport

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md