### PR TITLE
fix: sdk7 remove material glossiness property

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Defaults/PBMaterial_Defaults.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Defaults/PBMaterial_Defaults.cs
@@ -83,14 +83,6 @@ namespace DCL.ECSComponents
             return 0.5f;
         }
 
-        public static float GetGlossiness(this PBMaterial self)
-        {
-            if (self.Pbr != null)
-                return self.Pbr.HasGlossiness ? self.Pbr.Glossiness : 1f;
-
-            return 1f;
-        }
-
         public static float GetSpecularIntensity(this PBMaterial self)
         {
             if (self.Pbr != null)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Material/MaterialHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Material/MaterialHandler.cs
@@ -151,7 +151,7 @@ namespace DCL.ECSComponents
             return AssetPromise_Material_Model.CreatePBRMaterial(albedoTexture, alphaTexture, emissiveTexture, bumpTexture,
                 model.GetAlphaTest(), model.GetCastShadows(), model.GetAlbedoColor().ToUnityColor(), model.GetEmissiveColor().ToUnityColor(),
                 model.GetReflectiveColor().ToUnityColor(), (AssetPromise_Material_Model.TransparencyMode)model.GetTransparencyMode(), model.GetMetallic(),
-                model.GetRoughness(), model.GetGlossiness(), model.GetSpecularIntensity(),
+                model.GetRoughness(), model.GetSpecularIntensity(),
                 model.GetEmissiveIntensity(), model.GetDirectIntensity());
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Material/AssetPromise_Material.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Material/AssetPromise_Material.cs
@@ -69,7 +69,7 @@ namespace DCL
             if (model.isPbrMaterial)
             {
                 PBRMaterial.SetUpColors(material, model.albedoColor, model.emissiveColor, model.reflectivityColor, model.emissiveIntensity);
-                PBRMaterial.SetUpProps(material, model.metallic, model.roughness, model.glossiness, model.specularIntensity, model.directIntensity);
+                PBRMaterial.SetUpProps(material, model.metallic, model.roughness, model.specularIntensity, model.directIntensity);
                 PBRMaterial.SetUpTransparency(material, model.transparencyMode, model.alphaTexture, model.albedoColor, model.alphaTest);
             }
             else

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Material/AssetPromise_Material_Model.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Material/AssetPromise_Material_Model.cs
@@ -47,7 +47,6 @@ namespace DCL
 
         public readonly float metallic;
         public readonly float roughness;
-        public readonly float glossiness;
 
         public readonly float specularIntensity;
         public readonly float emissiveIntensity;
@@ -59,24 +58,24 @@ namespace DCL
             bool defaultShadow = true;
             return new AssetPromise_Material_Model(false, albedoTexture, null, null, null,
                 alphaTest, defaultShadow, defaultColor, diffuseColor, defaultColor, defaultColor, TransparencyMode.Auto,
-                0, 0, 0, 0, 0, 0);
+                0, 0, 0, 0, 0);
         }
 
         public static AssetPromise_Material_Model CreatePBRMaterial(Texture? albedoTexture, Texture? alphaTexture,
             Texture? emissiveTexture, Texture? bumpTexture, float alphaTest, bool castShadows, Color albedoColor, Color emissiveColor,
-            Color reflectivityColor, TransparencyMode transparencyMode, float metallic, float roughness, float glossiness,
+            Color reflectivityColor, TransparencyMode transparencyMode, float metallic, float roughness,
             float specularIntensity, float emissiveIntensity, float directIntensity)
         {
             Color defaultColor = Color.white;
             return new AssetPromise_Material_Model(true, albedoTexture, alphaTexture,
                 emissiveTexture, bumpTexture, alphaTest, castShadows, albedoColor, defaultColor, emissiveColor,
-                reflectivityColor, transparencyMode, metallic, roughness, glossiness,
+                reflectivityColor, transparencyMode, metallic, roughness,
                 specularIntensity, emissiveIntensity, directIntensity);
         }
 
         public AssetPromise_Material_Model(bool isPbrMaterial, Texture? albedoTexture, Texture? alphaTexture,
             Texture? emissiveTexture, Texture? bumpTexture, float alphaTest, bool castShadows, Color albedoColor, Color diffuseColor, Color emissiveColor,
-            Color reflectivityColor, TransparencyMode transparencyMode, float metallic, float roughness, float glossiness,
+            Color reflectivityColor, TransparencyMode transparencyMode, float metallic, float roughness,
             float specularIntensity, float emissiveIntensity, float directIntensity)
         {
             this.isPbrMaterial = isPbrMaterial;
@@ -93,7 +92,6 @@ namespace DCL
             this.transparencyMode = transparencyMode;
             this.metallic = metallic;
             this.roughness = roughness;
-            this.glossiness = glossiness;
             this.specularIntensity = specularIntensity;
             this.emissiveIntensity = emissiveIntensity;
             this.directIntensity = directIntensity;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Material/MaterialHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Material/MaterialHelper.cs
@@ -47,12 +47,11 @@ namespace DCL
             material.SetColor(ShaderUtils.SpecColor, reflectivity);
         }
 
-        public static void SetUpProps(Material material, float metallic, float roughness, float glossiness,
+        public static void SetUpProps(Material material, float metallic, float roughness,
             float specularIntensity, float directIntensity)
         {
             material.SetFloat(ShaderUtils.Metallic, metallic);
             material.SetFloat(ShaderUtils.Smoothness, 1 - roughness);
-            material.SetFloat(ShaderUtils.EnvironmentReflections, glossiness);
             material.SetFloat(ShaderUtils.SpecularHighlights, specularIntensity * directIntensity);
         }
 


### PR DESCRIPTION
## What does this PR change?
related to issue https://github.com/decentraland/sdk/issues/877
and protocol PR https://github.com/decentraland/protocol/pull/155

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af10ef4</samp>

The pull request replaces the obsolete `glossiness` property of the PBR material system with the `specularIntensity` property, which is more consistent with the PBR material model. This affects the `AssetPromise_Material_Model`, `PBRMaterial`, and `AssetPromise_Material` classes, as well as the `MaterialHandler` and `PBMaterial_Defaults` classes. The pull request also updates the relevant method calls and parameters in these classes and removes unused code.
