### PR TITLE
fix: add isWorld field to the event’s metrics

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/ExploreV2Analytics/ExploreV2Analytics.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Analytics/ExploreV2Analytics/ExploreV2Analytics.cs
@@ -8,14 +8,14 @@ namespace ExploreV2Analytics
     {
         void SendStartMenuVisibility(bool isVisible, ExploreUIVisibilityMethod method);
         void SendStartMenuSectionVisibility(ExploreSection section, bool isVisible);
-        void SendEventTeleport(string eventId, string eventName, Vector2Int coords, ActionSource source = ActionSource.FromExplore);
-        void SendClickOnEventInfo(string eventId, string eventName, int resultPosition = -1, ActionSource source = ActionSource.FromExplore);
+        void SendEventTeleport(string eventId, string eventName, bool isWorld, Vector2Int coords, ActionSource source = ActionSource.FromExplore);
+        void SendClickOnEventInfo(string eventId, string eventName, bool isWorld, int resultPosition = -1, ActionSource source = ActionSource.FromExplore);
         void SendPlaceTeleport(string placeId, string placeName, Vector2Int coords, ActionSource source = ActionSource.FromExplore);
         void SendWorldTeleport(string worldId, string worldName, ActionSource source = ActionSource.FromExplore);
         void SendClickOnPlaceInfo(string placeId, string placeName, int resultPosition = -1, ActionSource source = ActionSource.FromExplore);
         void SendClickOnWorldInfo(string worldId, string worldName, int resultPosition = -1, ActionSource source = ActionSource.FromExplore);
-        void SendParticipateEvent(string eventId, ActionSource source = ActionSource.FromExplore);
-        void SendRemoveParticipateEvent(string eventId, ActionSource source = ActionSource.FromExplore);
+        void SendParticipateEvent(string eventId, bool isWorld, ActionSource source = ActionSource.FromExplore);
+        void SendRemoveParticipateEvent(string eventId, bool isWorld, ActionSource source = ActionSource.FromExplore);
         void TeleportToPlaceFromFavorite(string placeUUID, string placeName);
         void SendSearchEvents(string searchString, Vector2Int[] firstResultsCoordinates, string[] firstResultsIds);
         void SendSearchPlaces(string searchString, Vector2Int[] firstResultsCoordinates, string[] firstResultsIds);
@@ -95,38 +95,42 @@ namespace ExploreV2Analytics
             GenericAnalytics.SendAnalytic(START_MENU_SECTION_VISIBILITY, data);
         }
 
-        public void SendEventTeleport(string eventId, string eventName, Vector2Int coords, ActionSource source = ActionSource.FromExplore)
+        public void SendEventTeleport(string eventId, string eventName, bool isWorld, Vector2Int coords, ActionSource source = ActionSource.FromExplore)
         {
             Dictionary<string, string> data = new Dictionary<string, string>();
             data.Add("event_id", eventId);
             data.Add("event_name", eventName);
+            data.Add("isWorld", isWorld.ToString());
             data.Add("event_coords_x", coords.x.ToString());
             data.Add("event_coords_y", coords.y.ToString());
             data.Add("source", source.ToString());
             GenericAnalytics.SendAnalytic(EXPLORE_EVENT_TELEPORT, data);
         }
 
-        public void SendParticipateEvent(string eventId, ActionSource source = ActionSource.FromExplore)
+        public void SendParticipateEvent(string eventId, bool isWorld, ActionSource source = ActionSource.FromExplore)
         {
             Dictionary<string, string> data = new Dictionary<string, string>();
             data.Add("event_id", eventId);
+            data.Add("isWorld", isWorld.ToString());
             data.Add("source", source.ToString());
             GenericAnalytics.SendAnalytic(EXPLORE_PARTICIPATE_EVENT, data);
         }
 
-        public void SendRemoveParticipateEvent(string eventId, ActionSource source = ActionSource.FromExplore)
+        public void SendRemoveParticipateEvent(string eventId, bool isWorld, ActionSource source = ActionSource.FromExplore)
         {
             Dictionary<string, string> data = new Dictionary<string, string>();
             data.Add("event_id", eventId);
+            data.Add("isWorld", isWorld.ToString());
             data.Add("source", source.ToString());
             GenericAnalytics.SendAnalytic(EXPLORE_REMOVE_PARTICIPATE_EVENT, data);
         }
 
