### PR TITLE
fix: channel link redirecting to blank window when posted in another channel

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Mentions/MentionLinkDetector.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Mentions/MentionLinkDetector.cs
@@ -70,7 +70,7 @@ namespace DCL.Social.Chat.Mentions
 
         private string GetUserNameByPointerPosition(Vector2 pointerPosition)
         {
-            if (textComponent == null)
+            if (textComponent == null || textComponent.canvas == null)
                 return null;
 
             int linkIndex = TMP_TextUtilities.FindIntersectingLink(textComponent, pointerPosition, textComponent.canvas.worldCamera);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -108,11 +108,14 @@ namespace DCL.Chat.HUD
 
         public void SetVisibility(bool visible)
         {
-            isVisible = visible;
+            if (isVisible != visible)
+            {
+                isVisible = visible;
 
-            SetVisiblePanelList(visible);
-            chatHudController.SetVisibility(visible);
-            dataStore.HUDs.chatInputVisible.Set(visible);
+                SetVisiblePanelList(visible);
+                chatHudController.SetVisibility(visible);
+                dataStore.HUDs.chatInputVisible.Set(visible);
+            }
 
             if (visible)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/ChatChannelHUDController.cs
@@ -108,9 +108,6 @@ namespace DCL.Chat.HUD
 
         public void SetVisibility(bool visible)
         {
-            if (isVisible == visible)
-                return;
-
             isVisible = visible;
 
             SetVisiblePanelList(visible);


### PR DESCRIPTION
## What does this PR change?
Fix #4435 

When we clicked in a channel link posted into another channel, it redirected to the correct channel but the chat window appeared blank without any history loaded.

![image](https://github.com/decentraland/unity-renderer/assets/64659061/fa01560a-cbdc-431e-ba10-255fa57e8824)

**VIDEO OF THE ISSUE**: https://images.zenhubusercontent.com/337227404/2253772d-959f-4313-9383-e6107fe1ac8f/2023_02_16_16_15_36.mp4

## How to test the changes?
1. Log in with a wallet account.
2. Open up the Chat menu from taskbar and go to any channel. In there post a link to another channel (# followed by the channel name).
3. Click on that channel link.
4. Check the opened channel is loading the conversation's history correctly.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acc5c3c</samp>

Fixed a potential null reference exception in `MentionLinkDetector` when hovering over a disabled or destroyed text component. This improves the stability and usability of the mentions HUD feature.