### PR TITLE
hotfix: add discover tab metrics

### DIFF
--- a/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
+++ b/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
@@ -191,20 +191,18 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
 
         public void CaptureScreenshot(string source)
         {
-            StopAllCoroutines();
-            StartCoroutine(CaptureScreenshotAtTheFrameEnd(source));
+            CaptureScreenshotAtTheFrameEnd(source);
         }
 
-        private IEnumerator CaptureScreenshotAtTheFrameEnd(string source)
+        private void CaptureScreenshotAtTheFrameEnd(string source)
         {
-            if (!isScreencaptureCameraActive.Get() || isGuest || isOnCooldown || !storageStatus.HasFreeSpace) yield break;
+            if (!isScreencaptureCameraActive.Get() || isGuest || isOnCooldown || !storageStatus.HasFreeSpace) return;
 
             lastScreenshotTime = Time.realtimeSinceStartup;
 
             screencaptureCameraHUDController.SetVisibility(false, storageStatus.HasFreeSpace);
-            yield return waitEndOfFrameYield;
 
-            Texture2D screenshot = screenRecorderLazy.CaptureScreenshot();
+            Texture2D screenshot = screenRecorderLazy.CaptureScreenshotWithRenderTexture(SkyboxController.i.SkyboxCamera.BaseCamera);
 
             screencaptureCameraHUDController.SetVisibility(true, storageStatus.HasFreeSpace);
             screencaptureCameraHUDController.PlayScreenshotFX(screenshot, SPLASH_FX_DURATION, MIDDLE_PAUSE_FX_DURATION, IMAGE_TRANSITION_FX_DURATION);

--- a/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/ScreenshotCamera.asmdef
+++ b/unity-renderer/Assets/DCLFeatures/ScreencaptureCamera/ScreenshotCamera.asmdef
@@ -35,7 +35,8 @@
         "GUID:fc6576239b03d8445ba1a26d4b7b7b5d",
         "GUID:49176a91bbf7f8a4aaf35f6df0643d1a",
         "GUID:6426fc92c49cbb342916620a1009be8d",
-        "GUID:4307f53044263cf4b835bd812fc161a4"
+        "GUID:4307f53044263cf4b835bd812fc161a4",
+        "GUID:15fc0a57446b3144c949da3e2b9737a9"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLServices/PlacesAPIService/PlacesAnalytics.cs
+++ b/unity-renderer/Assets/DCLServices/PlacesAPIService/PlacesAnalytics.cs
@@ -12,11 +12,25 @@ namespace DCLServices.PlacesAPIService
             FromNavmap
         }
 
+        public enum FilterType
+        {
+            PointOfInterest,
+            Featured
+        }
+
+        public enum SortingType
+        {
+            MostActive,
+            HighestRated
+        }
+
         void AddFavorite(string placeUUID, ActionSource source);
         void RemoveFavorite(string placeUUID, ActionSource source);
         void Like(string placeUUID, IPlacesAnalytics.ActionSource source);
         void Dislike(string placeUUID, IPlacesAnalytics.ActionSource source);
         void RemoveVote(string placeUUID, IPlacesAnalytics.ActionSource source);
+        void Filter(FilterType filterType);
+        void Sort(IPlacesAnalytics.SortingType sortingType);
     }
 
     public class PlacesAnalytics : IPlacesAnalytics
@@ -26,6 +40,8 @@ namespace DCLServices.PlacesAPIService
         private const string LIKE_PLACE = "player_like_place";
         private const string DISLIKE_PLACE = "player_dislike_place";
         private const string REMOVE_VOTE_PLACE = "player_remove_vote_place";
+        private const string FILTER_PLACES = "player_filter_places";
+        private const string SORT_PLACES = "player_sort_places";
 
         public void AddFavorite(string placeUUID, IPlacesAnalytics.ActionSource source)
         {
@@ -75,6 +91,24 @@ namespace DCLServices.PlacesAPIService
                 ["source"] = source.ToString()
             };
             GenericAnalytics.SendAnalytic(REMOVE_VOTE_PLACE, data);
