### PR TITLE
fix: scene emotes not working

### DIFF
--- a/unity-renderer/Assets/DCLServices/EmotesService/EmotesService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesService/EmotesService.cs
@@ -136,7 +136,7 @@ namespace DCL.Emotes
             if (!emoteId.StartsWith("urn"))
                 return emotesCatalogService.RequestEmoteFromBuilderAsync(emoteId, ct);
 
-            WearableItem emoteItem = SceneEmoteHelper.TryGetDataFromEmoteId(emoteId, out string emoteHash, out bool loop) ? new EmoteItem(emoteId, emoteBodyId.BodyShapeId, emoteHash, catalyst.contentUrl, loop) : null;
+            WearableItem emoteItem = SceneEmoteHelper.TryGetDataFromEmoteId(emoteId, out string emoteHash, out bool loop) ? new EmoteItem(emoteBodyId.BodyShapeId, emoteId, emoteHash, catalyst.contentUrl, loop) : null;
 
             return new UniTask<WearableItem>(emoteItem);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/SceneEmoteHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/SceneEmoteHelper.cs
@@ -46,6 +46,6 @@ namespace AvatarAssets
         }
 
         public static bool IsSceneEmote(string emoteId) =>
-            emoteId.StartsWith(SCENE_EMOTE_PREFIX);
+            emoteId.Contains(SCENE_EMOTE_PREFIX, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugConfigComponent.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Debugging/DebugParameters/DebugConfigComponent.cs
@@ -39,6 +39,7 @@ namespace DCL
             ZONE,
             ORG,
             LOCAL_HOST,
+            SDK_TEST_SCENES,
             CUSTOM,
         }
 
@@ -188,6 +189,7 @@ namespace DCL
                     return;
                 }
             }
+            else if (baseUrlMode.Equals(BaseUrl.SDK_TEST_SCENES)) { baseUrl = "http://sdk-test-scenes.decentraland.zone/?"; }
             else
             {
                 baseUrl = "http://play.decentraland.zone/?";


### PR DESCRIPTION
## What does this PR change?

This will fix https://github.com/decentraland/unity-renderer/issues/5870

## How to test the changes?

[NOTE FOR QA] Please add this case to the testing plan, test scene is at `80,0` in `sdk-test-scenes.decentraland.zone`

- Go to https://sdk-test-scenes.decentraland.zone/?NETWORK=sepolia&position=80%2C0&realm=LocalPreview&explorer-branch=fix/scene-emotes
- Click the white cubes
- Animations should trigger

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd1c432</samp>

Added a new debug mode for testing scenes using the SDK and fixed some bugs and inconsistencies related to scene emotes. The changes affect the files `DebugConfigComponent.cs`, `EmotesService.cs`, and `SceneEmoteHelper.cs`.
