### PR TITLE
hotfix: remove pooling from Animator and AudioSources

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/CoreComponentsPlugin/Resources/PoolableCoreComponentsFactory.asset
+++ b/unity-renderer/Assets/DCLPlugins/CoreComponentsPlugin/Resources/PoolableCoreComponentsFactory.asset
@@ -21,12 +21,12 @@ MonoBehaviour:
   - classId: 33
     prefab: {fileID: 1438135810206001881, guid: d3a11958c03a6e2468f8173c6f80b0c1,
       type: 3}
-    usePool: 1
+    usePool: 0
     prewarmCount: 170
   - classId: 201
     prefab: {fileID: 5455216942449862864, guid: 8cf47145b31d0fe4db23561457579fab,
       type: 3}
-    usePool: 1
+    usePool: 0
     prewarmCount: 220
   - classId: 21
     prefab: {fileID: 6259529893562660078, guid: a374a32b18d38b94081521e49705cf74,


### PR DESCRIPTION
## What does this PR change?
Closes #5428
Fix NRE's
https://decentraland.sentry.io/issues/4292646944/?project=4504361738698752&query=is%3Aunresolved&referrer=issue-stream&stream_index=1
https://decentraland.sentry.io/issues/4291193790/?project=4504361738698752&query=is%3Aunresolved&referrer=issue-stream&stream_index=3

- removed Animator and AudioSources from using the pool

It will introduce small degradation in performance (mainly because of removing Animator's pooling)

![image](https://github.com/decentraland/unity-renderer/assets/35366872/5383103c-35c5-42a0-8807-ed6d51276a4a)


## How to test the changes?

1. Launch the explorer
2. ......


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d17c26a</samp>

Disabled object pooling for some core components that caused bugs. Modified `PoolableCoreComponentsFactory.asset` to reflect this change.