-        public void SendClickOnEventInfo(string eventId, string eventName, int resultPosition = -1, ActionSource source = ActionSource.FromExplore)
+        public void SendClickOnEventInfo(string eventId, string eventName, bool isWorld, int resultPosition = -1, ActionSource source = ActionSource.FromExplore)
         {
             Dictionary<string, string> data = new Dictionary<string, string>();
             data.Add("event_id", eventId);
             data.Add("event_name", eventName);
+            data.Add("isWorld", isWorld.ToString());
             data.Add("source", source.ToString());
             data.Add("result_position", resultPosition.ToString());
             GenericAnalytics.SendAnalytic(EXPLORE_CLICK_EVENT_INFO, data);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/EventsCardsConfigurator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/EventsCardsConfigurator.cs
@@ -22,8 +22,8 @@ public static class EventsCardsConfigurator
     /// <param name="OnEventJumpInClicked">Action to inform when the JumpIn button has been clicked.</param>
     /// <param name="OnEventSubscribeEventClicked">Action to inform when the Subscribe button has been clicked.</param>
     /// <param name="OnEventUnsubscribeEventClicked">Action to inform when the Unsubscribe button has been clicked.</param>
-    public static EventCardComponentView Configure(EventCardComponentView eventCard, EventCardComponentModel eventInfo, Action<EventCardComponentModel> OnEventInfoClicked, Action<EventFromAPIModel> OnEventJumpInClicked, Action<string> OnEventSubscribeEventClicked,
-        Action<string> OnEventUnsubscribeEventClicked)
+    public static EventCardComponentView Configure(EventCardComponentView eventCard, EventCardComponentModel eventInfo, Action<EventCardComponentModel> OnEventInfoClicked, Action<EventFromAPIModel> OnEventJumpInClicked, Action<string, bool> OnEventSubscribeEventClicked,
+        Action<string, bool> OnEventUnsubscribeEventClicked)
     {
         eventCard.Configure(eventInfo);
 
@@ -35,8 +35,8 @@ public static class EventsCardsConfigurator
         eventCard.onJumpInClick?.AddListener(() => OnEventJumpInClicked?.Invoke(eventInfo.eventFromAPIInfo));
         eventCard.onSecondaryJumpInClick?.RemoveAllListeners();
         eventCard.onSecondaryJumpInClick?.AddListener(() => OnEventJumpInClicked?.Invoke(eventInfo.eventFromAPIInfo));
-        eventCard.onSubscribeClick?.AddListener(() => OnEventSubscribeEventClicked?.Invoke(eventInfo.eventId));
-        eventCard.onUnsubscribeClick?.AddListener(() => OnEventUnsubscribeEventClicked?.Invoke(eventInfo.eventId));
+        eventCard.onSubscribeClick?.AddListener(() => OnEventSubscribeEventClicked?.Invoke(eventInfo.eventId, !string.IsNullOrEmpty(eventInfo.worldAddress)));
+        eventCard.onUnsubscribeClick?.AddListener(() => OnEventUnsubscribeEventClicked?.Invoke(eventInfo.eventId, !string.IsNullOrEmpty(eventInfo.worldAddress)));
 
         return eventCard;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsCardsFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/PlacesAndEventsCardsFactory.cs
@@ -34,7 +34,7 @@ public static class PlacesAndEventsCardsFactory
         return pool;
     }
 
-    public static EventCardComponentView CreateConfiguredEventCard(Pool pool, EventCardComponentModel eventInfo, Action<EventCardComponentModel> OnEventInfoClicked, Action<EventFromAPIModel> OnEventJumpInClicked, Action<string> OnEventSubscribeEventClicked, Action<string> OnEventUnsubscribeEventClicked) =>
+    public static EventCardComponentView CreateConfiguredEventCard(Pool pool, EventCardComponentModel eventInfo, Action<EventCardComponentModel> OnEventInfoClicked, Action<EventFromAPIModel> OnEventJumpInClicked, Action<string, bool> OnEventSubscribeEventClicked, Action<string, bool> OnEventUnsubscribeEventClicked) =>
         EventsCardsConfigurator.Configure(pool.Get<EventCardComponentView>(), eventInfo, OnEventInfoClicked, OnEventJumpInClicked, OnEventSubscribeEventClicked, OnEventUnsubscribeEventClicked);
 
     public static PlaceCardComponentView CreateConfiguredPlaceCard(Pool pool, PlaceCardComponentModel placeInfo, Action<PlaceCardComponentModel> OnPlaceInfoClicked, Action<PlaceInfo> OnPlaceJumpInClicked, Action<string, bool?> OnVoteChanged, Action<string, bool> OnFavoriteClicked) =>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentController.cs
@@ -359,7 +359,7 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
     internal void ShowEventDetailedInfo(EventCardComponentModel eventModel)
     {
         view.ShowEventModal(eventModel);
-        exploreV2Analytics.SendClickOnEventInfo(eventModel.eventId, eventModel.eventName);
+        exploreV2Analytics.SendClickOnEventInfo(eventModel.eventId, eventModel.eventName, !string.IsNullOrEmpty(eventModel.worldAddress));
     }
 
     internal void OnJumpInToEvent(EventFromAPIModel eventFromAPI)
@@ -368,24 +368,24 @@ public class EventsSubSectionComponentController : IEventsSubSectionComponentCon
         view.HideEventModal();
 
         OnCloseExploreV2?.Invoke();
-        exploreV2Analytics.SendEventTeleport(eventFromAPI.id, eventFromAPI.name, new Vector2Int(eventFromAPI.coordinates[0], eventFromAPI.coordinates[1]));
+        exploreV2Analytics.SendEventTeleport(eventFromAPI.id, eventFromAPI.name, eventFromAPI.world, new Vector2Int(eventFromAPI.coordinates[0], eventFromAPI.coordinates[1]));
     }
 
