### PR TITLE
fix hot reload for smart wearables

### DIFF
--- a/browser-interface/packages/unity-interface/dcl.ts
+++ b/browser-interface/packages/unity-interface/dcl.ts
@@ -15,7 +15,7 @@ import { traceDecoratorUnityGame } from './trace'
 import defaultLogger from 'lib/logger'
 import { ContentMapping, EntityType, Scene, sdk } from '@dcl/schemas'
 import { ensureMetaConfigurationInitialized } from 'shared/meta'
-import { reloadScenePortableExperience } from 'shared/portableExperiences/actions'
+import { denyPortableExperiences, reloadScenePortableExperience } from 'shared/portableExperiences/actions'
 import { wearableToSceneEntity } from 'shared/wearablesPortableExperience/sagas'
 import { fetchScenesByLocation } from 'shared/scene-loader/sagas'
 import { sleep } from 'lib/javascript/sleep'
@@ -149,7 +149,7 @@ export async function loadPreviewScene(message: sdk.Messages) {
   }
 
   if (message.type === sdk.SCENE_UPDATE && sdk.SceneUpdate.validate(message)) {
-    if (message.payload.sceneType === sdk.ProjectType.PORTABLE_EXPERIENCE) {
+    if ([sdk.ProjectType.PORTABLE_EXPERIENCE, 'smart-wearable'].includes(message.payload.sceneType)) {
       try {
         const { sceneId } = message.payload
         const url = `${rootURLPreviewMode()}/preview-wearables/${sceneId}`
@@ -159,7 +159,7 @@ export async function loadPreviewScene(message: sdk.Messages) {
           const wearable = collection.data[0]
 
           const entity = await wearableToSceneEntity(wearable, wearable.baseUrl)
-
+          store.dispatch(denyPortableExperiences([]))
           store.dispatch(reloadScenePortableExperience(entity))
         }
       } catch (err) {


### PR DESCRIPTION
Fix hot reload for smart wearables.

It doesnt change any code that can be reached at play.decentraland.org.

It changes only a piece of code that is being called only with the Preivew mode

### how to test
- create a smart wearable
- install this version of the sdk https://github.com/decentraland/js-sdk-toolchain/pull/822#issuecomment-1789569493
- run npm start and when the explorer opens, add the following param to the url `&explorer-branch=fix/sw-hot-reload`