### PR TITLE
Feat: navmap animated player compass

### DIFF
--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Addressables/PlayerMarkerObject.prefab
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Addressables/PlayerMarkerObject.prefab
@@ -27,7 +27,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_LocalScale: {x: 3.6, y: 3.6, z: 3.6}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1389453839309178053}
@@ -74,7 +74,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: a3437e4e4a6bcda44acdec2e496a71a0, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.29803923}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.101960786}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -111,7 +111,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_LocalScale: {x: 2.7, y: 2.7, z: 2.7}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1389453839309178053}
@@ -196,7 +196,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 3, y: 3, z: 3}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8974767756704403402}
@@ -234,5 +234,3 @@ MonoBehaviour:
   endScaleFactor: 0.85
   animationDuration: 0.6
   easyType: 7
-  startScale: {x: 2, y: 2, z: 2}
-  endScale: {x: 1.7, y: 1.7, z: 1.7}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Addressables/PlayerMarkerObject.prefab
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Addressables/PlayerMarkerObject.prefab
@@ -1,5 +1,89 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1807546153869457810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3888005628135922926}
+  - component: {fileID: 6444326099614180711}
+  m_Layer: 27
+  m_Name: Sprite-1Circle)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3888005628135922926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807546153869457810}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389453839309178053}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6444326099614180711
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807546153869457810}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: a3437e4e4a6bcda44acdec2e496a71a0, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.29803923}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.88, y: 0.88}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &6724450241793584319
 GameObject:
   m_ObjectHideFlags: 0
@@ -11,7 +95,7 @@ GameObject:
   - component: {fileID: 8974767756704403402}
   - component: {fileID: 2467749465983235452}
   m_Layer: 27
-  m_Name: Sprite-1Unit
+  m_Name: Sprite-Compas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -94,6 +178,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1389453839309178053}
   - component: {fileID: 7407565857618779872}
+  - component: {fileID: 7995362809987533211}
   m_Layer: 27
   m_Name: PlayerMarkerObject
   m_TagString: Untagged
@@ -115,6 +200,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8974767756704403402}
+  - {fileID: 3888005628135922926}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7407565857618779872
@@ -130,4 +216,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <pivot>k__BackingField: {x: 0.5, y: 0.5}
-  <spriteRenderer>k__BackingField: {fileID: 2467749465983235452}
+  compass: {fileID: 2467749465983235452}
+  circle: {fileID: 6444326099614180711}
+--- !u!114 &7995362809987533211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8621381714524313974}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d6b97043455469d92d13ac602153c43, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  circle: {fileID: 3888005628135922926}
+  endScaleFactor: 0.85
+  animationDuration: 0.6
+  easyType: 7
+  startScale: {x: 2, y: 2, z: 2}
+  endScale: {x: 1.7, y: 1.7, z: 1.7}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/MapRendererDrawOrder.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/MapRendererDrawOrder.cs
@@ -6,8 +6,8 @@
         internal const int HOME_POINT = 2;
         internal const int COLD_USER_MARKERS = 10;
         internal const int HOT_USER_MARKERS = 11;
-        internal const int PLAYER_MARKER = 12;
         internal const int SCENES_OF_INTEREST = 15;
+        internal const int PLAYER_MARKER = 17;
 
         internal const int PARCEL_HIGHLIGHT = 30;
 

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/PlayerMarkerInstaller.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/PlayerMarkerInstaller.cs
@@ -1,5 +1,4 @@
 ﻿using Cysharp.Threading.Tasks;
-using Cysharp.Threading.Tasks.Linq;
 using DCL;
 using DCL.Providers;
 using DCLServices.MapRendererV2.CoordsUtils;
