### PR TITLE
fix smart wearables without scene.json

### DIFF
--- a/browser-interface/packages/shared/wearablesPortableExperience/sagas.ts
+++ b/browser-interface/packages/shared/wearablesPortableExperience/sagas.ts
@@ -121,8 +121,8 @@ function findWearableContent(wearable: WearableV2): [KeyAndHash[], KeyAndHash] |
 export async function wearableToSceneEntity(wearable: WearableV2, defaultBaseUrl: string): Promise<LoadableScene> {
   const [wearableContent, mainFile] = findWearableContent(wearable) ?? []
   if (!wearableContent) throw new Error('Invalid wearable')
-  const defaultSceneJson = () => ({
-    main: mainFile?.key ?? 'bin/game.js',
+  const defaultSceneJson: () => Scene = () => ({
+    main: mainFile?.key ? getFile(mainFile?.key) : 'bin/game.js',
     scene: {
       parcels: ['0,0'],
       base: '0,0'
@@ -147,7 +147,7 @@ export async function wearableToSceneEntity(wearable: WearableV2, defaultBaseUrl
   }
 
   const content = wearableContent.map(($) => ({ file: getFile($.key), hash: $.hash }))
-  const metadata: Scene = sceneJson ? await jsonFetch(baseUrl + sceneJson.hash) : defaultSceneJson
+  const metadata: Scene = sceneJson ? await jsonFetch(baseUrl + sceneJson.hash) : defaultSceneJson()
 
   return {
     id: wearable.id,


### PR DESCRIPTION
## What does this PR change?
Fix smart wearable that doesn't provide a scene.json

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 47901c9</samp>

Improve type safety and correctness of `defaultSceneJson` function for wearable portable experiences. Fix a bug in `browser-interface/packages/shared/wearablesPortableExperience/sagas.ts`.
