### PR TITLE
chore: url params check for debugging in webgl

### DIFF
--- a/unity-renderer/Assets/Plugins/JSFunctions.jslib
+++ b/unity-renderer/Assets/Plugins/JSFunctions.jslib
@@ -3,36 +3,56 @@
  */
 
 mergeInto(LibraryManager.library, {
-  StartDecentraland: function() {
-    window.DCL.JSEvents = JSEvents
-    window.DCL.EngineStarted();
-
-    // We expose the GL object to be able to generate WebGL textures in kernel and use them in Unity
-    window.DCL.GL = GL;
+    StartDecentraland: function() {
+        window.DCL.JSEvents = JSEvents;
+        window.DCL.EngineStarted();
     
-    // Cache query string to be consulted later
-    window.DCL.queryString = new URLSearchParams(window.location.search);
-  },
-  MessageFromEngine: function(type, message) {
-    window.DCL.MessageFromEngine(UTF8ToString(type), UTF8ToString(message));
-  },
-  BinaryMessageFromEngine: function(dataPtr, dataSize) {
-    var bytes = HEAPU8.subarray(dataPtr, dataPtr + dataSize)
-    window.DCL.BinaryMessageFromEngine(bytes);
-  },
-  GetGraphicCard: function() {
-    const glcontext = GL.currentContext.GLctx;
-    const debugInfo = glcontext.getExtension('WEBGL_debug_renderer_info');
-    const graphicCard = glcontext.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
-
-    // How to return strings: https://docs.unity3d.com/Manual/webgl-interactingwithbrowserscripting.html
-    var bufferSize = lengthBytesUTF8(graphicCard) + 1;
-    var buffer = _malloc(bufferSize);
-    stringToUTF8(graphicCard, buffer, bufferSize);
-    return buffer;
-  },
-  ToggleFPSCap: function(useFPSCap) {
-    window.capFPS = useFPSCap;
-  }
+        // We expose the GL object to be able to generate WebGL textures in kernel and use them in Unity
+        window.DCL.GL = GL;
+    
+        // Cache query string to be consulted later
+        window.DCL.queryString = new URLSearchParams(window.location.search);
+    },
+    MessageFromEngine: function(type, message) {
+        window.DCL.MessageFromEngine(UTF8ToString(type), UTF8ToString(message));
+    },
+    BinaryMessageFromEngine: function(dataPtr, dataSize) {
+        var bytes = HEAPU8.subarray(dataPtr, dataPtr + dataSize);
+        window.DCL.BinaryMessageFromEngine(bytes);
+    },
+    GetGraphicCard: function() {
+        const glcontext = GL.currentContext.GLctx;
+        const debugInfo = glcontext.getExtension('WEBGL_debug_renderer_info');
+        const graphicCard = glcontext.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+        
+        // How to return strings: https://docs.unity3d.com/Manual/webgl-interactingwithbrowserscripting.html
+        var bufferSize = lengthBytesUTF8(graphicCard) + 1;
+        var buffer = _malloc(bufferSize);
+        stringToUTF8(graphicCard, buffer, bufferSize);
+        return buffer;
+    },
+    ToggleFPSCap: function(useFPSCap) {
+        window.capFPS = useFPSCap;
+    },
+    CheckURLParam: function(targetParam) {
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        return urlSearchParams.has(Pointer_stringify(targetParam));
+    },
+    GetURLParam: function(targetParam) {
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        const stringifiedTargetParam = Pointer_stringify(targetParam);
+        
+        if(urlSearchParams.has(stringifiedTargetParam)) {
+          const urlParamValue = urlSearchParams.get(stringifiedTargetParam);
+        
+          // How to return strings: https://docs.unity3d.com/Manual/webgl-interactingwithbrowserscripting.html
+          var bufferSize = lengthBytesUTF8(urlParamValue) + 1;
+          var buffer = _malloc(bufferSize);
+          stringToUTF8(urlParamValue, buffer, bufferSize);
+          return buffer;
+        }
+        
+        return '';
+    }
 });
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -889,6 +889,8 @@ namespace DCL.Interface
     [DllImport("__Internal")] public static extern void StartDecentraland();
     [DllImport("__Internal")] public static extern void MessageFromEngine(string type, string message);
     [DllImport("__Internal")] public static extern string GetGraphicCard();
+    [DllImport("__Internal")] public static extern bool CheckURLParam(string targetParam);
+    [DllImport("__Internal")] public static extern string GetURLParam(string targetParam);
 
     public static System.Action<string, string> OnMessageFromEngine;
 #else
@@ -909,7 +911,11 @@ namespace DCL.Interface
         private static bool hasQueuedMessages = false;
         private static List<(string, string)> queuedMessages = new List<(string, string)>();
         public static void StartDecentraland() { }
+
+        // CheckURLParam() is only available on web builds.
         public static bool CheckURLParam(string targetParam) { return false; }
+
+        // GetURLParam() is only available on web builds.
         public static string GetURLParam(string targetParam) { return String.Empty; }
 
         public static void MessageFromEngine(string type, string message)


### PR DESCRIPTION
* Added `CheckURLParam()` and `GetURLParam()` for debugging a lot easier on webgl builds.
* Corrected tabulation in `JSFunctions.jslib`

With this capability custom url query params can be used to debug things that only happen in a webgl build (accompanied by custom debugging code in the build asking for that custom query param of course)

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a8d11f</samp>

Added functionality to access URL query parameters from the web browser in Unity WebGL builds. This involved adding new methods to `Interface.cs` and new JS functions to `JSFunctions.jslib`. URL parameters can be used to configure or debug the Unity renderer.
