### PR TITLE
fix: friends toggling on when writing in a text box

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -156,7 +156,7 @@ public class InputController : MonoBehaviour
                     break;
                 case DCLAction_Trigger.ToggleFriends:
                     if (!allUIHidden)
-                        InputProcessor.FromKey(action, KeyCode.L, modifiers: InputProcessor.Modifier.None);
+                        InputProcessor.FromKey(action, KeyCode.L, modifiers: InputProcessor.Modifier.FocusNotInInput);
                     break;
                 case DCLAction_Trigger.ToggleWorldChat:
                     if (!allUIHidden)


### PR DESCRIPTION
## What does this PR change?

Fixes the issue with the new genesis plaza. When using text-box in the new SDK7, if we type the letter "L" it opens the friends panel

## How to test the changes?

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
