### PR TITLE
feat: add learn more button for content moderation

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/ContentModerationHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/ContentModerationHUDController.cs
@@ -16,7 +16,7 @@ namespace DCL.ContentModeration
     {
         private const int SECONDS_TO_HIDE_ADULT_CONTENT_ENABLED_NOTIFICATION = 5;
         private const int REPORT_PLACE_TIMEOUT = 30;
-        private const string LEARN_MORE_URL = "https://decentraland.org/blog/"; // TODO (Santi): Change this to the correct URL when it's ready
+        private const string LEARN_MORE_URL = "https://docs.decentraland.org/player/general/in-world-features/age-rating-scene-reporting/";
         private const string REPORTING_ERROR_MESSAGE = "There was an error sending the information. Please try again later...";
 
         private readonly IAdultContentSceneWarningComponentView adultContentSceneWarningComponentView;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/ContentModerationReportingHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/ContentModerationReportingHUD.prefab
@@ -2427,11 +2427,11 @@ RectTransform:
   - {fileID: 5762333373132544110}
   m_Father: {fileID: 5380290776934363934}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 32}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -24, y: 32}
   m_SizeDelta: {x: 192, y: 46}
-  m_Pivot: {x: 0.5, y: 0}
+  m_Pivot: {x: 1, y: 0}
 --- !u!222 &6253415474650258945
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3653,7 +3653,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &4334833367268508755
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?
We have added a new **[LEARN MORE]** button in the modal that appears after we report a scene. If the user clicks on it, he will be redirected to the corresponding documentation: `https://docs.decentraland.org/player/general/in-world-features/age-rating-scene-reporting/`

![image](https://github.com/decentraland/unity-renderer/assets/64659061/7f902e08-17d5-481e-aa61-d30905ef5f10)

## How to test the changes?
1. Launch the explorer.
2. Click on the button to report a scene (below the minimap).
3. Send the report.
4. You will see the success modal with the new LEARN MORE button.
5. Click on it and check that you're correctly redirected to `https://docs.decentraland.org/player/general/in-world-features/age-rating-scene-reporting/`.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44a22f8</samp>

This pull request improves the content moderation reporting HUD by changing its layout and linking to the relevant documentation. It affects the `ContentModerationReportingHUD.prefab` and the `ContentModerationHUDController.cs` files.
