### PR TITLE
Feat: hide screencapture camera HUD

### DIFF
--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
@@ -80,6 +80,7 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
 
         private InputAction_Trigger toggleScreenshotCameraAction;
         private InputAction_Trigger toggleCameraReelAction;
+        private InputAction_Trigger exitScreenshotModeAction;
 
         public DataStore_Player Player { private get; set; }
         public bool HasStorageSpace => storageStatus.HasFreeSpace;
@@ -110,9 +111,12 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
         {
             toggleScreenshotCameraAction = Resources.Load<InputAction_Trigger>("ToggleScreenshotCamera");
             toggleCameraReelAction = Resources.Load<InputAction_Trigger>("ToggleCameraReelSection");
+            exitScreenshotModeAction = Resources.Load<InputAction_Trigger>("CloseScreenshotCamera");
 
             toggleScreenshotCameraAction.OnTriggered += ToggleScreenshotCamera;
             toggleCameraReelAction.OnTriggered += OpenCameraReelGallery;
+
+            exitScreenshotModeAction.OnTriggered += CloseScreenshotCamera;
         }
 
         private void Start()
@@ -131,6 +135,7 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
         {
             toggleScreenshotCameraAction.OnTriggered -= ToggleScreenshotCamera;
             toggleCameraReelAction.OnTriggered -= OpenCameraReelGallery;
+            exitScreenshotModeAction.OnTriggered -= CloseScreenshotCamera;
         }
 
         private void OpenCameraReelGallery(DCLAction_Trigger _) =>
@@ -238,8 +243,11 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
             isScreencaptureCameraActive.Set(true);
         }
 
+        private void CloseScreenshotCamera(DCLAction_Trigger _) =>
+            ToggleScreenshotCamera("Shortcut", isEnabled: false);
+
         private void ToggleScreenshotCamera(DCLAction_Trigger _) =>
