### PR TITLE
fix: fetch realms info before showing the realm selector

### DIFF
--- a/browser-interface/packages/shared/renderer/sagas.ts
+++ b/browser-interface/packages/shared/renderer/sagas.ts
@@ -125,7 +125,7 @@ function* reportRealmChangeToRenderer() {
   }
 }
 
-async function fetchAndReportRealmsInfo(url: string) {
+export async function fetchAndReportRealmsInfo(url: string) {
   try {
     const response = await fetch(url)
     if (response.ok) {

--- a/browser-interface/packages/unity-interface/BrowserInterface.ts
+++ b/browser-interface/packages/unity-interface/BrowserInterface.ts
@@ -26,7 +26,7 @@ import { notifyStatusThroughChat } from 'shared/chat'
 import { sendMessage } from 'shared/chat/actions'
 import { sendPublicChatMessage } from 'shared/comms'
 import { changeRealm } from 'shared/dao'
-import { getSelectedNetwork } from 'shared/dao/selectors'
+import {getExploreRealmsService, getSelectedNetwork} from 'shared/dao/selectors'
 import { getERC20Balance } from 'lib/web3/EthereumService'
 import { leaveChannel, updateUserData } from 'shared/friends/actions'
 import { ensureFriendProfile } from 'shared/friends/ensureFriendProfile'
@@ -120,6 +120,7 @@ import { GIFProcessor } from './gif-processor'
 import { getUnityInstance } from './IUnityInterface'
 import { encodeParcelPosition } from 'lib/decentraland'
 import { Vector2 } from 'shared/protocol/decentraland/common/vectors.gen'
+import {fetchAndReportRealmsInfo} from "../shared/renderer/sagas";
 
 declare const globalThis: { gifProcessor?: GIFProcessor; __debug_wearables: any }
 export const futures: Record<string, IFuture<any>> = {}
@@ -1075,6 +1076,13 @@ export class BrowserInterface {
         defaultLogger.error(e)
       }
     )
+  }
+
+  public async FetchRealmsInfo() {
+    const url = getExploreRealmsService(store.getState());
+    if (url) {
+      await fetchAndReportRealmsInfo(url)
+    }
   }
 
   public async UpdateMemoryUsage() {

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/ExploreV2/ExploreV2Desktop.asmdef
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/ExploreV2/ExploreV2Desktop.asmdef
@@ -31,7 +31,8 @@
         "GUID:6afcac5154f98e846bbd9f27e454b57a",
         "GUID:e7f9ac14a58e0b84e81407a90a1ba77a",
         "GUID:006c0e0a70294dbba8a4cbcfb77e1f7d",
-        "GUID:1e2130f38da0e4ae8a87318375ea2266"
+        "GUID:1e2130f38da0e4ae8a87318375ea2266",
+        "GUID:57a7040eaf02d4eadaa266755f23857a"
     ],
     "includePlatforms": [
         "Editor",

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/ExploreV2/ExploreV2FeatureDesktop.cs
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/ExploreV2/ExploreV2FeatureDesktop.cs
@@ -16,7 +16,9 @@ public class ExploreV2FeatureDesktop : IPlugin
     }
 
     internal virtual IExploreV2MenuComponentController CreateController() =>
-        new ExploreV2MenuComponentControllerDesktop(Environment.i.serviceLocator.Get<IPlacesAPIService>(), Environment.i.serviceLocator.Get<IWorldsAPIService>(), new PlacesAnalytics());
+        new ExploreV2MenuComponentControllerDesktop(Environment.i.serviceLocator.Get<IPlacesAPIService>(),
+            Environment.i.serviceLocator.Get<IWorldsAPIService>(), new PlacesAnalytics(),
+            RealmsInfoBridge.i);
 
     public void Dispose()
     {

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/ExploreV2/ExploreV2MenuComponentControllerDesktop.cs
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/ExploreV2/ExploreV2MenuComponentControllerDesktop.cs
@@ -1,3 +1,4 @@
+using DCL;
 using DCLServices.PlacesAPIService;
 using DCLServices.WorldsAPIService;
 
@@ -9,5 +10,8 @@ public class ExploreV2MenuComponentControllerDesktop : ExploreV2MenuComponentCon
     protected override IExploreV2MenuComponentView CreateView() =>
         ExploreV2MenuComponentViewDesktop.Create();
 
-    public ExploreV2MenuComponentControllerDesktop(IPlacesAPIService placesAPIService, IWorldsAPIService worldsAPIService, IPlacesAnalytics placesAnalytics) : base(placesAPIService, worldsAPIService, placesAnalytics) {}
+    public ExploreV2MenuComponentControllerDesktop(IPlacesAPIService placesAPIService,
+        IWorldsAPIService worldsAPIService, IPlacesAnalytics placesAnalytics,
+        IRealmsInfoBridge realmsInfoBridge)
+        : base(placesAPIService, worldsAPIService, placesAnalytics, realmsInfoBridge) {}
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/IRealmsInfoBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/IRealmsInfoBridge.cs
@@ -1,0 +1,12 @@
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+using Variables.RealmsInfo;
+
+namespace DCL
+{
+    public interface IRealmsInfoBridge
+    {
+        UniTask<IReadOnlyList<RealmModel>> FetchRealmsInfo(CancellationToken cancellationToken);
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/IRealmsInfoBridge.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/IRealmsInfoBridge.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 087bc15406794d55a1ea13e76fa99d47
+timeCreated: 1697139761

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/RealmsInfoBridge.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/RealmsInfoBridge.asmdef
@@ -6,7 +6,8 @@
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:4973650d2444c4561a15d50f24d91cd9",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
-        "GUID:3c7b57a14671040bd8c549056adc04f5"
+        "GUID:3c7b57a14671040bd8c549056adc04f5",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/RealmsInfoBridge.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/RealmsInfoBridge.cs
@@ -1,17 +1,36 @@
+using Cysharp.Threading.Tasks;
 using DCL.Helpers;
 using System;
 using JetBrains.Annotations;
+using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
+using Variables.RealmsInfo;
 using static DCL.Interface.WebInterface;
 
 namespace DCL
 {
-    public class RealmsInfoBridge : MonoBehaviour
+    public class RealmsInfoBridge : MonoBehaviour, IRealmsInfoBridge
     {
+        private static RealmsInfoBridge instance;
+        public static RealmsInfoBridge i => instance;
+
         public event Action<JumpInPayload> OnRealmConnectionSuccess;
         public event Action<JumpInPayload> OnRealmConnectionFailed;
 
         private readonly RealmsInfoHandler handler = new RealmsInfoHandler();
+
+        private void Awake()
+        {
+            if (!instance)
+                instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+                instance = null;
+        }
 
         public void UpdateRealmsInfo(string payload) { handler.Set(payload); }
 
@@ -32,5 +51,8 @@ namespace DCL
         {
             handler.SetAbout(payload);
         }
+
+        public UniTask<IReadOnlyList<RealmModel>> FetchRealmsInfo(CancellationToken cancellationToken) =>
+            handler.FetchRealmsInfo(cancellationToken);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/RealmsInfoHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/RealmsInfoHandler.cs
@@ -1,3 +1,5 @@
+using Cysharp.Threading.Tasks;
+using DCL.Interface;
 using UnityEngine;
 using System;
 using Variables.RealmsInfo;
@@ -5,10 +7,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Decentraland.Bff;
 using Google.Protobuf;
+using System.Threading;
 
 namespace DCL
 {
-    public class RealmsInfoHandler
+    public class RealmsInfoHandler : IRealmsInfoBridge
     {
         private RealmsInfoModel model = new RealmsInfoModel();
 
@@ -19,6 +22,7 @@ namespace DCL
         private BaseVariable<AboutResponse.Types.ContentInfo> playerRealmAboutContent => DataStore.i.realm.playerRealmAboutContent;
 
         private BaseVariable<string> realmName => DataStore.i.realm.realmName;
+        private UniTaskCompletionSource<IReadOnlyList<RealmModel>> fetchRealmsTask;
 
         public void Set(string json)
         {
@@ -36,7 +40,14 @@ namespace DCL
                 realmName.Set(DataStore.i.realm.playerRealm.Get().serverName);
             }
 
-            DataStore.i.realm.realmsInfo.Set(newModel.realms != null ? newModel.realms.ToList() : new List<RealmModel>());
+            List<RealmModel> realms = newModel.realms != null ? newModel.realms.ToList() : new List<RealmModel>();
+            DataStore.i.realm.realmsInfo.Set(realms);
+
+            if (fetchRealmsTask != null)
+            {
+                fetchRealmsTask.TrySetResult(realms);
+                fetchRealmsTask = null;
+            }
         }
 
         public void SetAbout(string json)
@@ -47,6 +58,20 @@ namespace DCL
             playerRealmAboutContent.Set(aboutResponse.Content);
             playerRealmAboutLambda.Set(aboutResponse.Lambdas);
             realmName.Set(aboutResponse.Configurations.RealmName);
+        }
+
+        public UniTask<IReadOnlyList<RealmModel>> FetchRealmsInfo(CancellationToken cancellationToken)
+        {
+            if (fetchRealmsTask != null)
+                return fetchRealmsTask.Task.AttachExternalCancellation(cancellationToken)
+                                            .Timeout(TimeSpan.FromSeconds(30));
+
+            fetchRealmsTask = new UniTaskCompletionSource<IReadOnlyList<RealmModel>>();
+
+            WebInterface.FetchRealmsInfo();
+
+            return fetchRealmsTask.Task.AttachExternalCancellation(cancellationToken)
+                                  .Timeout(TimeSpan.FromSeconds(30));
         }
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/ExploreV2.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/ExploreV2.asmdef
@@ -50,7 +50,8 @@
         "GUID:7ac9f9c835ec1084ab35e3f9b176cf1e",
         "GUID:1e2130f38da0e4ae8a87318375ea2266",
         "GUID:4d7712e4b2446440a8af21fd3ce8690e",
-        "GUID:58fe09667e2ae4af895c042b0238e32a"
+        "GUID:58fe09667e2ae4af895c042b0238e32a",
+        "GUID:57a7040eaf02d4eadaa266755f23857a"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/ExploreV2Feature.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Scripts/ExploreV2Feature.cs
@@ -15,7 +15,11 @@ public class ExploreV2Feature : IPlugin
         exploreV2MenuComponentController.Initialize();
     }
 
-    internal virtual IExploreV2MenuComponentController CreateController() => new ExploreV2MenuComponentController(Environment.i.serviceLocator.Get<IPlacesAPIService>(),Environment.i.serviceLocator.Get<IWorldsAPIService>(), new PlacesAnalytics());
+    internal virtual IExploreV2MenuComponentController CreateController() =>
+        new ExploreV2MenuComponentController(Environment.i.serviceLocator.Get<IPlacesAPIService>(),
+            Environment.i.serviceLocator.Get<IWorldsAPIService>(),
+            new PlacesAnalytics(),
+            RealmsInfoBridge.i);
 
     public void Dispose()
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2Tests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Tests/ExploreV2Tests.asmdef
@@ -28,7 +28,8 @@
         "GUID:006c0e0a70294dbba8a4cbcfb77e1f7d",
         "GUID:1e2130f38da0e4ae8a87318375ea2266",
         "GUID:4d7712e4b2446440a8af21fd3ce8690e",
-        "GUID:58fe09667e2ae4af895c042b0238e32a"
+        "GUID:58fe09667e2ae4af895c042b0238e32a",
+        "GUID:57a7040eaf02d4eadaa266755f23857a"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -2038,5 +2038,10 @@ namespace DCL.Interface
         {
             SendMessage("GetWithItemsUrlParam");
         }
+
+        public static void FetchRealmsInfo()
+        {
+            SendMessage("FetchRealmsInfo");
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Request the list of available realms, so the user count is updated before showing the realm selector popup.
Fixes cases when the user count is displaying incorrect.

## How to test the changes?

1. Launch the explorer
2. Open the start menu
3. Open the realm selector
4. You should be able to see the realms correctly
5. Interact with the realm selector popup, everything should keep working as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 820d8b0</samp>

Added a new feature to the explore menu to allow users to select a different realm. Implemented a bridge between the web interface and the unity interface to fetch and display realms information. Updated the `RealmsInfoHandler` class to use `UniTask` and `WebInterface` for asynchronous requests. Added the necessary assembly references and dependencies to use the `RealmsInfoBridge` and `IRealmsInfoBridge` classes.
