### PR TITLE
fix: sdk7 AudioStream and Video not playing on scene start

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AudioStream/Tests/ECSAudioStreamShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AudioStream/Tests/ECSAudioStreamShould.cs
@@ -64,7 +64,6 @@ namespace Tests
             // We prepare the componentHandler
             audioSourceComponentHandler.isInsideScene = true;
             audioSourceComponentHandler.isRendererActive = true;
-            audioSourceComponentHandler.hadUserInteraction = true;
 
             // We prepare the models
             PBAudioStream model = CreateAudioStreamModel();
@@ -129,7 +128,6 @@ namespace Tests
             model.Playing = true;
             audioSourceComponentHandler.isInsideScene = true;
             audioSourceComponentHandler.isRendererActive = true;
-            audioSourceComponentHandler.hadUserInteraction = true;
 
             // Act
             audioSourceComponentHandler.OnComponentModelUpdated(scene, entity, model);
@@ -151,8 +149,7 @@ namespace Tests
             model.Playing = true;
             model.Url = URL;
             audioSourceComponentHandler.isInsideScene = true;
-            audioSourceComponentHandler.isRendererActive = true;
-            audioSourceComponentHandler.hadUserInteraction = false;
+            audioSourceComponentHandler.isRendererActive = false;
 
             // Act
             audioSourceComponentHandler.OnComponentModelUpdated(scene, entity, model);
@@ -224,7 +221,6 @@ namespace Tests
 
             audioSourceComponentHandler.isInsideScene = true;
             audioSourceComponentHandler.isRendererActive = true;
-            audioSourceComponentHandler.hadUserInteraction = true;
 
             audioSourceComponentHandler.OnComponentModelUpdated(scene, entity, model);
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -72,7 +72,6 @@ namespace Tests
         public IEnumerator TryToStartVideo()
         {
             videoPlayerHandler.isRendererActive = true;
-            videoPlayerHandler.hadUserInteraction = true;
             PBVideoPlayer model = new PBVideoPlayer()
             {
                 Src = "video.mp4",
@@ -106,7 +105,6 @@ namespace Tests
         public IEnumerator VideoUpdateOnRuntime()
         {
             videoPlayerHandler.isRendererActive = true;
-            videoPlayerHandler.hadUserInteraction = true;
             videoPlayerHandler.OnComponentModelUpdated(scene, entity, new PBVideoPlayer()
             {
                 Src = "video.mp4"
@@ -139,7 +137,6 @@ namespace Tests
             Assert.IsNull(internalVideoPlayerComponent.GetFor(scene, entity));
 
             videoPlayerHandler.OnComponentCreated(scene, entity);
-            videoPlayerHandler.hadUserInteraction = true;
             videoPlayerHandler.OnComponentModelUpdated(scene, entity, new PBVideoPlayer()
             {
                 Src = "other-video.mp4",
@@ -219,7 +216,6 @@ namespace Tests
         public IEnumerator StopVideoIfRenderingIsDisabled()
         {
             videoPlayerHandler.OnComponentCreated(scene, entity);
-            videoPlayerHandler.hadUserInteraction = true;
             PBVideoPlayer model = new PBVideoPlayer()
             {
                 Src = "video.mp4",
@@ -235,30 +231,6 @@ namespace Tests
             loadingScreenDataStore.decoupledLoadingHUD.visible.Set(true);
 
             Assert.AreEqual(false, videoPlayerHandler.videoPlayer.playing);
-
-            videoPlayerHandler.OnComponentRemoved(scene, entity);
-        }
-
-        [UnityTest]
-        public IEnumerator StartVideoAfterUserInteraction()
-        {
-            videoPlayerHandler.OnComponentCreated(scene, entity);
-            videoPlayerHandler.hadUserInteraction = false;
-            PBVideoPlayer model = new PBVideoPlayer()
-            {
-                Src = "video.mp4",
-                Playing = true
-            };
-            videoPlayerHandler.OnComponentModelUpdated(scene, entity, model);
-            yield return new WaitUntil(() => videoPlayerHandler.videoPlayer.GetState() == VideoState.READY);
-            videoPlayerHandler.videoPlayer.Update();
-
-            Assert.AreEqual(false, videoPlayerHandler.videoPlayer.playing);
-
-            // change user interaction bool
-            DCL.Helpers.Utils.LockCursor();
-
-            Assert.AreEqual(true, videoPlayerHandler.videoPlayer.playing);
 
             videoPlayerHandler.OnComponentRemoved(scene, entity);
         }


### PR DESCRIPTION
## What does this PR change?
removed condition where user action was awaited before trying to play videos or audiostream, that were there to avoid browsers blocking the play call without user input
since it was not needed for video, which will retry to play when that exception is thrown
and modified the code for playing the audiostream to retry playing when the exception is thrown

fixes https://github.com/decentraland/sdk/issues/927
fixes https://github.com/decentraland/sdk/issues/928

## How to test the changes?
Both Videos and AudioStreams should work as expected on Web platform
*AudioStream modifications also affect sdk6 scenes

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa05be4</samp>

Removed the `hadUserInteraction` field and logic from the audio stream and video player components and handlers in the ECS7 plugin. This improves the user experience by allowing audio and video to play without requiring user input. Refactored the audio stream playback logic in the browser interface to handle browser restrictions and retries. Updated the tests accordingly.
