### PR TITLE
chore: Remove tech leads group as a required reviewers for PR

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -5,15 +5,14 @@ addReviewers: true
 numberOfReviewers: 1
 useReviewGroups: true
 reviewGroups:
-  techleads:
-    - Kinerius
-    - mikhail-dcl
   devs:    
     - sandrade-dcl    
     - lorux0
     - davidejensen
     - dalkia
-    - popuz    
+    - popuz
+    - Kinerius
+    - mikhail-dcl
   qa:
     - kwssbocian
     - kwsskulinski


### PR DESCRIPTION
## What does this PR change?

As agreed in the team and increased workload for tech leads, removing tech leads group as a required reviewer for every PR.
Still common sense apply, and please assign any of tech leads when making major changes.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87f93d1</samp>

Updated auto-assign configuration to balance review workload. Removed `techleads` from auto-assign list and added them to `reviewers` group in `.github/auto_assign_config.yml`.
