### PR TITLE
fix: avatar animations in backpack & passport

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using DCL;
 using GPUSkinning;
 using UnityEngine;
 
@@ -11,6 +12,8 @@ namespace AvatarSystem
     // [ADR 65 - https://github.com/decentraland/adr]
     public class Avatar : IAvatar
     {
+        private const string NEW_CDN_FF = "ab-new-cdn";
+
         private const float RESCALING_BOUNDS_FACTOR = 100f;
         internal const string LOADING_VISIBILITY_CONSTRAIN = "Loading";
 
@@ -29,6 +32,7 @@ namespace AvatarSystem
         public Vector3 extents { get; private set; }
         public int lodLevel => lod?.lodIndex ?? 0;
         public event Action<Renderer> OnCombinedRendererUpdate;
+        private FeatureFlag featureFlags => DataStore.i.featureFlags.flags.Get();
 
         internal Avatar(IAvatarCurator avatarCurator, ILoader loader, IAnimator animator,
             IVisibility visibility, ILOD lod, IGPUSkinning gpuSkinning, IGPUSkinningThrottlerService gpuSkinningThrottlerService,
@@ -91,18 +95,32 @@ namespace AvatarSystem
 
             GameObject container = loader.bodyshapeContainer;
 
-            if (loader.bodyshapeContainer.transform.childCount > 0)
+            if (featureFlags.IsFeatureEnabled(NEW_CDN_FF))
             {
-                Transform child = loader.bodyshapeContainer.transform.GetChild(0);
+                if (loader.bodyshapeContainer.transform.childCount > 0)
+                {
+                    loader.bodyshapeContainer.transform.Find("Armature");
+                    Transform child = loader.bodyshapeContainer.transform.GetChild(0);
 
-                // Asset bundles assets dont have the gltf-scene name as the root, they have the file hash, for this particular object we need it to be Armature
-                child.name = "Armature";
+                    // Asset bundles assets dont have the gltf-scene name as the root, they have the file hash, for this particular object we need it to be Armature
+                    child.name = "Armature";
+                }
             }
+            else
+                container = GetDeepParentOf(loader.bodyshapeContainer, "Armature");
 
             animator.Prepare(settings.bodyshapeId, container);
             Prepare(settings, emotes, loader.bodyshapeContainer);
             Bind();
             Inform(loader.combinedRenderer);
+        }
+
+        private GameObject GetDeepParentOf(GameObject container, string childName)
+        {
+            foreach (Transform child in container.transform)
+                return child.name == childName ? child.parent.gameObject : GetDeepParentOf(child.gameObject, childName);
+
+            return null;
         }
 
         protected async UniTask<List<WearableItem>> LoadWearables(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, SkinnedMeshRenderer bonesRenderers = null, CancellationToken linkedCt = default)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -107,7 +107,10 @@ namespace AvatarSystem
                 }
             }
             else
-                container = GetDeepParentOf(loader.bodyshapeContainer, "Armature");
+            {
+                GameObject parent = GetDeepParentOf(loader.bodyshapeContainer, "Armature");
+                container = parent != null ? parent : container;
+            }
 
             animator.Prepare(settings.bodyshapeId, container);
             Prepare(settings, emotes, loader.bodyshapeContainer);


### PR DESCRIPTION
## What does this PR change?

Added an old code that made sure that the avatar animator had its correct target, this workaround should be removed once we get rid of the old ABs

## How to test the changes?

- test in https://play.decentraland.org/?explorer-branch=fix/avatar-preview
- Open backpack and see that the character animates correctly
- Open passport and see that the character animates correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md