### PR TITLE
Feat: navmap layer parametrization

### DIFF
--- a/unity-renderer/Assets/DCLServices/MapRendererV2/CommonBehavior/IMapActivityOwner.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/CommonBehavior/IMapActivityOwner.cs
@@ -1,7 +1,11 @@
-﻿namespace DCLServices.MapRendererV2.CommonBehavior
+﻿using DCLServices.MapRendererV2.MapCameraController;
+using DCLServices.MapRendererV2.MapLayers;
+using System.Collections.Generic;
+
+namespace DCLServices.MapRendererV2.CommonBehavior
 {
     public interface IMapActivityOwner
     {
-        
+        IReadOnlyDictionary<MapLayer, IMapLayerParameter> LayersParameters { get; }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/CommonBehavior/IMapActivityOwner.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/CommonBehavior/IMapActivityOwner.cs
@@ -1,0 +1,7 @@
+﻿namespace DCLServices.MapRendererV2.CommonBehavior
+{
+    public interface IMapActivityOwner
+    {
+        
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/CommonBehavior/IMapActivityOwner.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/CommonBehavior/IMapActivityOwner.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 425cb8b8a85743388db48538017260c7
+timeCreated: 1696597924

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapCameraController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapCameraController.cs
@@ -1,4 +1,5 @@
 ﻿using Cysharp.Threading.Tasks;
+using DCLServices.MapRendererV2.CommonBehavior;
 using DCLServices.MapRendererV2.MapLayers;
 using System;
 using System.Threading;
@@ -63,6 +64,6 @@ namespace DCLServices.MapRendererV2.MapCameraController
         /// </summary>
         void ResumeRendering();
 
-        void Release();
+        void Release(IMapActivityOwner owner);
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapCameraControllerInternal.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/IMapCameraControllerInternal.cs
@@ -1,4 +1,5 @@
-﻿using DCLServices.MapRendererV2.MapLayers;
+﻿using DCLServices.MapRendererV2.CommonBehavior;
+using DCLServices.MapRendererV2.MapLayers;
 using System;
 using UnityEngine;
 
@@ -12,7 +13,7 @@ namespace DCLServices.MapRendererV2.MapCameraController
     {
         event Action<float, float> ZoomChanged;
 
-        event Action<IMapCameraControllerInternal> OnReleasing;
+        event Action<IMapActivityOwner, IMapCameraControllerInternal> OnReleasing;
 
         Camera Camera { get; }
 

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraController.cs
@@ -1,4 +1,5 @@
 ﻿using DCL;
+using DCLServices.MapRendererV2.CommonBehavior;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
 using DCLServices.MapRendererV2.MapLayers;
@@ -15,7 +16,7 @@ namespace DCLServices.MapRendererV2.MapCameraController
 
         private const int MAX_TEXTURE_SIZE = 4096;
 
-        public event Action<IMapCameraControllerInternal> OnReleasing;
+        public event Action<IMapActivityOwner, IMapCameraControllerInternal> OnReleasing;
         public event Action<float, float> ZoomChanged;
 
         public MapLayer EnabledLayers { get; private set; }
@@ -245,12 +246,12 @@ namespace DCLServices.MapRendererV2.MapCameraController
             return new Rect((Vector2) mapCameraObject.transform.localPosition - new Vector2(cameraXSize, cameraYSize), size);
         }
 
-        public void Release()
+        public void Release(IMapActivityOwner owner)
         {
             cullingController.OnCameraRemoved(this);
             renderTexture?.Release();
             interactivityBehavior.Release();
-            OnReleasing?.Invoke(this);
+            OnReleasing?.Invoke(owner, this);
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraInput.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraInput.cs
@@ -12,7 +12,6 @@ namespace DCLServices.MapRendererV2.MapCameraController
         public readonly float Zoom;
         public readonly Vector2Int TextureResolution;
         public readonly Vector2Int ZoomValues;
-        public readonly Dictionary<MapLayer, IMapLayerParameter> LayerParameters;
         public readonly IMapActivityOwner ActivityOwner;
 
         /// <param name="enabledLayers">active layers</param>
@@ -20,7 +19,7 @@ namespace DCLServices.MapRendererV2.MapCameraController
         /// <param name="zoom">default zoom</param>
         /// <param name="textureResolution">desired texture resolution</param>
         /// <param name="zoomValues">zoom thresholds in parcels</param>
-        public MapCameraInput(IMapActivityOwner activityOwner, MapLayer enabledLayers, Dictionary<MapLayer, IMapLayerParameter> layerParameters, Vector2Int position, float zoom,
+        public MapCameraInput(IMapActivityOwner activityOwner, MapLayer enabledLayers, Vector2Int position, float zoom,
             Vector2Int textureResolution, Vector2Int zoomValues)
         {
             EnabledLayers = enabledLayers;
@@ -28,7 +27,6 @@ namespace DCLServices.MapRendererV2.MapCameraController
             Zoom = zoom;
             TextureResolution = textureResolution;
             ZoomValues = zoomValues;
-            LayerParameters = layerParameters;
             ActivityOwner = activityOwner;
         }
     }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraInput.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapCameraController/MapCameraInput.cs
@@ -1,4 +1,6 @@
-﻿using DCLServices.MapRendererV2.MapLayers;
+﻿using DCLServices.MapRendererV2.CommonBehavior;
+using DCLServices.MapRendererV2.MapLayers;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace DCLServices.MapRendererV2.MapCameraController
@@ -10,19 +12,24 @@ namespace DCLServices.MapRendererV2.MapCameraController
         public readonly float Zoom;
         public readonly Vector2Int TextureResolution;
         public readonly Vector2Int ZoomValues;
+        public readonly Dictionary<MapLayer, IMapLayerParameter> LayerParameters;
+        public readonly IMapActivityOwner ActivityOwner;
 
         /// <param name="enabledLayers">active layers</param>
         /// <param name="position">default position</param>
         /// <param name="zoom">default zoom</param>
         /// <param name="textureResolution">desired texture resolution</param>
         /// <param name="zoomValues">zoom thresholds in parcels</param>
-        public MapCameraInput(MapLayer enabledLayers, Vector2Int position, float zoom, Vector2Int textureResolution, Vector2Int zoomValues)
+        public MapCameraInput(IMapActivityOwner activityOwner, MapLayer enabledLayers, Dictionary<MapLayer, IMapLayerParameter> layerParameters, Vector2Int position, float zoom,
+            Vector2Int textureResolution, Vector2Int zoomValues)
         {
             EnabledLayers = enabledLayers;
             Position = position;
             Zoom = zoom;
             TextureResolution = textureResolution;
             ZoomValues = zoomValues;
+            LayerParameters = layerParameters;
+            ActivityOwner = activityOwner;
         }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/ParcelAtlas/ParcelChunkAtlasController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/ParcelAtlas/ParcelChunkAtlasController.cs
@@ -1,6 +1,8 @@
 using Cysharp.Threading.Tasks;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
+using DCLServices.MapRendererV2.MapCameraController;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
@@ -92,6 +94,11 @@ namespace DCLServices.MapRendererV2.MapLayers.Atlas
         {
             instantiationParent.gameObject.SetActive(false);
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(IMapLayerParameter layerParameter)
+        {
+
         }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/ParcelAtlas/ParcelChunkAtlasController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/ParcelAtlas/ParcelChunkAtlasController.cs
@@ -95,10 +95,5 @@ namespace DCLServices.MapRendererV2.MapLayers.Atlas
             instantiationParent.gameObject.SetActive(false);
             return UniTask.CompletedTask;
         }
-
-        public void SetParameter(IMapLayerParameter layerParameter)
-        {
-
-        }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkAtlasController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkAtlasController.cs
@@ -92,11 +92,6 @@ namespace DCLServices.MapRendererV2.MapLayers.SatelliteAtlas
             return UniTask.CompletedTask;
         }
 
-        public void SetParameter(IMapLayerParameter layerParameter)
-        {
-
-        }
-
         protected override void DisposeImpl()
         {
             foreach (IChunkController chunk in chunks)

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkAtlasController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkAtlasController.cs
@@ -1,6 +1,7 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
+using DCLServices.MapRendererV2.MapCameraController;
 using DCLServices.MapRendererV2.MapLayers.Atlas;
 using System;
 using System.Collections.Generic;
@@ -89,6 +90,11 @@ namespace DCLServices.MapRendererV2.MapLayers.SatelliteAtlas
         {
             instantiationParent.gameObject.SetActive(false);
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(IMapLayerParameter layerParameter)
+        {
+
         }
 
         protected override void DisposeImpl()

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Favorites/FavoritesMarkerController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Favorites/FavoritesMarkerController.cs
@@ -1,9 +1,11 @@
 using Cysharp.Threading.Tasks;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
+using DCLServices.MapRendererV2.MapCameraController;
 using DCLServices.PlacesAPIService;
 using MainScripts.DCL.Controllers.HotScenes;
 using MainScripts.DCL.Helpers.Utils;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
@@ -152,6 +154,11 @@ namespace DCLServices.MapRendererV2.MapLayers.Favorites
             isEnabled = false;
 
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(IMapLayerParameter layerParameter)
+        {
+
         }
 
         public UniTask Enable(CancellationToken cancellationToken)

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Favorites/FavoritesMarkerController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/Favorites/FavoritesMarkerController.cs
@@ -156,11 +156,6 @@ namespace DCLServices.MapRendererV2.MapLayers.Favorites
             return UniTask.CompletedTask;
         }
 
-        public void SetParameter(IMapLayerParameter layerParameter)
-        {
-
-        }
-
         public UniTask Enable(CancellationToken cancellationToken)
         {
             GetFavorites(CancellationToken.None).Forget();

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/HomePoint/HomePointMarkerController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/HomePoint/HomePointMarkerController.cs
@@ -1,6 +1,8 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
+using DCLServices.MapRendererV2.MapCameraController;
+using System;
 using System.Threading;
 using UnityEngine;
 
@@ -65,6 +67,11 @@ namespace DCLServices.MapRendererV2.MapLayers.HomePoint
             homePointCoordinates.OnChange -= OnHomePointCoordinatesChange;
 
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(IMapLayerParameter layerParameter)
+        {
+
         }
 
         private void OnHomePointCoordinatesChange(Vector2Int current, Vector2Int previous)

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/HomePoint/HomePointMarkerController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/HomePoint/HomePointMarkerController.cs
@@ -69,11 +69,6 @@ namespace DCLServices.MapRendererV2.MapLayers.HomePoint
             return UniTask.CompletedTask;
         }
 
-        public void SetParameter(IMapLayerParameter layerParameter)
-        {
-
-        }
-
         private void OnHomePointCoordinatesChange(Vector2Int current, Vector2Int previous)
         {
             SetMarkerPosition(current);

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/IMapLayerController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/IMapLayerController.cs
@@ -5,11 +5,12 @@ using System.Threading;
 
 namespace DCLServices.MapRendererV2.MapLayers
 {
-    internal interface IMapLayerController<T> : IMapLayerController
+    internal interface IMapLayerController<in T> : IMapLayerController
     {
         void SetParameter(T param);
 
-        void IMapLayerController.SetParameter(IMapLayerParameter mapLayerParameter) => SetParameter((T)mapLayerParameter);
+        void IMapLayerController.SetParameter(IMapLayerParameter mapLayerParameter) =>
+            SetParameter((T)mapLayerParameter);
     }
 
     internal interface IMapLayerController : IDisposable
@@ -26,6 +27,6 @@ namespace DCLServices.MapRendererV2.MapLayers
         /// <param name="cancellationToken">Cancellation Token is bound to both `Abort` (changing to the `Enabled` state) and `Dispose`</param>
         UniTask Disable(CancellationToken cancellationToken);
 
-        void SetParameter(IMapLayerParameter layerParameter);
+        void SetParameter(IMapLayerParameter layerParameter) { }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/IMapLayerController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/IMapLayerController.cs
@@ -1,9 +1,17 @@
 ﻿using Cysharp.Threading.Tasks;
+using DCLServices.MapRendererV2.MapCameraController;
 using System;
 using System.Threading;
 
 namespace DCLServices.MapRendererV2.MapLayers
 {
+    internal interface IMapLayerController<T> : IMapLayerController
+    {
+        void SetParameter(T param);
+
+        void IMapLayerController.SetParameter(IMapLayerParameter mapLayerParameter) => SetParameter((T)mapLayerParameter);
+    }
+
     internal interface IMapLayerController : IDisposable
     {
         /// <summary>
@@ -17,5 +25,7 @@ namespace DCLServices.MapRendererV2.MapLayers
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token is bound to both `Abort` (changing to the `Enabled` state) and `Dispose`</param>
         UniTask Disable(CancellationToken cancellationToken);
+
+        void SetParameter(IMapLayerParameter layerParameter);
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/IMapLayerParameter.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/IMapLayerParameter.cs
@@ -1,0 +1,7 @@
+namespace DCLServices.MapRendererV2.MapCameraController
+{
+    public interface IMapLayerParameter
+    {
+        
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/IMapLayerParameter.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/IMapLayerParameter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d873023ddba642cda8bf7668e80a63b7
+timeCreated: 1696240059

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/MapLayerControllerBase.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/MapLayerControllerBase.cs
@@ -29,6 +29,7 @@ namespace DCLServices.MapRendererV2.MapLayers
 
         protected virtual void DisposeImpl() { }
 
+
         protected CancellationTokenSource LinkWithDisposeToken(CancellationToken globalCancellation) =>
             CancellationTokenSource.CreateLinkedTokenSource(globalCancellation, ctsDisposing.Token);
     }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/IPlayerMarker.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/IPlayerMarker.cs
@@ -14,5 +14,7 @@ namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
         void SetZoom(float baseZoom, float zoom);
 
         void ResetToBaseScale();
+
+        void SetBackgroundVisibility(bool backgroundIsActive);
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarker.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarker.cs
@@ -34,6 +34,11 @@ namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
             markerObject.gameObject.SetActive(active);
         }
 
+        public void SetBackgroundVisibility(bool backgroundIsActive)
+        {
+            markerObject.SetAnimatedCircleVisibility(backgroundIsActive);
+        }
+
         public void SetRotation(Quaternion rot)
         {
             markerObject.transform.localRotation = rot;

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerController.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
 {
-    internal class PlayerMarkerController : MapLayerControllerBase, IMapLayerController, IZoomScalingLayer
+    internal class PlayerMarkerController : MapLayerControllerBase, IMapLayerController<PlayerMarkerParameter>, IZoomScalingLayer
     {
         internal delegate IPlayerMarker PlayerMarkerBuilder(Transform parent);
 
@@ -53,6 +53,11 @@ namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
             playerWorldPosition.OnChange -= OnPlayerWorldPositionChange;
             playerRotation.OnChange -= OnPlayerRotationChange;
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(PlayerMarkerParameter param)
+        {
+            playerMarker?.SetBackgroundVisibility(param.BackgroundIsActive);
         }
 
         private void SetPosition()

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerParameter.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerParameter.cs
@@ -1,0 +1,9 @@
+using DCLServices.MapRendererV2.MapCameraController;
+
+namespace DCLServices.MapRendererV2.MapLayers.PlayerMarker
+{
+    public class PlayerMarkerParameter : IMapLayerParameter
+    {
+        public bool BackgroundIsActive;
+    }
+}

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerParameter.cs.meta
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PlayerMarker/PlayerMarkerParameter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 213f04d52e214e3aaecbae23d95eebf9
+timeCreated: 1696240104

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
@@ -1,7 +1,9 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
+using DCLServices.MapRendererV2.MapCameraController;
 using MainScripts.DCL.Helpers.Utils;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
@@ -154,6 +156,11 @@ namespace DCLServices.MapRendererV2.MapLayers.PointsOfInterest
             isEnabled = false;
 
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(IMapLayerParameter layerParameter)
+        {
+
         }
 
         public UniTask Enable(CancellationToken cancellationToken)

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
@@ -158,11 +158,6 @@ namespace DCLServices.MapRendererV2.MapLayers.PointsOfInterest
             return UniTask.CompletedTask;
         }
 
-        public void SetParameter(IMapLayerParameter layerParameter)
-        {
-
-        }
-
         public UniTask Enable(CancellationToken cancellationToken)
         {
             foreach (ISceneOfInterestMarker marker in markers.Values)

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/ColdArea/UsersMarkersColdAreaController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/ColdArea/UsersMarkersColdAreaController.cs
@@ -2,7 +2,9 @@
 using DCL;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
+using DCLServices.MapRendererV2.MapCameraController;
 using MainScripts.DCL.Controllers.HotScenes;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -189,6 +191,11 @@ namespace DCLServices.MapRendererV2.MapLayers.UsersMarkers.ColdArea
             }
             // cancellation of `ColdAreasUpdateLoop` is handled by the cancellation token
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(IMapLayerParameter layerParameter)
+        {
+
         }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/ColdArea/UsersMarkersColdAreaController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/ColdArea/UsersMarkersColdAreaController.cs
@@ -192,10 +192,5 @@ namespace DCLServices.MapRendererV2.MapLayers.UsersMarkers.ColdArea
             // cancellation of `ColdAreasUpdateLoop` is handled by the cancellation token
             return UniTask.CompletedTask;
         }
-
-        public void SetParameter(IMapLayerParameter layerParameter)
-        {
-
-        }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/Friends/FriendsMarkersAreaController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/Friends/FriendsMarkersAreaController.cs
@@ -133,10 +133,5 @@ namespace DCLServices.MapRendererV2.MapLayers.UsersMarkers.Friends
             markers.Clear();
             return UniTask.CompletedTask;
         }
-
-        public void SetParameter(IMapLayerParameter layerParameter)
-        {
-
-        }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/Friends/FriendsMarkersAreaController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/Friends/FriendsMarkersAreaController.cs
@@ -2,6 +2,7 @@
 using DCL.Social.Friends;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
+using DCLServices.MapRendererV2.MapCameraController;
 using MainScripts.DCL.Helpers.Utils;
 using System;
 using System.Collections.Generic;
@@ -131,6 +132,11 @@ namespace DCLServices.MapRendererV2.MapLayers.UsersMarkers.Friends
 
             markers.Clear();
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(IMapLayerParameter layerParameter)
+        {
+
         }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/HotArea/UsersMarkersHotAreaController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/HotArea/UsersMarkersHotAreaController.cs
@@ -1,7 +1,9 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCLServices.MapRendererV2.CoordsUtils;
 using DCLServices.MapRendererV2.Culling;
+using DCLServices.MapRendererV2.MapCameraController;
 using MainScripts.DCL.Helpers.Utils;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
@@ -90,6 +92,11 @@ namespace DCLServices.MapRendererV2.MapLayers.UsersMarkers.HotArea
 
             markers.Clear();
             return UniTask.CompletedTask;
+        }
+
+        public void SetParameter(IMapLayerParameter layerParameter)
+        {
+
         }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/HotArea/UsersMarkersHotAreaController.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapLayers/UsersMarkers/HotArea/UsersMarkersHotAreaController.cs
@@ -93,10 +93,5 @@ namespace DCLServices.MapRendererV2.MapLayers.UsersMarkers.HotArea
             markers.Clear();
             return UniTask.CompletedTask;
         }
-
-        public void SetParameter(IMapLayerParameter layerParameter)
-        {
-
-        }
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/MapRenderer.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/MapRenderer.cs
@@ -9,7 +9,6 @@ using DCLServices.MapRendererV2.MapLayers;
 using MainScripts.DCL.Helpers.Utils;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.Pool;
@@ -197,7 +196,7 @@ namespace DCLServices.MapRendererV2
                 }
                 else
                 {
-                    var currentOwner = mapLayerStatus.ActivityOwners.Last();
+                    var currentOwner = mapLayerStatus.ActivityOwners[^1];
                     IReadOnlyDictionary<MapLayer, IMapLayerParameter> parametersByLayer = currentOwner.LayersParameters;
 
                     if (parametersByLayer.ContainsKey(mapLayer))

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/TestScene/Editor/MapRendererTestSceneCameraRentals.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/TestScene/Editor/MapRendererTestSceneCameraRentals.cs
@@ -1,4 +1,5 @@
-﻿using DCLServices.MapRendererV2.MapCameraController;
+﻿using DCLServices.MapRendererV2.CommonBehavior;
+using DCLServices.MapRendererV2.MapCameraController;
 using DCLServices.MapRendererV2.MapLayers;
 using System;
 using System.Collections.Generic;
@@ -8,7 +9,7 @@ using UnityEngine.UIElements;
 
 namespace DCLServices.MapRendererV2.TestScene
 {
-    public class MapRendererTestSceneCameraRentals : IMapRendererTestSceneElementProvider
+    public class MapRendererTestSceneCameraRentals : IMapRendererTestSceneElementProvider, IMapActivityOwner
     {
         private readonly MapRenderer mapRenderer;
 
@@ -44,11 +45,14 @@ namespace DCLServices.MapRendererV2.TestScene
             {
                 var rent = mapRenderer.RentCamera(
                     new MapCameraInput(
+                        this,
                         (MapLayer)enabledLayers.value,
+                        new Dictionary<MapLayer, IMapLayerParameter>(),
                         position.value,
                         zoom.value,
                         texRes.value,
-                        zoomThreshold.value));
+                        zoomThreshold.value
+                        ));
 
                 mapCameraControllers.Add(rent);
 
@@ -106,7 +110,7 @@ namespace DCLServices.MapRendererV2.TestScene
 
             controls.Add(new Button(() =>
             {
-                cameraController.Release();
+                cameraController.Release(this);
                 rents.Remove(controls);
                 mapCameraControllers.Remove(cameraController);
             }) { text = "Release" });

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/TestScene/Editor/MapRendererTestSceneCameraRentals.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/TestScene/Editor/MapRendererTestSceneCameraRentals.cs
@@ -12,9 +12,10 @@ namespace DCLServices.MapRendererV2.TestScene
     public class MapRendererTestSceneCameraRentals : IMapRendererTestSceneElementProvider, IMapActivityOwner
     {
         private readonly MapRenderer mapRenderer;
+        private readonly List<IMapCameraController> mapCameraControllers = new ();
 
         private VisualElement rents;
-        private readonly List<IMapCameraController> mapCameraControllers = new ();
+        public IReadOnlyDictionary<MapLayer, IMapLayerParameter> LayersParameters { get; } = new Dictionary<MapLayer, IMapLayerParameter>();
 
         public MapRendererTestSceneCameraRentals(MapRenderer mapRenderer)
         {
@@ -47,7 +48,6 @@ namespace DCLServices.MapRendererV2.TestScene
                     new MapCameraInput(
                         this,
                         (MapLayer)enabledLayers.value,
-                        new Dictionary<MapLayer, IMapLayerParameter>(),
                         position.value,
                         zoom.value,
                         texRes.value,

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/MapRendererShould.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/MapRendererShould.cs
@@ -1,5 +1,6 @@
 ﻿using Cysharp.Threading.Tasks;
 using Cysharp.Threading.Tasks.Linq;
+using DCLServices.MapRendererV2.CommonBehavior;
 using DCLServices.MapRendererV2.ComponentsFactory;
 using DCLServices.MapRendererV2.Culling;
 using DCLServices.MapRendererV2.MapCameraController;
@@ -61,7 +62,9 @@ namespace DCLServices.MapRendererV2.Tests
         [Test]
         public void EnableLayerByMask([ValueSource(nameof(TEST_MAP_LAYERS))] MapLayer mask)
         {
-            mapRenderer.EnableLayers_Test(mask);
+            IMapActivityOwner owner = Substitute.For<IMapActivityOwner>();
+
+            mapRenderer.EnableLayers_Test(owner, mask);
 
             foreach (MapLayer mapLayer in EnumUtils.Values<MapLayer>())
             {
@@ -73,8 +76,10 @@ namespace DCLServices.MapRendererV2.Tests
         [Test]
         public void DisableLayerByMask([ValueSource(nameof(TEST_MAP_LAYERS))] MapLayer mask)
         {
-            mapRenderer.EnableLayers_Test(mask);
-            mapRenderer.DisableLayers_Test(mask);
+            IMapActivityOwner owner = Substitute.For<IMapActivityOwner>();
+
+            mapRenderer.EnableLayers_Test(owner, mask);
+            mapRenderer.DisableLayers_Test(owner, mask);
 
             foreach (MapLayer mapLayer in EnumUtils.Values<MapLayer>())
             {
@@ -86,10 +91,12 @@ namespace DCLServices.MapRendererV2.Tests
         [Test]
         public void NotDisableLayerIfStillUsed([ValueSource(nameof(TEST_MAP_LAYERS))] MapLayer mask)
         {
-            mapRenderer.EnableLayers_Test(mask);
-            mapRenderer.EnableLayers_Test(mask);
+            IMapActivityOwner owner = Substitute.For<IMapActivityOwner>();
 
-            mapRenderer.DisableLayers_Test(mask);
+            mapRenderer.EnableLayers_Test(owner, mask);
+            mapRenderer.EnableLayers_Test(owner, mask);
+
+            mapRenderer.DisableLayers_Test(owner, mask);
 
             foreach (MapLayer mapLayer in EnumUtils.Values<MapLayer>())
             {

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/TestSuite/MapRendererTestSuite.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/TestSuite/MapRendererTestSuite.cs
@@ -1,4 +1,6 @@
-﻿using DCLServices.MapRendererV2.MapLayers;
+﻿using DCLServices.MapRendererV2.CommonBehavior;
+using DCLServices.MapRendererV2.MapCameraController;
+using DCLServices.MapRendererV2.MapLayers;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -16,10 +18,10 @@ namespace DCLServices.MapRendererV2
 
         internal Dictionary<MapLayer, IMapLayerController> layersDictionary_Test => layers.ToDictionary(l => l.Key, l => l.Value.MapLayerController);
 
-        internal void EnableLayers_Test(MapLayer mask) =>
-            EnableLayers(mask);
+        internal void EnableLayers_Test(IMapActivityOwner owner, MapLayer mask) =>
+            EnableLayers(owner, mask, new Dictionary<MapLayer, IMapLayerParameter>());
 
-        internal void DisableLayers_Test(MapLayer mask) =>
-            DisableLayers(mask);
+        internal void DisableLayers_Test(IMapActivityOwner owner, MapLayer mask) =>
+            DisableLayers(owner, mask);
     }
 }

--- a/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/TestSuite/MapRendererTestSuite.cs
+++ b/unity-renderer/Assets/DCLServices/MapRendererV2/Tests/TestSuite/MapRendererTestSuite.cs
@@ -19,7 +19,7 @@ namespace DCLServices.MapRendererV2
         internal Dictionary<MapLayer, IMapLayerController> layersDictionary_Test => layers.ToDictionary(l => l.Key, l => l.Value.MapLayerController);
 
         internal void EnableLayers_Test(IMapActivityOwner owner, MapLayer mask) =>
-            EnableLayers(owner, mask, new Dictionary<MapLayer, IMapLayerParameter>());
+            EnableLayers(owner, mask);
 
         internal void DisableLayers_Test(IMapActivityOwner owner, MapLayer mask) =>
             DisableLayers(owner, mask);

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/HUDDesktop.asmdef
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/HUDDesktop.asmdef
@@ -30,7 +30,8 @@
         "GUID:2ce94b4811f2a4b9b8dfd650158f7796",
         "GUID:e5b8a8ed154ad624f99bcb73d3284a90",
         "GUID:70263d10ecfb462ba0f6762dda35634b",
-        "GUID:97d8897529779cb49bebd400c7f402a6"
+        "GUID:97d8897529779cb49bebd400c7f402a6",
+        "GUID:d0d87470ef1844e08586dabeb6d672bd"
     ],
     "includePlatforms": [
         "Editor",

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUD.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUD.asmdef
@@ -90,7 +90,8 @@
         "GUID:0f15c7a7fa0e4b94aaceddb51ad829ac",
         "GUID:006c0e0a70294dbba8a4cbcfb77e1f7d",
         "GUID:2ce94b4811f2a4b9b8dfd650158f7796",
-        "GUID:70263d10ecfb462ba0f6762dda35634b"
+        "GUID:70263d10ecfb462ba0f6762dda35634b",
+        "GUID:d0d87470ef1844e08586dabeb6d672bd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapVisibilityBehaviour.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapVisibilityBehaviour.cs
@@ -2,16 +2,19 @@ using DCL.Browser;
 using System;
 using DCL.Helpers;
 using DCLServices.MapRendererV2;
+using DCLServices.MapRendererV2.CommonBehavior;
 using DCLServices.MapRendererV2.ConsumerUtils;
 using DCLServices.MapRendererV2.MapCameraController;
 using DCLServices.MapRendererV2.MapLayers;
+using DCLServices.MapRendererV2.MapLayers.PlayerMarker;
 using DCLServices.PlacesAPIService;
 using ExploreV2Analytics;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace DCL
 {
-    public class NavmapVisibilityBehaviour : IDisposable
+    public class NavmapVisibilityBehaviour : IDisposable, IMapActivityOwner
     {
         private const MapLayer ACTIVE_MAP_LAYERS =
             MapLayer.SatelliteAtlas | MapLayer.ParcelsAtlas | MapLayer.HomePoint | MapLayer.ScenesOfInterest | MapLayer.PlayerMarker | MapLayer.HotUsersMarkers | MapLayer.ColdUsersMarkers | MapLayer.ParcelHoverHighlight;
@@ -43,6 +46,7 @@ namespace DCL
 
         private IMapCameraController cameraController;
         private readonly BaseVariable<FeatureFlag> featureFlagsFlags;
+        private readonly Dictionary<MapLayer, IMapLayerParameter> mapLayerParameters = new() { { MapLayer.PlayerMarker, new PlayerMarkerParameter {BackgroundIsActive = true} } };
         private Camera hudCamera => DataStore.i.camera.hudsCamera.Get();
 
         public NavmapVisibilityBehaviour(
@@ -110,7 +114,7 @@ namespace DCL
         {
             if (cameraController != null)
             {
-                cameraController.Release();
+                cameraController.Release(this);
                 cameraController = null;
             }
         }
@@ -171,11 +175,14 @@ namespace DCL
 
                 cameraController = mapRenderer.Ref.RentCamera(
                     new MapCameraInput(
+                        this,
                         ACTIVE_MAP_LAYERS,
+                        mapLayerParameters,
                         Utils.WorldToGridPosition(DataStore.i.player.playerWorldPosition.Get()),
                         navmapZoomViewController.ResetZoomToMidValue(),
                         rendererConfiguration.PixelPerfectMapRendererTextureProvider.GetPixelPerfectTextureResolution(),
-                        zoomView.zoomVerticalRange));
+                        zoomView.zoomVerticalRange
+                        ));
 
                 SetRenderImageTransparency(false);
 
@@ -209,7 +216,7 @@ namespace DCL
 
                 SetRenderImageTransparency(true);
 
-                cameraController.Release();
+                cameraController.Release(this);
                 cameraController = null;
 
                 navmapIsRendered.Set(false);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapVisibilityBehaviour.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapVisibilityBehaviour.cs
@@ -46,7 +46,9 @@ namespace DCL
 
         private IMapCameraController cameraController;
         private readonly BaseVariable<FeatureFlag> featureFlagsFlags;
-        private readonly Dictionary<MapLayer, IMapLayerParameter> mapLayerParameters = new() { { MapLayer.PlayerMarker, new PlayerMarkerParameter {BackgroundIsActive = true} } };
+        public IReadOnlyDictionary<MapLayer, IMapLayerParameter> LayersParameters  { get; } = new Dictionary<MapLayer, IMapLayerParameter>
+            { { MapLayer.PlayerMarker, new PlayerMarkerParameter {BackgroundIsActive = true} } };
+
         private Camera hudCamera => DataStore.i.camera.hudsCamera.Get();
 
         public NavmapVisibilityBehaviour(
@@ -177,7 +179,6 @@ namespace DCL
                     new MapCameraInput(
                         this,
                         ACTIVE_MAP_LAYERS,
-                        mapLayerParameters,
                         Utils.WorldToGridPosition(DataStore.i.player.playerWorldPosition.Get()),
                         navmapZoomViewController.ResetZoomToMidValue(),
                         rendererConfiguration.PixelPerfectMapRendererTextureProvider.GetPixelPerfectTextureResolution(),


### PR DESCRIPTION
## What does this PR change?

Introduce parametrization to the map layers. Currently, only PlayerMarker has this functionality. 

Note: wasn't able to extract parametrization interface from `IMapLayerController`, which resulted in empty functions in all layers except PlayerMarker :( 
 
## How to test the changes?
https://play.decentraland.org/?explorer-branch=feat/navmap-layer-parametrization&ENABLE_map_focus_home_or_user&ENABLE_navmap_header&ENABLE_navmap-satellite-view&

https://play.decentraland.zone/?explorer-branch=feat/navmap-layer-parametrization&ENABLE_map_focus_home_or_user&ENABLE_navmap_header&ENABLE_navmap-satellite-view&

1. Launch the explorer
2. Observe now white pulsing background in PlayerMarker on MiniMap
3. Open NavMap and observe this background presented
4. Close NavMap and observe no background on PlayerMarker on MiniMap
5. Open NavMap again, observe background presented
6. Teleport to some far point on map -> after loading observe on Minimap there is no background of PlayerMarker

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6f4118a</samp>

This pull request refactors the map rendering system to support different types of map layer parameters and map activity owners. This allows more flexibility and customization of the map layers and their behavior or appearance. The pull request modifies several interfaces and classes related to the map camera controller and the map layer controllers, and adds new files for the new interfaces and classes.
