### PR TITLE
fix: filter catalyst node on realm picking when it does not contains realm name

### DIFF
--- a/browser-interface/packages/shared/dao/index.ts
+++ b/browser-interface/packages/shared/dao/index.ts
@@ -66,7 +66,8 @@ export async function fetchCatalystStatus(
     aboutResponse.status === ServerConnectionStatus.OK &&
     result &&
     result.comms &&
-    result.configurations &&
+    result.configurations && 
+    result.configurations.realmName &&
     result.bff &&
     result.content &&
     result.lambdas &&

--- a/browser-interface/test/dao/fetchCatalystStatuses.test.ts
+++ b/browser-interface/test/dao/fetchCatalystStatuses.test.ts
@@ -89,4 +89,66 @@ describe('Fetch catalyst server status', () => {
     console.log({ a: results[0], b: EXPECTED })
     expect(results[0]).to.eql(EXPECTED)
   })
+
+  it('Should filter out catalyst that does not return realm name on response', async () => {
+    const askFunction: typeof ping.ask = async (domain) => {
+      if (domain.endsWith('/about')) {
+        return {
+          status: 0,
+          elapsed: 309,
+          httpStatus: 200,
+          result: {
+            comms: {
+              protocol: EXPECTED.protocol,
+              version: EXPECTED.protocol
+            },
+            configurations: {
+              realmName: domain.includes('peer-ec1') ? undefined : EXPECTED.catalystName
+            },
+            bff: {
+              userCount: EXPECTED.usersCount,
+              version: '1.0.0'
+            },
+            content: {
+              version: '1.0.0'
+            },
+            lambdas: {
+              version: '1.0.0'
+            },
+            acceptingUsers: true
+          }
+        }
+      } else {
+        return {
+          status: 0,
+          elapsed: 309,
+          httpStatus: 200,
+          result: {
+            parcels: [
+              {
+                peersCount: 3,
+                parcel: {
+                  x: 1,
+                  y: 1
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    const NODES = [
+      {
+        domain: 'peer.decentraland.org'
+      },
+      {
+        domain: 'peer-ec1.decentraland.org'
+      }
+    ]
+
+    const results = await fetchCatalystStatuses(NODES, [], askFunction)
+    expect(results.length).to.eql(1)
+    expect(results[0]).to.eql(EXPECTED)
+  })
 })


### PR DESCRIPTION
## What does this PR change?

This PR updates the criteria when picking a catalyst node through the realm-picking algorithm. From now on, all those catalysts that does not return its realm name when fetching its /about will be excluded from the candidates.

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d189774</samp>

Filter out catalysts without realm name and add test case. The changes in `dao/index.ts` and `fetchCatalystStatuses.test.ts` improve the client's ability to select a valid catalyst by ignoring those that do not provide a realm name. The test case verifies the filtering logic.
