### PR TITLE
fix: NRE caused by wearable not converted to AB

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/WearableRetriever.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/WearableRetriever.cs
@@ -56,6 +56,8 @@ namespace AvatarSystem
                             Debug.Log($"<color=red>Wearable AB FAILED -> {mainFile} {wearable.entityId} use this ID to reconvert</color>");
                         }
 #endif
+
+                        contentProvider.assetBundlesFetched = true;
                     }
                 }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -34,6 +34,9 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
 
         private string GetEntityIdFromSceneId(string sceneId)
         {
+            if (sceneId == null)
+                return null;
+
             // This case happens when loading worlds
             if (sceneId.StartsWith(URN_PREFIX))
             {
@@ -64,6 +67,12 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
             };
 
             if (string.IsNullOrEmpty(contentUrl))
+            {
+                onSuccess();
+                return;
+            }
+
+            if (string.IsNullOrEmpty(hash))
             {
                 onSuccess();
                 return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -155,7 +155,10 @@ namespace DCL.Components
                 return;
             }
 
-            if (featureFlags.IsFeatureEnabled(NEW_CDN_FF)) { FetchAssetBundlesManifest(OnSuccess, OnFail, hasFallback, hash); }
+            if (featureFlags.IsFeatureEnabled(NEW_CDN_FF))
+            {
+                FetchAssetBundlesManifest(OnSuccess, OnFail, hasFallback, hash);
+            }
             else
             {
                 string bundlesBaseUrl = useCustomContentServerUrl ? customContentServerUrl : bundlesContentUrl;
@@ -176,8 +179,13 @@ namespace DCL.Components
                 LoadAssetBundles(onSuccess, onFail, hasFallback, contentProvider.assetBundlesBaseUrl, hash);
             else
             {
-                sceneABPromise = new AssetPromise_SceneAB(contentProvider.baseUrlBundles, contentProvider.sceneCid);
+                if (contentProvider.assetBundlesFetched)
+                {
+                    OnFailWrapper(onFail, new Exception("Asset not converted to asset bundles"), hasFallback);
+                    return;
+                }
 
+                sceneABPromise = new AssetPromise_SceneAB(contentProvider.baseUrlBundles, contentProvider.sceneCid);
                 sceneABPromise.OnSuccessEvent += ab =>
                 {
                     if (ab.IsSceneConverted())
@@ -188,6 +196,8 @@ namespace DCL.Components
                         LoadAssetBundles(onSuccess, onFail, hasFallback, contentProvider.assetBundlesBaseUrl, hash);
                     }
                     else { OnFailWrapper(onFail, new Exception("Asset not converted to asset bundles"), hasFallback); }
+
+                    contentProvider.assetBundlesFetched = true;
                 };
 
                 sceneABPromise.OnFailEvent += (_, exception) => { OnFailWrapper(onFail, exception, hasFallback); };

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
@@ -20,6 +20,7 @@ namespace DCL
         public List<MappingPair> contents = new ();
         public Dictionary<string, string> fileToHash = new ();
         public HashSet<string> assetBundles = new ();
+        public bool assetBundlesFetched;
 
         public override string ToString()
         {


### PR DESCRIPTION
## What does this PR change?

Fix #5427

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6257d7</samp>

This pull request enhances the asset bundle loading system by adding null checks, avoiding redundant requests, and handling edge cases. It affects the classes `AssetPromise_SceneAB`, `RendereableAssetLoadHelper`, `WearableRetriever`, and `ContentProvider`.
