### PR TITLE
fix: green blockers not appearing when AB-NEW-CDN ff is on

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.asmdef
@@ -7,11 +7,12 @@
         "GUID:ee6523961ef177343ad763fcd55c7c46",
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
         "GUID:8af21c3a612af2645a9953d4b9b3f6d5",
-        "GUID:18ee28afad71091499d9ebad494c995e",
         "GUID:2995626b54c60644988f134a69a77450",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
-        "GUID:2fe81fa47ac9ca345860b544ce917241"
+        "GUID:2fe81fa47ac9ca345860b544ce917241",
+        "GUID:26861d1714ac819459758e0b653efd06",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
@@ -12,6 +12,7 @@ namespace DCL
         public static bool VERBOSE = false;
 
         public string baseUrl;
+        public string baseUrlBundles;
         public string assetBundlesBaseUrl;
         public string assetBundlesVersion;
         public string sceneCid;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/GlobalScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/GlobalScene.cs
@@ -36,6 +36,7 @@ namespace DCL.Controllers
                 baseUrl = data.baseUrl,
                 contents = data.contents,
                 sceneCid = data.id,
+                baseUrlBundles = data.baseUrlBundles,
             };
 
             contentProvider.BakeHashes();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ParcelScene.cs
@@ -94,20 +94,10 @@ namespace DCL.Controllers
                 baseUrl = data.baseUrl,
                 contents = data.contents,
                 sceneCid = data.id,
+                baseUrlBundles = data.baseUrlBundles,
             };
 
             contentProvider.BakeHashes();
-
-            if (featureFlags.IsFeatureEnabled(NEW_CDN_FF))
-            {
-                var sceneAb = await FetchSceneAssetBundles(data.id, data.baseUrlBundles);
-                if (sceneAb.IsSceneConverted())
-                {
-                    contentProvider.assetBundles = sceneAb.GetConvertedFiles();
-                    contentProvider.assetBundlesBaseUrl = sceneAb.GetBaseUrl();
-                    contentProvider.assetBundlesVersion = sceneAb.GetVersion();
-                }
-            }
 
             SetupPositionAndParcels();
 
@@ -117,14 +107,6 @@ namespace DCL.Controllers
             metricsCounter.Enable();
 
             OnSetData?.Invoke(data);
-        }
-
-        private async UniTask<Asset_SceneAB> FetchSceneAssetBundles(string sceneId, string dataBaseUrlBundles)
-        {
-            AssetPromise_SceneAB promiseSceneAb = new AssetPromise_SceneAB(dataBaseUrlBundles, sceneId);
-            AssetPromiseKeeper_SceneAB.i.Keep(promiseSceneAb);
-            await promiseSceneAb.ToUniTask();
-            return promiseSceneAb.asset;
         }
 
         void SetupPositionAndParcels()


### PR DESCRIPTION
## What does this PR change?

Fetching the asset bundles for each scene blocked the flow of the scene loading causing the green blockers to appear very late, causing lots of issues with the avatar clipping through colliders

Fix #5406

## How to test the changes?

Try running through the world.
Issue is present in https://play.decentraland.zone/
Issue should be fixed in https://play.decentraland.zone/?explorer-branch=fix/ab-blockers


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
