### PR TITLE
fix: empty world shown after pressing "i" key during new character creation

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Shortcuts/ShortcutsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Shortcuts/ShortcutsController.cs
@@ -54,13 +54,13 @@ public class ShortcutsController : IDisposable
     }
 
     private void ToggleControlsTriggered(DCLAction_Trigger action) { DataStore.i.HUDs.controlsVisible.Set(!DataStore.i.HUDs.controlsVisible.Get()); }
-    
-    private void ToggleAvatarEditorTriggered(DCLAction_Trigger action) 
+
+    private void ToggleAvatarEditorTriggered(DCLAction_Trigger action)
     {
-        if (!DataStore.i.HUDs.isAvatarEditorInitialized.Get())
+        if (!DataStore.i.HUDs.isAvatarEditorInitialized.Get() || DataStore.i.common.isSignUpFlow.Get())
             return;
 
-        DataStore.i.HUDs.avatarEditorVisible.Set(!DataStore.i.HUDs.avatarEditorVisible.Get()); 
+        DataStore.i.HUDs.avatarEditorVisible.Set(!DataStore.i.HUDs.avatarEditorVisible.Get());
     }
 
     private void ToggleAvatarNamesTriggered(DCLAction_Trigger action) { DataStore.i.HUDs.avatarNamesVisible.Set(!DataStore.i.HUDs.avatarNamesVisible.Get()); }
@@ -91,12 +91,12 @@ public class ShortcutsController : IDisposable
         }
     }
 
-    private void ToggleNavMapTriggered(DCLAction_Trigger action) 
+    private void ToggleNavMapTriggered(DCLAction_Trigger action)
     {
         if (!DataStore.i.HUDs.isNavMapInitialized.Get())
             return;
 
-        DataStore.i.HUDs.navmapVisible.Set(!DataStore.i.HUDs.navmapVisible.Get()); 
+        DataStore.i.HUDs.navmapVisible.Set(!DataStore.i.HUDs.navmapVisible.Get());
     }
 
     private void TogglePlacesAndEventsTriggered(DCLAction_Trigger action)
@@ -112,7 +112,7 @@ public class ShortcutsController : IDisposable
     public void Dispose() { Unsubscribe(); }
 
     // In the future the analytics will be received through DI in the shape of a service locator,
-    // so we can remove these methods and mock the locator itself    
+    // so we can remove these methods and mock the locator itself
     internal virtual void SendQuestToggledAnalytic(bool value) { QuestsUIAnalytics.SendQuestLogVisibiltyChanged(value, "input_action"); }
     internal virtual void SendExploreToggledAnalytics(bool value) { new ExploreV2Analytics.ExploreV2Analytics().SendStartMenuVisibility(value, ExploreUIVisibilityMethod.FromShortcut); }
 


### PR DESCRIPTION
## What does this PR change?
Fix #5362 

During new character creation flow, while we were in the wearable choice menu, if we pressed the `I` key, it closed the menu and showed the default avatar in an empty world.

![image](https://github.com/decentraland/unity-renderer/assets/64659061/ed4f5146-b720-4ab5-b599-b1cc0897a761)

## How to test the changes?
1. Launch the explorer in the SignUp flow.
2. When you are in the backpack step, try to press `I` to close the backpack.
3. Notice it's imposible to close it during all the SignUp process.
4. Once you have passed the SignUp process, you should be able to open/close the backpack as usual.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30067d3</samp>

Fix avatar editor toggle bug and refactor `ShortcutsController` code style.