### PR TITLE
fix: wrong buy url for nfts

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerPassportHUDController.cs
@@ -12,7 +12,7 @@ namespace DCL.Social.Passports
     {
         private const string URL_COLLECTIBLE_NAME = "https://market.decentraland.org/accounts/{userId}?section=ens";
         private const string URL_COLLECTIBLE_LAND = "https://market.decentraland.org/accounts/{userId}?section=land";
-        private const string URL_BUY_SPECIFIC_COLLECTIBLE = "https://market.decentraland.org/contracts/{collectionId}/tokens/{tokenId}?utm_source=dcl_explorer";
+        private const string URL_BUY_SPECIFIC_COLLECTIBLE = "https://market.decentraland.org/contracts/{collectionId}/items/{blockchainId}?utm_source=dcl_explorer";
         private const string URL_COLLECTIBLE_GENERIC = "https://market.decentraland.org?utm_source=dcl_explorer";
         private const string NAME_TYPE = "name";
         private const string PARCEL_TYPE = "parcel";
@@ -220,7 +220,7 @@ namespace DCL.Social.Passports
 
         private void OpenNftMarketUrl(Nft nft)
         {
-            passportApiBridge.OpenURL(URL_BUY_SPECIFIC_COLLECTIBLE.Replace("{collectionId}", nft.collectionId).Replace("{tokenId}", nft.tokenId));
+            passportApiBridge.OpenURL(URL_BUY_SPECIFIC_COLLECTIBLE.Replace("{collectionId}", nft.collectionId).Replace("{blockchainId}", nft.blockchainId));
             //TODO: integrate ItemType itemType once new lambdas are active
             socialAnalytics.SendNftBuy(PlayerActionSource.Passport);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/Interfaces/Nft/NftTypes.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/Interfaces/Nft/NftTypes.cs
@@ -11,6 +11,7 @@ public class Nft
     public string collectionId;
     public string tokenId;
     public string urn;
+    public string blockchainId;
 }
 
 [Serializable]
@@ -29,6 +30,7 @@ internal class NftQueryResult
 internal class NftData
 {
     public NftCollectionData collection;
+    public NftItemData item;
     public string tokenId;
     public string urn;
 }
@@ -37,4 +39,10 @@ internal class NftData
 internal class NftCollectionData
 {
     public string id;
+}
+
+[Serializable]
+internal class NftItemData
+{
+    public string blockchainId;
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraph.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraph.cs
@@ -213,8 +213,9 @@ public class TheGraph : ITheGraph
                 nfts.Add(new Nft
                 {
                     collectionId = nft.collection.id,
+                    blockchainId =  nft.item.blockchainId,
                     tokenId = nft.tokenId,
-                    urn = nft.urn
+                    urn = nft.urn,
                 });
             }
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraphQueries.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/TheGraph/TheGraphQueries.cs
@@ -90,6 +90,9 @@ public static class TheGraphQueries
             collection {
                 id
             }
+            item {
+                blockchainId
+            }
             tokenId
         }
     }
@@ -101,6 +104,9 @@ public static class TheGraphQueries
             urn,
             collection {
                 id
+            }
+            item {
+                blockchainId
             }
             tokenId
         }


### PR DESCRIPTION
## What does this PR change?
Fix #5448 

When we clicked on the BUY button of an NFT inside an user's passport we were redirecting to the [OWNER's NFT detail page](https://market.decentraland.org/contracts/0xcbd17d94f5be12fff27566c23888d6936b8e70b8/tokens/631873750011343120187508166102022593913370572403294667525865865243?assetType=nft&section=all&vendor=decentraland&page=1&sortBy=newest) that didn't include an option to buy:

![image](https://github.com/decentraland/unity-renderer/assets/64659061/367519d6-d100-446e-9d2e-590e70dcdc85)

But now it's redirecting to the [CREATOR's NFT detail page](https://market.decentraland.org/contracts/0xcbd17d94f5be12fff27566c23888d6936b8e70b8/items/6) that groups all the buying options:

![image](https://github.com/decentraland/unity-renderer/assets/64659061/b8e43771-9820-496c-9cc9-80ceba8e01d7)

## How to test the changes?
1. Launch the explorer.
2. Open the passport of any user.
3. Put your mouse over any of his wearables.
4. Click on BUY and notice the destination url is the new one described above.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a353dd</samp>

This pull request updates the logic and data structures for handling NFTs in the passport HUD and the TheGraph service to support the new ERC1155 standard. It replaces `tokenId` with `blockchainId` and adds new fields and classes to the Nft types.