-    private void SubscribeToEvent(string eventId)
+    private void SubscribeToEvent(string eventId, bool isWorld)
     {
         if (userProfileBridge.GetOwn().isGuest)
             ConnectWallet();
         else
         {
             eventsAPIApiController.RegisterParticipation(eventId);
-            exploreV2Analytics.SendParticipateEvent(eventId);
+            exploreV2Analytics.SendParticipateEvent(eventId, isWorld);
         }
     }
 
-    private void UnsubscribeToEvent(string eventId)
+    private void UnsubscribeToEvent(string eventId, bool isWorld)
     {
         eventsAPIApiController.RemoveParticipation(eventId);
-        exploreV2Analytics.SendRemoveParticipateEvent(eventId);
+        exploreV2Analytics.SendRemoveParticipateEvent(eventId, isWorld);
     }
 
     private void OnChannelToJoinChanged(string currentChannelId, string previousChannelId)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/EventsSubSectionComponentView.cs
@@ -92,8 +92,8 @@ public class EventsSubSectionComponentView : BaseComponentView, IEventsSubSectio
     public event Action OnReady;
     public event Action<EventCardComponentModel> OnInfoClicked;
     public event Action<EventFromAPIModel> OnJumpInClicked;
-    public event Action<string> OnSubscribeEventClicked;
-    public event Action<string> OnUnsubscribeEventClicked;
+    public event Action<string, bool> OnSubscribeEventClicked;
+    public event Action<string, bool> OnUnsubscribeEventClicked;
     public event Action OnShowMoreEventsClicked;
     public event Action OnConnectWallet;
     public event Action OnEventsSubSectionEnable;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/IEventsSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/EventsSubSection/EventsSubSectionMenu/IEventsSubSectionComponentView.cs
@@ -59,12 +59,12 @@ public interface IEventsSubSectionComponentView: IPlacesAndEventsSubSectionCompo
     /// <summary>
     /// It will be triggered when the subscribe event button is clicked.
     /// </summary>
-    event Action<string> OnSubscribeEventClicked;
+    event Action<string, bool> OnSubscribeEventClicked;
 
     /// <summary>
     /// It will be triggered when the unsubscribe event button is clicked.
     /// </summary>
