### PR TITLE
feat: add support for worlds using ens domains

### DIFF
--- a/browser-interface/packages/shared/apis/host/PortableExperiences.ts
+++ b/browser-interface/packages/shared/apis/host/PortableExperiences.ts
@@ -13,7 +13,7 @@ import type { PortContext } from './context'
 import * as codegen from '@dcl/rpc/dist/codegen'
 
 import { PortableExperiencesServiceDefinition } from 'shared/protocol/decentraland/kernel/apis/portable_experiences.gen'
-import { isDclEns, isEns } from '../../realm/resolver'
+import { isEns } from '../../realm/resolver'
 
 export function registerPortableExperiencesServiceServerImplementation(port: RpcServerPort<PortContext>) {
   codegen.registerService(port, PortableExperiencesServiceDefinition, async () => ({
@@ -30,7 +30,7 @@ export function registerPortableExperiencesServiceServerImplementation(port: Rpc
         return px
       }
       // Load via Worlds ENS url
-      if (!isEns(req.ens) && !isDclEns(req.ens)) throw new Error('Invalid ens name')
+      if (!isEns(req.ens)) throw new Error('Invalid ens name')
       const px = await spawnPortableExperienceFromEns(req.ens, ctx.sceneData.id)
       return { ...px, ens: req.ens }
     },

--- a/browser-interface/packages/shared/apis/host/PortableExperiences.ts
+++ b/browser-interface/packages/shared/apis/host/PortableExperiences.ts
@@ -13,7 +13,7 @@ import type { PortContext } from './context'
 import * as codegen from '@dcl/rpc/dist/codegen'
 
 import { PortableExperiencesServiceDefinition } from 'shared/protocol/decentraland/kernel/apis/portable_experiences.gen'
-import { isDclEns } from '../../realm/resolver'
+import { isDclEns, isEns } from '../../realm/resolver'
 
 export function registerPortableExperiencesServiceServerImplementation(port: RpcServerPort<PortContext>) {
   codegen.registerService(port, PortableExperiencesServiceDefinition, async () => ({
@@ -30,7 +30,7 @@ export function registerPortableExperiencesServiceServerImplementation(port: Rpc
         return px
       }
       // Load via Worlds ENS url
-      if (!isDclEns(req.ens)) throw new Error('Invalid ens name')
+      if (!isEns(req.ens) && !isDclEns(req.ens)) throw new Error('Invalid ens name')
       const px = await spawnPortableExperienceFromEns(req.ens, ctx.sceneData.id)
       return { ...px, ens: req.ens }
     },

--- a/browser-interface/packages/shared/realm/connections/ArchipelagoConnection.ts
+++ b/browser-interface/packages/shared/realm/connections/ArchipelagoConnection.ts
@@ -11,7 +11,6 @@ import { wsAsAsyncChannel } from '../../comms/logic/ws-async-channel'
 import { Vector3 } from 'lib/math/Vector3'
 import { BringDownClientAndShowError } from 'shared/loading/ReportFatalError'
 import { AboutResponse } from 'shared/protocol/decentraland/renderer/about.gen'
-import { commsLogger } from 'shared/comms/logger'
 
 // shared writer to leverage pools
 const writer = new Writer()

--- a/browser-interface/packages/shared/realm/resolver.ts
+++ b/browser-interface/packages/shared/realm/resolver.ts
@@ -72,11 +72,7 @@ export function prettyRealmName(realm: string, candidates: Candidate[]) {
 }
 
 export function isEns(str: string | undefined): str is `${string}.eth` {
-  return !!str?.match(/^[a-zA-Z0-9]+\.eth$/)?.length
-}
-
-export function isDclEns(str: string | undefined): str is `${string}.dcl.eth` {
-  return !!str?.match(/^[a-zA-Z0-9]+\.dcl\.eth$/)?.length
+  return !!str?.match(/^[a-zA-Z0-9.]+\.eth$/)?.length
 }
 
 export function dclWorldUrl(dclName: string) {
@@ -90,7 +86,7 @@ export function realmToConnectionString(realm: IRealmAdapter) {
     return realmName
   }
 
-  if ((isEns(realmName) || isDclEns(realmName)) && realm.baseUrl === dclWorldUrl(realmName)) {
+  if (isEns(realmName) && realm.baseUrl === dclWorldUrl(realmName)) {
     return realmName
   }
 
@@ -110,10 +106,6 @@ export function resolveRealmBaseUrlFromRealmQueryParameter(realmString: string, 
   }
 
   if (isEns(realmString)) {
-    return dclWorldUrl(realmString)
-  }
-
-  if (isDclEns(realmString)) {
     return dclWorldUrl(realmString)
   }
 

--- a/browser-interface/packages/shared/realm/resolver.ts
+++ b/browser-interface/packages/shared/realm/resolver.ts
@@ -71,6 +71,10 @@ export function prettyRealmName(realm: string, candidates: Candidate[]) {
   return realm
 }
 
+export function isEns(str: string | undefined): str is `${string}.eth` {
+  return !!str?.match(/^[a-zA-Z0-9]+\.eth$/)?.length
+}
+
 export function isDclEns(str: string | undefined): str is `${string}.dcl.eth` {
   return !!str?.match(/^[a-zA-Z0-9]+\.dcl\.eth$/)?.length
 }
@@ -86,7 +90,7 @@ export function realmToConnectionString(realm: IRealmAdapter) {
     return realmName
   }
 
-  if (isDclEns(realmName) && realm.baseUrl === dclWorldUrl(realmName)) {
+  if ((isEns(realmName) || isDclEns(realmName)) && realm.baseUrl === dclWorldUrl(realmName)) {
     return realmName
   }
 
@@ -103,6 +107,10 @@ export function resolveRealmBaseUrlFromRealmQueryParameter(realmString: string, 
     if (candidate.catalystName === realmString) {
       return urlWithProtocol(candidate.domain)
     }
+  }
+
+  if (isEns(realmString)) {
+    return dclWorldUrl(realmString)
   }
 
   if (isDclEns(realmString)) {


### PR DESCRIPTION
## What does this PR change?
Worlds Content Server now also supports deployment of ENS names apart from currently supported DCL names. So you can now have a world deployed as `your-name.eth` if you own it.
This PR adds support for:
1. Entering the world directly via URL `https://play.decentraland.org/?realm=yourname.eth`
2. Entering the world via /changerealm chatbox command `/changerealm yourname.eth`.
3. Entering the world via /world chatbox command `/world yourname.eth`.

...

## How to test the changes?

Use any of the 3 methods listed above as 3 different ways for entering a World deployed under an ENS domain.


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 844a5cc</samp>

Improved the support for ENS names in portable experiences and realm resolution. Removed an unused import from `ArchipelagoConnection.ts`.
