### PR TITLE
fix: issues with component pooling

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
@@ -88,6 +88,12 @@ namespace DCL.Components
                 animationShape.OnLoaded -= OnShapeLoaded;
         }
 
+        public override void Cleanup()
+        {
+            base.Cleanup();
+            animComponent = null;
+        }
+
         public override IEnumerator ApplyChanges(BaseModel model)
         {
             entity.OnShapeLoaded -= OnEntityShapeLoaded;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
@@ -212,6 +212,12 @@ namespace DCL.Components
             audioSource = null;
         }
 
+        public override void Cleanup()
+        {
+            base.Cleanup();
+            audioSource = null;
+        }
+
         public void UpdateOutOfBoundariesState(bool isInsideBoundaries)
         {
             if (scene.isPersistent)


### PR DESCRIPTION
## What does this PR change?

Fixed an issue caused by properties not being properly reset after being re-used by pools. 

## How to test the changes?

- Go to Wondermine and wait for the first meteor to fall, it should animate correctly
- Mine the first meteor and wait for the second to fall, it should animate correctly
- Press F5 and start over at least 1 or 2 times since this bug was not deterministic enough to reproduce

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md