-    event Action<string> OnUnsubscribeEventClicked;
+    event Action<string, bool> OnUnsubscribeEventClicked;
 
     /// <summary>
     /// It will be triggered when the "Show More" button is clicked.

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/SearchSubSection/ISearchSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/SearchSubSection/ISearchSubSectionComponentView.cs
@@ -16,8 +16,8 @@ public interface ISearchSubSectionComponentView : IPlacesAndEventsSubSectionComp
     public event Action<EventFromAPIModel> OnEventJumpInClicked;
     public event Action<IHotScenesController.PlaceInfo> OnPlaceJumpInClicked;
     public event Action<string, bool> OnPlaceFavoriteChanged;
-    public event Action<string> OnSubscribeEventClicked;
-    public event Action<string> OnUnsubscribeEventClicked;
+    public event Action<string, bool> OnSubscribeEventClicked;
+    public event Action<string, bool> OnUnsubscribeEventClicked;
 
     void ShowEvents(List<EventCardComponentModel> events, string searchText);
     void ShowAllEvents(List<EventCardComponentModel> events, bool showMoreButton);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/SearchSubSection/SearchSubSectionComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/SearchSubSection/SearchSubSectionComponentController.cs
@@ -111,7 +111,7 @@ public class SearchSubSectionComponentController : ISearchSubSectionComponentCon
     {
         OnCloseExploreV2?.Invoke();
         EventsSubSectionComponentController.JumpInToEvent(eventFromAPI);
-        exploreV2Analytics.SendEventTeleport(eventFromAPI.id, eventFromAPI.name, new Vector2Int(eventFromAPI.coordinates[0], eventFromAPI.coordinates[1]), ActionSource.FromSearch);
+        exploreV2Analytics.SendEventTeleport(eventFromAPI.id, eventFromAPI.name, eventFromAPI.world, new Vector2Int(eventFromAPI.coordinates[0], eventFromAPI.coordinates[1]), ActionSource.FromSearch);
     }
 
     private void JumpInToPlace(IHotScenesController.PlaceInfo place)
@@ -124,7 +124,7 @@ public class SearchSubSectionComponentController : ISearchSubSectionComponentCon
     private void OpenEventDetailsModal(EventCardComponentModel eventModel, int index)
     {
         view.ShowEventModal(eventModel);
-        exploreV2Analytics.SendClickOnEventInfo(eventModel.eventId, eventModel.eventName, index, ActionSource.FromSearch);
+        exploreV2Analytics.SendClickOnEventInfo(eventModel.eventId, eventModel.eventName, !string.IsNullOrEmpty(eventModel.worldAddress), index, ActionSource.FromSearch);
     }
 
     private void OpenPlaceDetailsModal(PlaceCardComponentModel placeModel, int index)
@@ -145,21 +145,21 @@ public class SearchSubSectionComponentController : ISearchSubSectionComponentCon
         SearchWorlds(searchText, cancellationToken: minimalSearchCts.Token).Forget();
     }
 
-    private void SubscribeToEvent(string eventId)
+    private void SubscribeToEvent(string eventId, bool isWorld)
     {
         if (userProfileBridge.GetOwn().isGuest)
             dataStore.HUDs.connectWalletModalVisible.Set(true);
         else
         {
-            exploreV2Analytics.SendParticipateEvent(eventId, ActionSource.FromSearch);
+            exploreV2Analytics.SendParticipateEvent(eventId, isWorld, ActionSource.FromSearch);
             eventsAPI.RegisterParticipation(eventId);
         }
     }
 
-    private void UnsubscribeToEvent(string eventId)
+    private void UnsubscribeToEvent(string eventId, bool isWorld)
     {
         eventsAPI.RemoveParticipation(eventId);
-        exploreV2Analytics.SendParticipateEvent(eventId, ActionSource.FromSearch);
+        exploreV2Analytics.SendParticipateEvent(eventId, isWorld, ActionSource.FromSearch);
     }
 
     private void SearchAllEvents(int pageNumber)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/SearchSubSection/SearchSubSectionComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection/SubSections/SearchSubSection/SearchSubSectionComponentView.cs
@@ -66,8 +66,8 @@ public class SearchSubSectionComponentView : BaseComponentView, ISearchSubSectio
     public event Action<IHotScenesController.PlaceInfo> OnPlaceJumpInClicked;
     public event Action<string, bool?> OnVoteChanged;
     public event Action<string, bool> OnPlaceFavoriteChanged;
