### PR TITLE
fix: base wearables loading from incorrect catalyst

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfileController.cs
@@ -1,11 +1,9 @@
 using Cysharp.Threading.Tasks;
 using DCL.Interface;
 using DCL.UserProfiles;
-using DCLServices.WearablesCatalogService;
 using System;
 using JetBrains.Annotations;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using UnityEngine;
 
@@ -22,7 +20,6 @@ public class UserProfileController : MonoBehaviour
     private readonly Dictionary<string, UniTaskCompletionSource<UserProfile>> pendingUserProfileTasks = new (StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, UniTaskCompletionSource<UserProfile>> saveProfileTask = new ();
     private readonly List<WebInterface.SaveLinksPayload.Link> linkList = new ();
-    private bool baseWearablesAlreadyRequested;
 
     public static UserProfileDictionary userProfilesCatalog
     {
@@ -50,25 +47,9 @@ public class UserProfileController : MonoBehaviour
     [PublicAPI]
     public void LoadProfile(string payload)
     {
-        async UniTaskVoid RequestBaseWearablesAsync(CancellationToken ct)
-        {
-            try
-            {
-                await DCL.Environment.i.serviceLocator.Get<IWearablesCatalogService>().RequestBaseWearablesAsync(ct);
-            }
-            catch (Exception e)
-            {
-                OnBaseWereablesFail?.Invoke();
-                Debug.LogError(e.Message);
-            }
-        }
-
-        if (!baseWearablesAlreadyRequested)
-        {
-            baseWearablesAlreadyRequested = true;
-            RequestBaseWearablesAsync(CancellationToken.None).Forget();
-        }
-
+        // We used to request base wearables here but it raises race condition issues
+        // The current realm is not set yet thus ends up requesting wearables to an incorrect catalyst's content url
+        // Resolving inconsistent wearables information
         if (payload == null)
             return;
 


### PR DESCRIPTION
## What does this PR change?

Fixes a race condition when getting base wearables.
The base wearable collection request has been removed when loading the profile for the first time. The current realm url was not set by then (via kernel), so a request was performed to the wrong realm, provoking inconsistencies in the base wearables.

## How to test the changes?

1. Add `&CATALYST=https://peer-testing-3.decentraland.org` url param
2. Check that all wearables are loaded as expected, specially base wearables (your avatar, people around you, backpack, etc)
3. Remove the `&CATALYST` param
4. Check that all wearables are loaded as expected, specially base wearables (your avatar, people around you, backpack, etc)
5. Check that the first time avatar creation flow works as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ec2059</samp>

Improved user profile loading by removing unnecessary and error-prone code. Simplified `UserProfileController` and fixed base wearables issues.
