### PR TITLE
Hotfix: emotes and audiosource null refs

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/CoreComponentsPlugin/Resources/PoolableCoreComponentsFactory.asset
+++ b/unity-renderer/Assets/DCLPlugins/CoreComponentsPlugin/Resources/PoolableCoreComponentsFactory.asset
@@ -21,12 +21,12 @@ MonoBehaviour:
   - classId: 33
     prefab: {fileID: 1438135810206001881, guid: d3a11958c03a6e2468f8173c6f80b0c1,
       type: 3}
-    usePool: 1
+    usePool: 0
     prewarmCount: 170
   - classId: 201
     prefab: {fileID: 5455216942449862864, guid: 8cf47145b31d0fe4db23561457579fab,
       type: 3}
-    usePool: 1
+    usePool: 0
     prewarmCount: 220
   - classId: 21
     prefab: {fileID: 6259529893562660078, guid: a374a32b18d38b94081521e49705cf74,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/WearableRetriever.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Loader/WearableRetriever.cs
@@ -56,6 +56,8 @@ namespace AvatarSystem
                             Debug.Log($"<color=red>Wearable AB FAILED -> {mainFile} {wearable.entityId} use this ID to reconvert</color>");
                         }
 #endif
+
+                        contentProvider.assetBundlesFetched = true;
                     }
                 }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/SceneAB/AssetPromise_SceneAB.cs
@@ -34,6 +34,9 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
 
         private string GetEntityIdFromSceneId(string sceneId)
         {
+            if (sceneId == null)
+                return null;
+
             // This case happens when loading worlds
             if (sceneId.StartsWith(URN_PREFIX))
             {
@@ -64,6 +67,12 @@ namespace MainScripts.DCL.Controllers.AssetManager.AssetBundles.SceneAB
             };
 
             if (string.IsNullOrEmpty(contentUrl))
+            {
+                onSuccess();
+                return;
+            }
+
+            if (string.IsNullOrEmpty(hash))
             {
                 onSuccess();
                 return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/RendereableAssetLoadHelper/RendereableAssetLoadHelper.cs
@@ -155,7 +155,10 @@ namespace DCL.Components
                 return;
             }
 
-            if (featureFlags.IsFeatureEnabled(NEW_CDN_FF)) { FetchAssetBundlesManifest(OnSuccess, OnFail, hasFallback, hash); }
+            if (featureFlags.IsFeatureEnabled(NEW_CDN_FF))
+            {
+                FetchAssetBundlesManifest(OnSuccess, OnFail, hasFallback, hash);
+            }
             else
             {
                 string bundlesBaseUrl = useCustomContentServerUrl ? customContentServerUrl : bundlesContentUrl;
@@ -176,8 +179,13 @@ namespace DCL.Components
                 LoadAssetBundles(onSuccess, onFail, hasFallback, contentProvider.assetBundlesBaseUrl, hash);
             else
             {
-                sceneABPromise = new AssetPromise_SceneAB(contentProvider.baseUrlBundles, contentProvider.sceneCid);
+                if (contentProvider.assetBundlesFetched)
+                {
+                    OnFailWrapper(onFail, new Exception("Asset not converted to asset bundles"), hasFallback);
+                    return;
+                }
 
+                sceneABPromise = new AssetPromise_SceneAB(contentProvider.baseUrlBundles, contentProvider.sceneCid);
                 sceneABPromise.OnSuccessEvent += ab =>
                 {
                     if (ab.IsSceneConverted())
@@ -188,6 +196,8 @@ namespace DCL.Components
                         LoadAssetBundles(onSuccess, onFail, hasFallback, contentProvider.assetBundlesBaseUrl, hash);
                     }
                     else { OnFailWrapper(onFail, new Exception("Asset not converted to asset bundles"), hasFallback); }
+
+                    contentProvider.assetBundlesFetched = true;
                 };
 
                 sceneABPromise.OnFailEvent += (_, exception) => { OnFailWrapper(onFail, exception, hasFallback); };

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ContentProvider/ContentProvider.cs
@@ -20,6 +20,7 @@ namespace DCL
         public List<MappingPair> contents = new ();
         public Dictionary<string, string> fileToHash = new ();
         public HashSet<string> assetBundles = new ();
+        public bool assetBundlesFetched;
 
         public override string ToString()
         {


### PR DESCRIPTION
## What does this PR change?
- fix 2 null ref exceptions

## How to test the changes?

1. Launch the explorer
2. Go to Ice Poker and check that UI is showing up. 
3. Go to wondermine and check that animation of asteroid works fine
4. Also check console for both cases that NullReferenceException should not be present there

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
