### PR TITLE
style: update discover tab copies

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesSubSection/PlacesSubSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesSubSection/PlacesSubSection.prefab
@@ -432,7 +432,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 47, y: 30}
+  m_AnchoredPosition: {x: 47, y: 35}
   m_SizeDelta: {x: 42, y: 42}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &623369209086634543
@@ -901,8 +901,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 382.13397, y: -27}
-  m_SizeDelta: {x: 700.2679, y: 46}
+  m_AnchoredPosition: {x: 418.24573, y: -24}
+  m_SizeDelta: {x: 772.4914, y: 59}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9037340069108881467
 CanvasRenderer:
@@ -932,8 +932,10 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Genesis City is a massive open world created and owned by its community.
-    Make friends, play games, explore, and discover all Decentraland has to offer!
+  m_text: Decentraland's Genesis City map is made up of thousands of parcels owned
+    and populated with dynamic content by its diverse community. Browse through some
+    of the virtual world's most popular locations and jump directly to places of
+    interest.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -1037,7 +1039,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 148, y: 29}
+  m_AnchoredPosition: {x: 148, y: 34}
   m_SizeDelta: {x: 150, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7865865505972316471

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/WorldsSubSection/WorldsSubSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/WorldsSubSection/WorldsSubSection.prefab
@@ -145,8 +145,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 354.62994, y: -27}
-  m_SizeDelta: {x: 645.2599, y: 46}
+  m_AnchoredPosition: {x: 361.19177, y: -24}
+  m_SizeDelta: {x: 658.3835, y: 59.0881}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5414737497678830102
 CanvasRenderer:
@@ -176,9 +176,10 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "Claim your own corner of the Metaverse outside of Genesis City, where
-    you can build, experiment, host events\u2014whatever you want, it\u2019s your
-    World! "
+  m_text: With just a Decentraland NAME, you can claim your own World, a personal
+    3D space separate from Genesis City, where you can unleash your creativity, host
+    events, and more! Browse the directory and explore how others have used their
+    Worlds.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -582,7 +583,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 162, y: 29}
+  m_AnchoredPosition: {x: 162, y: 34}
   m_SizeDelta: {x: 260, y: 34}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3890308096992435626
@@ -1139,9 +1140,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Only Worlds belonging to LAND owners or renters appear here. The decision
-    was taken by the community through <color=#FF2D55><u><link="dao"><b>this DAO
-    proposal.</b></link></u></color>
+  m_text: Only Worlds belonging to LAND owners or renters appear here as per <color=#FF2D55><u><link="dao"><b>this
+    DAO proposal.</b></link></u></color>
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 6708c7eadd49b49f4ac3469e5104e7c9, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: dd1effe058ec94479a0dd10765262662, type: 2}
@@ -1517,7 +1517,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 800, y: -27}
+  m_AnchoredPosition: {x: 800, y: -21}
   m_SizeDelta: {x: 160, y: 46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4060694181056187896


### PR DESCRIPTION
This PR was created to update the banners' copies inside `Genesis City` and `Worlds` sub-sections of the Discover tab.

Genesis city banner now says
`Decentraland's Genesis City map is made up of thousands of parcels owned and populated with dynamic content by its diverse community. Browse through some of the virtual world's most popular locations and jump directly to places of interest.
`
Worlds banner now says
`With just a Decentraland NAME, you can claim your own World, a personal 3D space separate from Genesis City, where you can unleash your creativity, host events, and more! Browse the directory and explore how others have used their Worlds.`

DAO disclaimer now says
`For the text underneath it could say: Only Worlds belonging to LAND owners or renters appear here as per this DAO proposal.`

How to test this PR
1- Open this [link](https://play.decentraland.org/?explorer-branch=style/UpdateDiscoverCopy)
2- Ope the main menu and go to the Discover tab. Check that the copy in Genesis City's banner is the one quoted above.
3- Go to the Worlds tab and check that the copy in the banner and the DAO disclaimer are the ones quoted above.