### PR TITLE
fix: sdk6 colliders and gltf visibility

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/BaseShape/BaseShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/BaseShape/BaseShape.cs
@@ -68,18 +68,17 @@ namespace DCL.Components
             if (meshRenderers == null)
                 meshRenderers = meshGameObject.GetComponentsInChildren<Renderer>(true);
 
-            Collider onPointerEventCollider;
-
             for (var i = 0; i < meshRenderers.Length; i++)
             {
                 if (meshRenderers[i] == null)
                     continue;
 
                 meshRenderers[i].enabled = shouldBeVisible;
+                Transform meshRendererT = meshRenderers[i].transform;
 
-                if (meshRenderers[i].transform.childCount > 0)
+                for (int j = 0; j < meshRendererT.transform.childCount; j++)
                 {
-                    onPointerEventCollider = meshRenderers[i].transform.GetChild(0).GetComponent<Collider>();
+                    Collider onPointerEventCollider = meshRendererT.GetChild(j).GetComponent<Collider>();
 
                     if (onPointerEventCollider != null && onPointerEventCollider.gameObject.layer == PhysicsLayers.onPointerEventLayer)
                         onPointerEventCollider.enabled = shouldBeVisible;


### PR DESCRIPTION
## What does this PR change?
while toggling off/on a gltf visibility, in certain scenarios, pointer event colliders where being skip and never enabled,
because it was assumed that only one collider exist and that it was the first child in the hierarchy

the following hierarchy, for example, was not working
```
gltf
-child
-child
-pointer event collider
```

## How to test the changes?
pointer events should work as usual

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2a3f6a</samp>

Simplified and optimized the code for shape visibility in `BaseShape.cs`.
