### PR TITLE
fix: usage of string comparison not working correctly in webgl

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
@@ -13,7 +13,6 @@ namespace AvatarSystem
     {
         public const float AVATAR_Y_OFFSET = 0.75f;
         private const string AB_FEATURE_FLAG_NAME = "wearable_asset_bundles";
-        private const StringComparison SC = StringComparison.InvariantCultureIgnoreCase;
 
         public static bool IsCategoryRequired(string category) { return WearableLiterals.Categories.REQUIRED_CATEGORIES.Contains(category); }
 
@@ -71,11 +70,11 @@ namespace AvatarSystem
                 {
                     // If this is modified, check DecentralandMaterialGenerator.SetMaterialName,
                     // its important for the asset bundles materials to have normalized names but this functionality should work too
-                    string name = material.name;
+                    string name = material.name.ToLower();
 
-                    if (name.Contains("skin", SC))
+                    if (name.Contains("skin"))
                         material.SetColor(ShaderUtils.BaseColor, skinColor);
-                    else if (name.Contains("hair", SC))
+                    else if (name.Contains("hair"))
                         material.SetColor(ShaderUtils.BaseColor, hairColor);
                 }
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
@@ -71,12 +71,19 @@ namespace AvatarSystem
                     // If this is modified, check DecentralandMaterialGenerator.SetMaterialName,
                     // its important for the asset bundles materials to have normalized names but this functionality should work too
                     string name = material.name.ToLower();
-                    Debug.LogError(name); //logging material name as error to see it in the console
 
                     if (name.Contains("skin"))
+                    {
+                        Debug.LogError("> " + name + " contains skin");
                         material.SetColor(ShaderUtils.BaseColor, skinColor);
+                    }
                     else if (name.Contains("hair"))
+                    {
+                        Debug.LogError("> " + name + " contains hair");
                         material.SetColor(ShaderUtils.BaseColor, hairColor);
+                    }
+                    else
+                        Debug.LogError("! " + name);
                 }
             }
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
@@ -73,17 +73,9 @@ namespace AvatarSystem
                     string name = material.name.ToLower();
 
                     if (name.Contains("skin"))
-                    {
-                        Debug.LogError("> " + name + " contains skin");
                         material.SetColor(ShaderUtils.BaseColor, skinColor);
-                    }
                     else if (name.Contains("hair"))
-                    {
-                        Debug.LogError("> " + name + " contains hair");
                         material.SetColor(ShaderUtils.BaseColor, hairColor);
-                    }
-                    else
-                        Debug.LogError("! " + name);
                 }
             }
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystemUtils.cs
@@ -71,6 +71,7 @@ namespace AvatarSystem
                     // If this is modified, check DecentralandMaterialGenerator.SetMaterialName,
                     // its important for the asset bundles materials to have normalized names but this functionality should work too
                     string name = material.name.ToLower();
+                    Debug.LogError(name); //logging material name as error to see it in the console
 
                     if (name.Contains("skin"))
                         material.SetColor(ShaderUtils.BaseColor, skinColor);

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -54,7 +54,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "75f485918a93247053137aad677521c8ebee1d0b"
+      "hash": "9cf6268270fb9273b51afaaa9b302b21109eae22"
     },
     "com.decentraland.videoplayer": {
       "version": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",


### PR DESCRIPTION
## What does this PR change?

Apparently the overload for `string.Compare(string, StringComparison)` does not work correctly in `WebGL`

## How to test the changes?

All avatars should have their custom skin an hair colors: https://play.decentraland.org/?explorer-branch=fix/white-skin-webgl

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