-            ToggleScreenshotCamera("Shortcut", !isScreencaptureCameraActive.Get());
+            ToggleScreenshotCamera("Shortcut", isEnabled: !isScreencaptureCameraActive.Get());
 
         private void ToggleCameraSystems(bool activateScreenshotCamera)
         {

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
@@ -82,6 +82,7 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
         private InputAction_Trigger toggleCameraReelAction;
 
         public DataStore_Player Player { private get; set; }
+        public bool HasStorageSpace => storageStatus.HasFreeSpace;
 
         private ICameraReelStorageService cameraReelStorageService => cameraReelStorageServiceLazyValue ??= Environment.i.serviceLocator.Get<ICameraReelStorageService>();
         private ICameraReelAnalyticsService analytics => Environment.i.serviceLocator.Get<ICameraReelAnalyticsService>();

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraBehaviour.cs
@@ -63,7 +63,6 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
         private ICameraReelStorageService cameraReelStorageServiceLazyValue;
 
         // Cached states
-        private bool prevUiHiddenState;
         private bool prevMouseLockState;
         private bool prevMouseButtonCursorLockMode;
         private Camera prevSkyboxCamera;
@@ -288,7 +287,6 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
         {
             if (activateScreenshotCamera)
             {
-                prevUiHiddenState = allUIHidden.Get();
                 allUIHidden.Set(true);
 
                 cameraModeInputLocked.Set(true);
@@ -298,7 +296,7 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
             }
             else
             {
-                allUIHidden.Set(prevUiHiddenState);
+                allUIHidden.Set(false);
                 cameraModeInputLocked.Set(false);
                 cameraLeftMouseButtonCursorLock.Set(prevMouseButtonCursorLockMode);
             }

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraFactory.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreencaptureCameraFactory.cs
@@ -26,7 +26,7 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
         {
             ScreencaptureCameraHUDView screencaptureCameraHUDView = Object.Instantiate(viewPrefab);
 
-            var screencaptureCameraHUDController = new ScreencaptureCameraHUDController(screencaptureCameraHUDView, mainBehaviour, DataStore.i);
+            var screencaptureCameraHUDController = new ScreencaptureCameraHUDController(screencaptureCameraHUDView, mainBehaviour, DataStore.i, HUDController.i);
             screencaptureCameraHUDController.Initialize();
 
             return (screencaptureCameraHUDController, screencaptureCameraHUDView);

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Tests/ScreencaptureCameraShould.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Tests/ScreencaptureCameraShould.cs
@@ -21,7 +21,9 @@ namespace DCLFeatures.ScreencaptureCamera.Tests
         {
             ScreencaptureCameraHUDView screencaptureCameraHUDView = Object.Instantiate(viewPrefab);
 
-            var screencaptureCameraHUDController = new ScreencaptureCameraHUDController(screencaptureCameraHUDView, mainBehaviour, DataStore.i);
+            var screencaptureCameraHUDController = new ScreencaptureCameraHUDController(screencaptureCameraHUDView,
+                mainBehaviour, DataStore.i, HUDController.i);
+
             return (screencaptureCameraHUDController, screencaptureCameraHUDView);
         }
 

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/ScreencaptureCamera.asmdef
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/ScreencaptureCamera.asmdef
@@ -37,7 +37,8 @@
         "GUID:4307f53044263cf4b835bd812fc161a4",
         "GUID:15fc0a57446b3144c949da3e2b9737a9",
         "GUID:bd51ff2b035ce4ab4be7c38c43c88889",
-        "GUID:a3ceb534947fac14da25035bc5c24788"
+        "GUID:a3ceb534947fac14da25035bc5c24788",
+        "GUID:3bdb7fe910cce8d4888137cded3ba4a2"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Prefabs/ScreencaptureCameraHUD.prefab
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Prefabs/ScreencaptureCameraHUD.prefab
@@ -2852,6 +2852,11 @@ PrefabInstance:
       propertyPath: m_PreferredHeight
       value: 20
       objectReference: {fileID: 0}
+    - target: {fileID: 2418331181663010303, guid: 7ed4827c381405e458c685420f6e002b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -264
+      objectReference: {fileID: 0}
     - target: {fileID: 2573757888587528437, guid: 7ed4827c381405e458c685420f6e002b,
         type: 3}
       propertyPath: m_MinWidth
@@ -2938,6 +2943,16 @@ PrefabInstance:
       propertyPath: m_sharedMaterial
       value: 
       objectReference: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
+    - target: {fileID: 3588575458002850743, guid: 7ed4827c381405e458c685420f6e002b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -264
+      objectReference: {fileID: 0}
+    - target: {fileID: 3630878721520962119, guid: 7ed4827c381405e458c685420f6e002b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3720230331210976649, guid: 7ed4827c381405e458c685420f6e002b,
         type: 3}
       propertyPath: m_text
@@ -3037,7 +3052,7 @@ PrefabInstance:
     - target: {fileID: 4986538752391755247, guid: 7ed4827c381405e458c685420f6e002b,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 289.128
+      value: 319.6255
       objectReference: {fileID: 0}
     - target: {fileID: 4986538752391755247, guid: 7ed4827c381405e458c685420f6e002b,
         type: 3}

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Prefabs/ShortcutsInfoPanel.prefab
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Prefabs/ShortcutsInfoPanel.prefab
@@ -861,13 +861,14 @@ RectTransform:
   - {fileID: 8588240422650355866}
   - {fileID: 7774420677803298153}
   - {fileID: 86016116193999297}
+  - {fileID: 4828699503058622746}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: -132, y: 14}
-  m_SizeDelta: {x: 309, y: 346}
+  m_SizeDelta: {x: 309, y: 370.3026}
   m_Pivot: {x: 1, y: 0}
 --- !u!222 &6522528764040689676
 CanvasRenderer:
@@ -1591,6 +1592,44 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3630878721520962119
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4828699503058622746}
+  m_Layer: 5
+  m_Name: Show/Hide UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4828699503058622746
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3630878721520962119}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3588575458002850743}
+  - {fileID: 2418331181663010303}
+  m_Father: {fileID: 4986538752391755247}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000030517578, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3764908879606615682
 GameObject:
   m_ObjectHideFlags: 0
@@ -3483,6 +3522,104 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7487063829063389291
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3588575458002850743}
+  - component: {fileID: 8353459189838415937}
+  - component: {fileID: 3489705711911365898}
+  - component: {fileID: 667410686459500434}
+  m_Layer: 19
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3588575458002850743
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7487063829063389291}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7862298734269050492}
+  m_Father: {fileID: 4828699503058622746}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 30, y: -329.3}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &8353459189838415937
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7487063829063389291}
+  m_CullTransparentMesh: 0
+--- !u!114 &3489705711911365898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7487063829063389291}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 08d52e28c31ca4d049008be051e8b8a1, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.01
+--- !u!114 &667410686459500434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7487063829063389291}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 22
+  m_MinHeight: 22
+  m_PreferredWidth: 22
+  m_PreferredHeight: 22
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &7487397327910231578
 GameObject:
   m_ObjectHideFlags: 0