-    public event Action<string> OnSubscribeEventClicked;
-    public event Action<string> OnUnsubscribeEventClicked;
+    public event Action<string, bool> OnSubscribeEventClicked;
+    public event Action<string, bool> OnUnsubscribeEventClicked;
 
     private UnityObjectPool<EventCardComponentView> eventsPool;
     internal List<EventCardComponentView> pooledEvents = new List<EventCardComponentView>();
@@ -302,8 +302,8 @@ public class SearchSubSectionComponentView : BaseComponentView, ISearchSubSectio
         view.onSecondaryJumpInClick?.RemoveAllListeners();
         view.onInfoClick.AddListener(() => OnEventInfoClicked?.Invoke(model, view.transform.GetSiblingIndex()));
         view.onBackgroundClick.AddListener(() => OnEventInfoClicked?.Invoke(model, view.transform.GetSiblingIndex()));
-        view.onSubscribeClick.AddListener(() => OnSubscribeEventClicked?.Invoke(model.eventId));
-        view.onUnsubscribeClick.AddListener(() => OnUnsubscribeEventClicked?.Invoke(model.eventId));
+        view.onSubscribeClick.AddListener(() => OnSubscribeEventClicked?.Invoke(model.eventId, !string.IsNullOrEmpty(model.worldAddress)));
+        view.onUnsubscribeClick.AddListener(() => OnUnsubscribeEventClicked?.Invoke(model.eventId, !string.IsNullOrEmpty(model.worldAddress)));
         view.onJumpInClick.AddListener(() => OnEventJumpInClicked?.Invoke(model.eventFromAPIInfo));
         view.onSecondaryJumpInClick?.AddListener(() => OnEventJumpInClicked?.Invoke(model.eventFromAPIInfo));
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventsSubSectionComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/EventsSubSectionComponentControllerTests.cs
@@ -233,7 +233,7 @@ public class EventsSubSectionComponentControllerTests
 
         // Assert
         eventsSubSectionComponentView.Received().ShowEventModal(testEventCardModel);
-        exploreV2Analytics.Received().SendClickOnEventInfo(testEventCardModel.eventId, testEventCardModel.eventName);
+        exploreV2Analytics.Received().SendClickOnEventInfo(testEventCardModel.eventId, testEventCardModel.eventName, !string.IsNullOrEmpty(testEventCardModel.worldAddress));
     }
 
     [Test]
@@ -250,6 +250,6 @@ public class EventsSubSectionComponentControllerTests
         // Assert
         eventsSubSectionComponentView.Received().HideEventModal();
         Assert.IsTrue(exploreClosed);
-        exploreV2Analytics.Received().SendEventTeleport(testEventFromAPI.id, testEventFromAPI.name, new Vector2Int(testEventFromAPI.coordinates[0], testEventFromAPI.coordinates[1]));
+        exploreV2Analytics.Received().SendEventTeleport(testEventFromAPI.id, testEventFromAPI.name, testEventFromAPI.world, new Vector2Int(testEventFromAPI.coordinates[0], testEventFromAPI.coordinates[1]));
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/SearchSubSectionComponentControllerTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/SearchSubSectionComponentControllerTests.cs
@@ -122,6 +122,7 @@ public class SearchSubSectionComponentControllerTests
         searchSubSectionComponentController.OnCloseExploreV2 += () => onCloseExploreV2Triggered = true;
         const string TEST_EVENT_ID = "testEventId";
         const string TEST_EVENT_NAME = "testEventName";
+        const bool TEST_EVENT_IS_WORLD = false;
         Vector2Int testEventCoors = new Vector2Int(100, 100);
 
         // Act
@@ -129,12 +130,13 @@ public class SearchSubSectionComponentControllerTests
         {
             id = TEST_EVENT_ID,
             name = TEST_EVENT_NAME,
+            world = TEST_EVENT_IS_WORLD,
             coordinates = new[] {testEventCoors.x, testEventCoors.y},
         });
 
         // Assert
         Assert.IsTrue(onCloseExploreV2Triggered);
