### PR TITLE
fix: the passport content is wrongly placed the first time we open the hud

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentView.cs
@@ -1,3 +1,4 @@
+using DCL.Helpers;
 using DCLServices.Lambdas.LandsService;
 using DCLServices.Lambdas.NamesService;
 using System;
@@ -34,6 +35,7 @@ namespace DCL.Social.Passports
         private const int PAGE_SIZE = 4;
 
         [SerializeField] private GameObject aboutPanel;
+        [SerializeField] private RectTransform aboutContainerTransform;
         [SerializeField] private GameObject wearablesPanel;
         [SerializeField] private Toggle aboutToggle;
         [SerializeField] private Toggle collectiblesToggle;
@@ -350,6 +352,8 @@ namespace DCL.Social.Passports
                     equippedNftWearableViews.Add(nftIconComponentView);
                 }
             }
+
+            Utils.ForceRebuildLayoutImmediate(aboutContainerTransform);
         }
 
         public void SetCollectibleWearables(WearableItem[] wearables)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Resources/PlayerPassport.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Resources/PlayerPassport.prefab
@@ -961,6 +961,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   showHideAnimator: {fileID: 0}
   aboutPanel: {fileID: 2382736849560994066}
+  aboutContainerTransform: {fileID: 678770521573999315}
   wearablesPanel: {fileID: 7713033100312123324}
   aboutToggle: {fileID: 3873247503335729505}
   collectiblesToggle: {fileID: 1669034797117624556}


### PR DESCRIPTION
## What does this PR change?
Fix #5450 

The first time we open the passport of some users, we saw the equiped wearables grid superimposed on the above information.

![image.png](https://images.zenhubusercontent.com/5eb2b8ca65c88f6e391ef16e/16f78b4c-ed87-458f-89bd-d64e89c19071)

## How to test the changes?
1. Launch the explorer
2. Open the passport of several users (from your list of friends or directly from someone in the world).
3. Check that, after the HUD is open, all the information (about info + equipped wearables grid) are correctly placed.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b55a4a4</samp>

Added a field and a method to improve the layout of the passport UI's about section. Modified the `PlayerPassport.prefab` file to assign the field to the correct rect transform.