### PR TITLE
fix: the passport_edit_profile metric stopped sending

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/SocialAnalytics/SocialAnalyticsTypes.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/SocialAnalytics/SocialAnalyticsTypes.cs
@@ -12,7 +12,8 @@ namespace SocialFeaturesAnalytics
         ProfileContextMenu,
         FriendsHUD,
         Conversation,
-        ProfileEditHUD
+        ProfileEditHUD,
+        MyProfile,
     }
 
     public enum AvatarOpenSource

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyAccountHUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyAccountHUD.asmdef
@@ -22,7 +22,8 @@
         "GUID:e99faafecbf8dd74d8130597511b9b27",
         "GUID:0663fad624d836944b40ae27c3414652",
         "GUID:dffbb581f2650ea4990781f603ac258a",
-        "GUID:b1087c5731ff68448a0a9c625bb7e52d"
+        "GUID:b1087c5731ff68448a0a9c625bb7e52d",
+        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyAccountPlugin.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyAccountPlugin.cs
@@ -2,6 +2,7 @@
 using DCL.Providers;
 using DCL.Tasks;
 using DCLServices.Lambdas.NamesService;
+using SocialFeaturesAnalytics;
 using System.Threading;
 
 namespace DCL.MyAccount
@@ -46,6 +47,8 @@ namespace DCL.MyAccount
 
             var dataStore = DataStore.i;
 
+            var userProfileWebInterfaceBridge = new UserProfileWebInterfaceBridge();
+
             myAccountSectionHUDController = new MyAccountSectionHUDController(
                 myAccountSectionView,
                 dataStore);
@@ -53,12 +56,13 @@ namespace DCL.MyAccount
             myProfileController = new MyProfileController(
                 myAccountSectionView.CurrentMyProfileView,
                 dataStore,
-                new UserProfileWebInterfaceBridge(),
+                userProfileWebInterfaceBridge,
                 Environment.i.serviceLocator.Get<INamesService>(),
                 new WebInterfaceBrowserBridge(),
                 myAccountSectionHUDController,
                 KernelConfig.i,
                 new MyAccountAnalyticsService(Environment.i.platform.serviceProviders.analytics),
+                new SocialAnalytics(Environment.i.platform.serviceProviders.analytics, userProfileWebInterfaceBridge),
                 countryListProvider,
                 genderListProvider,
                 sexualOrientationProvider,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyProfileController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/MyProfileController.cs
@@ -3,6 +3,7 @@ using DCL.Browser;
 using DCL.Tasks;
 using DCL.UserProfiles;
 using DCLServices.Lambdas.NamesService;
+using SocialFeaturesAnalytics;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -25,6 +26,7 @@ namespace DCL.MyAccount
         private readonly MyAccountSectionHUDController myAccountSectionHUDController;
         private readonly KernelConfig kernelConfig;
         private readonly IMyAccountAnalyticsService myAccountAnalyticsService;
+        private readonly ISocialAnalytics socialAnalytics;
         private readonly IProfileAdditionalInfoValueListProvider countryListProvider;
         private readonly IProfileAdditionalInfoValueListProvider genderListProvider;
         private readonly IProfileAdditionalInfoValueListProvider sexualOrientationProvider;
@@ -55,6 +57,7 @@ namespace DCL.MyAccount
             MyAccountSectionHUDController myAccountSectionHUDController,
             KernelConfig kernelConfig,
             IMyAccountAnalyticsService myAccountAnalyticsService,
+            ISocialAnalytics socialAnalytics,
             IProfileAdditionalInfoValueListProvider countryListProvider,
             IProfileAdditionalInfoValueListProvider genderListProvider,
             IProfileAdditionalInfoValueListProvider sexualOrientationProvider,
@@ -71,6 +74,7 @@ namespace DCL.MyAccount
             this.myAccountSectionHUDController = myAccountSectionHUDController;
             this.kernelConfig = kernelConfig;
             this.myAccountAnalyticsService = myAccountAnalyticsService;
+            this.socialAnalytics = socialAnalytics;
             this.countryListProvider = countryListProvider;
             this.genderListProvider = genderListProvider;
             this.sexualOrientationProvider = sexualOrientationProvider;
@@ -247,6 +251,7 @@ namespace DCL.MyAccount
 
                 myAccountSectionHUDController.ShowAccountSettingsUpdatedToast();
                 myAccountAnalyticsService.SendProfileInfoEditAnalytic(newDesc.Length);
+                socialAnalytics.SendProfileEdit(newDesc.Length, false, PlayerActionSource.MyProfile);
             }
 
             saveDescriptionCancellationToken = saveDescriptionCancellationToken.SafeRestart();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/Tests/MyProfileControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/Tests/MyProfileControllerShould.cs
