### PR TITLE
fix: exception when listing wearables of an user in the picture details

### DIFF
--- a/unity-renderer/Assets/DCLFeatures/CameraReel/ScreenshotViewer/Scripts/ScreenshotVisiblePersonController.cs
+++ b/unity-renderer/Assets/DCLFeatures/CameraReel/ScreenshotViewer/Scripts/ScreenshotVisiblePersonController.cs
@@ -77,21 +77,28 @@ namespace DCLFeatures.CameraReel.ScreenshotViewer
         {
             foreach (string wearable in person.wearables)
             {
-                WearableItem wearableItem = await wearablesCatalogService.RequestWearableAsync(wearable, cancellationToken);
-
-                var nftModel = new NFTIconComponentModel
+                try
                 {
-                    name = wearableItem.GetName(),
-                    imageURI = wearableItem.ComposeThumbnailUrl(),
-                    rarity = wearableItem.rarity,
-                    nftInfo = wearableItem.GetNftInfo(),
-                    marketplaceURI = wearableItem.GetMarketplaceLink(),
-                    showMarketplaceButton = true,
-                    showType = false,
-                    type = wearableItem.data.category,
-                };
+                    WearableItem wearableItem = await wearablesCatalogService.RequestWearableAsync(wearable, cancellationToken);
 
-                view.AddWearable(nftModel);
+                    if (wearableItem == null) continue;
+
+                    var nftModel = new NFTIconComponentModel
+                    {
+                        name = wearableItem.GetName(),
+                        imageURI = wearableItem.ComposeThumbnailUrl(),
+                        rarity = wearableItem.rarity,
+                        nftInfo = wearableItem.GetNftInfo(),
+                        marketplaceURI = wearableItem.GetMarketplaceLink(),
+                        showMarketplaceButton = true,
+                        showType = false,
+                        type = wearableItem.data.category,
+                    };
+
+                    view.AddWearable(nftModel);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception e) { Debug.LogException(e); }
             }
         }
 
@@ -101,13 +108,11 @@ namespace DCLFeatures.CameraReel.ScreenshotViewer
             {
                 UserProfile profile = userProfileBridge.Get(userId)
                                       ?? await userProfileBridge.RequestFullUserProfileAsync(userId, cancellationToken);
+
                 view.SetProfilePicture(profile.face256SnapshotURL);
             }
             catch (OperationCanceledException) { }
-            catch (Exception e)
-            {
-                Debug.LogException(e);
-            }
+            catch (Exception e) { Debug.LogException(e); }
         }
 
         private void OnOpenProfileRequested()


### PR DESCRIPTION
## What does this PR change?

When listing wearables of a person in the picture, there was a possibility of retrieving an invalid wearable. This safe check fixes the issue allowing the listing of the rest of the wearables.

## How to test the changes?

1. Launch the explorer
2. Take a picture with the camera (you can access it by pressing `C`)
3. Go to the camera gallery through the start menu
4. Click over any of the pictures listed
5. All the wearables of the users should be listed as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
