### PR TITLE
feat: Remove Goerli

### DIFF
--- a/browser-interface/packages/config/index.ts
+++ b/browser-interface/packages/config/index.ts
@@ -110,7 +110,6 @@ export const commConfigurations = {
 
 export enum ETHEREUM_NETWORK {
   MAINNET = 'mainnet',
-  GOERLI = 'goerli',
   SEPOLIA = 'sepolia'
 }
 
@@ -194,18 +193,6 @@ export namespace ethereumConfigurations {
     EstateProxy: assertValue(contractInfo.mainnet.EstateProxy),
     CatalystProxy: assertValue(contractInfo.mainnet.CatalystProxy),
     MANAToken: assertValue(contractInfo.mainnet.MANAToken)
-  }
-  export const goerli = {
-    wss: 'wss://rpc.decentraland.org/goerli',
-    http: 'https://rpc.decentraland.org/goerli',
-    etherscan: 'https://goerli.etherscan.io',
-    names: 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace-goerli',
-
-    // contracts
-    LANDProxy: assertValue(contractInfo.goerli.LANDProxy),
-    EstateProxy: assertValue(contractInfo.goerli.EstateProxy),
-    CatalystProxy: assertValue(contractInfo.goerli.CatalystProxy || contractInfo.goerli.Catalyst),
-    MANAToken: assertValue(contractInfo.goerli.MANAToken)
   }
   export const sepolia = {
     wss: 'wss://rpc.decentraland.org/sepolia',

--- a/browser-interface/packages/entryPoints/index.ts
+++ b/browser-interface/packages/entryPoints/index.ts
@@ -136,7 +136,7 @@ async function hasStoredSession(address: string, networkId: number) {
 
   const profile = await localProfilesRepo.get(
     address,
-    networkId === 1 ? ETHEREUM_NETWORK.MAINNET : networkId === 5 ? ETHEREUM_NETWORK.GOERLI : ETHEREUM_NETWORK.SEPOLIA
+    networkId === 1 ? ETHEREUM_NETWORK.MAINNET : ETHEREUM_NETWORK.SEPOLIA
   )
 
   return { result: !!profile, profile: profile || null } as any

--- a/browser-interface/packages/lib/web3/fetchCatalystNodesFromContract.ts
+++ b/browser-interface/packages/lib/web3/fetchCatalystNodesFromContract.ts
@@ -37,10 +37,12 @@ export async function fetchCatalystNodesFromContract(): Promise<CatalystNode[]> 
         { domain: 'https://peer.kyllian.me' },
         { domain: 'https://peer.melonwave.com' }
       ]
-    } else if (net === ETHEREUM_NETWORK.GOERLI) {
-      return [{ domain: 'https://peer.decentraland.zone' }, { domain: 'https://peer-ap1.decentraland.zone' }]
     } else if (net === ETHEREUM_NETWORK.SEPOLIA) {
-      return [{ domain: 'https://peer-ue-2.decentraland.zone' }]
+      return [
+        { domain: 'https://peer.decentraland.zone' },
+        { domain: 'https://peer-ap1.decentraland.zone' },
+        { domain: 'https://peer-ue-2.decentraland.zone' }
+      ]
     }
   }
 

--- a/browser-interface/packages/lib/web3/getEthereumNetworkFromProvider.ts
+++ b/browser-interface/packages/lib/web3/getEthereumNetworkFromProvider.ts
@@ -4,7 +4,6 @@ import { requestManager } from './provider'
 export async function getEthereumNetworkFromProvider(): Promise<ETHEREUM_NETWORK> {
   const web3Network = await requestManager.net_version()
   const chainId = parseInt(web3Network, 10)
-  const web3net =
-    chainId === 1 ? ETHEREUM_NETWORK.MAINNET : chainId === 5 ? ETHEREUM_NETWORK.GOERLI : ETHEREUM_NETWORK.SEPOLIA
+  const web3net = chainId === 1 ? ETHEREUM_NETWORK.MAINNET : ETHEREUM_NETWORK.SEPOLIA
   return web3net
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/Resources/DebugView.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DebugController/Resources/DebugView.prefab
@@ -928,7 +928,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Goerli
+  m_text: Sepolia
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugConfigComponent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugConfigComponent.cs
@@ -45,7 +45,6 @@ namespace DCL
         public enum Network
         {
             MAINNET,
-            GOERLI,
             SEPOLIA,
         }
 
@@ -198,9 +197,6 @@ namespace DCL
             {
                 case Network.SEPOLIA:
                     debugString = "NETWORK=sepolia&";
-                    break;
-                case Network.GOERLI:
-                    debugString = "NETWORK=goerli&";
                     break;
                 case Network.MAINNET:
                     debugString = "NETWORK=mainnet&";


### PR DESCRIPTION
## What does this PR change?

+ Removes Goerli references from the code only keeping sepolia
+ Add the catalysts used in Goerli to the Sepolia list

## How to test the changes?

1. Launch the explorer with `NETWORK=sepolia` in the url
2. Check that the realm being connected to is not only `poseidon` but `artemis` and `zeus` as well

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef78fdb</samp>

Removed Goerli network configuration and references from `browser-interface` and `unity-renderer` packages. This network is no longer supported by the Decentraland platform and was replaced by Sepolia for testing purposes.
