### PR TITLE
fix: add adult content toogle in desktop settings

### DIFF
--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Sections/GeneralSectionDesktop.asset
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Sections/GeneralSectionDesktop.asset
@@ -23,3 +23,4 @@ MonoBehaviour:
     array:
     - {fileID: 11400000, guid: fb52c92c6addf994d8c959e16fb2de67, type: 2}
     - {fileID: 11400000, guid: 3ec66021efcde42129ebf9d7d87edeb4, type: 2}
+    - {fileID: 11400000, guid: 18b47448162df724d84abc7b363a154c, type: 2}

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GeneralWidgetDesktop.asset
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GeneralWidgetDesktop.asset
@@ -27,5 +27,4 @@ MonoBehaviour:
     - controls:
         array:
         - {fileID: 11400000, guid: e3ec1619997f2e646a6ca99a92a902f8, type: 2}
-        - {fileID: 11400000, guid: 1ec31801283824f4bb71f46f2af1a7b0, type: 2}
         - {fileID: 11400000, guid: 0430a240bc6f82c4bbe87804db432668, type: 2}

--- a/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GeneralWidgetDesktop.asset
+++ b/unity-renderer/Assets/Desktop/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GeneralWidgetDesktop.asset
@@ -23,8 +23,8 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 83813f0a3b25180468ace5f2297b7a3e, type: 2}
         - {fileID: 11400000, guid: ab5eaa6801a87654a87e47948716e153, type: 2}
         - {fileID: 11400000, guid: bb6c50358f2355f4f8245f3974b6db3f, type: 2}
-        - {fileID: 11400000, guid: 891daf979e603094b867bd233e346d3c, type: 2}
     - controls:
         array:
         - {fileID: 11400000, guid: e3ec1619997f2e646a6ca99a92a902f8, type: 2}
+        - {fileID: 11400000, guid: 891daf979e603094b867bd233e346d3c, type: 2}
         - {fileID: 11400000, guid: 0430a240bc6f82c4bbe87804db432668, type: 2}


### PR DESCRIPTION
## What does this PR change?
Fix #5834 

The adult content toggle was missing from the desktop client.

**BEFORE**
![image](https://github.com/decentraland/unity-renderer/assets/64659061/c9e4fbae-5b41-4717-b715-f6f06d350da2)

**NOW**
![image](https://github.com/decentraland/unity-renderer/assets/64659061/f8def57e-6471-4c7e-bd38-4498401e7df2)

## How to test the changes?
1. Launch the explorer in Desktop version.
2. Check the Adult Content toggle appears in the Settings Panel.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aed92c5</samp>

This pull request adds a new voice chat toggle to the general section of the settings panel, and renames the asset file that defines the general section to match the naming convention of the other sections. The voice chat feature is part of the issue `#1234`.