@@ -25,7 +24,7 @@ namespace DCLServices.MapRendererV2.ComponentsFactory
             IMapCullingController cullingController,
             CancellationToken cancellationToken)
         {
-            var prefab = await GetPrefab(cancellationToken);
+            PlayerMarkerObject prefab = await GetPrefab(cancellationToken);
 
             var controller = new PlayerMarkerController(
                 CreateMarker,
@@ -43,11 +42,16 @@ namespace DCLServices.MapRendererV2.ComponentsFactory
 
             IPlayerMarker CreateMarker(Transform parent)
             {
-                PlayerMarkerObject obj = Object.Instantiate(prefab, parent);
-                coordsUtils.SetObjectScale(obj);
-                obj.SetSortingOrder(MapRendererDrawOrder.PLAYER_MARKER);
+                PlayerMarkerObject pmObject = Object.Instantiate(prefab, parent);
+                coordsUtils.SetObjectScale(pmObject);
+                pmObject.SetSortingOrder(MapRendererDrawOrder.PLAYER_MARKER);
 
-                return new PlayerMarker(obj);
+                if (DataStore.i.featureFlags.flags.Get().IsInitialized)
+                    pmObject.SetAnimatedCircleVisibility(DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("map_focus_home_or_user"));
+                else
+                    DataStore.i.featureFlags.flags.OnChange += (current, previous) => { pmObject.SetAnimatedCircleVisibility(current.IsFeatureEnabled("map_focus_home_or_user")); };
+
+                return new PlayerMarker(pmObject);
             }
         }
 

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/PlayerMarkerInstaller.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/ComponentsFactory/PlayerMarkerInstaller.cs
@@ -27,14 +27,6 @@ namespace DCLServices.MapRendererV2.ComponentsFactory
         {
             var prefab = await GetPrefab(cancellationToken);
 
-            IPlayerMarker CreateMarker(Transform parent)
-            {
-                var obj = Object.Instantiate(prefab, parent);
-                coordsUtils.SetObjectScale(obj);
-                obj.spriteRenderer.sortingOrder = MapRendererDrawOrder.PLAYER_MARKER;
-                return new PlayerMarker(obj);
-            }
-
             var controller = new PlayerMarkerController(
                 CreateMarker,
                 DataStore.i.player.playerWorldPosition,
@@ -45,7 +37,18 @@ namespace DCLServices.MapRendererV2.ComponentsFactory
             );
 
             controller.Initialize();
+
             writer.Add(MapLayer.PlayerMarker, controller);
+            return;
+
+            IPlayerMarker CreateMarker(Transform parent)
+            {
+                PlayerMarkerObject obj = Object.Instantiate(prefab, parent);
+                coordsUtils.SetObjectScale(obj);
+                obj.SetSortingOrder(MapRendererDrawOrder.PLAYER_MARKER);
+
+                return new PlayerMarker(obj);
+            }
         }
 
         internal async UniTask<PlayerMarkerObject> GetPrefab(CancellationToken cancellationToken) =>

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerCircleAnimation.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerCircleAnimation.cs
@@ -1,0 +1,52 @@
+﻿using DG.Tweening;
+using UnityEngine;
+
+namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
+{
+    public class PlayerMarkerCircleAnimation : MonoBehaviour
+    {
+        [Space]
+        [SerializeField] private Transform circle;
+
+        [SerializeField] private float endScaleFactor = 0.85f;
+        [SerializeField] private float animationDuration = 0.5f;
+        [SerializeField] private Ease easyType = Ease.InOutQuart;
+
+        private Vector3 startScale;
+        private Vector3 endScale;
+
+        private Tween tween;
+
+        private void Start()
+        {
+            startScale = circle.localScale;
+            endScale = startScale * endScaleFactor;
+
+            if (tween == null)
+                StartPingPongAnimation();
+        }
+
+        private void OnEnable()
+        {
+            if (startScale == Vector3.zero) return;
+
+            StartPingPongAnimation();
+        }
+
+        private void OnDisable()
+        {
+            if (tween == null || !tween.IsActive()) return;
+
+            tween.Kill();
+            circle.localScale = startScale;
+        }
+
+        [ContextMenu(nameof(StartPingPongAnimation))]
+        private void StartPingPongAnimation()
+        {
+            tween = circle.DOScale(endScale, animationDuration)
+                          .SetLoops(-1, LoopType.Yoyo) // -1 for infinite loops
+                          .SetEase(easyType);
+        }
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerCircleAnimation.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerCircleAnimation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0d6b97043455469d92d13ac602153c43
+timeCreated: 1695757555

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerObject.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerObject.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using DCL;
+using UnityEngine;
 
 namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
 {
@@ -6,6 +7,12 @@ namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
     {
         [SerializeField] private SpriteRenderer compass;
         [SerializeField] private SpriteRenderer circle;
+
+        private void Start()
+        {
+            if (!DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("map_focus_home_or_user"))
+                circle.enabled = false;
+        }
 
         public void SetSortingOrder(int sortingOrder)
         {

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerObject.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerObject.cs
@@ -8,10 +8,9 @@ namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
         [SerializeField] private SpriteRenderer compass;
         [SerializeField] private SpriteRenderer circle;
 
-        private void Start()
+        public void SetAnimatedCircleVisibility(bool visible)
         {
-            if (!DataStore.i.featureFlags.flags.Get().IsFeatureEnabled("map_focus_home_or_user"))
-                circle.enabled = false;
+            circle.enabled = visible;
         }
 
         public void SetSortingOrder(int sortingOrder)

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerObject.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerObject.cs
@@ -4,7 +4,13 @@ namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
 {
     internal class PlayerMarkerObject : MapRendererMarkerBase
     {
-        [field: SerializeField]
-        internal SpriteRenderer spriteRenderer { get; private set; }
+        [SerializeField] private SpriteRenderer compass;
+        [SerializeField] private SpriteRenderer circle;
+
+        public void SetSortingOrder(int sortingOrder)
+        {
+            compass.sortingOrder = sortingOrder;
+            circle.sortingOrder = sortingOrder - 1;
+        }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapRendererV2.asmdef
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapRendererV2.asmdef
@@ -19,7 +19,8 @@
         "GUID:c34e38f41494f834abff029ddf82af43",
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:0e967802b778d404eac1ca5ea340e290",
-        "GUID:fbcc413e192ef9048811d47ab0aca0c0"
+        "GUID:fbcc413e192ef9048811d47ab0aca0c0",
+        "GUID:2995626b54c60644988f134a69a77450"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?

Improvements on player visibility on the map: add pulsing circle to the player marker. 
Note: removing it from the minimap will be handled in separate branch (because low-prio for now)

...

## How to test the changes?

1. Launch the explorer
2. Open NavMap and observe pulsing circle around player marker

Please, also verify that it is not present if launching without enabled feature flag

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 009927f</samp>

This pull request adds and modifies some files related to the player marker on the map, which is a UI element that shows the player's position and orientation. The main changes are: adding a circle sprite to the `PlayerMarkerObject` prefab and a script to animate it, refactoring the code for creating and initializing the player marker, and changing the sorting order of the player marker layer to make it visible on top of other map elements.
