### PR TITLE
feat: discover tab metrics

### DIFF
--- a/unity-renderer/Assets/DCLServices/PlacesAPIService/PlacesAnalytics.cs
+++ b/unity-renderer/Assets/DCLServices/PlacesAPIService/PlacesAnalytics.cs
@@ -12,11 +12,25 @@ namespace DCLServices.PlacesAPIService
             FromNavmap
         }
 
+        public enum FilterType
+        {
+            PointOfInterest,
+            Featured
+        }
+
+        public enum SortingType
+        {
+            MostActive,
+            HighestRated
+        }
+
         void AddFavorite(string placeUUID, ActionSource source);
         void RemoveFavorite(string placeUUID, ActionSource source);
         void Like(string placeUUID, IPlacesAnalytics.ActionSource source);
         void Dislike(string placeUUID, IPlacesAnalytics.ActionSource source);
         void RemoveVote(string placeUUID, IPlacesAnalytics.ActionSource source);
+        void Filter(FilterType filterType);
+        void Sort(IPlacesAnalytics.SortingType sortingType);
     }
 
     public class PlacesAnalytics : IPlacesAnalytics
@@ -26,6 +40,8 @@ namespace DCLServices.PlacesAPIService
         private const string LIKE_PLACE = "player_like_place";
         private const string DISLIKE_PLACE = "player_dislike_place";
         private const string REMOVE_VOTE_PLACE = "player_remove_vote_place";
+        private const string FILTER_PLACES = "player_filter_places";
+        private const string SORT_PLACES = "player_sort_places";
 
         public void AddFavorite(string placeUUID, IPlacesAnalytics.ActionSource source)
         {
@@ -75,6 +91,24 @@ namespace DCLServices.PlacesAPIService
                 ["source"] = source.ToString()
             };
             GenericAnalytics.SendAnalytic(REMOVE_VOTE_PLACE, data);
+        }
+
+        public void Filter(IPlacesAnalytics.FilterType filterType)
+        {
+            var data = new Dictionary<string, string>
+            {
+                ["type"] = filterType.ToString()
+            };
+            GenericAnalytics.SendAnalytic(FILTER_PLACES, data);
+        }
+
+        public void Sort(IPlacesAnalytics.SortingType sortingType)
+        {
+            var data = new Dictionary<string, string>
+            {
+                ["type"] = sortingType.ToString()
+            };
+            GenericAnalytics.SendAnalytic(SORT_PLACES, data);
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/ExploreV2Analytics/ExploreV2AnalyticsTypes.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/ExploreV2Analytics/ExploreV2AnalyticsTypes.cs
@@ -11,4 +11,14 @@ namespace ExploreV2Analytics
         FromExplore,
         FromSearch
     }
+
+    public enum FilterType
+    {
+        Featured,
+        Trending,
+        WantToGo,
+        Frequency,
+        Category,
+        Time
+    }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
@@ -77,7 +77,10 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
         view.OnUnsubscribeEventClicked -= UnsubscribeToEvent;
         view.OnShowMoreEventsClicked -= ShowMoreEvents;
         view.OnEventsSubSectionEnable -= RequestAllEvents;
-        view.OnFiltersChanged -= LoadFilteredEvents;
+        view.OnEventTypeFiltersChanged -= ApplyEventTypeFilters;
+        view.OnEventFrequencyFilterChanged -= ApplyEventFrequencyFilter;
+        view.OnEventCategoryFilterChanged -= ApplyEventCategoryFilter;
+        view.OnEventTimeFilterChanged -= ApplyEventTimeFilter;
         view.OnConnectWallet -= ConnectWallet;
 
         dataStore.channels.currentJoinChannelModal.OnChange -= OnChannelToJoinChanged;
