### PR TITLE
chore: main realm is always available, but won't be realm picked unless FF is enabled

### DIFF
--- a/browser-interface/packages/lib/web3/fetchCatalystNodesFromContract.ts
+++ b/browser-interface/packages/lib/web3/fetchCatalystNodesFromContract.ts
@@ -3,7 +3,6 @@ import { bytesToHex, ContractFactory } from 'eth-connect'
 import { retry } from 'lib/javascript/retry'
 import { defaultLogger } from 'lib/logger'
 import { getSelectedNetwork } from 'shared/dao/selectors'
-import { isMainRealmEnabled } from 'shared/meta/selectors'
 import { store } from 'shared/store/isolatedStore'
 import { catalystABI } from './catalystABI'
 import { requestManager } from './provider'
@@ -26,12 +25,10 @@ export async function fetchCatalystNodesFromContract(): Promise<CatalystNode[]> 
   const net = getSelectedNetwork(state)
   const catalysts = await fetchCatalysts(net)
 
-  if (isMainRealmEnabled(state)) {
-    if (net === ETHEREUM_NETWORK.MAINNET) {
-      catalysts.push({ domain: 'https://realm-provider.decentraland.org/main' })
-    } else if (net === ETHEREUM_NETWORK.SEPOLIA) {
-      catalysts.push({ domain: 'https://realm-provider.decentraland.zone/main' })
-    }
+  if (net === ETHEREUM_NETWORK.MAINNET) {
+    catalysts.push({ domain: 'https://realm-provider.decentraland.org/main' })
+  } else if (net === ETHEREUM_NETWORK.SEPOLIA) {
+    catalysts.push({ domain: 'https://realm-provider.decentraland.zone/main' })
   }
 
   return catalysts

--- a/browser-interface/packages/shared/dao/sagas.ts
+++ b/browser-interface/packages/shared/dao/sagas.ts
@@ -77,7 +77,7 @@ function* pickCatalystRealm() {
       return false
     }
     if (!mainRealmEnabled) {
-      return candidate.catalystName != 'main'
+      return candidate.catalystName !== 'main'
     }
     return true
   })


### PR DESCRIPTION
This means:

- If FF is disabled (is currently disabled): you won't be ever assigned to main realm by realm picking algorithm
- `/changerealm main` will work irregardless of the FF status
- jumping on the main realm from the UI will work irregardless of the FF status