### PR TITLE
fix: replace the current health endpoint by the new one

### DIFF
--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/World Timer/WorldTimer.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/World Timer/WorldTimer.cs
@@ -12,7 +12,7 @@ namespace DCL.ServerTime
         public event OnTimeUpdated OnTimeChanged;
 
         public float serverHitFrequency;
-        public string serverURL = "https://peer.decentraland.org/lambdas/health";
+        public string serverURL = "https://peer.decentraland.org/about";
 
         private bool initialized = false;
         private DateTime lastTimeFromServer = DateTime.Now.ToUniversalTime();


### PR DESCRIPTION
## What does this PR change?
Fix #5447 

The Platform team we have been deprecating some endpoints from the Catalyst, specifically from Lambdas service. One of them is the next one:
```
https://peer.decentraland.org/lambdas/health
```

It has been replaced by this new one:
```
https://peer.decentraland.org/about
```

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9643b37</samp>

Changed the endpoint for getting the server time in `WorldTimer.cs`. This improves the procedural skybox rendering.