### PR TITLE
fix: the metric close_report_form is being sent always at the beginning 

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/ContentModerationReportingComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/ContentModerationReportingComponentView.cs
@@ -115,7 +115,7 @@ namespace DCL.ContentModeration
 
         public void HidePanel(bool isCancelled)
         {
-            if (isLoadingActive)
+            if (isLoadingActive || !isVisible)
                 return;
 
             Hide();


### PR DESCRIPTION
## What does this PR change?
The metric `close_report_form` (related to the Content Moderation feature) was being sent always at the beginning.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
copilot:summary
