### PR TITLE
fix: avoid to load an empty hud when a realm comes with a null name

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/RealmViewer/RealmRowComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/MainMenu/RealmViewer/RealmRowComponentView.cs
@@ -134,6 +134,9 @@ public class RealmRowComponentView : BaseComponentView, IRealmRowComponentView, 
 
     public void SetName(string name)
     {
+        if (string.IsNullOrEmpty(name))
+            name = string.Empty;
+
         model.name = name;
 
         if (nameText == null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/RealmRowComponentViewTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/RealmRowComponentViewTests.cs
@@ -38,17 +38,17 @@ public class RealmRowComponentViewTests
     }
 
     [Test]
-    public void SetNameCorrectly()
+    [TestCase("Test Name")]
+    [TestCase(null)]
+    public void SetNameCorrectly(string realmName)
     {
-        // Arrange
-        string testName = "Test Name";
-
         // Act
-        realmRowComponent.SetName(testName);
+        realmRowComponent.SetName(realmName);
 
         // Assert
-        Assert.AreEqual(testName, realmRowComponent.model.name, "The realm name does not match in the model.");
-        Assert.AreEqual(testName.ToUpper(), realmRowComponent.nameText.text.ToUpper());
+        string nameResult = string.IsNullOrEmpty(realmName) ? string.Empty : realmName;
+        Assert.AreEqual(nameResult, realmRowComponent.model.name, "The realm name does not match in the model.");
+        Assert.AreEqual(nameResult.ToUpper(), realmRowComponent.nameText.text.ToUpper());
     }
 
     [Test]


### PR DESCRIPTION
## What does this PR change?
We make the `RealmViewer` doesn't break in case any of the realms come with its name as null.

## How to test the changes?
1. Launch the explorer.
2. Open the Explore menu.
3. Open the RealmViewer (top left of the screen).
4. Check that all realms are being loaded (even if some of them come with its name as null).

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a141aa</samp>

Fixed a bug that caused invalid realm names to appear in the explore menu. Updated the corresponding unit test to use a parameterized test case.