### PR TITLE
chore: Update QA review group for auto assign

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -17,6 +17,7 @@ reviewGroups:
   qa:
     - kwssbocian
     - kwsskulinski
+    - anicalbano
 
 filterLabels:
   exclude:


### PR DESCRIPTION
## What does this PR change?

Adding @anicalbano to QA review group for auto-assign

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 641fb70</samp>

Updated the auto-assign configuration to include a new reviewer and exclude a label. This helps to balance the load and avoid conflicts for the `unity-renderer` pull requests.
