### PR TITLE
add: two more default scene permissions

### DIFF
--- a/browser-interface/packages/shared/apis/host/Permissions.ts
+++ b/browser-interface/packages/shared/apis/host/Permissions.ts
@@ -12,7 +12,9 @@ import type { PortContext } from './context'
 export const defaultParcelPermissions: PermissionItem[] = [
   PermissionItem.PI_USE_WEB3_API,
   PermissionItem.PI_USE_FETCH,
-  PermissionItem.PI_USE_WEBSOCKET
+  PermissionItem.PI_USE_WEBSOCKET,
+  PermissionItem.PI_ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE,
+  PermissionItem.PI_ALLOW_TO_TRIGGER_AVATAR_EMOTE
 ]
 export const defaultPortableExperiencePermissions: PermissionItem[] = []
 


### PR DESCRIPTION
## How to test the changes?
Non-px scenes should always be able to trigger emotes/move the player

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b6ae3a</samp>

Added new scene permissions for portable experiences. The file `Permissions.ts` defines two new permissions that allow scenes to move the player and trigger avatar emotes.