@@ -3581,6 +3718,143 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &7702279939805746720
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7862298734269050492}
+  - component: {fileID: 1440168719927253403}
+  - component: {fileID: 652549439678247633}
+  m_Layer: 19
+  m_Name: Text (TMP) (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7862298734269050492
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7702279939805746720}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3588575458002850743}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0002002716, y: 0.1731987}
+  m_SizeDelta: {x: -4.1583, y: -3.1188}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1440168719927253403
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7702279939805746720}
+  m_CullTransparentMesh: 0
+--- !u!114 &652549439678247633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7702279939805746720}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: U
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
+  m_sharedMaterial: {fileID: 1196159134475820439, guid: a02669827dd9144f39b4b164e753a21a,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14.1
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 10
+  m_fontSizeMax: 20
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7779826637792129359
 GameObject:
   m_ObjectHideFlags: 0
@@ -3855,6 +4129,143 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &8746853450616694312
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2418331181663010303}
+  - component: {fileID: 8737594373107244015}
+  - component: {fileID: 4380410420121973682}
+  m_Layer: 19
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2418331181663010303
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8746853450616694312}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4828699503058622746}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 58, y: -329.3}
+  m_SizeDelta: {x: 206.3795, y: 19}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &8737594373107244015
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8746853450616694312}
+  m_CullTransparentMesh: 0
+--- !u!114 &4380410420121973682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8746853450616694312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Show/Hide UI
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
+  m_sharedMaterial: {fileID: 1196159134475820439, guid: a02669827dd9144f39b4b164e753a21a,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 10
+  m_fontSizeMax: 20
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0.24816895, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &9052009620742564450
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Scripts/ScreencaptureCameraHUDController.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Scripts/ScreencaptureCameraHUDController.cs
@@ -11,6 +11,7 @@ namespace DCLFeatures.ScreencaptureCamera.UI
         private readonly ScreencaptureCameraHUDView view;
         private readonly ScreencaptureCameraBehaviour screencaptureCameraBehaviour;
         private readonly DataStore dataStore;
+        private readonly HUDController hudController;
 
         private InputAction_Trigger takeScreenshotAction;
         private InputAction_Trigger closeWindowAction;
@@ -18,11 +19,12 @@ namespace DCLFeatures.ScreencaptureCamera.UI
         private InputAction_Trigger toggleScreenshotCameraHUDAction;
 
         public ScreencaptureCameraHUDController(ScreencaptureCameraHUDView view, ScreencaptureCameraBehaviour screencaptureCameraBehaviour,
-            DataStore dataStore)
+            DataStore dataStore, HUDController hudController)
         {
             this.view = view;
             this.screencaptureCameraBehaviour = screencaptureCameraBehaviour;
             this.dataStore = dataStore;
+            this.hudController = hudController;
         }
 
         public void Initialize()
