### PR TITLE
hotfix: peers broadcasting

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/comms/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/comms/index.ts
@@ -13,7 +13,7 @@ export async function fetchPeerProfile(
   minimumVersion?: number
 ): Promise<Avatar | null> {
   const targetVersion = minimumVersion || 0
-  const isConnectedToPeer = requestProfileFromPeers(room, userId, targetVersion)
+  const isConnectedToPeer = await requestProfileFromPeers(room, userId, targetVersion)
   if (!isConnectedToPeer) {
     return null
   }


### PR DESCRIPTION
## What does this PR change?

`Fix for #5773 #5496 `

An await of the async operation for requesting a peer was missing when any peer profile update was performed, specially version changes.

## How to test the changes?

1. Launch the explorer
2. Follow the steps in the described issues

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33ff3fd</samp>

Added `await` to `requestProfileFromPeers` to fix a comms bug. This change makes the function return a correct boolean value and use the cached or catalyst profile if available.
