### PR TITLE
fix: Mic trigger action

### DIFF
--- a/unity-renderer/Assets/Prefabs/Resources/Player.prefab
+++ b/unity-renderer/Assets/Prefabs/Resources/Player.prefab
@@ -102,7 +102,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   voiceChatHoldAction: {fileID: 11400000, guid: 01f0b80c7a1c044868504467140ae590,
     type: 2}
-  voiceChatLeaveOnShortcutTrigger: {fileID: 11400000, guid: cc2c99abe33848af5819b363546ec09f,
+  voiceChatToggleAction: {fileID: 11400000, guid: cc2c99abe33848af5819b363546ec09f,
     type: 2}
 --- !u!1001 &326638023093733539
 PrefabInstance:

--- a/unity-renderer/Assets/Prefabs/Resources/Player.prefab
+++ b/unity-renderer/Assets/Prefabs/Resources/Player.prefab
@@ -24,6 +24,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 326638023455565216}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.80036104, y: 1.035187, z: -1.8401191}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -35,7 +36,6 @@ Transform:
   - {fileID: 326638024105302694}
   - {fileID: 555242717119797939}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7113987045115629054
 MonoBehaviour:
@@ -80,13 +80,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1295785821004055616}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.80036104, y: 1.035187, z: -1.8401191}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 326638023455565217}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8883608762900970871
 MonoBehaviour:
@@ -100,12 +100,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d890778bc77ace2f7b873adba2288f12, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  voiceChatAction: {fileID: 11400000, guid: 01f0b80c7a1c044868504467140ae590, type: 2}
+  voiceChatHoldAction: {fileID: 11400000, guid: 01f0b80c7a1c044868504467140ae590,
+    type: 2}
+  voiceChatLeaveOnShortcutTrigger: {fileID: 11400000, guid: cc2c99abe33848af5819b363546ec09f,
+    type: 2}
 --- !u!1001 &326638023093733539
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 326638023455565217}
     m_Modifications:
     - target: {fileID: 5175052615018462640, guid: ac14ae4eed4f6284ab80fc0881bc3f70,
@@ -170,6 +174,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 989298919143998950, guid: ac14ae4eed4f6284ab80fc0881bc3f70, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ac14ae4eed4f6284ab80fc0881bc3f70, type: 3}
 --- !u!114 &4852920391666169108 stripped
 MonoBehaviour:
