### PR TITLE
test: sdk ignore media hostnames for non portable experiences

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AudioStream/ECSAudioStreamComponentHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AudioStream/ECSAudioStreamComponentHandler.cs
@@ -61,7 +61,8 @@ namespace DCL.ECSComponents
             UpdateModel(model);
 
             isValidUrl = UtilsScene.TryGetMediaUrl(model.Url, scene.contentProvider,
-                scene.sceneData.requiredPermissions, scene.sceneData.allowedMediaHostnames, out string newUrl);
+                scene.sceneData.requiredPermissions, scene.sceneData.allowedMediaHostnames,
+                out string newUrl, scene.isPortableExperience);
 
             url = newUrl;
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Defaults/PBVideoPlayer_Defaults.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Defaults/PBVideoPlayer_Defaults.cs
@@ -30,10 +30,12 @@ namespace DCL.ECSComponents
         }
 
         public static string GetVideoUrl(this PBVideoPlayer self, ContentProvider sceneContentProvider,
-            IReadOnlyList<string> sceneRequiredPermissions, IReadOnlyList<string> sceneAllowedMediaHostnames)
+            IReadOnlyList<string> sceneRequiredPermissions, IReadOnlyList<string> sceneAllowedMediaHostnames,
+            bool isPortableExperience)
         {
             UtilsScene.TryGetMediaUrl(self.Src, sceneContentProvider,
-                sceneRequiredPermissions, sceneAllowedMediaHostnames, out string url);
+                sceneRequiredPermissions, sceneAllowedMediaHostnames,
+                out string url, isPortableExperience);
 
             return url;
         }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Defaults/Texture_Defaults.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Defaults/Texture_Defaults.cs
@@ -67,7 +67,8 @@ namespace DCL.ECSComponents
         public static string GetTextureUrl(this Texture self, IParcelScene scene)
         {
             UtilsScene.TryGetMediaUrl(self.Src, scene.contentProvider,
-                scene.sceneData.requiredPermissions, scene.sceneData.allowedMediaHostnames, out string url);
+                scene.sceneData.requiredPermissions, scene.sceneData.allowedMediaHostnames,
+                out string url, scene.isPortableExperience);
 
             return url;
         }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -167,7 +167,8 @@ namespace Tests
 
             string outputUrl = model.GetVideoUrl(scene.contentProvider,
                 scene.sceneData.requiredPermissions,
-                scene.sceneData.allowedMediaHostnames);
+                scene.sceneData.allowedMediaHostnames,
+                isPortableExperience: true);
 
             Assert.AreEqual(string.Empty, outputUrl);
         }
@@ -186,7 +187,8 @@ namespace Tests
 
             string outputUrl = model.GetVideoUrl(scene.contentProvider,
                 scene.sceneData.requiredPermissions,
-                scene.sceneData.allowedMediaHostnames);
+                scene.sceneData.allowedMediaHostnames,
+                isPortableExperience: true);
 
             Assert.AreEqual(model.Src, outputUrl);
         }
@@ -207,9 +209,27 @@ namespace Tests
 
             string outputUrl = model.GetVideoUrl(scene.contentProvider,
                 scene.sceneData.requiredPermissions,
-                scene.sceneData.allowedMediaHostnames);
+                scene.sceneData.allowedMediaHostnames,
+                isPortableExperience: true);
 
             Assert.AreEqual(string.Empty, outputUrl);
+        }
+
+        [Test]
+        public void AllowExternalVideoForNonPortableExperiences()
+        {
+            PBVideoPlayer model = new PBVideoPlayer()
+            {
+                Src = "http://fake/video.mp4",
+                Playing = true,
+            };
+
+            string outputUrl = model.GetVideoUrl(scene.contentProvider,
+                scene.sceneData.requiredPermissions,
+                scene.sceneData.allowedMediaHostnames,
+                isPortableExperience: false);
+
+            Assert.AreEqual(model.Src, outputUrl);
         }
 
         [UnityTest]

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
@@ -70,7 +70,8 @@ namespace DCL.ECSComponents
                     videoType = VideoType.Hls;
 
                 string videoUrl = videoType != VideoType.LiveKit
-                    ? model.GetVideoUrl(scene.contentProvider, scene.sceneData.requiredPermissions, scene.sceneData.allowedMediaHostnames)
+                    ? model.GetVideoUrl(scene.contentProvider, scene.sceneData.requiredPermissions,
+                        scene.sceneData.allowedMediaHostnames, scene.isPortableExperience)
                     : model.Src;
 
                 isValidUrl = !string.IsNullOrEmpty(videoUrl);

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Utils/Scene/Media.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Utils/Scene/Media.cs
@@ -39,7 +39,7 @@ public static partial class UtilsScene
 
     public static bool TryGetMediaUrl(string inputUrl, ContentProvider sceneContentProvider,
         IReadOnlyList<string> sceneRequiredPermissions, IReadOnlyList<string> sceneAllowedMediaHostnames,
-        out string url)
+        out string url, bool checkAllowedMediaHostnames = true)
     {
         if (string.IsNullOrEmpty(inputUrl))
         {
@@ -53,15 +53,16 @@ public static partial class UtilsScene
             return true;
         }
 
-        if (sceneRequiredPermissions == null || sceneAllowedMediaHostnames == null)
+        if (checkAllowedMediaHostnames && (sceneRequiredPermissions == null || sceneAllowedMediaHostnames == null))
         {
             url = string.Empty;
             Debug.LogError("External media asset url error: 'allowedMediaHostnames' missing in scene.json file.");
             return false;
         }
 
-        if (HasRequiredPermission(sceneRequiredPermissions, ScenePermissionNames.ALLOW_MEDIA_HOSTNAMES)
-            && IsUrlDomainAllowed(sceneAllowedMediaHostnames, inputUrl))
+        if (!checkAllowedMediaHostnames ||
+            (HasRequiredPermission(sceneRequiredPermissions, ScenePermissionNames.ALLOW_MEDIA_HOSTNAMES)
+            && IsUrlDomainAllowed(sceneAllowedMediaHostnames, inputUrl)))
         {
             url = inputUrl;
             return true;


### PR DESCRIPTION
Implemented media-hostname permissions ignoring for non portable experiences.

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77c5fbd</samp>

This pull request adds support for external media sources for portable experiences, which are special scenes that can be deployed and executed from any other scene. It modifies the `TryGetMediaUrl` method and its callers in various classes to add a new parameter `isPortableExperience` that allows skipping the check for the scene permissions and the allowed media hostnames. It also updates the unit tests for the `VideoPlayerHandler` class to reflect the new feature.
