### PR TITLE
chore: sdk7 correct tween dictionary to be static

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Tween/ECSTweenHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Tween/ECSTweenHandler.cs
@@ -12,9 +12,7 @@ using static DG.Tweening.Ease;
 
 public class ECSTweenHandler : IECSComponentHandler<PBTween>
 {
-    private readonly IInternalECSComponent<InternalTween> internalTweenComponent;
-    private readonly IInternalECSComponent<InternalSceneBoundsCheck> sbcInternalComponent;
-    private readonly Dictionary<EasingFunction, Ease> easingFunctionsMap = new Dictionary<EasingFunction,Ease>()
+    private static readonly Dictionary<EasingFunction, Ease> easingFunctionsMap = new Dictionary<EasingFunction,Ease>()
     {
         [EfLinear] = Linear,
         [EfEaseinsine] = InSine,
@@ -48,6 +46,9 @@ public class ECSTweenHandler : IECSComponentHandler<PBTween>
         [EfEaseoutback] = OutBack,
         [EfEaseback] = InOutBack
     };
+
+    private readonly IInternalECSComponent<InternalTween> internalTweenComponent;
+    private readonly IInternalECSComponent<InternalSceneBoundsCheck> sbcInternalComponent;
 
     public ECSTweenHandler(IInternalECSComponent<InternalTween> internalTweenComponent, IInternalECSComponent<InternalSceneBoundsCheck> sbcInternalComponent)
     {


### PR DESCRIPTION
Corrected tween easing functions dictionary to be static.

## Copilot summary

copilot:summary