+        }
+
+        public void Filter(IPlacesAnalytics.FilterType filterType)
+        {
+            var data = new Dictionary<string, string>
+            {
+                ["type"] = filterType.ToString()
+            };
+            GenericAnalytics.SendAnalytic(FILTER_PLACES, data);
+        }
+
+        public void Sort(IPlacesAnalytics.SortingType sortingType)
+        {
+            var data = new Dictionary<string, string>
+            {
+                ["type"] = sortingType.ToString()
+            };
+            GenericAnalytics.SendAnalytic(SORT_PLACES, data);
         }
     }
 }

--- a/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxCamera.cs
+++ b/unity-renderer/Assets/Rendering/ProceduralSkybox/ToolProceduralSkybox/Scripts/SkyboxCamera.cs
@@ -7,12 +7,12 @@ namespace DCL.Skybox
     public class SkyboxCamera
     {
         private readonly GameObject skyboxCameraGO;
-        private readonly Camera skyboxCamera;
         private readonly SkyboxCameraBehaviour camBehavior;
 
         private List<Camera> skyboxCameraStack;
 
         public Camera CurrentCamera { get; private set; }
+        public Camera BaseCamera { get; }
 
         public SkyboxCamera()
         {
@@ -22,18 +22,18 @@ namespace DCL.Skybox
             skyboxCameraGO.transform.rotation = Quaternion.identity;
 
             // Attach camera component
-            skyboxCamera = skyboxCameraGO.AddComponent<Camera>();
+            BaseCamera = skyboxCameraGO.AddComponent<Camera>();
 
-            UniversalAdditionalCameraData cameraData = skyboxCamera.GetUniversalAdditionalCameraData();
+            UniversalAdditionalCameraData cameraData = BaseCamera.GetUniversalAdditionalCameraData();
             cameraData.renderShadows = false;
 
             // This index is defined in UniversalRenderPipelineAsset
             // We are using a custom ForwardRenderer with less features that increase the performance and lowers the passes
             cameraData.SetRenderer(1);
 
-            skyboxCamera.useOcclusionCulling = false;
-            skyboxCamera.cullingMask = 1 << LayerMask.NameToLayer("Skybox");
-            skyboxCamera.farClipPlane = 5000;
+            BaseCamera.useOcclusionCulling = false;
+            BaseCamera.cullingMask = 1 << LayerMask.NameToLayer("Skybox");
+            BaseCamera.farClipPlane = 5000;
 
             // Attach follow script
             camBehavior = skyboxCameraGO.AddComponent<SkyboxCameraBehaviour>();
@@ -52,7 +52,7 @@ namespace DCL.Skybox
 
             if (skyboxCameraStack == null)
             {
-                UniversalAdditionalCameraData cameraData = skyboxCamera.GetUniversalAdditionalCameraData();
+                UniversalAdditionalCameraData cameraData = BaseCamera.GetUniversalAdditionalCameraData();
                 skyboxCameraStack = cameraData.cameraStack;
                 skyboxCameraStack.Add(CurrentCamera);
 
@@ -62,12 +62,12 @@ namespace DCL.Skybox
             else
                 skyboxCameraStack[0] = CurrentCamera;
 
-            camBehavior.AssignCamera(CurrentCamera, skyboxCamera);
+            camBehavior.AssignCamera(CurrentCamera, BaseCamera);
         }
 
         public void SetCameraEnabledState(bool enabled)
         {
-            skyboxCamera.enabled = enabled;
+            BaseCamera.enabled = enabled;
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/ExploreV2Analytics/ExploreV2AnalyticsTypes.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/ExploreV2Analytics/ExploreV2AnalyticsTypes.cs
@@ -11,4 +11,14 @@ namespace ExploreV2Analytics
         FromExplore,
         FromSearch
     }
+
+    public enum FilterType
+    {
+        Featured,
+        Trending,
+        WantToGo,
+        Frequency,
+        Category,
+        Time
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
@@ -77,7 +77,10 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
         view.OnUnsubscribeEventClicked -= UnsubscribeToEvent;
         view.OnShowMoreEventsClicked -= ShowMoreEvents;
         view.OnEventsSubSectionEnable -= RequestAllEvents;
-        view.OnFiltersChanged -= LoadFilteredEvents;
+        view.OnEventTypeFiltersChanged -= ApplyEventTypeFilters;
+        view.OnEventFrequencyFilterChanged -= ApplyEventFrequencyFilter;
+        view.OnEventCategoryFilterChanged -= ApplyEventCategoryFilter;
+        view.OnEventTimeFilterChanged -= ApplyEventTimeFilter;
         view.OnConnectWallet -= ConnectWallet;
 
         dataStore.channels.currentJoinChannelModal.OnChange -= OnChannelToJoinChanged;
@@ -88,12 +91,17 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     private void FirstLoading()
     {
         view.OnEventsSubSectionEnable += RequestAllEvents;
-        view.OnFiltersChanged += LoadFilteredEvents;
+        view.OnEventTypeFiltersChanged += ApplyEventTypeFilters;
+        view.OnEventFrequencyFilterChanged += ApplyEventFrequencyFilter;
+        view.OnEventCategoryFilterChanged += ApplyEventCategoryFilter;
+        view.OnEventTimeFilterChanged += ApplyEventTimeFilter;
         cardsReloader.Initialize();
     }
 
     internal void RequestAllEvents()
     {
+        exploreV2Analytics.SendEventsTabOpen();
+
         view.SetIsGuestUser(userProfileBridge.GetOwn().isGuest);
         if (cardsReloader.CanReload())
         {
@@ -117,6 +125,42 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
         view.SetFeaturedEvents(PlacesAndEventsCardsFactory.CreateEventsCards(FilterFeaturedEvents()));
         LoadFilteredEvents();
         RequestAndLoadCategories();
+    }
+
+    private void ApplyEventTypeFilters()
+    {
+        switch (view.SelectedEventType)
+        {
+            case EventsType.Featured:
+                exploreV2Analytics.SendFilterEvents(FilterType.Featured);
+                break;
+            case EventsType.Trending:
+                exploreV2Analytics.SendFilterEvents(FilterType.Trending);
+                break;
+            case EventsType.WantToGo:
+                exploreV2Analytics.SendFilterEvents(FilterType.WantToGo);
+                break;
+        }
+
+        LoadFilteredEvents();
+    }
+
+    private void ApplyEventFrequencyFilter()
+    {
+        exploreV2Analytics.SendFilterEvents(FilterType.Frequency, view.SelectedFrequency);
+        LoadFilteredEvents();
+    }
+
+    private void ApplyEventCategoryFilter()
+    {
+        exploreV2Analytics.SendFilterEvents(FilterType.Category, view.SelectedCategory);
+        LoadFilteredEvents();
+    }
+
+    private void ApplyEventTimeFilter()
+    {
+        exploreV2Analytics.SendFilterEvents(FilterType.Time);
+        LoadFilteredEvents();
     }
 
     private void LoadFilteredEvents()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentView.cs
@@ -99,7 +99,10 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
     public event Action OnShowMoreEventsClicked;
     public event Action OnConnectWallet;
     public event Action OnEventsSubSectionEnable;
-    public event Action OnFiltersChanged;
+    public event Action OnEventTypeFiltersChanged;
+    public event Action OnEventFrequencyFilterChanged;
+    public event Action OnEventCategoryFilterChanged;
+    public event Action OnEventTimeFilterChanged;
 
     public override void Awake()
     {
@@ -388,7 +391,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             SetWantToGoStatus(false);
         }
 
-        OnFiltersChanged?.Invoke();
+        OnEventTypeFiltersChanged?.Invoke();
     }
 
     private void ClickedOnTrending()
@@ -408,7 +411,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             SetWantToGoStatus(false);
         }
 
-        OnFiltersChanged?.Invoke();
+        OnEventTypeFiltersChanged?.Invoke();
     }
 
     private void ClickedOnWantToGo()
@@ -428,7 +431,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             SetTrendingStatus(false);
         }
 
