### PR TITLE
fix: mentions are not always working correctly

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -38,7 +38,6 @@ namespace DCL.Chat.HUD
         [SerializeField] private MentionLinkDetector mentionLinkDetector;
         [SerializeField] private Color autoMentionBackgroundColor;
         [SerializeField] private Image backgroundImage;
-        [SerializeField] internal UserProfile ownUserProfile;
 
         private float hoverPanelTimer;
         private float hoverGotoPanelTimer;
@@ -262,7 +261,7 @@ namespace DCL.Chat.HUD
             populationTaskCancellationTokenSource.Cancel();
 
             if (mentionLinkDetector != null)
-                mentionLinkDetector.OnOwnPlayerMentioned -= OnOwnPlayerMentioned;
+                mentionLinkDetector.OnPlayerMentioned -= OnPlayerMentioned;
         }
 
         public override void SetFadeout(bool enabled)
@@ -289,8 +288,8 @@ namespace DCL.Chat.HUD
                 return;
 
             mentionLinkDetector.SetContextMenu(userContextMenu);
-            mentionLinkDetector.OnOwnPlayerMentioned -= OnOwnPlayerMentioned;
-            mentionLinkDetector.OnOwnPlayerMentioned += OnOwnPlayerMentioned;
+            mentionLinkDetector.OnPlayerMentioned -= OnPlayerMentioned;
+            mentionLinkDetector.OnPlayerMentioned += OnPlayerMentioned;
         }
 
         private void Update()
@@ -359,10 +358,9 @@ namespace DCL.Chat.HUD
             return text.Replace("\t", "    ");
         }
 
-        private void OnOwnPlayerMentioned()
+        private void OnPlayerMentioned()
         {
-            if (model.subType != ChatEntryModel.SubType.RECEIVED ||
-                model.senderId == ownUserProfile.userId)
+            if (!MentionsUtils.IsUserMentionedInText(UserProfile.GetOwnUserProfile().userName, model.bodyText))
                 return;
 
             backgroundImage.color = autoMentionBackgroundColor;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -285,8 +285,6 @@ namespace DCL.Chat.HUD
 
         public override void ConfigureMentionLinkDetector(UserContextMenu userContextMenu)
         {
-            backgroundImage.color = initialEntryColor;
-
             if (mentionLinkDetector == null)
                 return;
 
@@ -366,7 +364,7 @@ namespace DCL.Chat.HUD
             if (model.senderId == ownUserProfile.userId)
                 return;
 
-            backgroundImage.color = autoMentionBackgroundColor;
+            //backgroundImage.color = autoMentionBackgroundColor;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -285,6 +285,8 @@ namespace DCL.Chat.HUD
 
         public override void ConfigureMentionLinkDetector(UserContextMenu userContextMenu)
         {
+            backgroundImage.color = initialEntryColor;
+
             if (mentionLinkDetector == null)
                 return;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ChatWidgetHUD/DefaultChatEntry.cs
@@ -361,10 +361,11 @@ namespace DCL.Chat.HUD
 
         private void OnOwnPlayerMentioned()
         {
-            if (model.senderId == ownUserProfile.userId)
+            if (model.subType != ChatEntryModel.SubType.RECEIVED ||
+                model.senderId == ownUserProfile.userId)
                 return;
 
-            //backgroundImage.color = autoMentionBackgroundColor;
+            backgroundImage.color = autoMentionBackgroundColor;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Mentions/MentionLinkDetector.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Mentions/MentionLinkDetector.cs
@@ -12,10 +12,9 @@ namespace DCL.Social.Chat.Mentions
     {
         private const string MENTION_URL_PREFIX = "mention://";
 
-        public event Action OnOwnPlayerMentioned;
+        public event Action OnPlayerMentioned;
 
         [SerializeField] internal TMP_Text textComponent;
-        [SerializeField] internal UserProfile ownUserProfile;
 
         internal bool isMentionsFeatureEnabled = true;
         internal string currentText;
@@ -107,7 +106,7 @@ namespace DCL.Social.Chat.Mentions
 
             hasNoParseLabel = textInfo.textComponent.text.Contains("<noparse>", StringComparison.OrdinalIgnoreCase);
             RefreshMentionPatterns(cancellationToken.Token).Forget();
-            CheckOwnPlayerMentionAsync(textInfo.textComponent, cancellationToken.Token).Forget();
+            CheckMentionAsync(textInfo.textComponent, cancellationToken.Token).Forget();
         }
 
         private async UniTask RefreshMentionPatterns(CancellationToken cancellationToken)
@@ -126,15 +125,12 @@ namespace DCL.Social.Chat.Mentions
             currentText = textComponent.text;
         }
 
-        private async UniTask CheckOwnPlayerMentionAsync(TMP_Text textComp, CancellationToken ct)
+        private async UniTask CheckMentionAsync(TMP_Text textComp, CancellationToken ct)
         {
-            if (ownUserProfile == null)
-                return;
-
             await UniTask.WaitForEndOfFrame(this, ct);
 
-            if (MentionsUtils.IsUserMentionedInText(ownUserProfile.userName, textComp.text))
-                OnOwnPlayerMentioned?.Invoke();
+            if (MentionsUtils.TextContainsMention(textComp.text))
+                OnPlayerMentioned?.Invoke();
         }
 
         private void OnFeatureFlagsChanged(FeatureFlag current, FeatureFlag previous) =>


### PR DESCRIPTION
## What does this PR change?
Fix #4861 

The background color of the chat entry was yellow for ALL mentions instead of only for the messages that contains a mention of OUR OWN USER.

![image](https://github.com/decentraland/unity-renderer/assets/64659061/6453568b-9cf7-49a7-87c1-0b1c4b3e5653)

## How to test the changes?
1. Launch 2 explorers with 2 different users (it doesn't matter if one of them is a guest).
2. Open the chat in both browsers (for example `nearby`).
3. With one of the users, mention to the other one.
4. Check that the color of the sent message is green (instead of yellow).
5. From the browser of the other user, check that the received message is yellow.
6. Do the same but starting the process from the other user and check that it works in the same way.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2699c73</samp>

Fix chat entry background color issue when hovering over mention links. Reset the color in `DefaultChatEntry.cs` after link detection.