@@ -39,7 +41,6 @@ namespace DCLFeatures.ScreencaptureCamera.UI
             takeScreenshotAction.OnTriggered += CaptureScreenshot;
 
             view.CameraReelButtonClicked += OpenCameraReelGallery;
-
             view.ShortcutsInfoButtonClicked += view.ToggleShortcutsInfosHelpPanel;
 
             mouseFirstClick.OnStarted += HideShortcutsInfoPanel;
@@ -74,14 +75,14 @@ namespace DCLFeatures.ScreencaptureCamera.UI
             else
                 AudioScriptableObjects.UIHide.Play();
 
-            HUDController.i?.ToggleAllUIHiddenNotification(isHidden: !view.IsVisible, false);
+            hudController.ToggleAllUIHiddenNotification(isHidden: !view.IsVisible, false);
         }
 
         public void SetVisibility(bool isVisible, bool hasStorageSpace)
         {
             // Hide AllUIHidden notification when entering camera mode
             if (isVisible)
-                HUDController.i?.ToggleAllUIHiddenNotification(isHidden: false, false);
+                hudController.ToggleAllUIHiddenNotification(isHidden: false, false);
 
             view.SetVisibility(isVisible, hasStorageSpace);
         }

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Scripts/ScreencaptureCameraHUDController.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Scripts/ScreencaptureCameraHUDController.cs
@@ -15,6 +15,7 @@ namespace DCLFeatures.ScreencaptureCamera.UI
         private InputAction_Trigger takeScreenshotAction;
         private InputAction_Trigger closeWindowAction;
         private InputAction_Hold mouseFirstClick;
+        private InputAction_Trigger toggleScreenshotCameraHUDAction;
 
         public ScreencaptureCameraHUDController(ScreencaptureCameraHUDView view, ScreencaptureCameraBehaviour screencaptureCameraBehaviour,
             DataStore dataStore)
@@ -29,6 +30,7 @@ namespace DCLFeatures.ScreencaptureCamera.UI
             takeScreenshotAction = Resources.Load<InputAction_Trigger>("TakeScreenshot");
             closeWindowAction = Resources.Load<InputAction_Trigger>("CloseWindow");
             mouseFirstClick = Resources.Load<InputAction_Hold>("MouseFirstClickDown");
+            toggleScreenshotCameraHUDAction = Resources.Load<InputAction_Trigger>("ToggleScreenshotCameraHUD");
 
             view.CloseButtonClicked += DisableScreenshotCameraMode;
             closeWindowAction.OnTriggered += DisableScreenshotCameraMode;
@@ -41,6 +43,8 @@ namespace DCLFeatures.ScreencaptureCamera.UI
             view.ShortcutsInfoButtonClicked += view.ToggleShortcutsInfosHelpPanel;
 
             mouseFirstClick.OnStarted += HideShortcutsInfoPanel;
+
+            toggleScreenshotCameraHUDAction.OnTriggered += ToggleViewVisibility;
         }
 
         public void Dispose()
@@ -54,9 +58,15 @@ namespace DCLFeatures.ScreencaptureCamera.UI
             view.CameraReelButtonClicked -= OpenCameraReelGallery;
 
             view.ShortcutsInfoButtonClicked -= view.ToggleShortcutsInfosHelpPanel;
-
+            toggleScreenshotCameraHUDAction.OnTriggered -= ToggleViewVisibility;
 
             Object.Destroy(view.gameObject);
