### PR TITLE
fix: Update sso client

### DIFF
--- a/browser-interface/package-lock.json
+++ b/browser-interface/package-lock.json
@@ -20,7 +20,7 @@
         "@dcl/rpc": "^1.1.1",
         "@dcl/scene-runtime": "7.0.6-20230915161611.commit-59578a0",
         "@dcl/schemas": "^9.1.1",
-        "@dcl/single-sign-on-client": "^0.0.12",
+        "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/urn-resolver": "^2.2.0",
         "@types/mocha": "^10.0.1",
         "@types/redux-logger": "^3.0.9",
@@ -614,11 +614,12 @@
       }
     },
     "node_modules/@dcl/single-sign-on-client": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@dcl/single-sign-on-client/-/single-sign-on-client-0.0.12.tgz",
-      "integrity": "sha512-oVkGKBZNQ5rabOLrl9F8fOb0BmxQBVPPOqTspe/a8B6AMMdW85trbZk1JbfwDwZCFZp2rpDe6+/FpJ0fWRg0FA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/single-sign-on-client/-/single-sign-on-client-0.1.0.tgz",
+      "integrity": "sha512-dbyTkC7jIQncPWbIzuymm0Mgkd7KkEk0moIMsB05z0QQM3p18vPvdmpqby0TAI+aa9AcdcyvOw8p9C0wj/YvUg==",
       "dependencies": {
-        "@dcl/crypto": "^3.4.3"
+        "@dcl/crypto": "^3.4.3",
+        "validator": "^13.11.0"
       }
     },
     "node_modules/@dcl/ts-proto": {
@@ -9774,6 +9775,14 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
@@ -10512,11 +10521,12 @@
       }
     },
     "@dcl/single-sign-on-client": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@dcl/single-sign-on-client/-/single-sign-on-client-0.0.12.tgz",
-      "integrity": "sha512-oVkGKBZNQ5rabOLrl9F8fOb0BmxQBVPPOqTspe/a8B6AMMdW85trbZk1JbfwDwZCFZp2rpDe6+/FpJ0fWRg0FA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/single-sign-on-client/-/single-sign-on-client-0.1.0.tgz",
+      "integrity": "sha512-dbyTkC7jIQncPWbIzuymm0Mgkd7KkEk0moIMsB05z0QQM3p18vPvdmpqby0TAI+aa9AcdcyvOw8p9C0wj/YvUg==",
       "requires": {
-        "@dcl/crypto": "^3.4.3"
+        "@dcl/crypto": "^3.4.3",
+        "validator": "^13.11.0"
       }
     },
     "@dcl/ts-proto": {
@@ -17437,6 +17447,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ=="
     },
     "varint": {
       "version": "6.0.0",

--- a/browser-interface/package.json
+++ b/browser-interface/package.json
@@ -66,7 +66,7 @@
     "@dcl/rpc": "^1.1.1",
     "@dcl/scene-runtime": "7.0.6-20230915161611.commit-59578a0",
     "@dcl/schemas": "^9.1.1",
-    "@dcl/single-sign-on-client": "^0.0.12",
+    "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/urn-resolver": "^2.2.0",
     "@types/mocha": "^10.0.1",
     "@types/redux-logger": "^3.0.9",


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Updates the version of the sso client.

When the identity is expired, it will return the identity as undefined instead of returning it expired.
This is already handled by the explorer but it might cover any unsuspected cases.

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer.
2. Sign the identity, unless you already have one. 
3. Go to the "Application" tab in the inspector and in the `id.decentraland.org` local storage, update the expiration of the identity to an expired date.
4. Refresh the browser, you should be asked to connect and sign again.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe50f9b</samp>

This pull request updates the `browser-interface` project to use the latest version of the `@dcl/single-sign-on-client` package, which provides authentication and authorization features for the Decentraland browser interface. It also adds the `validator` package as a new dependency, which is required by the `@dcl/single-sign-on-client` package.
