### PR TITLE
style: add missing texture when hover map zoom button

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Prefabs/NavigationPanel.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Prefabs/NavigationPanel.prefab
@@ -906,7 +906,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 8ba9b271a894b4f8695979cdfe864b48, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 5c569e851fe024c7e8e4b57c07575226, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1


### PR DESCRIPTION
This PR fixes the missing texture when hover the zoom button in the nav map.

<img width="43" alt="Screenshot 2023-10-25 at 09 02 37" src="https://github.com/decentraland/unity-renderer/assets/51088292/203a11d6-1874-4104-bbc5-352caf60553d">

### How to test
1- Open this [link](https://play.decentraland.org/?explorer-branch=style/ZoomHoverTexture)
2- Open the nav map pressing [M] or tab
3- Hover the zoom in button in the nav map and check that the texture has been fixed. It should look like the following screenshot, not squared.
<img width="67" alt="Screenshot 2023-10-25 at 10 58 55" src="https://github.com/decentraland/unity-renderer/assets/51088292/59102143-1a48-445e-bf00-8f9f169cd4e7">
