### PR TITLE
Chore: validation test for correct string comparison

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/SceneControllerService/SceneControllerServiceImpl.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/SceneControllerService/SceneControllerServiceImpl.cs
@@ -382,7 +382,7 @@ namespace RPC.Services
 
         private ScenePortableExperienceFeatureToggles ToScenePortableExperienceFeatureToggle(string str)
         {
-            if (string.Compare(str, "enabled", StringComparison.CurrentCultureIgnoreCase) == 0)
+            if (string.Compare(str, "enabled", StringComparison.OrdinalIgnoreCase) == 0)
                 return ScenePortableExperienceFeatureToggles.Enable;
             if (string.Compare(str, "disabled", StringComparison.OrdinalIgnoreCase) == 0)
                 return ScenePortableExperienceFeatureToggles.Disable;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/SceneControllerService/SceneControllerServiceImpl.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/SceneControllerService/SceneControllerServiceImpl.cs
@@ -382,7 +382,7 @@ namespace RPC.Services
 
         private ScenePortableExperienceFeatureToggles ToScenePortableExperienceFeatureToggle(string str)
         {
-            if (string.Compare(str, "enabled", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Compare(str, "enabled", StringComparison.CurrentCultureIgnoreCase) == 0)
                 return ScenePortableExperienceFeatureToggles.Enable;
             if (string.Compare(str, "disabled", StringComparison.OrdinalIgnoreCase) == 0)
                 return ScenePortableExperienceFeatureToggles.Disable;

--- a/unity-renderer/Assets/Scripts/Tests/ValidationTests/CodeConventionsTests.cs
+++ b/unity-renderer/Assets/Scripts/Tests/ValidationTests/CodeConventionsTests.cs
@@ -31,24 +31,6 @@ namespace Tests.ValidationTests
             AssetDatabase.FindAssets("t:Script")
                          .Select(AssetDatabase.GUIDToAssetPath)
                          .Where(assetPath => Path.GetFileName(assetPath) != "AssemblyInfo.cs" && Path.GetExtension(assetPath) == ".cs" &&
-                                             !assetPath.StartsWith("Packages/") && !EXCLUDED_PATHS.Any(assetPath.Contains) && !IsInEditorAssembly(assetPath));
-
-        private static bool IsInEditorAssembly(string assetPath)
-        {
-            string directory = Path.GetDirectoryName(assetPath);
-
-            while (directory != null && directory.StartsWith("Assets"))
-            {
-                string[] asmdefFiles = Directory.GetFiles(directory, "*.asmdef");
-
-                if (asmdefFiles.Select(File.ReadAllText)
-                               .Any(asmdefContent => asmdefContent.Contains("\"platforms\": [\"Editor\"]")))
-                    return true;
-
-                directory = Path.GetDirectoryName(directory);
-            }
-
-            return false;
-        }
+                                             !assetPath.StartsWith("Packages/") && !EXCLUDED_PATHS.Any(assetPath.Contains));
     }
 }

--- a/unity-renderer/Assets/Scripts/Tests/ValidationTests/CodeConventionsTests.cs
+++ b/unity-renderer/Assets/Scripts/Tests/ValidationTests/CodeConventionsTests.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+
+namespace Tests.ValidationTests
+{
+    public class CodeConventionsTests
+    {
+        private static readonly string[] EXCLUDED_PATHS = { "/Editor/", "/Tests/", "/EditorTests/" };
+
+        [Test]
+        public void AvoidUsingCurrentCultureIgnoreCase_SingleTest()
+        {
+            foreach (string file in AllCSharpFiles())
+            {
+                string fileContent = File.ReadAllText(file);
+
+                // Check if the file content contains the offending usage
+                bool foundOffendingUsage = fileContent.Contains("StringComparison.CurrentCultureIgnoreCase");
+
+                // Assert that there are no offending usages.
+                Assert.IsFalse(foundOffendingUsage, $"File {Path.GetFileName(file)} uses StringComparison.CurrentCultureIgnoreCase. Please use StringComparison.OrdinalIgnoreCase instead.");
+            }
+        }
+
+        private static IEnumerable<string> AllCSharpFiles() =>
+            AssetDatabase.FindAssets("t:Script")
+                         .Select(AssetDatabase.GUIDToAssetPath)
+                         .Where(assetPath => Path.GetFileName(assetPath) != "AssemblyInfo.cs" && Path.GetExtension(assetPath) == ".cs" &&
+                                             !assetPath.StartsWith("Packages/") && !EXCLUDED_PATHS.Any(assetPath.Contains) && !IsInEditorAssembly(assetPath));
+
+        private static bool IsInEditorAssembly(string assetPath)
+        {
+            string directory = Path.GetDirectoryName(assetPath);
+
+            while (directory != null && directory.StartsWith("Assets"))
+            {
+                string[] asmdefFiles = Directory.GetFiles(directory, "*.asmdef");
+
+                if (asmdefFiles.Select(File.ReadAllText)
+                               .Any(asmdefContent => asmdefContent.Contains("\"platforms\": [\"Editor\"]")))
+                    return true;
+
+                directory = Path.GetDirectoryName(directory);
+            }
+
+            return false;
+        }
+    }
+}

--- a/unity-renderer/Assets/Scripts/Tests/ValidationTests/CodeConventionsTests.cs
+++ b/unity-renderer/Assets/Scripts/Tests/ValidationTests/CodeConventionsTests.cs
@@ -6,21 +6,23 @@ using UnityEditor;
 
 namespace Tests.ValidationTests
 {
+    [Category("EditModeCI")]
     public class CodeConventionsTests
     {
         private static readonly string[] EXCLUDED_PATHS = { "/Editor/", "/Tests/", "/EditorTests/" };
 
         [Test]
-        public void AvoidUsingCurrentCultureIgnoreCase_SingleTest()
+        public void AvoidUsingCurrentCultureIgnoreCase()
         {
+            // Arrange
             foreach (string file in AllCSharpFiles())
             {
                 string fileContent = File.ReadAllText(file);
 
-                // Check if the file content contains the offending usage
+                // Act
                 bool foundOffendingUsage = fileContent.Contains("StringComparison.CurrentCultureIgnoreCase");
 
-                // Assert that there are no offending usages.
+                // Assert
                 Assert.IsFalse(foundOffendingUsage, $"File {Path.GetFileName(file)} uses StringComparison.CurrentCultureIgnoreCase. Please use StringComparison.OrdinalIgnoreCase instead.");
             }
         }

--- a/unity-renderer/Assets/Scripts/Tests/ValidationTests/CodeConventionsTests.cs.meta
+++ b/unity-renderer/Assets/Scripts/Tests/ValidationTests/CodeConventionsTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7c0087afa0424018a0cdcb5c173ac3fc
+timeCreated: 1694450222


### PR DESCRIPTION
## What does this PR change?

add validation to not use `StringComparison.CurrentCultureIgnoreCase`, because _it works well on **Desktop**/**Editor**, but in **WebGL** it doesn’t work… it’s case sensitive for **WebGL**._ .

Relates to this [bug ](https://github.com/decentraland/unity-renderer/pull/5676) 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f662ced</samp>

The pull request fixes a potential bug with string comparison in the scene controller service by using `StringComparison.OrdinalIgnoreCase` instead of `StringComparison.CurrentCultureIgnoreCase`. It also adds a unit test and a code convention to prevent future regressions of this issue.
