### PR TITLE
fix: sdk7 ui text position

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/UIAbstractElements/UIElementHandlerBase.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/UIAbstractElements/UIElementHandlerBase.cs
@@ -24,7 +24,14 @@ namespace DCL.ECSComponents.UIAbstractElements
         protected internal InternalUiContainer AddElementToRoot(IParcelScene scene, IDCLEntity entity, VisualElement uiElement)
         {
             var internalContainer = AddComponentToEntity(scene, entity);
+
             uiElement.pickingMode = PickingMode.Ignore;
+            if (internalContainer.rootElement.style.width.keyword == StyleKeyword.Auto
+                || internalContainer.rootElement.style.height.keyword == StyleKeyword.Auto)
+            {
+                uiElement.style.position = new StyleEnum<Position>(Position.Relative);
+            }
+
             internalContainer.rootElement.Add(uiElement);
             return internalContainer;
         }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Utils/UiElementUtils.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Utils/UiElementUtils.cs
@@ -10,7 +10,7 @@ public static class UiElementUtils
         elementStyle.bottom = 0;
         elementStyle.width = new StyleLength(StyleKeyword.Auto);
         elementStyle.height = new StyleLength(StyleKeyword.Auto);
-        elementStyle.position = new StyleEnum<Position>(Position.Relative);
+        elementStyle.position = new StyleEnum<Position>(Position.Absolute);
         elementStyle.justifyContent = new StyleEnum<Justify>(Justify.Center);
         elementStyle.alignItems = new StyleEnum<Align>(Align.Center);
     }


### PR DESCRIPTION
* Reverted initial position type for ui text
* Added position type update based on root element

-------------------------

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2cf7646</samp>

Refactor the UI system to fix layout issues and simplify UI element creation. Change the default position of UI elements to absolute and add a condition for auto width or height in `UIElementHandlerBase.cs`. Move the `SetElementDefaultStyle` method from `UiElementUtils.cs` to `UIElementHandlerBase.cs`.

-------------------------

### QA TEST INSTRUCTIONS

1. Enter the the residence tower at https://play.decentraland.org/?realm=main&position=116%2C-26&explorer-branch=fix/sdk7-ui-text-position
2. Enter the lobby and click on the "Elevator" button you'll see in the scene UI
3. Confirm the "Bar" button text is centered in the new panel that opens
4. If you test the same with https://play.decentraland.org/?realm=main&position=116%2C-26 (production build) you'll see it's not centered, so it's wrong in production.

<img width="1006" alt="Screen Shot 2023-11-01 at 15 32 50" src="https://github.com/decentraland/unity-renderer/assets/1031741/35fad44e-1a41-4cb5-b17a-eea129b02881">