-        exploreV2Analytics.Received(1).SendEventTeleport(TEST_EVENT_ID, TEST_EVENT_NAME, testEventCoors, ActionSource.FromSearch);
+        exploreV2Analytics.Received(1).SendEventTeleport(TEST_EVENT_ID, TEST_EVENT_NAME, TEST_EVENT_IS_WORLD, testEventCoors, ActionSource.FromSearch);
     }
 
     [Test]
@@ -181,6 +183,7 @@ public class SearchSubSectionComponentControllerTests
         // Arrange
         const string TEST_EVENT_ID = "testEventId";
         const string TEST_EVENT_NAME = "testEventName";
+        const bool TEST_EVENT_IS_WORLD = false;
         EventCardComponentModel testEventCardComponentModel = new EventCardComponentModel
         {
             eventId = TEST_EVENT_ID,
@@ -193,7 +196,7 @@ public class SearchSubSectionComponentControllerTests
 
         // Assert
         searchSubSectionComponentView.Received(1).ShowEventModal(testEventCardComponentModel);
-        exploreV2Analytics.Received(1).SendClickOnEventInfo(TEST_EVENT_ID, TEST_EVENT_NAME, testIndex, ActionSource.FromSearch);
+        exploreV2Analytics.Received(1).SendClickOnEventInfo(TEST_EVENT_ID, TEST_EVENT_NAME, TEST_EVENT_IS_WORLD, testIndex, ActionSource.FromSearch);
     }
 
     [Test]
@@ -222,12 +225,13 @@ public class SearchSubSectionComponentControllerTests
     {
         // Arrange
         const string TEST_EVENT_ID = "testEventId";
+        const bool TEST_EVENT_IS_WORLD = false;
 
         // Act
-        searchSubSectionComponentView.OnSubscribeEventClicked += Raise.Event<Action<string>>(TEST_EVENT_ID);
+        searchSubSectionComponentView.OnSubscribeEventClicked += Raise.Event<Action<string, bool>>(TEST_EVENT_ID, TEST_EVENT_IS_WORLD);
 
         // Assert
-        exploreV2Analytics.Received(1).SendParticipateEvent(TEST_EVENT_ID, ActionSource.FromSearch);
+        exploreV2Analytics.Received(1).SendParticipateEvent(TEST_EVENT_ID, TEST_EVENT_IS_WORLD, ActionSource.FromSearch);
         eventsAPIController.Received(1).RegisterParticipation(TEST_EVENT_ID);
     }
 
@@ -236,13 +240,14 @@ public class SearchSubSectionComponentControllerTests
     {
         // Arrange
         const string TEST_EVENT_ID = "testEventId";
+        const bool TEST_EVENT_IS_WORLD = false;
 
         // Act
-        searchSubSectionComponentView.OnUnsubscribeEventClicked += Raise.Event<Action<string>>(TEST_EVENT_ID);
+        searchSubSectionComponentView.OnUnsubscribeEventClicked += Raise.Event<Action<string, bool>>(TEST_EVENT_ID, TEST_EVENT_IS_WORLD);
 
         // Assert
         eventsAPIController.Received(1).RemoveParticipation(TEST_EVENT_ID);
-        exploreV2Analytics.Received(1).SendParticipateEvent(TEST_EVENT_ID, ActionSource.FromSearch);
+        exploreV2Analytics.Received(1).SendParticipateEvent(TEST_EVENT_ID, TEST_EVENT_IS_WORLD, ActionSource.FromSearch);
     }
 
     [Test]


### PR DESCRIPTION
## What does this PR change?
We add the new `isWorld` field to these event's metrics to indicate if the metric belongs to a WORLD or not:

```
explore_event_teleport
explore_click_event_info
explore_participate_event
explore_remove_participate_event
```

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8f89ad</samp>

This pull request adds a new `isWorld` parameter to various methods, actions, and events related to the Explore V2 feature, which allows tracking and distinguishing between events that are hosted in worlds and events that are hosted in scenes. The `isWorld` parameter is passed from the event card component model, which contains the event information, to the event card component view, which renders the event UI, and then to the event card configurator, which sets up the event actions and analytics. The `isWorld` parameter is also passed to the analytics service, which records the user interactions with the events. The pull request also updates the unit tests and the interfaces for the view classes that handle the events UI components. The files affected by this pull request are mostly located in the `unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/Sections/PlacesAndEventsSection` folder.