### PR TITLE
fix: preview mode crash on start

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentView.cs
@@ -52,7 +52,7 @@ namespace DCL.EmotesCustomization
         {
             emoteSlotSelector.RefreshControl();
             emotesGrid.RefreshControl();
-            columnsOrganizerComponentView.RefreshControl();
+            columnsOrganizerComponentView?.RefreshControl();
         }
 
         public override void Dispose()


### PR DESCRIPTION
* Added missing nullcheck since aparently in preview-mode/localhost the `columnsOrganizerComponentView` doesn't exist or is not initialized.
* This fixes the current broken state of the latest explorer release with any scene in preview-mode (it crashes and the world doesn't start in preview mode in localhost)

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95bb556</samp>

Fixed a potential null reference exception in the `EmotesCustomizationComponentView` class by making a field nullable. This improves the stability of the emotes customization UI.
