### PR TITLE
chore: increased playmode tests timeout to 40 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ jobs:
                 bash ci-playmode-test.sh
                 exit $?
             fi;
-          no_output_timeout: 30m
+          no_output_timeout: 40m
       - run:
           name: nunit-to-junit
           when: always


### PR DESCRIPTION
## What does this PR change?

We have pipelines failing due timeout in the playmode tests step. This change will try to mitigate the issue.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
