### PR TITLE
fix: unnamed scene on start on the map

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Tests/NavmapTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Tests/NavmapTests.cs
@@ -1,7 +1,6 @@
 using Cysharp.Threading.Tasks;
-using System.Collections;
-using System.Collections.Generic;
 using DCL;
+using DCL.Map;
 using DCLServices.CopyPaste.Analytics;
 using DCLServices.MapRendererV2;
 using DCLServices.PlacesAPIService;
@@ -9,6 +8,8 @@ using MainScripts.DCL.Controllers.HotScenes;
 using NSubstitute;
 using NSubstitute.Extensions;
 using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -17,13 +18,29 @@ namespace Tests
 {
     public class NavmapTests : IntegrationTestSuite_Legacy
     {
+        private const string INITIAL_SCENE_NAME = "INITIAL_SCENE";
+
         private MinimapHUDController controller;
         private NavmapView navmapView;
         private IPlacesAPIService placesAPIService;
+        private WebInterfaceMinimapApiBridgeMock minimapApiBridge;
 
         protected override List<GameObject> SetUp_LegacySystems()
         {
             List<GameObject> result = new List<GameObject>();
+            minimapApiBridge = new GameObject("WebInterfaceMinimapApiBridge").AddComponent<WebInterfaceMinimapApiBridgeMock>();
+            minimapApiBridge.ScenesInformationResult = new []
+            {
+                new MinimapMetadata.MinimapSceneInfo
+                {
+                    name = INITIAL_SCENE_NAME,
+                    parcels = new List<Vector2Int>
+                    {
+                        Vector2Int.zero,
+                    },
+                }
+            };
+            result.Add(minimapApiBridge.gameObject);
             result.Add(MainSceneFactory.CreateNavMap());
             return result;
         }
@@ -41,10 +58,14 @@ namespace Tests
             yield return base.SetUp();
 
             placesAPIService = Substitute.For<IPlacesAPIService>();
+            placesAPIService.Configure()
+                            .GetPlace(Arg.Any<Vector2Int>(), Arg.Any<CancellationToken>())
+                            .Returns(x => new UniTask<IHotScenesController.PlaceInfo>(new IHotScenesController.PlaceInfo()));
+
             controller = new MinimapHUDController(
                 Substitute.For<MinimapMetadataController>(),
                 Substitute.For<IHomeLocationController>(),
-                DCL.Environment.i,
+                Environment.i,
                 placesAPIService,
                 Substitute.For<IPlacesAnalytics>(),
                 Substitute.For<IClipboard>(),
@@ -90,9 +111,6 @@ namespace Tests
         [Test]
         public void ReactToPlayerCoordsChange()
         {
-            placesAPIService.Configure()
-                            .GetPlace(Arg.Any<Vector2Int>(), Arg.Any<CancellationToken>())
-                            .Returns(x => new UniTask<IHotScenesController.PlaceInfo>(new IHotScenesController.PlaceInfo()));
             const string sceneName = "SCENE_NAME";
             MinimapMetadata.GetMetadata()
                 .AddSceneInfo(
@@ -107,6 +125,26 @@ namespace Tests
             CommonScriptableObjects.playerCoords.Set(new Vector2Int(-77, -77));
             Assert.AreEqual(sceneName, navmapView.currentSceneNameText.text);
             Assert.AreEqual("-77,-77", navmapView.currentSceneCoordsText.text);
+        }
+
+        [Test]
+        public void DisplaySceneDataWhenInitialize()
+        {
+            Assert.AreEqual(INITIAL_SCENE_NAME, navmapView.currentSceneNameText.text);
+            Assert.AreEqual("0,0", navmapView.currentSceneCoordsText.text);
+        }
+
+        private class WebInterfaceMinimapApiBridgeMock : WebInterfaceMinimapApiBridge
+        {
+            public MinimapMetadata.MinimapSceneInfo[] ScenesInformationResult { get; set; }
+
+            public async override UniTask<MinimapMetadata.MinimapSceneInfo[]> GetScenesInformationAroundParcel(Vector2Int coordinate, int areaSize, CancellationToken cancellationToken)
+            {
+                foreach (MinimapMetadata.MinimapSceneInfo sceneInfo in ScenesInformationResult)
+                    MinimapMetadata.GetMetadata().AddSceneInfo(sceneInfo);
+
+                return ScenesInformationResult;
+            }
         }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Tests/NavmapToastViewShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Tests/NavmapToastViewShould.cs
@@ -6,6 +6,7 @@ using DCL.Map;
 using DCLServices.CopyPaste.Analytics;
 using DCLServices.MapRendererV2;
 using DCLServices.PlacesAPIService;
+using MainScripts.DCL.Controllers.HotScenes;
 using NSubstitute;
 using NUnit.Framework;
 using System;
@@ -45,11 +46,22 @@ namespace Tests
             yield return base.SetUp();
             yield return null;
 
+            IPlacesAPIService placesAPIService = Substitute.For<IPlacesAPIService>();
+
+            placesAPIService.GetPlace(default(Vector2Int), default, default)
+                            .ReturnsForAnyArgs(UniTask.FromResult(new IHotScenesController.PlaceInfo
+                             {
+                                 id = "placeId",
+                             }));
+
+            placesAPIService.IsFavoritePlace(default(IHotScenesController.PlaceInfo), default, default)
+                            .ReturnsForAnyArgs(UniTask.FromResult(false));
+
             controller = new MinimapHUDController(
                 Substitute.For<MinimapMetadataController>(),
                 Substitute.For<IHomeLocationController>(),
                 DCL.Environment.i,
-                Substitute.For<IPlacesAPIService>(),
+                placesAPIService,
                 Substitute.For<IPlacesAnalytics>(),
                 Substitute.For<IClipboard>(),
                 Substitute.For<ICopyPasteAnalyticsService>());

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/WebInterfaceMinimapApiBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/WebInterfaceMinimapApiBridge.cs
@@ -38,7 +38,7 @@ namespace DCL.Map
             task.TrySetResult(payload.scenesInfo);
         }
 
-        public UniTask<MinimapMetadata.MinimapSceneInfo[]> GetScenesInformationAroundParcel(Vector2Int coordinate, int areaSize, CancellationToken cancellationToken)
+        public virtual UniTask<MinimapMetadata.MinimapSceneInfo[]> GetScenesInformationAroundParcel(Vector2Int coordinate, int areaSize, CancellationToken cancellationToken)
         {
             if (pendingTasks.TryGetValue(GET_SCENES_INFO_ID, out var pendingTask))
                 return ((UniTaskCompletionSource<MinimapMetadata.MinimapSceneInfo[]>) pendingTask)


### PR DESCRIPTION
## What does this PR change?

`Fixes #5688 `

## How to test the changes?

1. Launch the explorer at 0,0
2. Open the map
3. Check that the scene name indicator at the bottom right says `Genesis Plaza`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f75d855</samp>

Added scene name feature to navmap HUD. The feature uses `Places API` and async tasks to show the name of the current scene in the `NavmapView.cs` script.