@@ -5,6 +5,7 @@ using DCLServices.Lambdas.NamesService;
 using KernelConfigurationTypes;
 using NSubstitute;
 using NUnit.Framework;
+using SocialFeaturesAnalytics;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -34,6 +35,7 @@ namespace DCL.MyAccount
         private IBrowserBridge browserBridge;
         private KernelConfig kernelConfig;
         private IMyAccountAnalyticsService myAccountAnalyticsService;
+        private ISocialAnalytics socialAnalytics;
         private IProfileAdditionalInfoValueListProvider countryListProvider;
         private IProfileAdditionalInfoValueListProvider genderListProvider;
         private IProfileAdditionalInfoValueListProvider sexualOrientationProvider;
@@ -85,6 +87,7 @@ namespace DCL.MyAccount
             });
 
             myAccountAnalyticsService = Substitute.For<IMyAccountAnalyticsService>();
+            socialAnalytics = Substitute.For<ISocialAnalytics>();
             countryListProvider = Substitute.For<IProfileAdditionalInfoValueListProvider>();
             genderListProvider = Substitute.For<IProfileAdditionalInfoValueListProvider>();
             sexualOrientationProvider = Substitute.For<IProfileAdditionalInfoValueListProvider>();
@@ -101,6 +104,7 @@ namespace DCL.MyAccount
                 myAccountSectionController,
                 kernelConfig,
                 myAccountAnalyticsService,
+                socialAnalytics,
                 countryListProvider,
                 genderListProvider,
                 sexualOrientationProvider,
@@ -331,6 +335,7 @@ namespace DCL.MyAccount
 
             userProfileBridge.SaveDescription(ANOTHER_DESCRIPTION, Arg.Any<CancellationToken>());
             myAccountAnalyticsService.Received(1).SendProfileInfoEditAnalytic(ANOTHER_DESCRIPTION.Length);
+            socialAnalytics.Received(1).SendProfileEdit(ANOTHER_DESCRIPTION.Length, false, PlayerActionSource.MyProfile);
         }
 
         [TestCase("l1", "http://whatever.com", "l0")]

--- a/unity-renderer/Assets/Scripts/MainScripts/TestsAsmdef/PlayModeTests/DCL.PlaymodeTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/TestsAsmdef/PlayModeTests/DCL.PlaymodeTests.asmdef
@@ -51,7 +51,8 @@
         "GUID:c44f6fd10d3d94432a107d581e0096b5",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:301149363e31a4bdaa1943465a825c8e",
-        "GUID:ab088438f3b94a0da2e753ee6cae5e25"
+        "GUID:ab088438f3b94a0da2e753ee6cae5e25",
+        "GUID:55b66aa56b81d2d4cafb4a5f02bc90ca"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?
Fix #5477 

The "Passport Edit Profile" metric stopped sending from the new Account feature release.

![image.png](https://images.zenhubusercontent.com/5eb2b8ca65c88f6e391ef16e/1a0c32e9-7a9f-45b0-9c2b-54ed264bb6f2)

## How to test the changes?
1. Launch the explorer.
2. Save your profile description from the new Account section.
3. Check the `passport_edit_profile` metric has been registered in Metabase (it could take several minutes/hours until you can see it reflected there).

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab89d61</samp>

This pull request refactors the `MyAccountHUD` code to use the `SocialFeaturesAnalytics` namespace and the `UserProfileWebInterfaceBridge` class. It also adds analytics tracking for the user profile description editing feature. It updates the relevant assembly definitions and unit tests to reflect these changes.