### PR TITLE
Hotfix: first person vie screenshot camera stuck and jump/run animation freeze

### DIFF
--- a/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
+++ b/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
@@ -292,21 +292,21 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
                 playerName.Hide();
             }
 
-            SetActivePlayerCamera(isActive: !activateScreenshotCamera);
-            SetActiveScreenshotCamera(isActive: activateScreenshotCamera);
+            SetPlayerCameraActive(isActive: !activateScreenshotCamera);
+            SetScreenshotCameraActive(isActive: activateScreenshotCamera);
             avatarsLODController.SetCamera(activateScreenshotCamera ? screenshotCamera : mainCamera);
         }
 
-        private void SetActiveScreenshotCamera(bool isActive)
+        private void SetScreenshotCameraActive(bool isActive)
         {
             screenshotCamera.gameObject.SetActive(isActive);
             screencaptureCameraHUDController.SetVisibility(isActive, storageStatus.HasFreeSpace);
         }
 
-        private void SetActivePlayerCamera(bool isActive)
+        private void SetPlayerCameraActive(bool isActive)
         {
             cameraController.SetCameraEnabledState(isActive);
-            characterController.SetEnabled(isActive);
+            characterController.SetMovementInputToZero();
             characterCinemachineBrain.enabled = isActive;
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
@@ -4,10 +4,8 @@ using System.Linq;
 using Cinemachine;
 using DCL.Helpers;
 using DCL.Interface;
-using DCL;
 using DCL.CameraTool;
 using UnityEngine;
-using UnityEngine.Rendering.Universal;
 
 namespace DCL.Camera
 {
@@ -57,8 +55,9 @@ namespace DCL.Camera
 
         public CameraStateBase currentCameraState => cachedModeToVirtualCamera[CommonScriptableObjects.cameraMode];
 
-        [HideInInspector]
-        public Action<CameraMode.ModeId> onSetCameraMode;
+        public event Action<CameraMode.ModeId> OnSetCameraMode;
+
+        public bool CameraIsBlending => cameraBrain.IsBlending;
 
         private void Awake()
         {
@@ -179,7 +178,7 @@ namespace DCL.Camera
 
             WebInterface.ReportCameraChanged(current);
 
-            onSetCameraMode?.Invoke(current);
+            OnSetCameraMode?.Invoke(current);
         }
 
         public CameraStateBase GetCameraMode(CameraMode.ModeId mode) { return cameraModes.FirstOrDefault(x => x.cameraModeId == mode); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraControllerAudioHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraControllerAudioHandler.cs
@@ -13,7 +13,7 @@ namespace DCL.Camera
         [SerializeField]
         AudioEvent eventCameraFadeIn, eventCameraFadeOut;
 
-        private void Awake() { cameraController.onSetCameraMode += OnSetCameraMode; }
+        private void Awake() { cameraController.OnSetCameraMode += OnSetCameraMode; }
 
         void OnSetCameraMode(CameraMode.ModeId mode)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -104,6 +104,12 @@ public class DCLCharacterController : MonoBehaviour
     public event System.Action OnHitGround;
     public event System.Action<float> OnMoved;
 
+    public void SetMovementInputToZero()
+    {
+        characterXAxis.SetValue(0);
+        characterYAxis.SetValue(0);
+    }
+
     void Awake()
     {
         if (i != null)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputAction_Measurable.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputAction_Measurable.cs
@@ -19,7 +19,7 @@ public class InputAction_Measurable : ScriptableObject
     [SerializeField] internal BooleanVariable blockMeasurable;
     public BooleanVariable isMeasurableBlocked { get => blockMeasurable; set => blockMeasurable = value; }
 
-    internal void RaiseOnValueChanged(float value)
+    public void SetValue(float value)
     {
         if (Math.Abs(currentValue - value) > Mathf.Epsilon)
         {
@@ -42,7 +42,7 @@ public class InputAction_Measurable : ScriptableObject
             changeValue = GUILayout.HorizontalSlider(changeValue, 0, 1);
             if (Application.isPlaying && GUILayout.Button("Raise OnChange"))
             {
-                ((InputAction_Measurable)target).RaiseOnValueChanged(changeValue);
+                ((InputAction_Measurable)target).SetValue(changeValue);
             }
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -435,6 +435,6 @@ public class InputController : MonoBehaviour
     private static void Stop_Measurable(InputAction_Measurable[] measurableActions)
     {
         foreach (var action in measurableActions)
-            action.RaiseOnValueChanged(0);
+            action.SetValue(0);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputProcessor.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputProcessor.cs
@@ -192,11 +192,11 @@ public static class InputProcessor
     {
         if (!PassModifiers(modifiers))
         {
-            action.RaiseOnValueChanged(0);
+            action.SetValue(0);
             return;
         }
 
-        action.RaiseOnValueChanged(Input.GetAxis(axisName));
+        action.SetValue(Input.GetAxis(axisName));
     }
 
     /// <summary>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Tests/InputController_Tests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Tests/InputController_Tests.cs
@@ -132,7 +132,7 @@ namespace InputController_Tests
         [TestCase(0.5f)]
         public void UpdateValueProperly(float newValue)
         {
-            action.RaiseOnValueChanged(newValue);
+            action.SetValue(newValue);
             Assert.AreEqual(newValue, action.GetValue());
         }
 
@@ -147,7 +147,7 @@ namespace InputController_Tests
                 called = true;
                 calledValue = value;
             };
-            action.RaiseOnValueChanged(18f);
+            action.SetValue(18f);
 
             Assert.IsTrue(called);
             Assert.AreEqual(18f, calledValue);


### PR DESCRIPTION
## What does this PR change?

- Awaited enter third person when enable screenshot camera. Fixes user to be in 1st person view and not possible to control camera (also being invisible on screenshot)
- zero character movement on enabling camera to fix player get stuck in jump or run animation when transitioning to camera mode

## How to test the changes?

1. Launch the explorer
2. Enter 1st person
3. Press C to open Screenshot Camera
4. Observe transition to 3rd person before entering camera mode
5. Verify you can take screenshots and switching between Screenshot/1st/3rd person camera works fine. 
6. Verify that you are not able to change between 1st/3rd person view while in Screenshot camera mode

1. Launch the explorer
3. Press C during run or Jump 
4. Observe that player finishes his jump or run animations
5. Verify you cannot move character while in Screenshot Camera mode
6. Verify you can move character after exiting Screenshot Camera mode

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4612715</samp>

This pull request enhances the screenshot camera feature and the camera controller component. It adds a smooth transition effect, fixes a camera mode bug, and exposes camera state and blending properties. It also cleans up and renames some namespaces and events to improve code quality and consistency.
