### PR TITLE
fix: px permission description & changed dont ask option as default

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/ExperiencesConfirmationPopupComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/ExperiencesConfirmationPopupComponentView.cs
@@ -104,11 +104,11 @@ namespace DCL.PortableExperiences.Confirmation
             gameObject.SetActive(true);
             base.Show(instant);
 
-            // let the subscribers know that the default option is 'dont show anymore'
-            if (!dontAskMeAgainToggle.isOn)
-                dontAskMeAgainToggle.isOn = true;
+            // let the subscribers know that the default option is 'keep showing'
+            if (dontAskMeAgainToggle.isOn)
+                dontAskMeAgainToggle.isOn = false;
             else
-                OnDontShowAnymore?.Invoke();
+                OnKeepShowing?.Invoke();
         }
 
         public override void Hide(bool instant = false)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/ExperiencesConfirmationPopupController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/ExperiencesConfirmationPopupController.cs
@@ -140,6 +140,8 @@ namespace DCL.PortableExperiences.Confirmation
                     return "Trigger emotes.";
                 case "ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE":
                     return "Move your position.";
+                case "ALLOW_MEDIA_HOSTNAMES":
+                    return "Play media content (video, audio, etc).";
             }
 
             return permissionId;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/ExperiencesConfirmationPopupController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/ExperiencesConfirmationPopupController.cs
@@ -129,17 +129,17 @@ namespace DCL.PortableExperiences.Confirmation
             switch (permissionId)
             {
                 case "USE_FETCH":
-                    return "Let the scene perform external HTTP requests.";
+                    return "Communicate with 3rd party servers.";
                 case "USE_WEBSOCKET":
-                    return "Let the scene use the Websocket API to establish external connections.";
+                    return "Exchange data with other servers.";
                 case "OPEN_EXTERNAL_LINK":
-                    return "Let the scene open a URL (in a browser tab or web view).";
+                    return "Open external links.";
                 case "USE_WEB3_API":
-                    return "Let the scene communicate with a wallet.";
+                    return "Interact with your wallet.";
                 case "ALLOW_TO_TRIGGER_AVATAR_EMOTE":
-                    return "Let the scene to animate the player’s avatar with an emote.";
+                    return "Trigger emotes.";
                 case "ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE":
-                    return "Let the scene to change the player’s position.";
+                    return "Move your position.";
             }
 
             return permissionId;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/Tests/ExperiencesConfirmationPopupControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/Tests/ExperiencesConfirmationPopupControllerShould.cs
@@ -150,12 +150,12 @@ namespace DCL.PortableExperiences.Confirmation
 
             view.Received(1)
                 .SetModel(Arg.Is<ExperiencesConfirmationViewModel>(e =>
-                     e.Permissions[0] == "Let the scene perform external HTTP requests."
-                     && e.Permissions[1] == "Let the scene use the Websocket API to establish external connections."
-                     && e.Permissions[2] == "Let the scene open a URL (in a browser tab or web view)."
-                     && e.Permissions[3] == "Let the scene communicate with a wallet."
-                     && e.Permissions[4] == "Let the scene to animate the player’s avatar with an emote."
-                     && e.Permissions[5] == "Let the scene to change the player’s position."));
+                     e.Permissions[0] == "Communicate with 3rd party servers."
+                     && e.Permissions[1] == "Exchange data with other servers."
+                     && e.Permissions[2] == "Open external links."
+                     && e.Permissions[3] == "Interact with your wallet."
+                     && e.Permissions[4] == "Trigger emotes."
+                     && e.Permissions[5] == "Move your position."));
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/Tests/ExperiencesConfirmationPopupControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExperiencesConfirmation/Tests/ExperiencesConfirmationPopupControllerShould.cs
@@ -142,6 +142,7 @@ namespace DCL.PortableExperiences.Confirmation
                         "USE_WEB3_API",
                         "ALLOW_TO_TRIGGER_AVATAR_EMOTE",
                         "ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE",
+                        "ALLOW_MEDIA_HOSTNAMES",
                     },
                 },
                 OnAcceptCallback = () => { },
@@ -155,7 +156,8 @@ namespace DCL.PortableExperiences.Confirmation
                      && e.Permissions[2] == "Open external links."
                      && e.Permissions[3] == "Interact with your wallet."
                      && e.Permissions[4] == "Trigger emotes."
-                     && e.Permissions[5] == "Move your position."));
+                     && e.Permissions[5] == "Move your position."
+                     && e.Permissions[6] == "Play media content (video, audio, etc)."));
         }
 
         [Test]


### PR DESCRIPTION
## What does this PR change?

Changed the description of the portable experience permissions.
The confirmation popup's dont ask again option is not unticked as default.

These are the permissions:
```
- Move your position.
- Trigger emotes.
- Interact with your wallet.
- Communicate with 3rd party servers.
- Exchange data with other servers.
- Open external links.
- Play media content (video, audio, etc).
```

## How to test the changes?

1. Try to launch a PX (from smart wearable or a scene)
2. Check that the PX confirmation popup appears
3. Check the scene permissions are correct
4. Check that the "dont ask option" is unticked as default

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb98e2a</samp>

This pull request changes the default value of the `dontAskMeAgainToggle` and the text descriptions of the permissions in the `ExperiencesConfirmationPopupComponentView` and the `ExperiencesConfirmationPopupController`, as part of a refactor to improve the user experience and clarity of the permissions system. It also updates the corresponding unit test in the `ExperiencesConfirmationPopupControllerShould` class.
