### PR TITLE
Hotfix: black screenshots on WebGL

### DIFF
--- a/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
+++ b/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
@@ -191,20 +191,18 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
 
         public void CaptureScreenshot(string source)
         {
-            StopAllCoroutines();
-            StartCoroutine(CaptureScreenshotAtTheFrameEnd(source));
+            CaptureScreenshotAtTheFrameEnd(source);
         }
 
-        private IEnumerator CaptureScreenshotAtTheFrameEnd(string source)
+        private void CaptureScreenshotAtTheFrameEnd(string source)
         {
-            if (!isScreencaptureCameraActive.Get() || isGuest || isOnCooldown || !storageStatus.HasFreeSpace) yield break;
+            if (!isScreencaptureCameraActive.Get() || isGuest || isOnCooldown || !storageStatus.HasFreeSpace) return;
 
             lastScreenshotTime = Time.realtimeSinceStartup;
 
             screencaptureCameraHUDController.SetVisibility(false, storageStatus.HasFreeSpace);
-            yield return waitEndOfFrameYield;
 
-            Texture2D screenshot = screenRecorderLazy.CaptureScreenshot();
+            Texture2D screenshot = screenRecorderLazy.CaptureScreenshotWithRenderTexture(SkyboxController.i.SkyboxCamera.BaseCamera);
 
             screencaptureCameraHUDController.SetVisibility(true, storageStatus.HasFreeSpace);
             screencaptureCameraHUDController.PlayScreenshotFX(screenshot, SPLASH_FX_DURATION, MIDDLE_PAUSE_FX_DURATION, IMAGE_TRANSITION_FX_DURATION);

--- a/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/ScreenshotCamera.asmdef
+++ b/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/ScreenshotCamera.asmdef
@@ -35,7 +35,8 @@
         "GUID:fc6576239b03d8445ba1a26d4b7b7b5d",
         "GUID:49176a91bbf7f8a4aaf35f6df0643d1a",
         "GUID:6426fc92c49cbb342916620a1009be8d",
-        "GUID:4307f53044263cf4b835bd812fc161a4"
+        "GUID:4307f53044263cf4b835bd812fc161a4",
+        "GUID:15fc0a57446b3144c949da3e2b9737a9"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxCamera.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxCamera.cs
@@ -7,12 +7,12 @@ namespace DCL.Skybox
     public class SkyboxCamera
     {
         private readonly GameObject skyboxCameraGO;
-        private readonly Camera skyboxCamera;
         private readonly SkyboxCameraBehaviour camBehavior;
 
         private List<Camera> skyboxCameraStack;
 
         public Camera CurrentCamera { get; private set; }
+        public Camera BaseCamera { get; }
 
         public SkyboxCamera()
         {
@@ -22,18 +22,18 @@ namespace DCL.Skybox
             skyboxCameraGO.transform.rotation = Quaternion.identity;
 
             // Attach camera component
-            skyboxCamera = skyboxCameraGO.AddComponent<Camera>();
+            BaseCamera = skyboxCameraGO.AddComponent<Camera>();
 
-            UniversalAdditionalCameraData cameraData = skyboxCamera.GetUniversalAdditionalCameraData();
+            UniversalAdditionalCameraData cameraData = BaseCamera.GetUniversalAdditionalCameraData();
             cameraData.renderShadows = false;
 
             // This index is defined in UniversalRenderPipelineAsset
             // We are using a custom ForwardRenderer with less features that increase the performance and lowers the passes
             cameraData.SetRenderer(1);
 
-            skyboxCamera.useOcclusionCulling = false;
-            skyboxCamera.cullingMask = 1 << LayerMask.NameToLayer("Skybox");
-            skyboxCamera.farClipPlane = 5000;
+            BaseCamera.useOcclusionCulling = false;
+            BaseCamera.cullingMask = 1 << LayerMask.NameToLayer("Skybox");
+            BaseCamera.farClipPlane = 5000;
 
             // Attach follow script
             camBehavior = skyboxCameraGO.AddComponent<SkyboxCameraBehaviour>();
@@ -52,7 +52,7 @@ namespace DCL.Skybox
 
             if (skyboxCameraStack == null)
             {
-                UniversalAdditionalCameraData cameraData = skyboxCamera.GetUniversalAdditionalCameraData();
+                UniversalAdditionalCameraData cameraData = BaseCamera.GetUniversalAdditionalCameraData();
                 skyboxCameraStack = cameraData.cameraStack;
                 skyboxCameraStack.Add(CurrentCamera);
 
@@ -62,12 +62,12 @@ namespace DCL.Skybox
             else
                 skyboxCameraStack[0] = CurrentCamera;
 
-            camBehavior.AssignCamera(CurrentCamera, skyboxCamera);
+            camBehavior.AssignCamera(CurrentCamera, BaseCamera);
         }
 
         public void SetCameraEnabledState(bool enabled)
         {
-            skyboxCamera.enabled = enabled;
+            BaseCamera.enabled = enabled;
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Replaced waitForEndOfFrame and unity built screenshot feature by Rendering into RenderTexture that solves black screenshots issue. 

It is not optimized and optimization will continue on [this branch](https://github.com/decentraland/unity-renderer/pull/5594), by replacing Creation/Destruction logic with RenderTexture.Get/ReleaseTemporary calls and caching

## How to test the changes?

1. Launch the explorer
2. Open screenshot camera (C)
3. Spam shot screenshots like crazy 🤪
4. Verify no black screenshots are taken
5. Verify no missing transition animations when taking screenshots
6. Verify screenshot image is the same as frame view and has 1920x1080 resolution and looks same (or better) as in-game view (has Bloom, Ambient occlusion, etc.)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aea1e5d</samp>

This pull request enhances the screenshot feature by using the Universal Render Pipeline to render and crop the camera output, and by refactoring the SkyboxCamera and ScreenRecorder classes to improve the code quality and the skybox rendering. It also updates the assembly definitions to include the necessary references.
