### PR TITLE
fix: reflection resolution setting missing on desktop client

### DIFF
--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GraphicsWidgetDesktop.asset
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GraphicsWidgetDesktop.asset
@@ -29,6 +29,7 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 6bc8110cbd37eac4483f2998f09e4d04, type: 2}
         - {fileID: 11400000, guid: 4197993d78854a848889813dbc0a011b, type: 2}
         - {fileID: 11400000, guid: d11af08d45b874130b0f17a8c938b96a, type: 2}
+        - {fileID: 11400000, guid: fdd8600a488ddf04595c29113482d6c1, type: 2}
         - {fileID: 11400000, guid: c82a025bfce6a4c93bf5943eabab8450, type: 2}
     - controls:
         array:


### PR DESCRIPTION
## What does this PR change?
Fix #5377 

Reflection Resolution inside Graphics section of the Settings was present for webGL but was not available on desktop clients.

#### Web
![image](https://github.com/decentraland/unity-renderer/assets/64659061/52744909-9eec-4961-8523-8ad4294fd79d)

#### Desktop
![image](https://github.com/decentraland/unity-renderer/assets/64659061/525ece91-af2b-4386-97be-fc36bf0b99fd)

## How to test the changes?
1. Log in via either a guest or a wallet account on both web and desktop client.
2. On both logins open up Settings menu and navigate to Graphics section.
3. Observe the contents of the menu. Notice that on web and on desktop the Reflection Resolution setting is available.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6450ae</samp>

Add graphics quality switcher to desktop settings panel. This feature lets the user choose from predefined graphics settings that affect the rendering performance and quality.