### PR TITLE
Hotfix: disable CameraReel for guests users

### DIFF
--- a/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
+++ b/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
@@ -128,15 +128,23 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
                 Destroy(gameObject);
             else
             {
-                Canvas enableCameraButtonCanvas = Instantiate(enableCameraButtonPrefab);
-                enableCameraButtonCanvas.GetComponentInChildren<Button>().onClick.AddListener(() => ToggleScreenshotCamera("Button"));
-                CommonScriptableObjects.allUIHidden.OnChange += (isHidden, _) => enableCameraButtonCanvas.enabled = !isHidden;
-
-                enabled = true;
-
                 yield return new WaitUntil(() => player.ownPlayer.Get() != null && !string.IsNullOrEmpty(player.ownPlayer.Get().id));
-                playerId = player.ownPlayer.Get().id;
-                UpdateStorageInfo();
+
+                if(isGuest)
+                {
+                    Destroy(gameObject);
+                }
+                else
+                {
+                    Canvas enableCameraButtonCanvas = Instantiate(enableCameraButtonPrefab);
+                    enableCameraButtonCanvas.GetComponentInChildren<Button>().onClick.AddListener(() => ToggleScreenshotCamera("Button"));
+                    CommonScriptableObjects.allUIHidden.OnChange += (isHidden, _) => enableCameraButtonCanvas.enabled = !isHidden;
+
+                    enabled = true;
+
+                    playerId = player.ownPlayer.Get().id;
+                    UpdateStorageInfo();
+                }
             }
         }
 

--- a/unity-renderer/Assets/DCLPlugins/CameraReelPlugin/CameraReelPlugin.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/CameraReelPlugin/CameraReelPlugin.asmdef
@@ -19,7 +19,8 @@
         "GUID:c8ea72e806cd2ab47b539b37895b86b7",
         "GUID:1de3566cccb280f4a982c59ad0d08c96",
         "GUID:6426fc92c49cbb342916620a1009be8d",
-        "GUID:fd6a19eb8dfe417a84a27e537222d98d"
+        "GUID:fd6a19eb8dfe417a84a27e537222d98d",
+        "GUID:c34e38f41494f834abff029ddf82af43"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/CameraReelPlugin/CameraReelPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/CameraReelPlugin/CameraReelPlugin.cs
@@ -30,6 +30,11 @@ namespace DCLPlugins.CameraReelPlugin
 
         private async UniTaskVoid Initialize()
         {
+            await UniTask.WaitUntil(() => DataStore.i.player.ownPlayer.Get() != null && !string.IsNullOrEmpty(DataStore.i.player.ownPlayer.Get().id));
+
+            if (UserProfileController.userProfilesCatalog.Get(DataStore.i.player.ownPlayer.Get().id).isGuest)
+                return;
+
             IAddressableResourceProvider assetProvider = Environment.i.platform.serviceLocator.Get<IAddressableResourceProvider>();
 
             CameraReelSectionView view = await CreateCameraReelSectionView(assetProvider);
@@ -44,7 +49,8 @@ namespace DCLPlugins.CameraReelPlugin
                 cameraReelModel,
                 () =>
                 {
-                    var screenshotViewerView = Object.Instantiate(view.ScreenshotViewerPrefab);
+                    ScreenshotViewerView screenshotViewerView = Object.Instantiate(view.ScreenshotViewerPrefab);
+
                     return new ScreenshotViewerController(screenshotViewerView, cameraReelModel, dataStore,
                         storageService, new UserProfileWebInterfaceBridge(),
                         Clipboard.Create(), new WebInterfaceBrowserBridge(),
@@ -64,10 +70,12 @@ namespace DCLPlugins.CameraReelPlugin
 
             foreach (ThumbnailContextMenuController controller in thumbnailContextMenuControllers)
                 controller.Dispose();
+
             thumbnailContextMenuControllers.Clear();
 
             foreach (ScreenshotVisiblePersonController controller in visiblePersonControllers)
                 controller.Dispose();
+
             visiblePersonControllers.Clear();
 
             reelSectionController.Dispose();
@@ -81,6 +89,7 @@ namespace DCLPlugins.CameraReelPlugin
                 DataStore.i,
                 Environment.i.serviceLocator.Get<ICameraReelAnalyticsService>(),
                 Environment.i.serviceLocator.Get<IEnvironmentProviderService>());
+
             thumbnailContextMenuControllers.Add(controller);
         }
 


### PR DESCRIPTION
## What does this PR change?

disable both Screencapture Camera and Camera Reel for guests users

## How to test the changes?

1. Launch the explorer
2. Enter as guest and verify there is no small camera button under minimap for Screencapture Camera
3. Open Explore Menu and verify there is no CameraReel section there

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6335c2</samp>

This pull request enhances the camera reel plugin, which allows users to take and manage screenshots in Decentraland. It improves the code quality, functionality, and performance of the plugin, and prevents guests from using the screenshot camera feature. It also updates the assembly references to reflect the new location of the screenshot camera feature.
