### PR TITLE
fix: change avatar modifier warning position for worlds

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/AvatarModifierAreaFeedbackPlugin/AvatarModifierAreaFeedbackPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/AvatarModifierAreaFeedbackPlugin/AvatarModifierAreaFeedbackPlugin.cs
@@ -6,12 +6,12 @@ using UnityEngine;
 
 public class AvatarModifierAreaFeedbackPlugin : IPlugin
 {
-    
+
     private AvatarModifierAreaFeedbackController avatarModifierAreaFeedbackController;
 
     public AvatarModifierAreaFeedbackPlugin()
     {
-        avatarModifierAreaFeedbackController = new AvatarModifierAreaFeedbackController(DataStore.i.HUDs.avatarAreaWarnings, AvatarModifierAreaFeedbackView.Create());
+        avatarModifierAreaFeedbackController = new AvatarModifierAreaFeedbackController(DataStore.i.HUDs.avatarAreaWarnings, AvatarModifierAreaFeedbackView.Create(), DataStore.i.common);
     }
 
     public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Resources/_AvatarModifierAreaFeedbackHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Resources/_AvatarModifierAreaFeedbackHUD.prefab
@@ -475,6 +475,7 @@ MonoBehaviour:
   contentTransform: {fileID: 1483900348370178711}
   containerForLandsTransform: {fileID: 6899800964194586478}
   containerForWorldsTransform: {fileID: 138476811516249217}
+  mainCanvas: {fileID: 5518088804749935907}
 --- !u!225 &1486261044637553431
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Resources/_AvatarModifierAreaFeedbackHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Resources/_AvatarModifierAreaFeedbackHUD.prefab
@@ -28,12 +28,12 @@ RectTransform:
   m_GameObject: {fileID: 2714242402098579644}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.8, y: 0.8, z: 1}
+  m_LocalScale: {x: 0.79999995, y: 0.79999995, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4572381096843199133}
   - {fileID: 4441703467273945839}
-  m_Father: {fileID: 8097679517560586846}
-  m_RootOrder: 0
+  m_Father: {fileID: 1483900348370178711}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -90,6 +90,41 @@ CanvasGroup:
   m_Interactable: 0
   m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
+--- !u!1 &2745697146247205633
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 138476811516249217}
+  m_Layer: 5
+  m_Name: ContainerForWorlds
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &138476811516249217
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2745697146247205633}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8097679517560586846}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -195, y: 126}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2914371139262367186
 GameObject:
   m_ObjectHideFlags: 0
@@ -118,11 +153,11 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8817571703558554207}
   - {fileID: 1064020571231334477}
   m_Father: {fileID: 7202744461137864034}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -196,10 +231,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8702178016756654996}
   m_Father: {fileID: 7202744461137864034}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -268,9 +303,9 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4572381096843199133}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -328,7 +363,6 @@ GameObject:
   - component: {fileID: 2296289379664879046}
   - component: {fileID: 7607127335931061082}
   - component: {fileID: 157340988008856442}
-  - component: {fileID: 9029093572074442589}
   - component: {fileID: 1486261044637553431}
   - component: {fileID: 4469379106547376070}
   m_Layer: 5
@@ -348,11 +382,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7202744461137864034}
-  - {fileID: 7300935035096097629}
+  - {fileID: 1483900348370178711}
+  - {fileID: 6899800964194586478}
+  - {fileID: 138476811516249217}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -376,9 +411,11 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!114 &2296289379664879046
 MonoBehaviour:
@@ -434,26 +471,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   warningContainer: {fileID: 8702178016756654996}
   pointerEnterTriggerArea: {fileID: 3468231791129230095}
-  messageAnimator: {fileID: 9029093572074442589}
---- !u!95 &9029093572074442589
-Animator:
-  serializedVersion: 3
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5759081851182207893}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 17f811f69ec0c4044aade75f3a53ed46, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  messageAnimator: {fileID: 7108955499911447548}
+  contentTransform: {fileID: 1483900348370178711}
+  containerForLandsTransform: {fileID: 6899800964194586478}
+  containerForWorldsTransform: {fileID: 138476811516249217}
 --- !u!225 &1486261044637553431
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -478,6 +499,100 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 30cedd7c5f8c0064e98640b29b2156a5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &7396819766628569072
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1483900348370178711}
+  - component: {fileID: 7108955499911447548}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1483900348370178711
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7396819766628569072}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7202744461137864034}
+  - {fileID: 7300935035096097629}
+  m_Father: {fileID: 8097679517560586846}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!95 &7108955499911447548
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7396819766628569072}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 17f811f69ec0c4044aade75f3a53ed46, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &7681980367309420189
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6899800964194586478}
+  m_Layer: 5
+  m_Name: ContainerForLands
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6899800964194586478
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7681980367309420189}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8097679517560586846}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8523391416563304957
 GameObject:
   m_ObjectHideFlags: 0
