### PR TITLE
fix: POI info button

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Prefabs/NavmapFilters.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/Prefabs/NavmapFilters.prefab
@@ -313,7 +313,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &5877066469086181843
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This branch is created to fix the missing info button next to the POI filter in the nav map. 
<img width="280" alt="Screenshot 2023-10-30 at 10 04 14" src="https://github.com/decentraland/unity-renderer/assets/51088292/0a015470-92e6-4f4e-be3b-99c2251e3025">

### How to test?
1- Open this [link](https://play.decentraland.org/?explorer-branch=fix/ToggleOnPoiInfo)
2- Open the Genesis City Map
3- Open the filters and check that the info button next to the POI filter is visible and the tooltip is shown when clicking it