@@ -88,12 +91,17 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     private void FirstLoading()
     {
         view.OnEventsSubSectionEnable += RequestAllEvents;
-        view.OnFiltersChanged += LoadFilteredEvents;
+        view.OnEventTypeFiltersChanged += ApplyEventTypeFilters;
+        view.OnEventFrequencyFilterChanged += ApplyEventFrequencyFilter;
+        view.OnEventCategoryFilterChanged += ApplyEventCategoryFilter;
+        view.OnEventTimeFilterChanged += ApplyEventTimeFilter;
         cardsReloader.Initialize();
     }
 
     internal void RequestAllEvents()
     {
+        exploreV2Analytics.SendEventsTabOpen();
+
         view.SetIsGuestUser(userProfileBridge.GetOwn().isGuest);
         if (cardsReloader.CanReload())
         {
@@ -117,6 +125,42 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
         view.SetFeaturedEvents(PlacesAndEventsCardsFactory.CreateEventsCards(FilterFeaturedEvents()));
         LoadFilteredEvents();
         RequestAndLoadCategories();
+    }
+
+    private void ApplyEventTypeFilters()
+    {
+        switch (view.SelectedEventType)
+        {
+            case EventsType.Featured:
+                exploreV2Analytics.SendFilterEvents(FilterType.Featured);
+                break;
+            case EventsType.Trending:
+                exploreV2Analytics.SendFilterEvents(FilterType.Trending);
+                break;
+            case EventsType.WantToGo:
+                exploreV2Analytics.SendFilterEvents(FilterType.WantToGo);
+                break;
+        }
+
+        LoadFilteredEvents();
+    }
+
+    private void ApplyEventFrequencyFilter()
+    {
+        exploreV2Analytics.SendFilterEvents(FilterType.Frequency, view.SelectedFrequency);
+        LoadFilteredEvents();
+    }
+
+    private void ApplyEventCategoryFilter()
+    {
+        exploreV2Analytics.SendFilterEvents(FilterType.Category, view.SelectedCategory);
+        LoadFilteredEvents();
+    }
+
+    private void ApplyEventTimeFilter()
+    {
+        exploreV2Analytics.SendFilterEvents(FilterType.Time);
+        LoadFilteredEvents();
     }
 
     private void LoadFilteredEvents()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentView.cs
@@ -4,11 +4,9 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL.Tasks;
-using TMPro;
 using UIComponents.Scripts.Components.RangeSlider;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectionComponentView
@@ -99,7 +97,10 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
     public event Action OnShowMoreEventsClicked;
     public event Action OnConnectWallet;
     public event Action OnEventsSubSectionEnable;
-    public event Action OnFiltersChanged;
+    public event Action OnEventTypeFiltersChanged;
+    public event Action OnEventFrequencyFilterChanged;
+    public event Action OnEventCategoryFilterChanged;
+    public event Action OnEventTimeFilterChanged;
 
     public override void Awake()
     {
@@ -388,7 +389,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             SetWantToGoStatus(false);
         }
 
-        OnFiltersChanged?.Invoke();
+        OnEventTypeFiltersChanged?.Invoke();
     }
 
     private void ClickedOnTrending()
@@ -408,7 +409,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             SetWantToGoStatus(false);
         }
 
-        OnFiltersChanged?.Invoke();
+        OnEventTypeFiltersChanged?.Invoke();
     }
 
     private void ClickedOnWantToGo()
@@ -428,7 +429,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             SetTrendingStatus(false);
         }
 
-        OnFiltersChanged?.Invoke();
+        OnEventTypeFiltersChanged?.Invoke();
     }
 
     private void OnFrequencyFilterChanged(bool isOn, string optionId, string optionName)
@@ -437,7 +438,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             return;
 
         SetFrequencyDropdownValue(optionId, optionName, false);
-        OnFiltersChanged?.Invoke();
+        OnEventFrequencyFilterChanged?.Invoke();
     }
 
     private void OnCategoryFilterChanged(bool isOn, string optionId, string optionName)
@@ -446,7 +447,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
             return;
 
         SetCategoryDropdownValue(optionId, optionName, false);
-        OnFiltersChanged?.Invoke();
+        OnEventCategoryFilterChanged?.Invoke();
     }
 
     private void OnTimeFilterChanged(float lowValue, float highValue)