-        OnFiltersChanged?.Invoke();
+        OnEventTypeFiltersChanged?.Invoke();
     }
 
     private void OnFrequencyFilterChanged(bool isOn, string optionId, string optionName)
@@ -437,7 +440,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             return;
 
         SetFrequencyDropdownValue(optionId, optionName, false);
-        OnFiltersChanged?.Invoke();
+        OnEventFrequencyFilterChanged?.Invoke();
     }
 
     private void OnCategoryFilterChanged(bool isOn, string optionId, string optionName)
@@ -446,7 +449,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             return;
 
         SetCategoryDropdownValue(optionId, optionName, false);
-        OnFiltersChanged?.Invoke();
+        OnEventCategoryFilterChanged?.Invoke();
     }
 
     private void OnTimeFilterChanged(float lowValue, float highValue)
@@ -454,7 +457,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
         SelectedLowTime = lowValue;
         SelectedHighTime = highValue;
         timeDropdown.SetTitle($"{ConvertToTimeString(lowValue)} - {ConvertToTimeString(highValue)} (UTC)");
-        OnFiltersChanged?.Invoke();
+        OnEventTimeFilterChanged?.Invoke();
     }
 
     private static string ConvertToTimeString(float hours)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/IEventsSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/IEventsSubSectionComponentView.cs
