### PR TITLE
feat: hands feature fixes

### DIFF
--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearableResponse.cs
@@ -82,6 +82,7 @@ namespace DCLServices.WearablesCatalogService
                         public string[] tags;
                         public string[] replaces;
                         public string[] hides;
+                        public string[] removesDefaultHiding;
                     }
 
                     public DataDto data;
@@ -118,6 +119,7 @@ namespace DCLServices.WearablesCatalogService
                             hides = metadata.data.hides,
                             replaces = metadata.data.replaces,
                             tags = metadata.data.tags,
+                            removesDefaultHiding = metadata.data.removesDefaultHiding,
                         },
                         baseUrl = contentBaseUrl,
                         baseUrlBundles = bundlesBaseUrl,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/AvatarSlot/NftTypeIcons.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/AvatarSlot/NftTypeIcons.asset
@@ -52,6 +52,6 @@ MonoBehaviour:
   - key: body_shape
     value: {fileID: 21300000, guid: 7df132fb4eb304d619c7dd33841261a1, type: 3}
   - key: hands_wear
-    value: {fileID: 21300000, guid: 1b8e5d35e0b2d46379b97bb7e7ab2c97, type: 3}
+    value: {fileID: 21300000, guid: 16866e729ce1061429170517e80ef313, type: 3}
   - key: hands
     value: {fileID: 21300000, guid: 1b8e5d35e0b2d46379b97bb7e7ab2c97, type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/NftBreadcrumbComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/NftBreadcrumbComponentView.cs
@@ -83,9 +83,12 @@ namespace DCL.Backpack
             NftSubCategoryFilterComponentView view = poolObj.gameObject.GetComponent<NftSubCategoryFilterComponentView>();
             Sprite icon = iconsByCategory.GetTypeImage(subCategory.Type);
 
+            string categoryName = subCategory.Name;
+            categoryName = WearableItem.CATEGORIES_READABLE_MAPPING.TryGetValue(categoryName, out string readableCategory) ? readableCategory : categoryName.Replace("_", " ");
+
             view.SetModel(new NftSubCategoryFilterModel
             {
-                Name = subCategory.Name.Replace("_", " "),
+                Name = categoryName,
                 Filter = subCategory.Filter,
                 ResultCount = model.ResultCount,
                 ShowResultCount = showResultCount,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/NFTIcons/NFTTypesIcons.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/NFTIcons/NFTTypesIcons.asset
@@ -60,7 +60,7 @@ MonoBehaviour:
   - key: all
     value: {fileID: 21300000, guid: e568dcbc864c24ab1a9b731a66e362cb, type: 3}
   - key: hands_wear
-    value: {fileID: 21300000, guid: 1b8e5d35e0b2d46379b97bb7e7ab2c97, type: 3}
+    value: {fileID: 21300000, guid: 16866e729ce1061429170517e80ef313, type: 3}
   - key: hands
     value: {fileID: 21300000, guid: 1b8e5d35e0b2d46379b97bb7e7ab2c97, type: 3}
   nftColors:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -64,6 +64,7 @@ public class WearableItem
         Categories.UPPER_BODY,
         Categories.LOWER_BODY,
         Categories.FEET,
+        Categories.HANDS,
         Categories.HANDS_WEAR,
         Categories.HEAD,
         Categories.FACIAL_HAIR

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -52,7 +52,7 @@ public class WearableItem
         { Categories.EYEBROWS, "Eyebrows" },
         { Categories.BODY_SHAPE, "Body shape" },
         { Categories.FACIAL_HAIR, "Facial hair" },
-        { Categories.HANDS_WEAR, "Hands Wear" },
+        { Categories.HANDS_WEAR, "Handwear" },
     };
 
     public static readonly string[] SKIN_IMPLICIT_CATEGORIES =

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -69,6 +69,12 @@ public class WearableItem
         Categories.FACIAL_HAIR
     };
 
+    public static readonly string[] UPPER_BODY_DEFAULT_HIDES =
+    {
+        Categories.HANDS,
+        Categories.HANDS_WEAR
+    };
+
     [Serializable]
     public class MappingPair
     {
@@ -95,6 +101,7 @@ public class WearableItem
         public string[] tags;
         public string[] replaces;
         public string[] hides;
+        public string[] removesDefaultHiding;
         public bool loop;
     }
 
@@ -230,6 +237,14 @@ public class WearableItem
                 ? SKIN_IMPLICIT_CATEGORIES
                 : hides.Concat(SKIN_IMPLICIT_CATEGORIES).Distinct().ToArray();
         }
