### PR TITLE
fix: use comms address instead of the one reported by the profile

### DIFF
--- a/browser-interface/packages/shared/comms/handlers.ts
+++ b/browser-interface/packages/shared/comms/handlers.ts
@@ -237,7 +237,9 @@ function processProfileRequest(message: Package<proto.ProfileRequest>) {
 function processProfileResponse(message: Package<proto.ProfileResponse>) {
   const peerTrackingInfo = setupPeerTrackingInfo(message.address)
 
-  const profile = ensureAvatarCompatibilityFormat(JSON.parse(message.data.serializedProfile))
+  const profileFromComms = JSON.parse(message.data.serializedProfile)
+  profileFromComms.avatars[0].address = message.address
+  const profile = ensureAvatarCompatibilityFormat(profileFromComms)
 
   if (!validateAvatar(profile)) {
     console.trace('Invalid avatar received', validateAvatar.errors)


### PR DESCRIPTION
## How to test the changes?

Check that other players show and render properly.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 257eb01</samp>

Add comms address to profile object in `comms/handlers.ts`. This improves profile identification and validation across the renderer and the comms service.
