### PR TITLE
hotfix: disabling bloom by default temporarily

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/BloomControlConfiguration.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/BloomControlConfiguration.asset
@@ -16,6 +16,11 @@ MonoBehaviour:
   controlPrefab: {fileID: 6580391891136655319, guid: 61fc2c179901ae844b48e21ae215a102,
     type: 3}
   controlController: {fileID: 11400000, guid: 5948ae5af73e63d40885bc1f25f01c2d, type: 2}
-  flagsThatDisableMe: []
-  flagsThatDeactivateMe: []
+  flagsThatDisableMe:
+  - {fileID: 11400000, guid: 02f056dbee57de84d888ed5bb685a747, type: 2}
+  flagsThatDeactivateMe:
+  - {fileID: 11400000, guid: 02f056dbee57de84d888ed5bb685a747, type: 2}
+  flagsThatOverrideMe: []
   isBeta: 0
+  infoButtonEnabled: 0
+  infoTooltipMessage: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Resources/ScriptableObjects/BloomDisabledAndOffByDefault.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Resources/ScriptableObjects/BloomDisabledAndOffByDefault.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdae4528345114a1fa069b0a59dc53c7, type: 3}
+  m_Name: BloomDisabledAndOffByDefault
+  m_EditorClassIdentifier: 
+  value: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Resources/ScriptableObjects/BloomDisabledAndOffByDefault.asset.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Resources/ScriptableObjects/BloomDisabledAndOffByDefault.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 02f056dbee57de84d888ed5bb685a747
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/BloomControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/BloomControlController.cs
@@ -7,7 +7,8 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
     [CreateAssetMenu(menuName = "Settings/Controllers/Controls/Bloom", fileName = "BloomControlController")]
     public class BloomControlController : ToggleSettingsControlController
     {
-        public override object GetStoredValue() { return currentQualitySetting.bloom; }
+        // TODO:: make it return the correct value when bloom is fixed
+        public override object GetStoredValue() { return false/*currentQualitySetting.bloom*/; }
 
         public override void UpdateSetting(object newValue)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/BloomControlController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SpecificControllers/BloomControlController.cs
@@ -8,7 +8,7 @@ namespace DCL.SettingsCommon.SettingsControllers.SpecificControllers
     public class BloomControlController : ToggleSettingsControlController
     {
         // TODO:: make it return the correct value when bloom is fixed
-        public override object GetStoredValue() { return false/*currentQualitySetting.bloom*/; }
+        public override object GetStoredValue() { return currentQualitySetting.bloom; }
 
         public override void UpdateSetting(object newValue)
         {


### PR DESCRIPTION
We need to temporarily disable Bloom by default due to a bright light problem only appearing when Bloom is active.

## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