@@ -79,9 +79,24 @@ public interface IEventsSubSectionComponentView: IPlacesAndEventsSubSectionCompo
     event Action OnEventsSubSectionEnable;
 
     /// <summary>
-    /// It will be triggered each time any filter is changed.
+    /// It will be triggered each time any event type filter is changed.
     /// </summary>
-    event Action OnFiltersChanged;
+    event Action OnEventTypeFiltersChanged;
+
+    /// <summary>
+    /// It will be triggered each time the frequency filter is changed.
+    /// </summary>
+    event Action OnEventFrequencyFilterChanged;
+
+    /// <summary>
+    /// It will be triggered each time the category filter is changed.
+    /// </summary>
+    event Action OnEventCategoryFilterChanged;
+
+    /// <summary>
+    /// It will be triggered each time the time filter is changed.
+    /// </summary>
+    event Action OnEventTimeFilterChanged;
 
     /// <summary>
     /// Set the featured events component with a list of events.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/FavoritesSubSection/FavoritesesSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/FavoritesSubSection/FavoritesesSubSectionComponentController.cs
@@ -115,6 +115,8 @@ public class FavoritesesSubSectionComponentController : IFavoritesSubSectionComp
 
     internal void RequestAllFavorites()
     {
+        exploreV2Analytics.SendFavoritesTabOpen();
+
         if (cardsReloader.CanReload())
         {
             availableUISlots = view.CurrentTilesPerRow * INITIAL_NUMBER_OF_ROWS;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/IPlacesSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/IPlacesSubSectionComponentView.cs
@@ -49,7 +49,8 @@ public interface IPlacesSubSectionComponentView:IPlacesAndEventsSubSectionCompon
     /// It will be triggered each time the view is enabled.
     /// </summary>
     event Action OnPlacesSubSectionEnable;
-    event Action OnFilterSorterChanged;
+    event Action OnFilterChanged;
+    event Action OnSortingChanged;
 
     /// <summary>
     /// It will be triggered when the "Show More" button is clicked.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentController.cs
@@ -20,6 +20,7 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
     internal const int INITIAL_NUMBER_OF_ROWS = 4;
     private const int PAGE_SIZE = 12;
     private const string ONLY_POI_FILTER = "only_pois=true";
+    private const string MOST_ACTIVE_FILTER_ID = "most_active";
 
     internal readonly IPlacesSubSectionComponentView view;
     internal readonly IPlacesAPIService placesAPIService;
@@ -87,8 +88,9 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
         view.OnJumpInClicked -= OnJumpInToPlace;
         view.OnFavoriteClicked -= View_OnFavoritesClicked;
         this.view.OnVoteChanged -= View_OnVoteChanged;
-        view.OnPlacesSubSectionEnable -= RequestAllPlaces;
-        view.OnFilterSorterChanged -= RequestAllPlaces;
+        view.OnPlacesSubSectionEnable -= OpenTab;
+        view.OnFilterChanged -= ApplyFilters;
+        view.OnSortingChanged -= ApplySorting;
         view.OnFriendHandlerAdded -= View_OnFriendHandlerAdded;
         view.OnShowMorePlacesClicked -= ShowMorePlaces;
 
@@ -134,9 +136,30 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
 
     private void FirstLoading()
     {
-        view.OnPlacesSubSectionEnable += RequestAllPlaces;
-        view.OnFilterSorterChanged += RequestAllPlaces;
+        view.OnPlacesSubSectionEnable += OpenTab;
+        view.OnFilterChanged += ApplyFilters;
+        view.OnSortingChanged += ApplySorting;
         cardsReloader.Initialize();
+    }
+
+    private void OpenTab()
+    {
+        exploreV2Analytics.SendPlacesTabOpen();
+        RequestAllPlaces();
+    }
+
+    private void ApplyFilters()
+    {
+        if (!string.IsNullOrEmpty(view.filter))
+            placesAnalytics.Filter(view.filter == ONLY_POI_FILTER ? IPlacesAnalytics.FilterType.PointOfInterest : IPlacesAnalytics.FilterType.Featured);
+
+        RequestAllPlaces();
+    }
+
+    private void ApplySorting()
+    {
+        placesAnalytics.Sort(view.sort == MOST_ACTIVE_FILTER_ID ? IPlacesAnalytics.SortingType.MostActive : IPlacesAnalytics.SortingType.HighestRated);
+        RequestAllPlaces();
     }
 
     internal void RequestAllPlaces()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentView.cs
@@ -77,7 +77,8 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
     public event Action<string, bool> OnFavoriteClicked;
     public event Action<FriendsHandler> OnFriendHandlerAdded;
     public event Action OnPlacesSubSectionEnable;
-    public event Action OnFilterSorterChanged;
+    public event Action OnFilterChanged;
+    public event Action OnSortingChanged;
     public event Action OnShowMorePlacesClicked;
 
     public override void Awake()
@@ -136,7 +137,7 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
             SetSortDropdownValue(HIGHEST_RATED_FILTER_ID, HIGHEST_RATED_FILTER_TEXT, false);
         }
 
-        OnFilterSorterChanged?.Invoke();
+        OnFilterChanged?.Invoke();
     }
 
     private void ClickedOnPOI()
