### PR TITLE
fix: scene frozen with many users connected

### DIFF
--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -367,7 +367,7 @@ export class SceneWorker {
           this.rpcContext.rpcSceneControllerService.sendBatch({ payload: event.data.bytes }).catch((err) => {
             this.logger.error('Error sending binary actions from Worker to Renderer', err)
           })
-        } else {
+        } else if (event.data.bytes.length > 0) {
           console.log(`[SANTI DEBUG] sdk6BinaryMessage => sceneNumber: ${this.rpcContext.sceneData.sceneNumber} | length: ${event.data.bytes.length}`)
           nativeMsgBridge.sdk6BinaryMessage(
             this.rpcContext.sceneData.sceneNumber,

--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -367,6 +367,7 @@ export class SceneWorker {
             this.logger.error('Error sending binary actions from Worker to Renderer', err)
           })
         } else {
+          this.logger.log(`[SANTI DEBUG] sdk6BinaryMessage => sceneNumber: ${this.rpcContext.sceneData.sceneNumber} | length: ${event.data.bytes.length} bytes`)
           nativeMsgBridge.sdk6BinaryMessage(
             this.rpcContext.sceneData.sceneNumber,
             event.data.bytes,

--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -358,9 +358,9 @@ export class SceneWorker {
     this.ready |= SceneWorkerReadyState.LOADED
 
     worker.addEventListener('message', (event) => {
-      console.log('[SANTI DEBUG] New message...')
       if (event.data?.type === 'actions') {
         if (event.data.bytes?.length > 50e3) {
+          console.log(`[SANTI LOG] Message too long: ${event.data.bytes?.length} bytes`)
           this.logger.log(`Received actions > 50k: ${event.data.bytes?.length} bytes`)
         }
         if (WSS_ENABLED || FORCE_SEND_MESSAGE) {
@@ -368,9 +368,7 @@ export class SceneWorker {
             this.logger.error('Error sending binary actions from Worker to Renderer', err)
           })
         } else {
-          console.log('[SANTI DEBUG] sdk6BinaryMessage => sceneNumber: ' + this.rpcContext.sceneData.sceneNumber)
-          console.log('[SANTI DEBUG] sdk6BinaryMessage => length: ' + event.data.bytes.length)
-          this.logger.log(`[SANTI DEBUG] sdk6BinaryMessage => sceneNumber: ${this.rpcContext.sceneData.sceneNumber} | length: ${event.data.bytes.length} bytes`)
+          console.log(`[SANTI DEBUG] sdk6BinaryMessage => sceneNumber: ${this.rpcContext.sceneData.sceneNumber} | length: ${event.data.bytes.length}`)
           nativeMsgBridge.sdk6BinaryMessage(
             this.rpcContext.sceneData.sceneNumber,
             event.data.bytes,

--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -360,15 +360,14 @@ export class SceneWorker {
     worker.addEventListener('message', (event) => {
       if (event.data?.type === 'actions') {
         if (event.data.bytes?.length > 50e3) {
-          this.logger.log(`[SANTI LOG] Message too long: ${event.data.bytes?.length} bytes`)
           this.logger.log(`Received actions > 50k: ${event.data.bytes?.length} bytes`)
+          return
         }
         if (WSS_ENABLED || FORCE_SEND_MESSAGE) {
           this.rpcContext.rpcSceneControllerService.sendBatch({ payload: event.data.bytes }).catch((err) => {
             this.logger.error('Error sending binary actions from Worker to Renderer', err)
           })
         } else if (event.data.bytes.length > 0) {
-          this.logger.log(`[SANTI LOG] sdk6BinaryMessage => sceneNumber: ${this.rpcContext.sceneData.sceneNumber} | length: ${event.data.bytes.length}`)
           nativeMsgBridge.sdk6BinaryMessage(
             this.rpcContext.sceneData.sceneNumber,
             event.data.bytes,

--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -360,7 +360,7 @@ export class SceneWorker {
     worker.addEventListener('message', (event) => {
       if (event.data?.type === 'actions') {
         if (event.data.bytes?.length > 50e3) {
-          console.log(`[SANTI LOG] Message too long: ${event.data.bytes?.length} bytes`)
+          this.logger.log(`[SANTI LOG] Message too long: ${event.data.bytes?.length} bytes`)
           this.logger.log(`Received actions > 50k: ${event.data.bytes?.length} bytes`)
         }
         if (WSS_ENABLED || FORCE_SEND_MESSAGE) {
@@ -368,7 +368,7 @@ export class SceneWorker {
             this.logger.error('Error sending binary actions from Worker to Renderer', err)
           })
         } else if (event.data.bytes.length > 0) {
-          console.log(`[SANTI DEBUG] sdk6BinaryMessage => sceneNumber: ${this.rpcContext.sceneData.sceneNumber} | length: ${event.data.bytes.length}`)
+          this.logger.log(`[SANTI LOG] sdk6BinaryMessage => sceneNumber: ${this.rpcContext.sceneData.sceneNumber} | length: ${event.data.bytes.length}`)
           nativeMsgBridge.sdk6BinaryMessage(
             this.rpcContext.sceneData.sceneNumber,
             event.data.bytes,

--- a/browser-interface/packages/shared/world/SceneWorker.ts
+++ b/browser-interface/packages/shared/world/SceneWorker.ts
@@ -358,6 +358,7 @@ export class SceneWorker {
     this.ready |= SceneWorkerReadyState.LOADED
 
     worker.addEventListener('message', (event) => {
+      console.log('[SANTI DEBUG] New message...')
       if (event.data?.type === 'actions') {
         if (event.data.bytes?.length > 50e3) {
           this.logger.log(`Received actions > 50k: ${event.data.bytes?.length} bytes`)
@@ -367,6 +368,8 @@ export class SceneWorker {
             this.logger.error('Error sending binary actions from Worker to Renderer', err)
           })
         } else {
+          console.log('[SANTI DEBUG] sdk6BinaryMessage => sceneNumber: ' + this.rpcContext.sceneData.sceneNumber)
+          console.log('[SANTI DEBUG] sdk6BinaryMessage => length: ' + event.data.bytes.length)
           this.logger.log(`[SANTI DEBUG] sdk6BinaryMessage => sceneNumber: ${this.rpcContext.sceneData.sceneNumber} | length: ${event.data.bytes.length} bytes`)
           nativeMsgBridge.sdk6BinaryMessage(
             this.rpcContext.sceneData.sceneNumber,


### PR DESCRIPTION
## What does this PR change?
The following screen freezes after a few users are connected at the same time and playing: https://play.decentraland.org/?realm=https%3A%2F%2Fworlds.dcl.guru%2Fworld%2Frooland.dcl.eth

It also happens if they deploy to Genesis instead of a world. 

![image.png](https://images.zenhubusercontent.com/5d91ff0b2836200001244acf/7302d493-f857-4345-92b3-cfd11bcdd2f0)[https://app.zenhub.com/files/337227404/f71861a6-44f0-47e0-befb-d8c6265b52bc/download](https://app.zenhub.com/files/337227404/f71861a6-44f0-47e0-befb-d8c6265b52bc/download)

## How to test the changes?
https://play.decentraland.org/?explorer-branch=fix/scene-frozen-with-many-users-connected/&realm=https%3A%2F%2Fworlds.dcl.guru%2Fworld%2Frooland.dcl.eth&DEBUG_SCENE_LOG

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 772f4da</samp>

Added a log message to `SceneWorker` to track binary messages from the SDK. This is part of the optimization effort for bandwidth usage in the renderer.