### PR TITLE
fix: the metric for outfits saving is not being sent

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Outfits/IOutfitsSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Outfits/IOutfitsSectionComponentView.cs
@@ -8,7 +8,6 @@ namespace DCL.Backpack
     {
         event Action<OutfitItem> OnOutfitEquipped;
         event Action<int> OnOutfitDiscarded;
-        event Action<OutfitItem> OnOutfitSaved;
         event Action<int> OnOutfitLocalSave;
         event Action OnTrySaveAsGuest;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Outfits/OutfitsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Outfits/OutfitsController.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using UnityEngine;
 
 namespace DCL.Backpack
 {
@@ -39,7 +38,6 @@ namespace DCL.Backpack
 
             view.OnOutfitEquipped += OutfitEquip;
             view.OnOutfitDiscarded += DiscardOutfit;
-            view.OnOutfitSaved += SaveOutfit;
             view.OnTrySaveAsGuest += ShowGuestModal;
             view.OnOutfitLocalSave += SaveOutfitLocally;
 
@@ -76,13 +74,12 @@ namespace DCL.Backpack
             localOutfits[outfitIndex] = outfitItem;
             view.ShowOutfit(outfitItem, GenerateAvatarModel(outfitItem), ctsShowOutfit.Token).Forget();
             shouldDeploy = true;
+
+            backpackAnalyticsService.SendOutfitSave(outfitIndex);
         }
 
         private void ShowGuestModal() =>
             dataStore.HUDs.connectWalletModalVisible.Set(true);
-
-        private void SaveOutfit(OutfitItem outfit) =>
-            backpackAnalyticsService.SendOutfitSave(outfit.slot);
 
         private void DiscardOutfit(int outfitIndex)
         {
@@ -149,7 +146,6 @@ namespace DCL.Backpack
             ctsShowOutfit = null;
             view.OnOutfitEquipped -= OutfitEquip;
             view.OnOutfitDiscarded -= DiscardOutfit;
-            view.OnOutfitSaved -= SaveOutfit;
             view.OnTrySaveAsGuest -= ShowGuestModal;
 
             dataStore.HUDs.avatarEditorVisible.OnChange -= ChangedVisibility;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Outfits/OutfitsSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Outfits/OutfitsSectionComponentView.cs
@@ -1,10 +1,7 @@
 using Cysharp.Threading.Tasks;
-using DCL;
 using DG.Tweening;
 using MainScripts.DCL.Controllers.HUD.CharacterPreview;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.UI;
@@ -27,7 +24,6 @@ namespace DCL.Backpack
         public event Action OnBackButtonPressed;
         public event Action<OutfitItem> OnOutfitEquipped;
         public event Action<int> OnOutfitDiscarded;
-        public event Action<OutfitItem> OnOutfitSaved;
         public event Action<int> OnOutfitLocalSave;
         public event Action OnTrySaveAsGuest;
 


### PR DESCRIPTION
## What does this PR change?
Fix #5445 

The metric `outfit_save` that we should send when we save an outfit was not being sent.

## How to test the changes?
1. Launch the explorer.
2. Go to the Outfits section.
3. Save one or more outfits.
4. Check the metric `outfit_save` was sent to Metabase (it could take several minutes).

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1daa309</samp>

Refactored `OutfitsController` and `OutfitsSectionComponentView` classes to remove unused code and add analytics for outfit saving. Removed `OnOutfitSaved` event from `IOutfitsSectionComponentView` interface.