### PR TITLE
chore: remove not used UserAcceptedCollectiblesPayload

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -401,12 +401,6 @@ namespace DCL.Interface
         public class RaycastHitAllResponse : RaycastResponse<RaycastHitEntities> { }
 
         [System.Serializable]
-        public class UserAcceptedCollectiblesPayload
-        {
-            public string id;
-        }
-
-        [System.Serializable]
         public class SendBlockPlayerPayload
         {
             public string userId;


### PR DESCRIPTION
## What does this PR change?

Removing not used `UserAcceptedCollectiblesPayload` that was supposed to be removed during AirDrop cleanup.


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e0b217</samp>

Removed unused `UserAcceptedCollectiblesPayload` class from `Interface.cs` and used the existing one from `ParcelScene.cs`. This was a code cleanup and refactoring change.