@@ -506,9 +621,9 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4572381096843199133}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -642,9 +757,9 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8097679517560586846}
-  m_RootOrder: 1
+  m_Father: {fileID: 1483900348370178711}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -730,9 +845,9 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4441703467273945839}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackController.cs
@@ -16,7 +16,7 @@ namespace DCL.AvatarModifierAreaFeedback
 
             this.commonDataStore = commonDataStore;
             commonDataStore.isWorld.OnChange += OnWorldModeChange;
-            OnWorldModeChange(DataStore.i.common.isWorld.Get(), false);
+            OnWorldModeChange(commonDataStore.isWorld.Get(), false);
         }
 
         private void OnWorldModeChange(bool isWorld, bool _) =>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackController.cs
@@ -1,21 +1,33 @@
 namespace DCL.AvatarModifierAreaFeedback
 {
-    public class AvatarModifierAreaFeedbackController 
+    public class AvatarModifierAreaFeedbackController
     {
         internal IAvatarModifierAreaFeedbackView view;
         private BaseRefCounter<AvatarModifierAreaID> avatarModifiersWarnings;
-        
-        public AvatarModifierAreaFeedbackController(BaseRefCounter<AvatarModifierAreaID> avatarAreaWarnings, IAvatarModifierAreaFeedbackView view)
+        private readonly DataStore_Common commonDataStore;
+
+        public AvatarModifierAreaFeedbackController(
+            BaseRefCounter<AvatarModifierAreaID> avatarAreaWarnings,
+            IAvatarModifierAreaFeedbackView view,
+            DataStore_Common commonDataStore)
         {
             this.view = view;
             view.SetUp(avatarAreaWarnings);
+
+            this.commonDataStore = commonDataStore;
+            commonDataStore.isWorld.OnChange += OnWorldModeChange;
+            OnWorldModeChange(DataStore.i.common.isWorld.Get(), false);
         }
+
+        private void OnWorldModeChange(bool isWorld, bool _) =>
+            view.SetWorldMode(isWorld);
 
         public void Dispose()
         {
+            commonDataStore.isWorld.OnChange -= OnWorldModeChange;
             view.Dispose();
         }
-   
+
     }
 }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackView.cs
@@ -24,6 +24,7 @@ namespace DCL.AvatarModifierAreaFeedback
         [SerializeField] private RectTransform contentTransform;
         [SerializeField] private RectTransform containerForLandsTransform;
         [SerializeField] private RectTransform containerForWorldsTransform;
+        [SerializeField] private Canvas mainCanvas;
 
         internal bool isVisible;
         internal AvatarModifierAreaFeedbackState currentState;
@@ -66,6 +67,7 @@ namespace DCL.AvatarModifierAreaFeedback
             contentTransform.offsetMin = Vector2.zero;
             contentTransform.offsetMax = Vector2.zero;
             contentTransform.anchoredPosition = Vector2.zero;
+            mainCanvas.sortingOrder = isWorld ? 1 : 0;
         }
 
         private void RemovedWarning(AvatarModifierAreaID obj)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/AvatarModifierAreaFeedbackView.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
