### PR TITLE
chore: removed new_avatar_flow feature flag

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystem/PluginSystemFactory.cs
@@ -81,7 +81,7 @@ namespace DCL
             pluginSystem.RegisterWithFlag<ECS7Plugin>(() => new ECS7Plugin(), "ecs7");
             pluginSystem.RegisterWithFlag<BlurFeature>(() => new BlurFeature(), "ui_blur_variant:enabled");
             pluginSystem.RegisterWithFlag<PromoteChannelsToastPlugin>(() => new PromoteChannelsToastPlugin(), "promote_channels_toast");
-            pluginSystem.RegisterWithFlag<PlayerPassportPlugin>(() => new PlayerPassportPlugin(), "new_avatar_flow");
+            pluginSystem.Register<PlayerPassportPlugin>(() => new PlayerPassportPlugin());
             pluginSystem.RegisterWithFlag<FavoritePlacesPlugin>(() => new FavoritePlacesPlugin(), "favourite_places");
             pluginSystem.RegisterWithFlag<OutlinerPlugin>(() => new OutlinerPlugin(), "avatar_outliner");
             pluginSystem.RegisterWithFlag<LoadingScreenV2Plugin>(() => new LoadingScreenV2Plugin(), "loading_screen_v2");


### PR DESCRIPTION
## What does this PR change?

Removed `new_avatar_flow` feature flag.
Always displays the new passport.

## How to test the changes?

1. Launch the explorer
2. Open passport from different sources
3. Always should open the standard passport

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f8406b9</samp>

Changed the registration of the `PlayerPassportPlugin` to enable the new avatar flow feature for all users. This plugin allows users to access their avatar customization and profile information in the `unity-renderer` project.
