### PR TITLE
Hotfix: MacOS desktop ui screenshot crash

### DIFF
--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreenRecorder.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreenRecorder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DCL;
+using System;
 using System.Collections;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -38,7 +39,11 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
 
             ScreenFrameData currentScreenFrame = CalculateCurrentScreenFrame();
             (_, float targetRescale) = CalculateTargetScreenFrame(currentScreenFrame);
-            int roundedUpscale = Application.platform == RuntimePlatform.OSXPlayer? 1 : Mathf.CeilToInt(targetRescale);
+            int roundedUpscale = Mathf.CeilToInt(targetRescale);
+
+            // Hotfix for MacOS Desktop crashing on taking screenshot when Explore panel is open
+            if (DataStore.i.exploreV2.isOpen.Get() && Application.platform == RuntimePlatform.OSXPlayer)
+                roundedUpscale = 1;
 
             ScreenFrameData rescaledScreenFrame = CalculateRoundRescaledScreenFrame(currentScreenFrame, roundedUpscale);
 

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreenRecorder.cs
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/CameraObject/Scripts/ScreenRecorder.cs
@@ -38,7 +38,8 @@ namespace DCLFeatures.ScreencaptureCamera.CameraObject
 
             ScreenFrameData currentScreenFrame = CalculateCurrentScreenFrame();
             (_, float targetRescale) = CalculateTargetScreenFrame(currentScreenFrame);
-            int roundedUpscale = Mathf.CeilToInt(targetRescale);
+            int roundedUpscale = Application.platform == RuntimePlatform.OSXPlayer? 1 : Mathf.CeilToInt(targetRescale);
+
             ScreenFrameData rescaledScreenFrame = CalculateRoundRescaledScreenFrame(currentScreenFrame, roundedUpscale);
 
             Texture2D screenshotTexture = ScreenCapture.CaptureScreenshotAsTexture(roundedUpscale); // upscaled Screen Frame resolution


### PR DESCRIPTION
## What does this PR change?

avoid the crash when screenshot takes Fullscreen UI


## How to test the changes?

1. Launch the explorer
2. Open Explore menu
3. Open Screenshot camera (press C)
4. Take screenshot (press E or button)
5. Verify screenshot is taken and saved to the Camera Reel gallery

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2d1c3a</samp>

Fixed screenshot functionality for MacOS Desktop and added namespace to `ScreenRecorder.cs`. The change improves the compatibility and organization of the screencapture feature.
