### PR TITLE
fix: 'file' named textures not loading

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFastDownloadProvider.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTFast/Wrappers/GLTFastDownloadProvider.cs
@@ -62,7 +62,7 @@ namespace DCL.GLTFast.Wrappers
 
             fileName = fileName.Replace(baseUrl, "");
 
-            if (fileName.StartsWith("file"))
+            if (fileName.StartsWith("file://"))
                 return fileName;
 
             // this can return false and the url is valid, only happens with asset with hash as a name ( mostly gltf )
@@ -107,7 +107,7 @@ namespace DCL.GLTFast.Wrappers
             if (!wrapper.Success)
             {
                 string errorMessage = promiseException != null ? promiseException.Message : wrapper.Error;
-                Debug.LogError($"[GLTFast Texture WebRequest Failed] Error: {errorMessage}" + finalUrl);
+                Debug.LogError($"[GLTFast Texture WebRequest Failed] Error: {errorMessage} | url: " + finalUrl);
             }
 
             return wrapper;


### PR DESCRIPTION
## What does this PR change?

This change should fix all scenes that contain textures named `file`

## How to test the changes?

- Enter [this link](https://play.decentraland.org/?realm=worlds-content-server.decentraland.zone%2Fworld%2Fafip.dcl.eth&position=0%2C0&explorer-branch=fix/file-gltf)
- The scene should load correctly (its only a tree)
- This is the [same link](https://play.decentraland.org/?realm=worlds-content-server.decentraland.zone%2Fworld%2Fafip.dcl.eth&position=0%2C0) but without this branch, no tree

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb2cf75</samp>

Fix local file detection and improve texture error logging in `GLTFastDownloadProvider` class. This class handles the downloading and loading of GLTF assets in the scene.