+        }
+
+        private void ToggleViewVisibility(DCLAction_Trigger _)
+        {
+            if (screencaptureCameraBehaviour.isScreencaptureCameraActive.Get())
+                SetVisibility(!view.IsVisible, screencaptureCameraBehaviour.HasStorageSpace);
         }
 
         public void SetVisibility(bool isVisible, bool hasStorageSpace) =>

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Scripts/ScreencaptureCameraHUDController.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Scripts/ScreencaptureCameraHUDController.cs
@@ -66,7 +66,14 @@ namespace DCLFeatures.ScreencaptureCamera.UI
         private void ToggleViewVisibility(DCLAction_Trigger _)
         {
             if (screencaptureCameraBehaviour.isScreencaptureCameraActive.Get())
+            {
+                if (view.IsVisible)
+                    AudioScriptableObjects.UIHide.Play();
+                else
+                    AudioScriptableObjects.UIShow.Play();
+
                 SetVisibility(!view.IsVisible, screencaptureCameraBehaviour.HasStorageSpace);
+            }
         }
 
         public void SetVisibility(bool isVisible, bool hasStorageSpace) =>

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Scripts/ScreencaptureCameraHUDController.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Scripts/ScreencaptureCameraHUDController.cs
@@ -65,19 +65,26 @@ namespace DCLFeatures.ScreencaptureCamera.UI
 
         private void ToggleViewVisibility(DCLAction_Trigger _)
         {
-            if (screencaptureCameraBehaviour.isScreencaptureCameraActive.Get())
-            {
-                if (view.IsVisible)
-                    AudioScriptableObjects.UIHide.Play();
-                else
-                    AudioScriptableObjects.UIShow.Play();
+            if (!screencaptureCameraBehaviour.isScreencaptureCameraActive.Get()) return;
 
-                SetVisibility(!view.IsVisible, screencaptureCameraBehaviour.HasStorageSpace);
-            }
+            SetVisibility(!view.IsVisible, screencaptureCameraBehaviour.HasStorageSpace);
+
+            if (view.IsVisible)
+                AudioScriptableObjects.UIShow.Play();
+            else
+                AudioScriptableObjects.UIHide.Play();
+
+            HUDController.i?.ToggleAllUIHiddenNotification(isHidden: !view.IsVisible, false);
         }
 
-        public void SetVisibility(bool isVisible, bool hasStorageSpace) =>
+        public void SetVisibility(bool isVisible, bool hasStorageSpace)
+        {
+            // Hide AllUIHidden notification when entering camera mode
+            if (isVisible)
+                HUDController.i?.ToggleAllUIHiddenNotification(isHidden: false, false);
+
             view.SetVisibility(isVisible, hasStorageSpace);
+        }
 
         private void HideShortcutsInfoPanel(DCLAction_Hold _)
         {

--- a/unity-renderer/Assets/Resources/Prefabs/InputController.prefab
+++ b/unity-renderer/Assets/Resources/Prefabs/InputController.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5175052615018462640}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 744.5, y: 332, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -91,7 +91,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 963604f308a161b4daa2e9ad5a9beba4, type: 2}
   - {fileID: 11400000, guid: 766b998e6c8734e3d9971cfc48b788cb, type: 2}
   - {fileID: 11400000, guid: 06d28566773ab401d82c0f1ac66713c8, type: 2}
-  - {fileID: 11400000, guid: db0191cd17187924f8982a9efe0d7815, type: 2}
+  - {fileID: 11400000, guid: fc494e45e4049c94c952532998beffeb, type: 2}
   - {fileID: 11400000, guid: fdfab5e29b7455f45996567365819641, type: 2}
   - {fileID: 11400000, guid: 4dba3cd16e0754e40aa328f383a2d52b, type: 2}
   - {fileID: 11400000, guid: 864e845936b1ef646b2a19fd9d1a4f34, type: 2}

--- a/unity-renderer/Assets/Resources/Prefabs/InputController.prefab
+++ b/unity-renderer/Assets/Resources/Prefabs/InputController.prefab
@@ -95,6 +95,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: fdfab5e29b7455f45996567365819641, type: 2}
   - {fileID: 11400000, guid: 4dba3cd16e0754e40aa328f383a2d52b, type: 2}
   - {fileID: 11400000, guid: 864e845936b1ef646b2a19fd9d1a4f34, type: 2}
