### PR TITLE
fix: avatar not loading anymore after the loading process was cancelled

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -72,12 +72,8 @@ namespace AvatarSystem
             {
                 // Cancel any ongoing process except the current loadCancellationToken
                 // since it was provoking a double cancellation thus inconsistencies in the flow
-                status = IAvatar.Status.Idle;
-                avatarCurator?.Dispose();
-                loader?.Dispose();
-                visibility?.Dispose();
-                lod?.Dispose();
-                gpuSkinningThrottlerService?.Unregister(gpuSkinning);
+                // TODO: disposing collaborators is an anti-pattern in the current context. Disposed objects should not be reused. Instead all collaborators should handle OperationCancelledException by their own so the internal state is restored
+                CancelAndRestoreOngoingProcessesExceptTheLoading();
 
                 throw;
             }
@@ -85,12 +81,8 @@ namespace AvatarSystem
             {
                 // Cancel any ongoing process except the current loadCancellationToken
                 // since it was provoking a double cancellation thus inconsistencies in the flow
-                status = IAvatar.Status.Idle;
-                avatarCurator?.Dispose();
-                loader?.Dispose();
-                visibility?.Dispose();
-                lod?.Dispose();
-                gpuSkinningThrottlerService?.Unregister(gpuSkinning);
+                // TODO: disposing collaborators is an anti-pattern in the current context. Disposed objects should not be reused. Instead all collaborators should handle OperationCancelledException by their own so the internal state is restored
+                CancelAndRestoreOngoingProcessesExceptTheLoading();
 
                 Debug.Log($"Avatar.Load failed with wearables:[{string.Join(",", wearablesIds)}] " +
                           $"for bodyshape:{settings.bodyshapeId} and player {settings.playerName}");
@@ -215,10 +207,15 @@ namespace AvatarSystem
 
         public void Dispose()
         {
-            status = IAvatar.Status.Idle;
             loadCancellationToken?.Cancel();
             loadCancellationToken?.Dispose();
             loadCancellationToken = null;
+            CancelAndRestoreOngoingProcessesExceptTheLoading();
+        }
+
+        private void CancelAndRestoreOngoingProcessesExceptTheLoading()
+        {
+            status = IAvatar.Status.Idle;
             avatarCurator?.Dispose();
             loader?.Dispose();
             visibility?.Dispose();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystem.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarSystem.asmdef
@@ -34,7 +34,8 @@
         "GUID:029c1c1b674aaae47a6841a0b89ad80e",
         "GUID:26861d1714ac819459758e0b653efd06",
         "GUID:97d8897529779cb49bebd400c7f402a6",
-        "GUID:a881b57670b1d2747a6d7f9e32b63230"
+        "GUID:a881b57670b1d2747a6d7f9e32b63230",
+        "GUID:4d3366a36e77f41cfb7436340334e236"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDV2ComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDV2ComponentView.cs
@@ -75,11 +75,13 @@ namespace DCL.Backpack
             IPreviewCameraZoomController avatarPreviewZoomController)
         {
             ConfigureSectionSelector();
+
             backpackPreviewPanel.Initialize(
                 characterPreviewFactory,
                 avatarPreviewRotationController,
                 avatarPreviewPanningController,
                 avatarPreviewZoomController);
+
             colorPickerComponentView.OnColorChanged += OnColorPickerColorChanged;
             colorPickerComponentView.OnColorPickerToggle += ColorPickerToggle;
 
@@ -98,9 +100,7 @@ namespace DCL.Backpack
         private void ToggleOutfitSection()
         {
             if (outfitSection.activeInHierarchy)
-            {
                 ToggleNormalSection();
-            }
             else
             {
                 normalSection.SetActive(false);
@@ -213,6 +213,7 @@ namespace DCL.Backpack
             {
                 ResetPreviewPanel();
                 await UniTask.Delay(MS_TO_RESET_PREVIEW_ANIMATION, cancellationToken: ct);
+
                 backpackPreviewPanel.TakeSnapshots(
                     (face256, body) => onSuccess?.Invoke(face256, body),
                     () => onFailed?.Invoke());
@@ -269,20 +270,23 @@ namespace DCL.Backpack
 
         private void ConfigureSectionSelector()
         {
-            sectionSelector.GetSection(AVATAR_SECTION_INDEX).onSelect.AddListener((isSelected) =>
-            {
-                wearablesSection.SetActive(isSelected);
+            sectionSelector.GetSection(AVATAR_SECTION_INDEX)
+                           .onSelect.AddListener((isSelected) =>
+                            {
+                                wearablesSection.SetActive(isSelected);
 
-                if (isSelected)
-                    ResetPreviewPanel();
-            });
-            sectionSelector.GetSection(EMOTES_SECTION_INDEX).onSelect.AddListener((isSelected) =>
-            {
-                emotesSection.SetActive(isSelected);
+                                if (isSelected)
+                                    ResetPreviewPanel();
+                            });
 
-                if (isSelected)
-                    ResetPreviewPanel();
-            });
+            sectionSelector.GetSection(EMOTES_SECTION_INDEX)
+                           .onSelect.AddListener((isSelected) =>
+                            {
+                                emotesSection.SetActive(isSelected);
+
+                                if (isSelected)
+                                    ResetPreviewPanel();
+                            });
         }
 
         public void ResetPreviewPanel()
@@ -302,11 +306,7 @@ namespace DCL.Backpack
                     backpackPreviewPanel.SetLoadingActive(false);
                     OnAvatarUpdated?.Invoke();
                 }
-                catch (OperationCanceledException e)
-                {
-                    Debug.LogWarning("Update avatar preview cancelled");
-                    Debug.LogWarning(e);
-                }
+                catch (OperationCanceledException) { Debug.LogWarning("Update avatar preview cancelled"); }
                 catch (Exception e) { Debug.LogException(e); }
             }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDV2ComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDV2ComponentView.cs
@@ -296,9 +296,18 @@ namespace DCL.Backpack
         {
             async UniTaskVoid UpdateAvatarAsync(CancellationToken ct)
             {
-                await backpackPreviewPanel.TryUpdatePreviewModelAsync(avatarModelToUpdate, ct);
-                backpackPreviewPanel.SetLoadingActive(false);
-                OnAvatarUpdated?.Invoke();
+                try
+                {
+                    await backpackPreviewPanel.TryUpdatePreviewModelAsync(avatarModelToUpdate, ct);
+                    backpackPreviewPanel.SetLoadingActive(false);
+                    OnAvatarUpdated?.Invoke();
+                }
+                catch (OperationCanceledException e)
+                {
+                    Debug.LogWarning("Update avatar preview cancelled");
+                    Debug.LogWarning(e);
+                }
+                catch (Exception e) { Debug.LogException(e); }
             }
 
             if (!isAvatarDirty)


### PR DESCRIPTION
## What does this PR change?

Fixes an endless loading in the the avatar preview during the avatar first-time creation process.
This may affect any other inconsistent avatar displaying if the loading process was cancelled by any reason.

## How to test the changes?

1. Launch the explorer
2. Clean cache
3. Enter as a guest
4. Follow the avatar creation process
5. Navigate through the world and check that the avatars are being loaded correctly around you

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9dd33c</samp>

This pull request refactors and improves the code quality and error handling of the avatar system and the backpack editor HUD. It simplifies the cancellation logic of avatar loading, adds debug warnings and exception logging, and follows code style and formatting conventions. It also adds a new assembly reference for the avatar system.
