### PR TITLE
fix: sdk7 scenes addition to loaded scenes datastore

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECS7Plugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECS7Plugin.cs
@@ -102,14 +102,14 @@ namespace DCL.ECS7
         {
             if (!scene.sceneData.sdk7) return;
 
-            loadedScenes.Add(scene);
-
             int sceneNumber = scene.sceneData.sceneNumber;
             sceneNumberMapping.Add(sceneNumber, scene);
             sceneStateHandler.InitializeEngineInfoComponent(sceneNumber);
             var outgoingMsgs = new DualKeyValueSet<long, int, WriteData>(10);
             scenesOutgoingMsgs.Add(sceneNumber, outgoingMsgs);
             componentWriters.Add(sceneNumber, new ComponentWriter(outgoingMsgs));
+
+            loadedScenes.Add(scene);
         }
 
         private void SceneControllerOnSceneRemoved(IParcelScene scene)


### PR DESCRIPTION
Moved scenes addition to sdk7 loaded scenes datastore to AFTER having its stuff initialized, the UiCanvasInformation system was not being able to update the component for late-loaded scenes since they didn't have their ComponentWriter initialized.

### TESTING

1. Access sdk7 goerli plaza world at 76, -10: https://sdk-test-scenes.decentraland.zone/?position=76%2C-10&realm=LocalPreview&explorer-branch=fix/sdk7-scenes-addition-to-datastore
2. After the world loads, without doing anything you should see a BLUE panel on top of the RED background panel, like so:

![Screen Shot 2023-08-23 at 17 30 43 Medium](https://github.com/decentraland/unity-renderer/assets/1031741/ed88a6fe-2700-4db6-944e-4690c415f687)