@@ -454,7 +455,7 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
         SelectedLowTime = lowValue;
         SelectedHighTime = highValue;
         timeDropdown.SetTitle($"{ConvertToTimeString(lowValue)} - {ConvertToTimeString(highValue)} (UTC)");
-        OnFiltersChanged?.Invoke();
+        OnEventTimeFilterChanged?.Invoke();
     }
 
     private static string ConvertToTimeString(float hours)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/IEventsSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/IEventsSubSectionComponentView.cs
@@ -79,9 +79,24 @@ public interface IEventsSubSectionComponentView: IPlacesAndEventsSubSectionCompo
     event Action OnEventsSubSectionEnable;
 
     /// <summary>
-    /// It will be triggered each time any filter is changed.
+    /// It will be triggered each time any event type filter is changed.
     /// </summary>
-    event Action OnFiltersChanged;
+    event Action OnEventTypeFiltersChanged;
+
+    /// <summary>
+    /// It will be triggered each time the frequency filter is changed.
+    /// </summary>
+    event Action OnEventFrequencyFilterChanged;
+
+    /// <summary>
+    /// It will be triggered each time the category filter is changed.
+    /// </summary>
+    event Action OnEventCategoryFilterChanged;
+
+    /// <summary>
+    /// It will be triggered each time the time filter is changed.
+    /// </summary>
+    event Action OnEventTimeFilterChanged;
 
     /// <summary>
     /// Set the featured events component with a list of events.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/FavoritesSubSection/FavoritesesSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/FavoritesSubSection/FavoritesesSubSectionComponentController.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using Environment = DCL.Environment;
-using MainScripts.DCL.Controllers.HotScenes;
 using System.Threading;
 using static MainScripts.DCL.Controllers.HotScenes.IHotScenesController;
 
