### PR TITLE
fix: make the events api endpoints point back to org

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsAPIController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsAPIController.cs
@@ -31,10 +31,10 @@ public interface IEventsAPIController
 [ExcludeFromCodeCoverage]
 public class EventsAPIController : IEventsAPIController
 {
-    internal const string URL_GET_ALL_EVENTS = "https://events.decentraland.zone/api/events"; // TODO: Set it back to .org before merging!!
+    internal const string URL_GET_ALL_EVENTS = "https://events.decentraland.org/api/events";
     private const string URL_GET_DETAILED_EVENT = "https://events.decentraland.org/api/events/{event_id}";
-    private const string URL_PARTICIPATE_EVENT = "https://events.decentraland.zone/api/events/{event_id}/attendees"; // TODO: Set it back to .org before merging!!
-    internal const string URL_GET_CATEGORIES = "https://events.decentraland.zone/api/events/categories"; // TODO: Set it back to .org before merging!!
+    private const string URL_PARTICIPATE_EVENT = "https://events.decentraland.org/api/events/{event_id}/attendees";
+    internal const string URL_GET_CATEGORIES = "https://events.decentraland.org/api/events/categories";
 
     internal UserProfile ownUserProfile => UserProfile.GetOwnUserProfile();
     private Service<IWebRequestController> webRequestController;


### PR DESCRIPTION
## What does this PR change?
Make the events API endpoints point back to `.org`

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5ed082</samp>

Changed events API URLs from `.zone` to `.org` in `EventsAPIController.cs`. This aligns the events explorer feature with the official production domain.