@@ -11,7 +10,6 @@ namespace DCL.AvatarModifierAreaFeedback
 {
     public class AvatarModifierAreaFeedbackView : MonoBehaviour, IAvatarModifierAreaFeedbackView, IPointerEnterHandler, IPointerExitHandler
     {
-        
         internal enum AvatarModifierAreaFeedbackState { NEVER_SHOWN, ICON_VISIBLE, WARNING_MESSAGE_VISIBLE, NONE_VISIBLE }
 
         private const string PATH = "_AvatarModifierAreaFeedbackHUD";
@@ -19,11 +17,14 @@ namespace DCL.AvatarModifierAreaFeedback
         private BaseRefCounter<AvatarModifierAreaID> avatarAreaWarningsCounter;
         private HUDCanvasCameraModeController hudCanvasCameraModeController;
 
-        
+
         [SerializeField] internal RectTransform warningContainer;
         [SerializeField] private CanvasGroup pointerEnterTriggerArea;
         [SerializeField] private Animator messageAnimator;
-       
+        [SerializeField] private RectTransform contentTransform;
+        [SerializeField] private RectTransform containerForLandsTransform;
+        [SerializeField] private RectTransform containerForWorldsTransform;
+
         internal bool isVisible;
         internal AvatarModifierAreaFeedbackState currentState;
         internal Dictionary<AvatarModifierAreaID, GameObject> warningMessagesDictionary;
@@ -33,7 +34,7 @@ namespace DCL.AvatarModifierAreaFeedback
         private string msgInAnimationTrigger = "MsgIn";
         private string iconInAnimationTrigger = "IconIn";
         private string iconOutAnimationTrigger = "IconOut";
-        
+
         public static AvatarModifierAreaFeedbackView Create() { return Instantiate(Resources.Load<GameObject>(PATH)).GetComponent<AvatarModifierAreaFeedbackView>(); }
 
         public void Awake()
@@ -49,14 +50,22 @@ namespace DCL.AvatarModifierAreaFeedback
             avatarAreaWarningsCounter.OnRemoved += RemovedWarning;
 
             warningMessagesDictionary = new Dictionary<AvatarModifierAreaID, GameObject>();
-            
+
             foreach (AvatarModifierAreaID warningMessageEnum in Enum.GetValues(typeof(AvatarModifierAreaID)))
             {
                 GameObject newWarningMessage = Instantiate(Resources.Load<GameObject>(PATH_TO_WARNING_MESSAGE), warningContainer);
                 newWarningMessage.GetComponent<TMP_Text>().text = GetWarningMessage(warningMessageEnum);
                 newWarningMessage.SetActive(false);
                 warningMessagesDictionary.Add(warningMessageEnum, newWarningMessage);
-            }  
+            }
+        }
+
+        public void SetWorldMode(bool isWorld)
+        {
+            contentTransform.SetParent(isWorld ? containerForWorldsTransform : containerForLandsTransform);
+            contentTransform.offsetMin = Vector2.zero;
+            contentTransform.offsetMax = Vector2.zero;
+            contentTransform.anchoredPosition = Vector2.zero;
         }
 
         private void RemovedWarning(AvatarModifierAreaID obj)
@@ -78,7 +87,7 @@ namespace DCL.AvatarModifierAreaFeedback
             if (isVisible) return;
             isVisible = true;
             ResetAllTriggers();
-            
+
             if (currentState.Equals(AvatarModifierAreaFeedbackState.NEVER_SHOWN))
             {
                 messageAnimator.SetTrigger(msgInAnimationTrigger);
@@ -92,15 +101,15 @@ namespace DCL.AvatarModifierAreaFeedback
                 currentState = AvatarModifierAreaFeedbackState.ICON_VISIBLE;
             }
         }
-        
+
         private void Hide()
         {
             isVisible = false;
-            
+
             deactivatePreviewCancellationToken.Cancel();
-            
+
             pointerEnterTriggerArea.blocksRaycasts = false;
-            
+
             if (currentState.Equals(AvatarModifierAreaFeedbackState.WARNING_MESSAGE_VISIBLE))
             {
                 messageAnimator.SetTrigger(msgOutAnimationTrigger);
@@ -111,7 +120,7 @@ namespace DCL.AvatarModifierAreaFeedback
             }
             currentState = AvatarModifierAreaFeedbackState.NONE_VISIBLE;
         }
-        
+
         public void OnPointerEnter(PointerEventData eventData)
         {
             if (!isVisible) return;
@@ -119,23 +128,23 @@ namespace DCL.AvatarModifierAreaFeedback
             messageAnimator.SetTrigger(msgInAnimationTrigger);
             currentState = AvatarModifierAreaFeedbackState.WARNING_MESSAGE_VISIBLE;
         }
-        
+
         public void OnPointerExit(PointerEventData eventData)
         {
             if (!isVisible) return;
-            
+
             messageAnimator.SetTrigger(iconInAnimationTrigger);
             currentState = AvatarModifierAreaFeedbackState.ICON_VISIBLE;
         }
-        
-      
+
+
         async UniTaskVoid HideFirstTimeWarningMessageUniTask(CancellationToken cancellationToken)
         {
             await UniTask.Delay(5000, cancellationToken: cancellationToken);
             await UniTask.SwitchToMainThread(cancellationToken);
             if (cancellationToken.IsCancellationRequested) return;
             messageAnimator.SetTrigger(iconInAnimationTrigger);
-            
+
             currentState = AvatarModifierAreaFeedbackState.ICON_VISIBLE;
             pointerEnterTriggerArea.blocksRaycasts = true;
         }