@@ -194,6 +201,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 326638023455565217}
     m_Modifications:
     - target: {fileID: 163332511, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
@@ -210,19 +218,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 573743093, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.940002
+      value: 0.93591976
       objectReference: {fileID: 0}
     - target: {fileID: 573743093, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.2922377
+      value: -0.29096857
       objectReference: {fileID: 0}
     - target: {fileID: 573743093, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.16495326
+      value: 0.18596354
       objectReference: {fileID: 0}
     - target: {fileID: 573743093, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.06151314
+      value: -0.06934813
       objectReference: {fileID: 0}
     - target: {fileID: 573743094, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
@@ -258,19 +266,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1404322283, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.87909716
+      value: 0.8759677
       objectReference: {fileID: 0}
     - target: {fileID: 1404322283, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.44969037
+      value: -0.44808954
       objectReference: {fileID: 0}
     - target: {fileID: 1404322283, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.1552973
+      value: 0.17553121
       objectReference: {fileID: 0}
     - target: {fileID: 1404322283, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.029146386
+      value: -0.032943904
       objectReference: {fileID: 0}
     - target: {fileID: 1404322284, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
@@ -286,19 +294,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2072030609, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9418131
+      value: 0.94109035
       objectReference: {fileID: 0}
     - target: {fileID: 2072030609, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.32848832
+      value: -0.32823622
       objectReference: {fileID: 0}
     - target: {fileID: 2072030609, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.06761722
+      value: 0.077103294
       objectReference: {fileID: 0}
     - target: {fileID: 2072030609, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.02261547
+      value: -0.025788212
       objectReference: {fileID: 0}
     - target: {fileID: 2072030610, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
@@ -377,22 +385,22 @@ PrefabInstance:
     - target: {fileID: 1526003882666009685, guid: bc570f5e94906eb47814191e0beaee7a,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.99743456
+      value: 0.9966691
       objectReference: {fileID: 0}
     - target: {fileID: 1526003882666009685, guid: bc570f5e94906eb47814191e0beaee7a,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0063951826
+      value: -0.0063902745
       objectReference: {fileID: 0}
     - target: {fileID: 1526003882666009685, guid: bc570f5e94906eb47814191e0beaee7a,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.07129754
+      value: 0.08129993
       objectReference: {fileID: 0}
     - target: {fileID: 1526003882666009685, guid: bc570f5e94906eb47814191e0beaee7a,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.00045713366
+      value: 0.000521265
       objectReference: {fileID: 0}
     - target: {fileID: 3920995719202391552, guid: bc570f5e94906eb47814191e0beaee7a,
         type: 3}
@@ -421,6 +429,9 @@ PrefabInstance:
       objectReference: {fileID: 326638024105302694}
     m_RemovedComponents:
     - {fileID: 5137756179740078520, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bc570f5e94906eb47814191e0beaee7a, type: 3}
 --- !u!114 &326638022635035865 stripped
 MonoBehaviour:
@@ -493,6 +504,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 326638023455565217}
     m_Modifications:
     - target: {fileID: 1215438618518764946, guid: cd31b73fc107a4f4aadc73662d704c6c,
@@ -606,6 +618,9 @@ PrefabInstance:
       value: CursorCanvas
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd31b73fc107a4f4aadc73662d704c6c, type: 3}
 --- !u!224 &3683705341634318121 stripped
 RectTransform:
@@ -624,6 +639,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 326638023455565217}
     m_Modifications:
     - target: {fileID: 110551818, guid: 68bb549c9718c7649abcfc45e6ad7190, type: 3}
@@ -719,6 +735,9 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 4096479600627248540}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 68bb549c9718c7649abcfc45e6ad7190, type: 3}
 --- !u!4 &326638024105302694 stripped
 Transform:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/VoiceChat/DCLVoiceChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/VoiceChat/DCLVoiceChatController.cs
@@ -12,7 +12,7 @@ namespace DCL
     {
         [Header("InputActions")]
         public InputAction_Hold voiceChatHoldAction;
-        public InputAction_Trigger voiceChatLeaveOnShortcutTrigger;
+        public InputAction_Trigger voiceChatToggleAction;
 
         private bool firstTimeVoiceRecorded = true;
         private ISocialAnalytics socialAnalytics;
@@ -27,7 +27,7 @@ namespace DCL
 
             voiceChatHoldAction.OnStarted += VoiceChatHoldActionStart;
             voiceChatHoldAction.OnFinished += VoiceChatHoldActionFinish;
-            voiceChatLeaveOnShortcutTrigger.OnTriggered += VoiceChatTriggered;
+            voiceChatToggleAction.OnTriggered += VoiceChatTriggered;
 
             KernelConfig.i.EnsureConfigInitialized().Then(config => EnableVoiceChat(config.comms.voiceChatEnabled));
             KernelConfig.i.OnChange += OnKernelConfigChanged;
@@ -63,7 +63,7 @@ namespace DCL
         {
             voiceChatHoldAction.OnStarted -= VoiceChatHoldActionStart;
             voiceChatHoldAction.OnFinished -= VoiceChatHoldActionFinish;
-            voiceChatLeaveOnShortcutTrigger.OnTriggered -= VoiceChatTriggered;
+            voiceChatToggleAction.OnTriggered -= VoiceChatTriggered;
 
             KernelConfig.i.OnChange -= OnKernelConfigChanged;
             DataStore.i.voiceChat.isRecording.OnChange -= IsVoiceChatRecordingChanged;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/VoiceChat/DCLVoiceChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/VoiceChat/DCLVoiceChatController.cs
@@ -10,7 +10,6 @@ namespace DCL
 {
     public class DCLVoiceChatController : MonoBehaviour
     {
-        [FormerlySerializedAs("voiceChatAction")]
         [Header("InputActions")]
         public InputAction_Hold voiceChatHoldAction;
         public InputAction_Trigger voiceChatLeaveOnShortcutTrigger;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/VoiceChat/DCLVoiceChatController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/VoiceChat/DCLVoiceChatController.cs
@@ -82,8 +82,6 @@ namespace DCL
 
         private void IsVoiceChatRecordingChanged(KeyValuePair<bool, bool> current, KeyValuePair<bool, bool> previous)
         {
-            Debug.Log("QUE CARAJO " + current.Key);
-
             if (!DataStore.i.voiceChat.isJoinedToVoiceChat.Get())
                 return;
 


### PR DESCRIPTION
## What does this PR change?

Brings back the shortcut key to toggle the mic state. 

## How to test the changes?

1. Go to 100,100
2. Press LeftAlt+T. Release. The mic should now be open
3. Press LeftAlt+T. Release. The mic should now be closed

And for the variants

1. Press LeftAlt+T. Release. The mic should now be open
2. Press and hold T. The mic should still be open
3. Release T. The mic should now be closed


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e38a4b4</samp>

This pull request adds a new voice chat feature to the `Player` prefab and the `DCLVoiceChatController` class. It allows the player to enable or disable voice chat with a toggle key and to speak with a hold key. It also updates the serialization format of the `Player` prefab and its components to be compatible with the latest Unity version.