@@ -115,6 +114,8 @@ public class FavoritesesSubSectionComponentController : IFavoritesSubSectionComp
 
     internal void RequestAllFavorites()
     {
+        exploreV2Analytics.SendFavoritesTabOpen();
+
         if (cardsReloader.CanReload())
         {
             availableUISlots = view.CurrentTilesPerRow * INITIAL_NUMBER_OF_ROWS;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/IPlacesSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/IPlacesSubSectionComponentView.cs
@@ -49,7 +49,8 @@ public interface IPlacesSubSectionComponentView:IPlacesAndEventsSubSectionCompon
     /// It will be triggered each time the view is enabled.
     /// </summary>
     event Action OnPlacesSubSectionEnable;
-    event Action OnFilterSorterChanged;
+    event Action OnFilterChanged;
+    event Action OnSortingChanged;
 
     /// <summary>
     /// It will be triggered when the "Show More" button is clicked.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentController.cs
@@ -20,6 +20,7 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
     internal const int INITIAL_NUMBER_OF_ROWS = 4;
     private const int PAGE_SIZE = 12;
     private const string ONLY_POI_FILTER = "only_pois=true";
+    private const string MOST_ACTIVE_FILTER_ID = "most_active";
 
     internal readonly IPlacesSubSectionComponentView view;
     internal readonly IPlacesAPIService placesAPIService;
@@ -87,8 +88,9 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
         view.OnJumpInClicked -= OnJumpInToPlace;
         view.OnFavoriteClicked -= View_OnFavoritesClicked;
         this.view.OnVoteChanged -= View_OnVoteChanged;
-        view.OnPlacesSubSectionEnable -= RequestAllPlaces;
-        view.OnFilterSorterChanged -= RequestAllPlaces;
+        view.OnPlacesSubSectionEnable -= OpenTab;
+        view.OnFilterChanged -= ApplyFilters;
+        view.OnSortingChanged -= ApplySorting;
         view.OnFriendHandlerAdded -= View_OnFriendHandlerAdded;
         view.OnShowMorePlacesClicked -= ShowMorePlaces;
 
@@ -134,9 +136,30 @@ public class PlacesSubSectionComponentController : IPlacesSubSectionComponentCon
 
     private void FirstLoading()
     {
-        view.OnPlacesSubSectionEnable += RequestAllPlaces;
-        view.OnFilterSorterChanged += RequestAllPlaces;
+        view.OnPlacesSubSectionEnable += OpenTab;
+        view.OnFilterChanged += ApplyFilters;
+        view.OnSortingChanged += ApplySorting;
         cardsReloader.Initialize();
+    }
+
+    private void OpenTab()
+    {
+        exploreV2Analytics.SendPlacesTabOpen();
+        RequestAllPlaces();
+    }
+
+    private void ApplyFilters()
+    {
+        if (!string.IsNullOrEmpty(view.filter))
+            placesAnalytics.Filter(view.filter == ONLY_POI_FILTER ? IPlacesAnalytics.FilterType.PointOfInterest : IPlacesAnalytics.FilterType.Featured);
+
+        RequestAllPlaces();
+    }
+
+    private void ApplySorting()
+    {
+        placesAnalytics.Sort(view.sort == MOST_ACTIVE_FILTER_ID ? IPlacesAnalytics.SortingType.MostActive : IPlacesAnalytics.SortingType.HighestRated);
+        RequestAllPlaces();
     }
 
     internal void RequestAllPlaces()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/PlacesSubSection/PlacesSubSectionMenu/PlacesSubSectionComponentView.cs
@@ -77,7 +77,8 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
     public event Action<string, bool> OnFavoriteClicked;
     public event Action<FriendsHandler> OnFriendHandlerAdded;
     public event Action OnPlacesSubSectionEnable;
-    public event Action OnFilterSorterChanged;
+    public event Action OnFilterChanged;
+    public event Action OnSortingChanged;
     public event Action OnShowMorePlacesClicked;
 
     public override void Awake()
@@ -136,7 +137,7 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
             SetSortDropdownValue(HIGHEST_RATED_FILTER_ID, HIGHEST_RATED_FILTER_TEXT, false);
         }
 
-        OnFilterSorterChanged?.Invoke();
+        OnFilterChanged?.Invoke();
     }
 
     private void ClickedOnPOI()
@@ -158,7 +159,7 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
             SetSortDropdownValue(HIGHEST_RATED_FILTER_ID, HIGHEST_RATED_FILTER_TEXT, false);
         }
 
-        OnFilterSorterChanged?.Invoke();
+        OnFilterChanged?.Invoke();
     }
 
     private void SortByDropdownValueChanged(bool isOn, string optionId, string optionName)
@@ -167,7 +168,7 @@ public class PlacesSubSectionComponentView : BaseComponentView, IPlacesSubSectio
             return;
 
         SetSortDropdownValue(optionId, optionName, false);
-        OnFilterSorterChanged?.Invoke();
+        OnSortingChanged?.Invoke();
     }
 
     private void SetPoiStatus(bool isSelected)


### PR DESCRIPTION
## What does this PR change?
Add these new metrics:
- Views of places tab → `explore_places_tab_open`
- Views of events tab → `explore_events_tab_open`
- Views of favorites tab → `explore_events_tab_open`
- Clicks on Points of Interest or featured filters in places → `player_filter_places`
- Changing sort order in places → `player_sort_places`
- Clicking on featured, trending or want to go filters in events → `player_filter_events`
- Filter by event frequency, category or time → `player_filter_events`

## How to test the changes?
1. Launch the explorer.
2. Open the Explore menu.
3. Check that Places and Events sections work exactly the same way as right now in prod.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7b2486</samp>

This pull request adds and improves analytics tracking for the explore V2 feature, especially for the places and events tabs and filters. It defines new filter types and events, splits existing events into more granular ones, and implements event sending for various user actions. It also refactors and fixes some scripts related to the explore V2 UI and logic. The main files affected are `PlacesAnalytics.cs`, `ExploreV2Analytics.cs`, and the component controllers and views for the places and events sub sections.