@@ -148,7 +157,7 @@ namespace DCL.AvatarModifierAreaFeedback
             avatarAreaWarningsCounter.OnRemoved -= RemovedWarning;
 			hudCanvasCameraModeController?.Dispose();
         }
-        
+
         private string GetWarningMessage(AvatarModifierAreaID idToSet)
         {
             switch (idToSet)
@@ -170,6 +179,6 @@ namespace DCL.AvatarModifierAreaFeedback
             messageAnimator.ResetTrigger(iconOutAnimationTrigger);
         }
 
-        
+
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/Interfaces/IAvatarModifierAreaFeedbackView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Scripts/Interfaces/IAvatarModifierAreaFeedbackView.cs
@@ -3,6 +3,6 @@ using System;
 public interface IAvatarModifierAreaFeedbackView : IDisposable
 {
     void SetUp(BaseRefCounter<AvatarModifierAreaID> avatarAreaWarnings);
-
+    void SetWorldMode(bool isWorld);
 }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Test/AvatarModifierAreaFeedbackControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarModifierAreaHUD/Test/AvatarModifierAreaFeedbackControllerShould.cs
@@ -11,25 +11,26 @@ namespace Tests.AvatarModifierAreaFeedback
 {
     public class AvatarModifierAreaFeedbackControllerShould
     {
-   
+
         private AvatarModifierAreaFeedbackController hudController;
         private IAvatarModifierAreaFeedbackView hudView;
         private BaseRefCounter<AvatarModifierAreaID> warningMessageList => DataStore.i.HUDs.avatarAreaWarnings;
+        private readonly DataStore_Common commonDataStore = new ();
 
         [SetUp]
         public void SetUp()
         {
             hudView = Substitute.For<IAvatarModifierAreaFeedbackView>();
-            hudController = new AvatarModifierAreaFeedbackController(warningMessageList, hudView);
+            hudController = new AvatarModifierAreaFeedbackController(warningMessageList, hudView, commonDataStore);
         }
-        
+
         [Test]
         public void InitializeProperly()
         {
             Assert.AreEqual(hudView, hudController.view);
             hudController.view.Received().SetUp(warningMessageList);
         }
-        
+
 
         [TearDown]
         protected void TearDown()


### PR DESCRIPTION
## What does this PR change?
Fix #5469 

When we were in a world where the change avatar modifier warning was activated, we had HUD floating wrongly in the middle of the screen:

![image](https://github.com/decentraland/unity-renderer/assets/64659061/e7af091f-0476-403d-a9ff-bf397278e7e6)
![image](https://github.com/decentraland/unity-renderer/assets/64659061/33a17578-6d01-4356-8257-c305f680fd39)

Now, in this case, this HUD is changing its position so when we are in a normal land it keeps its original position and when we are in a world it changes its position to the top-side of the screen:

![image](https://github.com/decentraland/unity-renderer/assets/64659061/cab0a9d1-6957-4e9f-ad31-080ac206dbaf)
![image](https://github.com/decentraland/unity-renderer/assets/64659061/74afd299-297d-44cf-80ca-e7d032ef8af3)

## How to test the changes?
1. Launch the explorer
2. Go to any non-world place where the avatar modifier warning HUD is activated (for example WonderMine, near the machine).
3. Observe the warning is well placed by the minimap.
4. Go to any world place (for example: `8metagames.dcl.eth`).
5. Observe the warning is well placed in the top-left of the screen, under the [GO TO GENESIS CITY] button.
6. Go again to any non-world place where the avatar modifier warning HUD is activated (for example WonderMine, near the machine).
7. Observe the warning is well placed by the minimap.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fcb54b2</samp>

The pull request modifies the `AvatarModifierAreaFeedbackHUD` prefab and its related scripts and tests to support different feedback modes depending on the world mode. The world mode is a boolean value that indicates whether the user is in a land or a world. The pull request adds a `DataStore_Common` argument to the `AvatarModifierAreaFeedbackController` and `AvatarModifierAreaFeedbackPlugin` classes to access and subscribe to the world mode changes. The pull request also adds a `SetWorldMode` method to the `IAvatarModifierAreaFeedbackView` interface and implements it in the `AvatarModifierAreaFeedbackView` class to adjust the HUD elements accordingly.