### PR TITLE
fix: set correct snapshots on comms profile messages

### DIFF
--- a/browser-interface/packages/lib/encoding/base64ToBlob.ts
+++ b/browser-interface/packages/lib/encoding/base64ToBlob.ts
@@ -26,3 +26,9 @@ export function base64ToBuffer(base64: string): Uint8Array {
 export function base64ToBlob(base64: string, type: string = 'image/jpeg'): Blob {
   return new Blob([base64ToBuffer(base64)], { type })
 }
+
+const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/
+
+export function isBase64(value: string): boolean {
+  return base64regex.test(value)
+}

--- a/browser-interface/packages/shared/profiles/sagas/handleDeployProfile.ts
+++ b/browser-interface/packages/shared/profiles/sagas/handleDeployProfile.ts
@@ -47,7 +47,7 @@ export function* handleDeployProfile(deployProfileAction: DeployProfile) {
   }
 }
 
-async function buildSnapshotContent(selector: string, value: string) {
+export async function buildSnapshotContent(selector: string, value: string) {
   let hash: string
   let contentFile: ContentFile | undefined
 


### PR DESCRIPTION
Addresses #4426.

## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Fixes the snapshot hashes being sent through comms messages. These were being stripped of their original snapshots (both body and face) to match the default ones that appear in the issue screenshots.

The cause of this seems to be that we are checking for an address (path or URL) or a valid IPFSv2 hash, when for the current user profile we are currently storing a base64 serialization of the snapshots. These were ultimately invalid for the above checks and where changed when announcing our own profiles to the rest of the players, thus showing the defaults instead.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer with different accounts using this same version
2. Gather them together so they are connected through comms
3. Check that the snapshots received (as seen in the nearby chat and other interfaces) should match the ones in their profiles (for the people using *this specific version*, the other players still using the release branch won't show up properly due to the announcing issue)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b188db4</samp>

The pull request adds functionality to convert base64 snapshots in profiles to content files and upload them to the catalyst server. It also adds caching and validation logic for the snapshots. The pull request modifies `comms/sagas.ts`, `handleDeployProfile.ts`, and adds a new function `isBase64` to `base64ToBlob.ts`.
