### PR TITLE
fix pex spawn every time

### DIFF
--- a/browser-interface/packages/lib/decentraland/profiles/transformations/profileToServerFormat.ts
+++ b/browser-interface/packages/lib/decentraland/profiles/transformations/profileToServerFormat.ts
@@ -23,6 +23,10 @@ export function ensureAvatarCompatibilityFormat(profile: Readonly<Avatar | OldAv
   avatarInfo.emotes = avatar?.emotes
   avatarInfo.snapshots = avatar?.snapshots
 
+  if (profile.links) {
+    profile.links.map(($) => ({ ...$, url: decodeURIComponent($.url) }))
+  }
+
   if (avatar && 'eyeColor' in avatar) {
     const eyes = stripAlpha(analizeColorPart(avatar, 'eyeColor', 'eyes'))
     const hair = stripAlpha(analizeColorPart(avatar, 'hairColor', 'hair'))

--- a/browser-interface/packages/unity-interface/portableExperiencesUtils.ts
+++ b/browser-interface/packages/unity-interface/portableExperiencesUtils.ts
@@ -88,7 +88,7 @@ export async function getPortableExperienceFromUrn(sceneUrn: string): Promise<Lo
   const baseUrl: string = resolvedEntity.baseUrl || new URL('.', resolvedUrl).toString()
 
   return {
-    id: sceneUrn,
+    id: removeQueryParamsFromUrn(sceneUrn),
     entity,
     baseUrl,
     parentCid: 'main'


### PR DESCRIPTION
fix avatar schema validation for links encoded

## What does this PR change?
### How we handle the Global PEX
We have some PEX that are always active via variant feature flags.
This pex has some urn like: `urn:entity:someid?baseUrl=someUrlHere` and that queryparam was breaking the logic to handle the enable/disable logic for pex.
This PR add a logic to remove that queryParam so the name/id of the pex is just the urn: `urn:entity:someid`


<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df760f3</samp>

This pull request fixes a bug with encoded links in profiles and refactors the handling of scene URNs. It decodes the link URLs in `profileToServerFormat.ts` and removes query parameters from the scene URN in `portableExperiencesUtils.ts`.
