### PR TITLE
fix: we cannot add links containing "@" in my profile

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyProfileComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyProfileComponentView.cs
@@ -6,6 +6,7 @@ using UIComponents.CollapsableSortedList;
 using UIComponents.Scripts.Components;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.Networking;
 using UnityEngine.UI;
 
 namespace DCL.MyAccount
@@ -152,7 +153,7 @@ namespace DCL.MyAccount
             };
             linkListView.OnRemoved += tuple =>
             {
-                OnLinkRemoved?.Invoke((tuple.title, tuple.url));
+                OnLinkRemoved?.Invoke((tuple.title, UnityWebRequest.EscapeURL(tuple.url)));
                 Utils.ForceRebuildLayoutImmediate(linksContainerTransform);
             };
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyProfileLinkListComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyProfileLinkListComponentView.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Networking;
 using UnityEngine.UI;
 
 namespace DCL.MyAccount
@@ -16,7 +17,8 @@ namespace DCL.MyAccount
         [SerializeField] private RectTransform linksContainer;
 
         private readonly List<MyProfileLinkComponentView> links = new ();
-        private readonly Regex httpRegex = new ("^((https?:)?\\/\\/)?([\\da-z.-]+)\\.([a-z.]{2,6})([\\/\\w .%()\\-]*)*\\/?$");
+        private readonly Regex httpRegex = new ("^((https?:)?\\/\\/)?([\\da-z.-]+)\\.([a-z.]{2,6})([\\/\\w .%@()\\-]*)*\\/?$");
+
         private bool isAddEnabled = true;
 
         public event Action<(string title, string url)> OnAddedNew;
@@ -30,7 +32,9 @@ namespace DCL.MyAccount
                     && !newLinkUrl.text.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
                     newLinkUrl.text = $"https://{newLinkUrl.text}";
 
-                OnAddedNew?.Invoke((title: newLinkTitle.text, url: newLinkUrl.text));
+                OnAddedNew?.Invoke((
+                    title: newLinkTitle.text,
+                    url: newLinkUrl.text.Replace("@", UnityWebRequest.EscapeURL("@"))));
             });
 
             newLinkTitle.onValueChanged.AddListener(str => EnableOrDisableAddButton());

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyProfileLinkListComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyProfileLinkListComponentView.cs
@@ -34,7 +34,7 @@ namespace DCL.MyAccount
 
                 OnAddedNew?.Invoke((
                     title: newLinkTitle.text,
-                    url: newLinkUrl.text.Replace("@", UnityWebRequest.EscapeURL("@"))));
+                    url: UnityWebRequest.EscapeURL(newLinkUrl.text)));
             });
 
             newLinkTitle.onValueChanged.AddListener(str => EnableOrDisableAddButton());
@@ -46,7 +46,7 @@ namespace DCL.MyAccount
         public void Add(string title, string url)
         {
             MyProfileLinkComponentView linkComponent = Instantiate(linkPrefab, linksContainer);
-            linkComponent.Set(title, url);
+            linkComponent.Set(title, UnityWebRequest.UnEscapeURL(url));
             linkComponent.OnRemoved += OnRemoved;
             links.Add(linkComponent);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentView.cs
@@ -8,6 +8,7 @@ using TMPro;
 using UIComponents.Scripts.Utils;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.Networking;
 using UnityEngine.UI;
 
 namespace DCL.Social.Passports
@@ -309,7 +310,7 @@ namespace DCL.Social.Passports
 
         private void ClickedLink(string obj)
         {
-            openUrlView.SetUrlInfo(obj, obj);
+            openUrlView.SetUrlInfo(UnityWebRequest.UnEscapeURL(obj), obj);
             openUrlView.SetVisibility(true);
             OnClickedLink?.Invoke();
         }


### PR DESCRIPTION
## What does this PR change?
Fix #5446 

The validation that we had for links didn't allow to add "@", and some social medias have such urls.

![image.png](https://images.zenhubusercontent.com/5eb2b8ca65c88f6e391ef16e/5130c4b7-5fdc-478c-9d3a-41c301dee30f)

## How to test the changes?
1. Launch the explorer.
2. Open the Explore menu.
3. Click on the ProfileHUD (top right of the screen).
4. Click on ACCOUNT SETTNIGS.
5. Try to add several links like in the screenshot above.
6. Go to your Passport and check that we can open these links.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffee644</samp>

Added email support and improved URL handling in `MyProfileLinkListComponentView.cs`, a script that manages the profile links in the My Account HUD.