### PR TITLE
fix: request profile from unknown peer if profile announcement was missed

### DIFF
--- a/browser-interface/packages/shared/comms/handlers.ts
+++ b/browser-interface/packages/shared/comms/handlers.ts
@@ -54,7 +54,7 @@ export async function bindHandlersToCommsContext(room: RoomConnection) {
   pingRequests.clear()
 
   // RFC4 messages
-  room.events.on('position', processPositionMessage)
+  room.events.on('position', (e) => processPositionMessage(room, e))
   room.events.on('profileMessage', processProfileUpdatedMessage)
   room.events.on('chatMessage', processChatMessage)
   room.events.on('sceneMessageBus', processParcelSceneCommsMessage)
@@ -240,7 +240,7 @@ function processProfileResponse(message: Package<proto.ProfileResponse>) {
   const profile = ensureAvatarCompatibilityFormat(JSON.parse(message.data.serializedProfile))
   profile.userId = message.address
   profile.ethAddress = message.address
-
+  peerTrackingInfo.lastProfileVersion = profile.version
   if (!validateAvatar(profile)) {
     console.trace('Invalid avatar received', validateAvatar.errors)
     debugger
@@ -281,6 +281,12 @@ export function createReceiveProfileOverCommsChannel() {
   })
 }
 
-function processPositionMessage(message: Package<proto.Position>) {
-  receiveUserPosition(message.address, message.data)
+function processPositionMessage(room: RoomConnection, message: Package<proto.Position>) {
+  const peer = receiveUserPosition(message.address, message.data)
+  if (peer?.lastProfileVersion === -1) {
+    room.sendProfileRequest({
+      address: message.address,
+      profileVersion: 0
+    })
+  }
 }

--- a/browser-interface/packages/shared/comms/peers.ts
+++ b/browser-interface/packages/shared/comms/peers.ts
@@ -160,6 +160,7 @@ export function receiveUserPosition(address: string, position: rfc4.Position) {
 
     sendPeerUserData(address)
   }
+  return peer
 }
 
 function avatarUiProfileForUserId(address: string, contentServerBaseUrl: string) {


### PR DESCRIPTION
## What does this PR change?

I saw sometimes you join a world and don't  see people around you, when joining a realm we send a profile announcement message with the version of the profile we are currently using. If for some reason that message is lost, a given peer won't request the profile again although other messages arrive and the original peer will be forever unknown. This is a pragmatic fix, if you get a position message from an unknown peer, request their profile.

## How to test the changes?

There is no specific way to reproduce this issue (specially if this fix actually works), but for QA this should be a basic comms test: go to the same place and you should be able to see people, talk to them, chat with them.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79c7925</samp>

This pull request enhances the profile synchronization feature for users in the same comms room. It modifies `handlers.ts` and `peers.ts` to send and receive profile requests and updates more efficiently.
