### PR TITLE
fix: emotes and avatar visibility

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -26,7 +26,7 @@ namespace AvatarSystem
         private readonly ILOD lod;
         private readonly IGPUSkinning gpuSkinning;
         private readonly IGPUSkinningThrottlerService gpuSkinningThrottlerService;
-        private readonly IAvatarEmotesController emotesController;
+        protected readonly IAvatarEmotesController emotesController;
 
         private CancellationTokenSource loadCancellationToken;
         public IAvatar.Status status { get; private set; } = IAvatar.Status.Idle;
@@ -111,7 +111,8 @@ namespace AvatarSystem
                 container = parent != null ? parent : container;
             }
 
-            Prepare(settings, emotes, container);
+            emotesController.Prepare(settings.bodyshapeId, container);
+            Prepare(settings, emotes);
             Bind();
             Inform(loader.combinedRenderer);
         }
@@ -139,12 +140,12 @@ namespace AvatarSystem
             return emotes;
         }
 
-        protected void Prepare(AvatarSettings settings, List<WearableItem> emotes, GameObject container)
+        protected void Prepare(AvatarSettings settings, List<WearableItem> emotes)
         {
             //Scale the bounds due to the giant avatar not being skinned yet
             extents = loader.combinedRenderer.localBounds.extents * 2f / RESCALING_BOUNDS_FACTOR;
 
-            emotesController.LoadEmotes(settings.bodyshapeId, emotes, container);
+            emotesController.LoadEmotes(settings.bodyshapeId, emotes);
             gpuSkinning.Prepare(loader.combinedRenderer);
             gpuSkinningThrottlerService.Register(gpuSkinning);
         }
@@ -165,6 +166,7 @@ namespace AvatarSystem
         public virtual void AddVisibilityConstraint(string key)
         {
             visibility.AddGlobalConstrain(key);
+            emotesController.StopEmote();
         }
 
         public void RemoveVisibilityConstrain(string key) =>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Avatar.cs
@@ -166,11 +166,14 @@ namespace AvatarSystem
         public virtual void AddVisibilityConstraint(string key)
         {
             visibility.AddGlobalConstrain(key);
-            emotesController.StopEmote();
+            emotesController.AddVisibilityConstraint(key);
         }
 
-        public void RemoveVisibilityConstrain(string key) =>
+        public void RemoveVisibilityConstrain(string key)
+        {
             visibility.RemoveGlobalConstrain(key);
+            emotesController.RemoveVisibilityConstraint(key);
+        }
 
         public IAvatarEmotesController GetEmotesController() => emotesController;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
@@ -33,13 +33,15 @@ namespace AvatarSystem
         public bool TryGetEquippedEmote(string bodyShape, string emoteId, out IEmoteReference emoteReference) =>
             equippedEmotes.TryGetValue(new EmoteBodyId(bodyShape, emoteId), out emoteReference);
 
-        // ReSharper disable once PossibleMultipleEnumeration (its intended)
-        public void LoadEmotes(string bodyShapeId, IEnumerable<WearableItem> newEmotes, GameObject container)
+        public void Prepare(string bodyShapeId, GameObject container)
         {
             this.bodyShapeId = bodyShapeId;
-
             animator.Prepare(bodyShapeId, container);
+        }
 
+        // ReSharper disable once PossibleMultipleEnumeration (its intended)
+        public void LoadEmotes(string bodyShapeId, IEnumerable<WearableItem> newEmotes)
+        {
             foreach (WearableItem emote in newEmotes)
                 LoadEmote(bodyShapeId, emote);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarWithHologram.cs
@@ -23,8 +23,9 @@ namespace AvatarSystem
         protected override async UniTask LoadTry(List<string> wearablesIds, List<string> emotesIds, AvatarSettings settings, CancellationToken linkedCt)
         {
             baseAvatar.FadeGhost(linkedCt).Forget(); //Avoid making the ghost fading a blocking part of the avatar
+            emotesController.Prepare(settings.bodyshapeId, baseAvatar.ArmatureContainer);
             List<WearableItem> emotes = await LoadWearables(wearablesIds, emotesIds, settings, baseAvatar.SkinnedMeshRenderer, linkedCt: linkedCt);
-            Prepare(settings, emotes, baseAvatar.ArmatureContainer);
+            Prepare(settings, emotes);
             Bind();
 
             MeshRenderer newCombinedRenderer = loader.combinedRenderer.GetComponent<MeshRenderer>();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
@@ -7,7 +7,9 @@ namespace AvatarSystem
 {
     public interface IAvatarEmotesController : IDisposable
     {
-        void LoadEmotes(string bodyShapeId, IEnumerable<WearableItem> emotes, GameObject container);
+        void Prepare(string bodyShapeId, GameObject container);
+
+        void LoadEmotes(string bodyShapeId, IEnumerable<WearableItem> emotes);
 
         void PlayEmote(string emoteId, long timestamps, bool spatial = true, bool occlude = true, bool ignoreTimestamp = false);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
@@ -23,5 +23,9 @@ namespace AvatarSystem
         event Action<string> OnEmoteUnequipped;
 
         bool TryGetEquippedEmote(string bodyShape, string emoteId, out IEmoteReference emoteReference);
+
+        void AddVisibilityConstraint(string key);
+
+        void RemoveVisibilityConstraint(string key);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/EmoteClipData.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/EmoteClipData.cs
@@ -58,6 +58,7 @@ namespace DCL.Emotes
                     renderer.enabled = true;
                     renderer.gameObject.layer = gameObjectLayer;
                     renderer.allowOcclusionWhenDynamic = occlude;
+                    renderer.forceRenderingOff = false;
                 }
             }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -357,7 +357,11 @@ public class WearableItem
     public static HashSet<string> ComposeHiddenCategoriesOrdered(string bodyShapeId, HashSet<string> forceRender, List<WearableItem> wearables)
     {
         var result = new HashSet<string>();
-        var wearablesByCategory = wearables.ToDictionary(w => w.data.category);
+        var wearablesByCategory = new Dictionary<string, WearableItem>();
+
+        foreach (var wearable in wearables)
+            wearablesByCategory.TryAdd(wearable.data.category, wearable);
+
         var previouslyHidden = new Dictionary<string, HashSet<string>>();
 
         foreach (string priorityCategory in CATEGORIES_PRIORITY)


### PR DESCRIPTION
## What does this PR change?

Fixed:
- Ghost avatars in T pose
- Emotes being executed and renderers when avatars are hidden within Avatar Modifier areas
- A rare exception when loading wearables
- Forced emotes to always render, the culling is broken so this is a workaround.

## How to test the changes?

- Log in to a zone with multiple avatars, they should not be T posing
- Go to an area with an Avatar Modifier area that hides the avatar ( I think the machines at Wondermine have one ) and execute an emote, the emote should not show or play a sound.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 847f412</samp>

Refactored the emotes loading logic in the `Avatar` system and fixed some bugs related to emote sound and visibility. Also improved the handling of duplicate categories in the `WearableItem` class.