+  - {fileID: 11400000, guid: 7c7653c0d9ba2c149adc5583fc1b4aba, type: 2}
   holdActions:
   - {fileID: 11400000, guid: 8eddef1fc072ec845aeb62f5e1041b52, type: 2}
   - {fileID: 11400000, guid: 0cfb8d150b7d6934d856665cf924d01d, type: 2}

--- a/unity-renderer/Assets/Resources/Prefabs/InputController.prefab
+++ b/unity-renderer/Assets/Resources/Prefabs/InputController.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5175052615018462640}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 744.5, y: 332, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -91,9 +91,10 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 963604f308a161b4daa2e9ad5a9beba4, type: 2}
   - {fileID: 11400000, guid: 766b998e6c8734e3d9971cfc48b788cb, type: 2}
   - {fileID: 11400000, guid: 06d28566773ab401d82c0f1ac66713c8, type: 2}
-  - {fileID: 11400000, guid: fc494e45e4049c94c952532998beffeb, type: 2}
+  - {fileID: 11400000, guid: db0191cd17187924f8982a9efe0d7815, type: 2}
   - {fileID: 11400000, guid: fdfab5e29b7455f45996567365819641, type: 2}
   - {fileID: 11400000, guid: 4dba3cd16e0754e40aa328f383a2d52b, type: 2}
+  - {fileID: 11400000, guid: 864e845936b1ef646b2a19fd9d1a4f34, type: 2}
   holdActions:
   - {fileID: 11400000, guid: 8eddef1fc072ec845aeb62f5e1041b52, type: 2}
   - {fileID: 11400000, guid: 0cfb8d150b7d6934d856665cf924d01d, type: 2}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -51,7 +51,7 @@ public class HUDController : IHUDController
         toggleUIVisibilityTrigger = Resources.Load<InputAction_Trigger>(TOGGLE_UI_VISIBILITY_ASSET_NAME);
         toggleUIVisibilityTrigger.OnTriggered += ToggleUIVisibility_OnTriggered;
 
-        CommonScriptableObjects.allUIHidden.OnChange += AllUIHiddenOnOnChange;
+        CommonScriptableObjects.allUIHidden.OnChange += ToggleAllUIHiddenNotification;
         UserContextMenu.OnOpenPrivateChatRequest += OpenPrivateChatWindow;
     }
 
@@ -133,16 +133,12 @@ public class HUDController : IHUDController
         CommonScriptableObjects.allUIHidden.Set(!CommonScriptableObjects.allUIHidden.Get());
     }
 
