### PR TITLE
chore: remove forced alphatest from srp batching helper

### DIFF
--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.coffee.ui-particle": "4.1.6",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src",
-    "com.decentraland.unity-shared-dependencies": "https://github.com/decentraland/unity-shared-dependencies.git#chore/srp-batching-helper-remove-forced-alphatest",
+    "com.decentraland.unity-shared-dependencies": "https://github.com/decentraland/unity-shared-dependencies.git",
     "com.decentraland.videoplayer": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",
     "com.decentraland.webgl-ime-input": "https://github.com/decentraland/webgl-ime-input.git",
     "com.madsbangh.easybuttons": "1.3.0",

--- a/unity-renderer/Packages/manifest.json
+++ b/unity-renderer/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.coffee.ui-particle": "4.1.6",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src",
-    "com.decentraland.unity-shared-dependencies": "https://github.com/decentraland/unity-shared-dependencies.git",
+    "com.decentraland.unity-shared-dependencies": "https://github.com/decentraland/unity-shared-dependencies.git#chore/srp-batching-helper-remove-forced-alphatest",
     "com.decentraland.videoplayer": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",
     "com.decentraland.webgl-ime-input": "https://github.com/decentraland/webgl-ime-input.git",
     "com.madsbangh.easybuttons": "1.3.0",

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -50,11 +50,11 @@
       "hash": "f2621a8b09b68f3a7639eea40a7aba18571f3f28"
     },
     "com.decentraland.unity-shared-dependencies": {
-      "version": "https://github.com/decentraland/unity-shared-dependencies.git#chore/srp-batching-helper-remove-forced-alphatest",
+      "version": "https://github.com/decentraland/unity-shared-dependencies.git",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "c549da3318d19846abc126caee77e4eb5b5114c9"
+      "hash": "466eb3c8d7aa82e896434911ea15f15b59f2519c"
     },
     "com.decentraland.videoplayer": {
       "version": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -50,11 +50,11 @@
       "hash": "f2621a8b09b68f3a7639eea40a7aba18571f3f28"
     },
     "com.decentraland.unity-shared-dependencies": {
-      "version": "https://github.com/decentraland/unity-shared-dependencies.git",
+      "version": "https://github.com/decentraland/unity-shared-dependencies.git#chore/srp-batching-helper-remove-forced-alphatest",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "b40c694fbe1136431fcf0b895ba0f5f55e7bff6b"
+      "hash": "c549da3318d19846abc126caee77e4eb5b5114c9"
     },
     "com.decentraland.videoplayer": {
       "version": "https://github.com/decentraland/DCLVideoPlayerUnity.git?path=Assets#main",


### PR DESCRIPTION
Updated shared-dependencies package used to point to the [implementation branch](https://github.com/decentraland/unity-shared-dependencies/pull/19).

This was done to tackle the [rendering problem found](https://github.com/decentraland/unity-renderer/pull/5663#issuecomment-1699889258) since unity `2022.3.6f1`.

-----------------------

### TESTING

We need this PR tested as thoroughly as an RC.

Including:
* Full RC testing
* [Rendering issue](https://github.com/decentraland/unity-renderer/pull/5663#issuecomment-1699889258) not happening anymore in the onboarding world
* Testing new user onboarding
* Testing some popular scenes behaviour to see they keep working as in production