### PR TITLE
feat: implemented portable experience white list

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL.Components;
 using DCL.World.PortableExperiences;
+using Newtonsoft.Json;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
@@ -845,11 +846,14 @@ namespace DCL
 
                 if (DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("px_confirm_enabled"))
                 {
-                    confirmPx = !IsPortableExperienceAlreadyConfirmed(pxId);
+                    if (!IsPortableExperienceInWhiteList(pxId))
+                    {
+                        confirmPx = !IsPortableExperienceAlreadyConfirmed(pxId);
 
-                    disablePx = IsPortableExperienceAlreadyConfirmed(pxId)
-                                && !ShouldForceAcceptPortableExperience(pxId)
-                                && !IsPortableExperienceConfirmedAndAccepted(pxId);
+                        disablePx = IsPortableExperienceAlreadyConfirmed(pxId)
+                                    && !ShouldForceAcceptPortableExperience(pxId)
+                                    && !IsPortableExperienceConfirmedAndAccepted(pxId);
+                    }
                 }
 
                 IWorldState worldState = Environment.i.world.state;
@@ -916,5 +920,22 @@ namespace DCL
 
         private bool IsPortableExperienceAlreadyConfirmed(string pxId) =>
             confirmedExperiencesRepository.Contains(pxId);
+
+        private bool IsPortableExperienceInWhiteList(string pxId)
+        {
+            FeatureFlag flags = DataStore.i.featureFlags.flags.Get();
+            FeatureFlagVariantPayload payload = flags.GetFeatureFlagVariantPayload("initial_portable_experiences:calendarpx");
+
+            if (payload == null) return false;
+
+            string[] whitelistedPxs = JsonConvert.DeserializeObject<string[]>(payload.value);
+
+            if (whitelistedPxs == null) return false;
+
+            for (var i = 0; i < whitelistedPxs.Length; i++)
+                if (whitelistedPxs[i].StartsWith(pxId)) return true;
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Allows the possibility to skip the manual user confirmation to enable a portable experience.

## How to test the changes?

1. Launch the explorer in incognito mode at `0,0`
2. Check that no PX confirmation popup is shown for name: `(-9, -9)`, id: `urn:decentraland:entity:bafkreicpzkqqaix77gctze4aauv7utmuithzywujeeg7xfca3u7apautya`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ea1f6b</samp>

Add feature flag for auto-accepting some portable experiences. Modify `SceneController.cs` to check px whitelist and skip user confirmation for allowed pxs.
