### PR TITLE
hotfix: catalyst urls not correctly normalized in worlds

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/Catalyst/Catalyst.cs
@@ -17,7 +17,7 @@ public class Catalyst : ICatalyst
     public string lambdasUrl { get; private set; }
 
     private string realmDomain = "https://peer.decentraland.org";
-    private string realmContentServerUrl = "https://peer.decentraland.org/content";
+    private string realmContentServerUrl = "https://peer.decentraland.org/content/";
 
     private readonly IDataCache<CatalystSceneEntityPayload[]> deployedScenesCache = new DataCache<CatalystSceneEntityPayload[]>();
 
@@ -46,12 +46,26 @@ public class Catalyst : ICatalyst
                 realmContentServerUrl = aboutContent.Get().PublicUrl;
         }
 
-        if (!realmContentServerUrl.EndsWith('/'))
-            realmContentServerUrl += "/";
+        NormalizeUrls();
 
         playerRealm.OnChange += PlayerRealmOnChange;
         aboutContent.OnChange += PlayerRealmAboutContentOnChange;
         aboutLambdas.OnChange += PlayerRealmAboutLambdasOnChange;
+    }
+
+    private void NormalizeUrls()
+    {
+        lambdasUrl = GetNormalizedUrl(lambdasUrl);
+        realmContentServerUrl = GetNormalizedUrl(realmContentServerUrl);
+    }
+
+    private string GetNormalizedUrl(string url)
+    {
+        if (string.IsNullOrEmpty(url)) return url;
+        if (!url.EndsWith('/'))
+            url += "/";
+
+        return url;
     }
 
     public void Dispose()
@@ -226,13 +240,18 @@ public class Catalyst : ICatalyst
         realmDomain = current.domain;
         lambdasUrl = $"{realmDomain}/lambdas";
         realmContentServerUrl = current.contentServerUrl;
+        NormalizeUrls();
     }
 
     private void PlayerRealmAboutLambdasOnChange(AboutResponse.Types.LambdasInfo current, AboutResponse.Types.LambdasInfo previous)
     {
         lambdasUrl = current.PublicUrl;
+        NormalizeUrls();
     }
 
-    private void PlayerRealmAboutContentOnChange(AboutResponse.Types.ContentInfo current, AboutResponse.Types.ContentInfo previous) =>
+    private void PlayerRealmAboutContentOnChange(AboutResponse.Types.ContentInfo current, AboutResponse.Types.ContentInfo previous)
+    {
         realmContentServerUrl = current.PublicUrl;
+        NormalizeUrls();
+    }
 }


### PR DESCRIPTION
## What does this PR change?

Fixed issue with URLs not correctly normalized.

## How to test the changes?

https://play.decentraland.org/?explorer-branch=hotfix/2023-06-22&realm=dclonboarding.dcl.eth
Go to `dclonboarding.dcl.eth` and check that your emotes load correctly.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
