### PR TITLE
chore: remove unused scene messages pool queue

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ECSComponentManagerLegacy/ECSComponentsManagerLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/ECSComponentManagerLegacy/ECSComponentsManagerLegacy.cs
@@ -537,7 +537,7 @@ namespace DCL
 
             switch (componentName)
             {
-                case "shape":
+                case ComponentNameLiterals.Shape:
                     if (entity.meshesInfo.currentShape is BaseShape baseShape)
                     {
                         baseShape.DetachFrom(entity);
@@ -591,7 +591,7 @@ namespace DCL
                         }
                     }
                     return;
-                case "transform":
+                case ComponentNameLiterals.Transform:
                     {
                         if (TryGetBaseComponent(entity, CLASS_ID_COMPONENT.AVATAR_ATTACH, out IEntityComponent component))
                         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/ISceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/ISceneController.cs
@@ -2,8 +2,6 @@
 using System;
 using DCL.Controllers;
 using DCL.Models;
-using System.Threading.Tasks;
-using UnityEngine;
 
 namespace DCL
 {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/NativeBridgeCommunication/NativeBridgeCommunication.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/NativeBridgeCommunication/NativeBridgeCommunication.cs
@@ -212,11 +212,7 @@ public class NativeBridgeCommunication : IKernelCommunication
 
         QueuedSceneMessage_Scene GetSceneMessageInstance()
         {
-            ConcurrentQueue<QueuedSceneMessage_Scene> sceneMessagesPool = queueHandler.sceneMessagesPool;
-
-            if (!sceneMessagesPool.TryDequeue(out QueuedSceneMessage_Scene message))
-                message = new QueuedSceneMessage_Scene();
-
+            var message = new QueuedSceneMessage_Scene();
             message.sceneNumber = currentSceneNumber;
             message.tag = currentTag;
             message.type = QueuedSceneMessage.Type.SCENE_MESSAGE;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MemoryManager/MemoryManager.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/MemoryManager/MemoryManager.cs
@@ -7,22 +7,15 @@ namespace DCL
 {
     public class MemoryManager : IMemoryManager
     {
-        private const long MAX_USED_MEMORY = 1300 * 1024 * 1024; // 1.3GB
+        private const ulong MAX_USED_MEMORY = (ulong)2600 * 1024 * 1024; // 2.6GB
         private const float TIME_FOR_NEW_MEMORY_CHECK = 60.0f;
 
         private Coroutine autoCleanupCoroutine;
 
-        private long memoryThresholdForCleanup = 0;
+        private ulong memoryThresholdForCleanup = 0;
         private float cleanupInterval;
 
         public event System.Action OnCriticalMemory;
-
-        public MemoryManager(long memoryThresholdForCleanup, float cleanupInterval)
-        {
-            this.memoryThresholdForCleanup = memoryThresholdForCleanup;
-            this.cleanupInterval = cleanupInterval;
-            autoCleanupCoroutine = CoroutineStarter.Start(AutoCleanup());
-        }
 
         public MemoryManager()
         {
@@ -43,14 +36,14 @@ namespace DCL
         {
         }
 
-        bool NeedsMemoryCleanup()
+        private bool NeedsMemoryCleanup()
         {
-            long usedMemory = Profiler.GetTotalAllocatedMemoryLong() + Profiler.GetMonoUsedSizeLong() +
-                              Profiler.GetAllocatedMemoryForGraphicsDriver();
+            ulong usedMemory = (ulong)Profiler.GetTotalAllocatedMemoryLong() + (ulong)Profiler.GetMonoUsedSizeLong() +
+                              (ulong)Profiler.GetAllocatedMemoryForGraphicsDriver();
             return usedMemory >= this.memoryThresholdForCleanup;
         }
 
-        IEnumerator AutoCleanup()
+        private IEnumerator AutoCleanup()
         {
             while (true)
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Messaging/Interfaces/IMessageQueueHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Messaging/Interfaces/IMessageQueueHandler.cs
@@ -6,6 +6,5 @@ namespace DCL
     public interface IMessageQueueHandler
     {
         void EnqueueSceneMessage(QueuedSceneMessage_Scene message);
-        ConcurrentQueue<QueuedSceneMessage_Scene> sceneMessagesPool { get; }
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Protocol/Protocol.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Protocol/Protocol.cs
@@ -32,6 +32,8 @@ namespace DCL.Models
         public const string OnPointerUp = "pointerUp";
         public const string OnPointerHoverEnter = "pointerHoverEnter";
         public const string OnPointerHoverExit = "pointerHoverExit";
+        public const string Transform = "transform";
+        public const string Shape = "shape";
     }
 
     public enum CLASS_ID_COMPONENT

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -54,7 +54,7 @@ namespace DCL
 
             DataStore.i.debugConfig.isDebugMode.OnChange += OnDebugModeSet;
 
-            // SetupDeferredRunners();
+            // SetupDeferredRunners(); // TODO: is this needed ?? (WebGL/Desktop appears to run OK without it)
 
             DataStore.i.player.playerGridPosition.OnChange += SetPositionDirty;
             CommonScriptableObjects.sceneNumber.OnChange += OnCurrentSceneNumberChange;

--- a/unity-renderer/ProjectSettings/ProjectSettings.asset
+++ b/unity-renderer/ProjectSettings/ProjectSettings.asset
@@ -17,8 +17,8 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 1, g: 1, b: 1, a: 1}
-  m_ShowUnitySplashScreen: 1
-  m_ShowUnitySplashLogo: 1
+  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashLogo: 0
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
   m_SplashScreenLogoStyle: 0

--- a/unity-renderer/ProjectSettings/ProjectSettings.asset
+++ b/unity-renderer/ProjectSettings/ProjectSettings.asset
@@ -17,8 +17,8 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 1, g: 1, b: 1, a: 1}
-  m_ShowUnitySplashScreen: 0
-  m_ShowUnitySplashLogo: 0
+  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
   m_SplashScreenLogoStyle: 0
@@ -765,7 +765,7 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
   webGLInitialMemorySize: 32
-  webGLMaximumMemorySize: 2048
+  webGLMaximumMemorySize: 4096
   webGLMemoryGrowthMode: 2
   webGLMemoryLinearGrowthStep: 16
   webGLMemoryGeometricGrowthStep: 0.2


### PR DESCRIPTION
* Removed SceneController's sceneMessagesPool usage, since that queue is being infinitely filled with every "entity component" message generating the memory leak reported at https://github.com/decentraland/unity-renderer/issues/5532#issuecomment-1718661066
* Increased memory manager minimum memory check, as the current explorer supports 4gbs max instead of the old 2gb (and triggering the unload of assets always introduces a big hiccup)
* updated webgl max memory size to 4096 in project settings just in case (should already be overwritten by [emscripten linker flag](https://github.com/decentraland/unity-renderer/blob/4c5f3d00a02b3a2f9a04bf76f589066817da1813/unity-renderer/Assets/Scripts/Editor/PreBuildProcessing.cs#L24))
* Minor code improvement

--------------------------

### TESTING
This PR shoul be tested as thoroughly as a Release Candidate test.

--------------------------

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a3ca31c</samp>

This pull request refactors the scene message handling logic in the `SceneController` class and its related interfaces. It removes the unused and inefficient `sceneMessagesPool` and simplifies the creation of `QueuedSceneMessage_Scene` instances. It also cleans up some unnecessary `using` directives and improves the code style.
