### PR TITLE
fix: sdk7 input events when asset bundles are enabled

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerCollidersHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerCollidersHandler.cs
@@ -44,16 +44,17 @@ namespace DCL.ECSComponents
 
             for (int i = 0; i < meshFilters.Count; i++)
             {
-                if (meshFilters[i].gameObject.layer == PhysicsLayers.characterOnlyLayer)
+                if (!IsCollider(meshFilters[i]))
+                    continue;
+
+                Collider collider = meshFilters[i].gameObject.GetComponent<Collider>();
+
+                if (collider != null)
                 {
-                    Collider collider = meshFilters[i].gameObject.GetComponent<Collider>();
                     collider.enabled = false;
                     invisibleMeshesColliders.Add(collider);
                     continue;
                 }
-
-                if (!IsCollider(meshFilters[i]))
-                    continue;
 
                 MeshCollider newCollider = meshFilters[i].gameObject.AddComponent<MeshCollider>();
                 newCollider.sharedMesh = meshFilters[i].sharedMesh;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerHandler.cs
@@ -74,7 +74,7 @@ namespace DCL.ECSComponents
             gltfLoader.settings.forceGPUOnlyMesh = true;
             gltfLoader.settings.parent = transform;
             gltfLoader.settings.visibleFlags = AssetPromiseSettings_Rendering.VisibleFlags.VISIBLE_WITH_TRANSITION;
-            gltfLoader.settings.smrUpdateWhenOffScreen = DataStore.i.featureFlags.flags.Get().IsFeatureEnabled(SMR_UPDATE_OFFSCREEN_FEATURE_FLAG);
+            gltfLoader.settings.smrUpdateWhenOffScreen = featureFlags.flags.Get().IsFeatureEnabled(SMR_UPDATE_OFFSCREEN_FEATURE_FLAG);
 
             collidersHandler = new GltfContainerCollidersHandler();
         }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/PointerInputSystem/ECSPointerInputSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/PointerInputSystem/ECSPointerInputSystem.cs
@@ -304,7 +304,7 @@ namespace ECSSystems.PointerInputSystem
 
             // If entity has pointer event component for this `pointerEventType` we setup the `hit` data
             // otherwise we leave it empty (global input)
-            if (HasInputEvent(entityEvents, pointerEventType, raycastHit.distance))
+            if (HasInputEvent(entityEvents, pointerEventType, buttonId, raycastHit.distance))
             {
                 ray.origin = WorldStateUtils.ConvertUnityToScenePosition(ray.origin, scene);
 
@@ -430,6 +430,7 @@ namespace ECSSystems.PointerInputSystem
         private static bool HasInputEvent(
             IReadOnlyList<InternalPointerEvents.Entry> entityEvents,
             PointerEventType pointerEventType,
+            InputAction actionButton,
             float distance)
         {
             if (entityEvents == null)
@@ -439,13 +440,15 @@ namespace ECSSystems.PointerInputSystem
             {
                 var inputEventEntry = entityEvents[i];
 
-                if (inputEventEntry.EventType == pointerEventType)
-                {
-                    if (distance <= inputEventEntry.EventInfo.MaxDistance)
-                    {
-                        return true;
-                    }
-                }
+                if (inputEventEntry.EventInfo.Button != actionButton
+                    && inputEventEntry.EventInfo.Button != InputAction.IaAny)
+                    continue;
+
+                if (inputEventEntry.EventType != pointerEventType)
+                    continue;
+
+                if (distance <= inputEventEntry.EventInfo.MaxDistance)
+                    return true;
             }
 
             return false;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/PointerInputSystem/Tests/EntityInputShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/PointerInputSystem/Tests/EntityInputShould.cs
@@ -295,7 +295,7 @@ namespace Tests
         [Test]
         public void DetectPointerHoverEnter_WithPointerEvents()
         {
-            dataStoreEcs7.inputActionState[(int)InputAction.IaPrimary] = false;
+            dataStoreEcs7.inputActionState[(int)InputAction.IaPointer] = false;
 
             dataStoreEcs7.lastPointerRayHit.didHit = true;
             dataStoreEcs7.lastPointerRayHit.hit.collider = colliderEntity1;
@@ -306,7 +306,7 @@ namespace Tests
                 {
                     new InternalPointerEvents.Entry(
                         PointerEventType.PetHoverEnter,
-                        new InternalPointerEvents.Info(InputAction.IaPrimary, string.Empty, float.MaxValue, false))
+                        new InternalPointerEvents.Info(InputAction.IaPointer, string.Empty, float.MaxValue, false))
                 })
             );
 
@@ -367,11 +367,11 @@ namespace Tests
                 {
                     new InternalPointerEvents.Entry(
                         PointerEventType.PetHoverLeave,
-                        new InternalPointerEvents.Info(InputAction.IaPrimary, string.Empty, float.MaxValue, false))
+                        new InternalPointerEvents.Info(InputAction.IaPointer, string.Empty, float.MaxValue, false))
                 })
             );
 
-            dataStoreEcs7.inputActionState[(int)InputAction.IaPrimary] = false;
+            dataStoreEcs7.inputActionState[(int)InputAction.IaPointer] = false;
 
             dataStoreEcs7.lastPointerRayHit.didHit = true;
             dataStoreEcs7.lastPointerRayHit.hit.collider = colliderEntity1;


### PR DESCRIPTION
## What does this PR change?
fixed: colliders were being created twice while using asset bundles
fixed: improve input filtering to avoid sending unnecessary event to the scene
fixes https://github.com/decentraland/sdk/issues/904

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch https://play.decentraland.org/?realm=luciddreams.dcl.eth&position=2%2C2
2. keys on the scene should be clickeable 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d4990c9</samp>

This pull request improves the performance and testability of the `GltfContainerHandler` and the `GltfContainerCollidersHandler` classes, and modifies the `PointerInputSystem` and the `EntityInputShould` test class to handle different input actions for pointer events.
