### PR TITLE
fix: the equip wearable metric is not being sent for outfits equipment

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackAnalyticsTypes.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackAnalyticsTypes.cs
@@ -4,6 +4,7 @@ namespace DCL.Backpack
     {
         Wearable,
         InfoCard,
+        Outfit,
         None
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -119,10 +119,10 @@ namespace DCL.Backpack
                 catch (Exception e) { Debug.LogWarning($"Cannot resolve the wearable {outfitWearable} for the outfit {outfit.slot}"); }
             }
 
-            EquipWearable(outfit.outfit.bodyShape, setAsDirty: false, updateAvatarPreview: false);
+            EquipWearable(outfit.outfit.bodyShape, EquipWearableSource.Outfit, setAsDirty: false, updateAvatarPreview: false);
 
             foreach (string outfitWearable in outfit.outfit.wearables)
-                EquipWearable(outfitWearable, setAsDirty: true, updateAvatarPreview: true);
+                EquipWearable(outfitWearable, EquipWearableSource.Outfit, setAsDirty: true, updateAvatarPreview: true);
 
             SetAllColors(outfit.outfit.eyes.color, outfit.outfit.hair.color, outfit.outfit.skin.color);
 
@@ -455,7 +455,7 @@ namespace DCL.Backpack
         }
 
         private void EquipWearable(string wearableId,
-            EquipWearableSource source = EquipWearableSource.None,
+            EquipWearableSource source,
             bool setAsDirty = true,
             bool updateAvatarPreview = true,
             bool resetOverride = true)
@@ -470,7 +470,7 @@ namespace DCL.Backpack
         }
 
         private void EquipWearable(WearableItem wearable,
-            EquipWearableSource source = EquipWearableSource.None,
+            EquipWearableSource source,
             bool setAsDirty = true,
             bool updateAvatarPreview = true,
             bool resetOverride = true)


### PR DESCRIPTION
## What does this PR change?
The `equip_wearable` metric was not being sent when we equipped an outfit.

## How to test the changes?
1. Launch the explorer
2. Go to Outfits
3. Equip an outfit
4. Check the metric `equip_wearable` is being registered in Metabase (it could take a long time).

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3906e9</samp>

This pull request adds a new feature to the backpack editor HUD that lets users save and load outfits. It also modifies the `EquipWearable` methods and the `EquipWearableSource` enum to track the source of the wearable equip actions for analytics purposes.
