### PR TITLE
Revert "fix: use comms address instead of the one reported by the pro…

### DIFF
--- a/browser-interface/packages/shared/comms/handlers.ts
+++ b/browser-interface/packages/shared/comms/handlers.ts
@@ -237,9 +237,7 @@ function processProfileRequest(message: Package<proto.ProfileRequest>) {
 function processProfileResponse(message: Package<proto.ProfileResponse>) {
   const peerTrackingInfo = setupPeerTrackingInfo(message.address)
 
-  const profileFromComms = JSON.parse(message.data.serializedProfile)
-  profileFromComms.avatars[0].address = message.address
-  const profile = ensureAvatarCompatibilityFormat(profileFromComms)
+  const profile = ensureAvatarCompatibilityFormat(JSON.parse(message.data.serializedProfile))
 
   if (!validateAvatar(profile)) {
     console.trace('Invalid avatar received', validateAvatar.errors)


### PR DESCRIPTION
…file (#5411)"

This reverts commit 2f4ec6e537148cdbc2c478066b6a62cc81d8f4b1.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