+
+        // Old UPPER_BODY Wearables are incompatible with the new Hands category,
+        // so we apply this rule to hide the hands by default
+        bool isOrHidesUpperBody = hides.Contains(Categories.UPPER_BODY) || data.category == Categories.UPPER_BODY;
+        bool removesDefault = data.removesDefaultHiding?.Contains(Categories.HANDS) ?? false;
+
+        if (isOrHidesUpperBody && !removesDefault)
+            hides = hides.Concat(UPPER_BODY_DEFAULT_HIDES).Distinct().ToArray();
 
         var replaces = GetReplacesList(bodyShapeType);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -52,7 +52,7 @@ public class WearableItem
         { Categories.EYEBROWS, "Eyebrows" },
         { Categories.BODY_SHAPE, "Body shape" },
         { Categories.FACIAL_HAIR, "Facial hair" },
-        { Categories.HANDS_WEAR, "Hands" },
+        { Categories.HANDS_WEAR, "Hands Wear" },
     };
 
     public static readonly string[] SKIN_IMPLICIT_CATEGORIES =

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -73,7 +73,6 @@ public class WearableItem
     public static readonly string[] UPPER_BODY_DEFAULT_HIDES =
     {
         Categories.HANDS,
-        Categories.HANDS_WEAR
     };
 
     [Serializable]

--- a/unity-renderer/Assets/Textures/UI/BackpackV2/BackpackIcons.spriteatlas
+++ b/unity-renderer/Assets/Textures/UI/BackpackV2/BackpackIcons.spriteatlas
@@ -59,6 +59,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: eb045bd1671ab4469815a093d8e7ab8e, type: 3}
   - {fileID: 21300000, guid: bda43422408ca42209dd311b23a1d06f, type: 3}
   - {fileID: 21300000, guid: 14b14542e832343729c812d8e4c8cbae, type: 3}
+  - {fileID: 21300000, guid: 16866e729ce1061429170517e80ef313, type: 3}
   - {fileID: 21300000, guid: a239a282af9bf48f7a26a34d76d77155, type: 3}
   - {fileID: 21300000, guid: 8d9ff403c413748a7a82ca7f9443e988, type: 3}
   - {fileID: 21300000, guid: 6084de83d5bc748b9a444a61a7c0b96a, type: 3}
@@ -113,6 +114,7 @@ SpriteAtlas:
   - CheckmarkGreen
   - SkinsIcon
   - InfoCardCommon
+  - HandWearIcn
   - BaseThumbnail
   - HiddenIcon
   - TopheadIcon

--- a/unity-renderer/Assets/Textures/UI/BackpackV2/BackpackTextures/HandWearIcn.png
+++ b/unity-renderer/Assets/Textures/UI/BackpackV2/BackpackTextures/HandWearIcn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20836fefaa2b703a51533a4bcc2d2c85893d2342302b246abf5915c71e5f8e6b
+size 438

--- a/unity-renderer/Assets/Textures/UI/BackpackV2/BackpackTextures/HandWearIcn.png.meta
+++ b/unity-renderer/Assets/Textures/UI/BackpackV2/BackpackTextures/HandWearIcn.png.meta
@@ -1,0 +1,147 @@
+fileFormatVersion: 2
+guid: 16866e729ce1061429170517e80ef313
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 0
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 0
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 128
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Textures/UI/Common/TexturesUI.spriteatlas
+++ b/unity-renderer/Assets/Textures/UI/Common/TexturesUI.spriteatlas
@@ -473,7 +473,7 @@ SpriteAtlas:
   - RectangleLoadingBar
   - InputFieldBuilderFocus
   - HandleThick
-  - SmartItemIcon
+  - SmartItemIcn
   - Key
   - NamesIcon
   - NFTUniqueContainer

--- a/unity-renderer/Assets/Textures/UI/Experiences/Experiences.spriteatlas
+++ b/unity-renderer/Assets/Textures/UI/Experiences/Experiences.spriteatlas
@@ -45,7 +45,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: c319fd971d09e1745b925fff3aa3012a, type: 3}
   - {fileID: 21300000, guid: bc1386f864ce3b64baafbb1e74763408, type: 3}
   m_PackedSpriteNamesToIndex:
-  - ExperienceImg
+  - ExperienceDefaultThumbnail
   - ExperienceIconOn
   - ExperienceIconOff
   - HideIcon


### PR DESCRIPTION
## What does this PR change?

Old upper-bodies will hide the base hands by default.

Updated hands-wear icon

Fixed category naming

## How to test the changes?

Enter https://play.decentraland.zone/?NETWORK=goerli&realm=artemis&explorer-branch=feat/hands-default-hide
- Check out the hands section in the backpack.
- Equip and unequip them correctly.
- Check that all names are `HANDWEAR`
- Check that wearables that hide hands have the hands icon, not the gloves icon, those are for handwear

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 726bd0f</samp>

This pull request adds a new feature to the wearables catalog service and the `WearableItem` class to allow wearables to override the default hiding behavior of some categories. This enables more avatar customization options and improves the appearance of some wearables.
