### PR TITLE
fix: colliders meshes are case sentive in SDK7 (ignore case comparison not working due to Unity Bug)

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerCollidersHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/GltfContainerCollidersHandler.cs
@@ -144,7 +144,7 @@ namespace DCL.ECSComponents
         // Compatibility layer for old GLTF importer and GLTFast
         private static bool IsCollider(MeshFilter meshFilter)
         {
-            const StringComparison IGNORE_CASE = StringComparison.CurrentCultureIgnoreCase;
+            const StringComparison IGNORE_CASE = StringComparison.OrdinalIgnoreCase;
             const string COLLIDER_SUFFIX = "_collider";
 
             return meshFilter.name.Contains(COLLIDER_SUFFIX, IGNORE_CASE)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/Tests/GltfContainerCollidersShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/GltfContainer/Tests/GltfContainerCollidersShould.cs
@@ -315,7 +315,7 @@ namespace Tests
 
         private static bool HasColliderName(Collider collider)
         {
-            const StringComparison IGNORE_CASE = StringComparison.CurrentCultureIgnoreCase;
+            const StringComparison IGNORE_CASE = StringComparison.OrdinalIgnoreCase;
 
             return collider.name.Contains("_collider", IGNORE_CASE)
                    || collider.transform.parent.name.Contains("_collider", IGNORE_CASE);

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Utils/Scene/Media.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Utils/Scene/Media.cs
@@ -29,7 +29,7 @@ public static partial class UtilsScene
         {
             for (int i = 0; i < allowedDomains.Count; i++)
             {
-                if (String.Equals(allowedDomains[i], uri.Host, StringComparison.CurrentCultureIgnoreCase))
+                if (String.Equals(allowedDomains[i], uri.Host, StringComparison.OrdinalIgnoreCase))
                     return true;
             }
         }


### PR DESCRIPTION
Fix https://github.com/decentraland/sdk/issues/843

Looks like `CurrentCultureIgnoreCase` doesn't work in WebGL.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b83df9b</samp>

Use `StringComparison.OrdinalIgnoreCase` instead of `StringComparison.CurrentCultureIgnoreCase` in various methods that compare strings for colliders and URL domains. This improves the consistency and reliability of the string comparisons across different cultures and cases.