@@ -158,7 +159,7 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
             SetSortDropdownValue(HIGHEST_RATED_FILTER_ID, HIGHEST_RATED_FILTER_TEXT, false);
         }
 
-        OnFilterSorterChanged?.Invoke();
+        OnFilterChanged?.Invoke();
     }
 
     private void SortByDropdownValueChanged(bool isOn, string optionId, string optionName)
@@ -167,7 +168,7 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
             return;
 
         SetSortDropdownValue(optionId, optionName, false);
-        OnFilterSorterChanged?.Invoke();
+        OnSortingChanged?.Invoke();
     }
 
     private void SetPoiStatus(bool isSelected)


### PR DESCRIPTION
## What does this PR change?
Add these new metrics:
- Views of places tab → `explore_places_tab_open`
- Views of events tab → `explore_events_tab_open`
- Views of favorites tab → `explore_events_tab_open`
- Clicks on Points of Interest or featured filters in places → `player_filter_places`
- Changing sort order in places → `player_sort_places`
- Clicking on featured, trending or want to go filters in events → `player_filter_events`
- Filter by event frequency, category or time → `player_filter_events`

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f32e1af</samp>

This pull request adds and improves analytics for the explore V2 feature, focusing on the places and events sub sections. It tracks user interactions with the different tabs, filters, and sorting options, and uses the `PlacesAnalytics` class to collect data on user preferences. It also refactors some of the view and controller classes to use more specific and consistent actions for filter and sorting changes. It affects the files `PlacesAnalytics.cs`, `ExploreV2Analytics.cs`, `ExploreV2AnalyticsTypes.cs`, and several files in the `ExploreV2/Scripts/Sections/PlacesAndEventsSection` folder.
