### PR TITLE
disabled throw exception on unsuccessfull partialResponse

### DIFF
--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -421,20 +421,24 @@ namespace DCLServices.WearablesCatalogService
                 {
                     if (!partialResponse.taskResponse.success)
                     {
-                        Exception e = new Exception($"The request of the wearables ('{string.Join(", ", partialResponse.wearablesRequested)}') failed!");
-                        sourceToAwait.TrySetException(e);
-                        throw e;
+                        Debug.Log("VV:: partial response - " + partialResponse.taskResponse);
+
+                        // Exception e = new Exception($"The request of the wearables ('{string.Join(", ", partialResponse.wearablesRequested)}') failed!");
+                        // sourceToAwait.TrySetException(e);
+                        // throw e;
                     }
+                    else
+                    {
+                        var response = partialResponse.taskResponse.response;
 
-                    var response = partialResponse.taskResponse.response;
+                        string contentBaseUrl = $"{catalyst.contentUrl}contents/";
 
-                    string contentBaseUrl = $"{catalyst.contentUrl}contents/";
+                        var wearables = response.Select(dto => dto.ToWearableItem(contentBaseUrl, assetBundlesUrl)).ToList();
 
-                    var wearables = response.Select(dto => dto.ToWearableItem(contentBaseUrl, assetBundlesUrl)).ToList();
-
-                    MapLambdasDataIntoWearableItem(wearables);
-                    AddWearablesToCatalog(wearables);
-                    result.AddRange(wearables);
+                        MapLambdasDataIntoWearableItem(wearables);
+                        AddWearablesToCatalog(wearables);
+                        result.AddRange(wearables);
+                    }
                 }
 
                 sourceToAwait.TrySetResult(result);


### PR DESCRIPTION
## What does this PR change?
https://app.zenhub.com/workspaces/workstream-core-tech-63aaac346e1c8d00104586e8/issues/gh/decentraland/unity-renderer/5211
<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

Steps to reproduce:

Log in using two guest or wallet accounts.
On both use the command /world ile.dcl.eth to teleport to the same world.
After loading in observe where the other avatar is located. Notice that it appears as either invisible or a hologram.
On both logins use the /world redeemer.dcl.eth command to teleport with both to another world.
Notice that the other avatar still doesn't appear normally.

/world dclonboarding.dcl.eth
/world mgoldman.dcl.eth
/world ile.dcl.eth
/world redeemer.dcl.eth 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e2090a</samp>

Improved logging and error handling for `LambdasWearablesCatalogService`. Added debug logs and partial failure handling to the class that fetches wearables data from the lambdas service.