-    private void AllUIHiddenOnOnChange(bool current, bool previous)
+    public void ToggleAllUIHiddenNotification(bool isHidden, bool _)
     {
-        if (current)
-        {
+        if (isHidden)
             NotificationsController.i?.ShowNotification(hiddenUINotification);
-        }
         else
-        {
             NotificationsController.i?.DismissAllNotifications(hiddenUINotification.groupID);
-        }
     }
 
     public async UniTask ConfigureHUDElement(HUDElementID hudElementId, HUDConfiguration configuration, CancellationToken cancellationToken = default,
@@ -451,7 +447,7 @@ public class HUDController : IHUDController
     public void Cleanup()
     {
         toggleUIVisibilityTrigger.OnTriggered -= ToggleUIVisibility_OnTriggered;
-        CommonScriptableObjects.allUIHidden.OnChange -= AllUIHiddenOnOnChange;
+        CommonScriptableObjects.allUIHidden.OnChange -= ToggleAllUIHiddenNotification;
 
         if (worldChatWindowHud != null)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -53,6 +53,7 @@ public enum DCLAction_Trigger
     TakeScreenshot = 157,
     ToggleCameraReelSection = 158,
     ToggleScreenshotCameraHUD = 159,
+    CloseScreenshotCamera = 160,
 
     Expression_Wave = 201,
     Expression_FistPump = 202,
@@ -308,6 +309,11 @@ public class InputController : MonoBehaviour
                 case DCLAction_Trigger.ToggleScreenshotCameraHUD:
                     InputProcessor.FromKey(action, KeyCode.U, modifiers: InputProcessor.Modifier.FocusNotInInput);
                     break;
+                case DCLAction_Trigger.CloseScreenshotCamera:
+                    if (!DataStore.i.common.isSignUpFlow.Get())
+                        InputProcessor.FromKey(action, KeyCode.Escape, modifiers: InputProcessor.Modifier.None);
+                    break;
+
                 case DCLAction_Trigger.TakeScreenshot:
                     InputProcessor.FromKey(action, KeyCode.E, modifiers: InputProcessor.Modifier.FocusNotInInput);
                     break;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -52,6 +52,8 @@ public enum DCLAction_Trigger
     ToggleScreenshotCamera = 156,
     TakeScreenshot = 157,
     ToggleCameraReelSection = 158,
+    ToggleScreenshotCameraHUD = 159,
+
     Expression_Wave = 201,
     Expression_FistPump = 202,
     Expression_Robot = 203,
@@ -302,6 +304,9 @@ public class InputController : MonoBehaviour
                     break;
                 case DCLAction_Trigger.ToggleScreenshotCamera:
                     InputProcessor.FromKey(action, KeyCode.C, modifiers: InputProcessor.Modifier.FocusNotInInput);
+                    break;
+                case DCLAction_Trigger.ToggleScreenshotCameraHUD:
+                    InputProcessor.FromKey(action, KeyCode.U, modifiers: InputProcessor.Modifier.FocusNotInInput);
                     break;
                 case DCLAction_Trigger.TakeScreenshot:
                     InputProcessor.FromKey(action, KeyCode.E, modifiers: InputProcessor.Modifier.FocusNotInInput);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/CloseScreenshotCamera.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/CloseScreenshotCamera.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8ba04a041474be2a7ac981e4fff73ef, type: 3}
+  m_Name: CloseScreenshotCamera
+  m_EditorClassIdentifier: 
+  dclAction: 160
+  blockTrigger: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/CloseScreenshotCamera.asset.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/CloseScreenshotCamera.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c7653c0d9ba2c149adc5583fc1b4aba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ToggleScreenshotCameraHUD.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ToggleScreenshotCameraHUD.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8ba04a041474be2a7ac981e4fff73ef, type: 3}
+  m_Name: ToggleScreenshotCameraHUD
+  m_EditorClassIdentifier: 
+  dclAction: 159
+  blockTrigger: {fileID: 0}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ToggleScreenshotCameraHUD.asset.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/InputController/Resources/ToggleScreenshotCameraHUD.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 864e845936b1ef646b2a19fd9d1a4f34
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?
Closes #5616

Add possibility to hide screencapture camera HUD
- created 2 new keyboard actions for this
- add ESC functionality to exit camera mode
- add info to shortcuts of screencapture camera HUD
- add Notification logic when HUD is hidden

## How to test the changes?

1. Launch the explorer
2. Open screencapture camera by pressing C
3. Observe additional line in shortcut Info Panel describing that **U** is for **Show/Hide UI**
4. Press U  and observe HUD is hidden
5. Press U again to see it back
 --- 

1. Launch the explorer
2. Hide in-game UI by pressing U
3. Open screencapture camera by pressing C
4. Press C again to exit
5. Observe in-game UI is shown
 --- 

1. Launch the explorer
2. Make exploratory testing by playing with hiding in-game UI (**U**), open/close screencapture camera (**C**), and hide/show its UI (**U**)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6175fcf</samp>

This pull request adds new input actions and UI elements for the screenshot camera feature. It allows the user to exit the screenshot mode, toggle the visibility of the HUD, and see the shortcuts information. It also refactors and cleans up some code related to the `ScreencaptureCameraBehaviour`, the `HUDController`, and the `InputController` classes. It updates the `ScreencaptureCameraHUD` prefab and the `ScreencaptureCamera` assembly definition file. It creates new asset files and meta files for the new input actions.
