### PR TITLE
fix: sdk7 web client video streaming

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -72,6 +72,7 @@ namespace Tests
         public IEnumerator TryToStartVideo()
         {
             videoPlayerHandler.isRendererActive = true;
+            videoPlayerHandler.hadUserInteraction = true;
             PBVideoPlayer model = new PBVideoPlayer()
             {
                 Src = "video.mp4",
@@ -105,6 +106,7 @@ namespace Tests
         public IEnumerator VideoUpdateOnRuntime()
         {
             videoPlayerHandler.isRendererActive = true;
+            videoPlayerHandler.hadUserInteraction = true;
             videoPlayerHandler.OnComponentModelUpdated(scene, entity, new PBVideoPlayer()
             {
                 Src = "video.mp4"
@@ -137,6 +139,7 @@ namespace Tests
             Assert.IsNull(internalVideoPlayerComponent.GetFor(scene, entity));
 
             videoPlayerHandler.OnComponentCreated(scene, entity);
+            videoPlayerHandler.hadUserInteraction = true;
             videoPlayerHandler.OnComponentModelUpdated(scene, entity, new PBVideoPlayer()
             {
                 Src = "other-video.mp4",
@@ -216,6 +219,7 @@ namespace Tests
         public IEnumerator StopVideoIfRenderingIsDisabled()
         {
             videoPlayerHandler.OnComponentCreated(scene, entity);
+            videoPlayerHandler.hadUserInteraction = true;
             PBVideoPlayer model = new PBVideoPlayer()
             {
                 Src = "video.mp4",
@@ -231,6 +235,30 @@ namespace Tests
             loadingScreenDataStore.decoupledLoadingHUD.visible.Set(true);
 
             Assert.AreEqual(false, videoPlayerHandler.videoPlayer.playing);
+
+            videoPlayerHandler.OnComponentRemoved(scene, entity);
+        }
+
+        [UnityTest]
+        public IEnumerator StartVideoAfterUserInteraction()
+        {
+            videoPlayerHandler.OnComponentCreated(scene, entity);
+            videoPlayerHandler.hadUserInteraction = false;
+            PBVideoPlayer model = new PBVideoPlayer()
+            {
+                Src = "video.mp4",
+                Playing = true
+            };
+            videoPlayerHandler.OnComponentModelUpdated(scene, entity, model);
+            yield return new WaitUntil(() => videoPlayerHandler.videoPlayer.GetState() == VideoState.READY);
+            videoPlayerHandler.videoPlayer.Update();
+
+            Assert.AreEqual(false, videoPlayerHandler.videoPlayer.playing);
+
+            // change user interaction bool
+            DCL.Helpers.Utils.LockCursor();
+
+            Assert.AreEqual(true, videoPlayerHandler.videoPlayer.playing);
 
             videoPlayerHandler.OnComponentRemoved(scene, entity);
         }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
@@ -20,10 +20,11 @@ namespace DCL.ECSComponents
 
         // Flags to check if we can activate the video
         internal bool isRendererActive = false;
+        internal bool hadUserInteraction = false;
         internal bool isValidUrl = false;
 
         private readonly IInternalECSComponent<InternalVideoPlayer> videoPlayerInternalComponent;
-        private bool canVideoBePlayed => isRendererActive && isValidUrl;
+        private bool canVideoBePlayed => isRendererActive && hadUserInteraction && isValidUrl;
 
         public VideoPlayerHandler(
             IInternalECSComponent<InternalVideoPlayer> videoPlayerInternalComponent,
@@ -37,11 +38,18 @@ namespace DCL.ECSComponents
         {
             isRendererActive = !loadingScreen.visible.Get();
 
+            // We need to check if the user interacted with the application before playing the video,
+            // otherwise browsers won't play the video, ending up in a fake 'playing' state.
+            hadUserInteraction = Helpers.Utils.IsCursorLocked;
+
+            if (!hadUserInteraction)
+                Helpers.Utils.OnCursorLockChanged += OnCursorLockChanged;
             loadingScreen.visible.OnChange += OnLoadingScreenStateChanged;
         }
 
         public void OnComponentRemoved(IParcelScene scene, IDCLEntity entity)
         {
+            Helpers.Utils.OnCursorLockChanged -= OnCursorLockChanged;
             loadingScreen.visible.OnChange -= OnLoadingScreenStateChanged;
 
             // ECSVideoPlayerSystem.Update() will run a video events check before the component is removed
@@ -63,7 +71,6 @@ namespace DCL.ECSComponents
                 var id = entity.entityId.ToString();
 
                 VideoType videoType = VideoType.Common;
-
                 if (model.Src.StartsWith("livekit-video://"))
                     videoType = VideoType.LiveKit;
                 else if (!NO_STREAM_EXTENSIONS.Any(x => model.Src.EndsWith(x)))
@@ -74,12 +81,10 @@ namespace DCL.ECSComponents
                     : model.Src;
 
                 isValidUrl = !string.IsNullOrEmpty(videoUrl);
-
                 if (!isValidUrl)
                     return;
 
                 videoPlayer = new WebVideoPlayer(id, videoUrl, videoType, DCLVideoTexture.videoPluginWrapperBuilder.Invoke());
-
                 videoPlayerInternalComponent.PutFor(scene, entity, new InternalVideoPlayer()
                 {
                     videoPlayer = videoPlayer,
@@ -89,10 +94,8 @@ namespace DCL.ECSComponents
 
             // Apply model values except 'Playing'
             float lastPosition = lastModel?.GetPosition() ?? 0.0f;
-
             if (Math.Abs(lastPosition - model.GetPosition()) > 0.01f) // 0.01s of tolerance
                 videoPlayer.SetTime(model.GetPosition());
-
             videoPlayer.SetVolume(model.GetVolume());
             videoPlayer.SetPlaybackRate(model.GetPlaybackRate());
             videoPlayer.SetLoop(model.GetLoop());
@@ -107,7 +110,6 @@ namespace DCL.ECSComponents
             if (lastModel == null) return;
 
             bool shouldBePlaying = lastModel.IsPlaying() && canVideoBePlayed;
-
             if (shouldBePlaying != videoPlayer.playing)
             {
                 if (shouldBePlaying)
@@ -115,6 +117,15 @@ namespace DCL.ECSComponents
                 else
                     videoPlayer.Pause();
             }
+        }
+
+        private void OnCursorLockChanged(bool isLocked)
+        {
+            if (!isLocked) return;
+
+            hadUserInteraction = true;
+            Helpers.Utils.OnCursorLockChanged -= OnCursorLockChanged;
+            ConditionsToPlayVideoChanged();
         }
 
         private void OnLoadingScreenStateChanged(bool isScreenEnabled, bool prevState)


### PR DESCRIPTION
Re-added recently-removed browser-interaction checks for streaming video in web client.

Possibly those checks are not really needed for deployed scenes, but for preview-mode scenes those browser checks are still needed to be able to start playing the video streaming.

------------------------
## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f2a81e</samp>

This pull request adds user interaction requirement to video player handler component and updates its unit tests. It modifies `VideoPlayerHandler.cs` to check for cursor lock state before playing videos, and `VideoPlayerHandlerShould.cs` to test this new behavior. It also fixes some code style issues.

------------------------

## QA Test Instructions

1. Enter https://sdk-test-scenes.decentraland.zone/?position=78%2C-3&realm=LocalPreview&explorer-branch=fix/sdk7-web-client-streaming and wait until the world loads
2. lock the mouse so that you can move the camera and go close to the big cinema screen
3. Confirm that the video streaming keeps working, it should automatically start playing when you lock your mouse and move inside the scene
