### PR TITLE
fix: content moderation visual fixes

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/AdultContentSceneWarningComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/AdultContentSceneWarningComponentView.cs
@@ -14,7 +14,7 @@ namespace DCL.ContentModeration
         [SerializeField] internal TMP_Text subTitle;
 
         private const string RESTRICTED_MODE_SUBTITLE = "This scene has been restricted by our community as it potentially contains prohibited content for the users.";
-        private const string ADULT_MODE_SUBTITLE = "This Scene has been flagged by our community as NSFW and it may contain adult or inappropriate content for some users. Please confirm your age at Settings Screen.";
+        private const string ADULT_MODE_SUBTITLE = @"This scene has been flagged by the community as containing 18+ Adult content that may be inappropriate for some users.\n\nTo see this and other Adult-rated scenes, please confirm your choice under 'Adult Content' in the General Settings.";
 
         public event Action OnGoToSettingsClicked;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/AdultContentAgeConfirmationHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/AdultContentAgeConfirmationHUD.prefab
@@ -301,7 +301,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: -114}
-  m_SizeDelta: {x: 350, y: 42}
+  m_SizeDelta: {x: 365, y: 42}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &8341230880218497641
 CanvasRenderer:
@@ -331,7 +331,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "You\u2019re about to unhide restricted content"
+  m_text: You're about to unhide 18+ Adult  content
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -436,7 +436,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: -175}
-  m_SizeDelta: {x: 340, y: 40}
+  m_SizeDelta: {x: 346, y: 40}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &6012879981614711902
 CanvasRenderer:
@@ -466,7 +466,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: To proceed you must confirm that you are over 18 years old.
+  m_text: To proceed, you must confirm that you are 18 years old or older.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 6708c7eadd49b49f4ac3469e5104e7c9, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: dd1effe058ec94479a0dd10765262662, type: 2}
@@ -932,7 +932,7 @@ PrefabInstance:
     - target: {fileID: 3005862737368832046, guid: 364e5896a70df11418dc18e8fa2049c7,
         type: 3}
       propertyPath: m_text
-      value: Yes, I am over 18 years old
+      value: Yes, I am at least 18 years old
       objectReference: {fileID: 0}
     - target: {fileID: 3005862737368832046, guid: 364e5896a70df11418dc18e8fa2049c7,
         type: 3}
@@ -1023,7 +1023,7 @@ PrefabInstance:
     - target: {fileID: 6128774804984969185, guid: 364e5896a70df11418dc18e8fa2049c7,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 237.8589
+      value: 253
       objectReference: {fileID: 0}
     - target: {fileID: 6128774804984969185, guid: 364e5896a70df11418dc18e8fa2049c7,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/AdultContentEnabledNotificationHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/AdultContentEnabledNotificationHUD.prefab
@@ -38,7 +38,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: -8}
-  m_SizeDelta: {x: 260, y: 50}
+  m_SizeDelta: {x: 312, y: 50}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &7847998442851674573
 CanvasRenderer:
@@ -123,10 +123,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3323986123616139294}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -117, y: 4}
-  m_SizeDelta: {x: 202, y: 15}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 13, y: 4}
+  m_SizeDelta: {x: -58, y: -35}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6827564703544619728
 CanvasRenderer:
@@ -156,7 +156,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Adult content is now enabled.
+  m_text: 18+ Adult Content will now be visible.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/AdultContentSceneWarningHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/AdultContentSceneWarningHUD.prefab
@@ -43,7 +43,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 430, y: 400}
+  m_SizeDelta: {x: 430, y: 437}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5026964471211828302
 CanvasRenderer:
@@ -533,7 +533,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -173}
-  m_SizeDelta: {x: -80, y: 97.9967}
+  m_SizeDelta: {x: -80, y: 150}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &7716796331833123203
 CanvasRenderer:
@@ -563,9 +563,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: This scene has been flagged by our community as NSFW, meaning that it may
-    contain adult or inappropriate content for some users. To see this type of scenes
-    enable adult content filter in Settings.
+  m_text: This scene has been flagged by the community as containing 18+ Adult content
+    that may be inappropriate for some users.\n\nTo see this and other Adult-rated
+    scenes, please confirm your choice under 'Adult Content' in the General Settings.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 6708c7eadd49b49f4ac3469e5104e7c9, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: dd1effe058ec94479a0dd10765262662, type: 2}
@@ -600,7 +600,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -1330,7 +1330,8 @@ PrefabInstance:
         type: 3}
       propertyPath: m_sharedMaterial
       value: 
-      objectReference: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
+      objectReference: {fileID: -1532326820724739884, guid: 6b705423dc77d4fceb4122f6d7e571d6,
+        type: 2}
     - target: {fileID: 4469143239268576428, guid: df2ca57878cc0834088cff37f213e619,
         type: 3}
       propertyPath: m_enableAutoSizing
@@ -1536,7 +1537,8 @@ PrefabInstance:
         type: 3}
       propertyPath: m_sharedMaterial
       value: 
-      objectReference: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
+      objectReference: {fileID: -1532326820724739884, guid: 6b705423dc77d4fceb4122f6d7e571d6,
+        type: 2}
     - target: {fileID: 4469143239268576428, guid: df2ca57878cc0834088cff37f213e619,
         type: 3}
       propertyPath: m_enableAutoSizing
@@ -1742,7 +1744,8 @@ PrefabInstance:
         type: 3}
       propertyPath: m_sharedMaterial
       value: 
-      objectReference: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
+      objectReference: {fileID: -1532326820724739884, guid: 6b705423dc77d4fceb4122f6d7e571d6,
+        type: 2}
     - target: {fileID: 4469143239268576428, guid: df2ca57878cc0834088cff37f213e619,
         type: 3}
       propertyPath: m_enableAutoSizing

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/ContentModerationRatingButton.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/ContentModerationRatingButton.prefab
@@ -836,7 +836,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: CURRENT RATE
+  m_text: CURRENT RATING
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 6b705423dc77d4fceb4122f6d7e571d6, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 9d9df32282a3c40299019c36b2157d37, type: 2}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/ContentModerationReportingHUD.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ContentModerationHUD/Prefabs/ContentModerationReportingHUD.prefab
@@ -1347,7 +1347,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: REPORT RATING
+  m_text: FLAG FOR REVIEW
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 1196159134475820439, guid: a02669827dd9144f39b4b164e753a21a,
@@ -1486,7 +1486,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: d254a3a3b9d5642e1ad6432c441d7f43, type: 3}
+  m_Sprite: {fileID: 21300000, guid: f02af068e11cb4902a1a4faad10b890a, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3490,7 +3490,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8120350213068474246}
   m_HandleRect: {fileID: 5331743487443924042}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -4244,21 +4244,21 @@ MonoBehaviour:
   reportSentModal: {fileID: 6783898561910975655}
   modalHeaderImage: {fileID: 2642339653663756838}
   teenHeaderSprite: {fileID: 21300000, guid: 60d50773a2ca4e240899c9b43cd770d7, type: 3}
-  teenOptionTitle: PG 13+ TEENS
-  teenOptionSubtitle: Content for everyone in the Metaverse
+  teenOptionTitle: PG 13+ TEEN
+  teenOptionSubtitle: Content for everyone in the metaverse
   teenOptions:
   - Moderate Violence
   - Suggestive or Horror-Themed
   - Frequent or Intense Cartoons
   - Simulated Gambling
   - Mild Language
-  teenDescription: "Scenarios in this category may contain mild or infrequent occurrences
+  teenDescription: Scenes in this category may contain mild or infrequent occurrences
     of cartoon, fantasy, or realistic violence, as well as infrequent or mild mature,
-    suggestive, or horror-themed content.\L\LAll content is in line with Decentraland's
-    terms, which require users to be 13 or older."
+    suggestive, or horror-themed content.\n\nAll content is in line with Decentraland's
+    terms and conditions, which require users to be 13 or older.
   adultHeaderSprite: {fileID: 21300000, guid: 93e14674749996744b80c0f1bae996f3, type: 3}
-  adultOptionTitle: PG 18+ ADULTS
-  adultOptionSubtitle: Categorized as NSFW
+  adultOptionTitle: PG 18+ ADULT
+  adultOptionSubtitle: Content categorized as NSFW
   adultOptions:
   - Intense Offensive Language
   - Graphic Violence
@@ -4267,11 +4267,11 @@ MonoBehaviour:
   - Alcohol, Tobacco and Drugs
   adultDescription: Content in this category is intended for mature audiences and
     may include strong language, graphic violence, or explicit themes. Users should
-    be 18 or older to access these scenes, as per Decentraland's guidelines.
+    be 18 or older to access these scenes, as per Decentraland's Terms & Conditions.
   restrictedHeaderSprite: {fileID: 21300000, guid: 93e1efcab17a8de4ba733f92f79f6a5e,
     type: 3}
-  restrictedOptionTitle: BLOCKED CONTENT
-  restrictedOptionSubtitle: "Content that shouldn\u2019t exist in DCL"
+  restrictedOptionTitle: RESTRICTED
+  restrictedOptionSubtitle: "Content that shouldn\u2019t exist in Decentraland"
   restrictedOptions:
   - Suspicious content or spam
   - Abusive or hateful content
@@ -4281,7 +4281,7 @@ MonoBehaviour:
   - Promotion of terrorism / violence
   - IP / Copyright infringement
   restrictedDescription: This scene contains content that violates Decentraland's
-    community standards. It may include harmful or illegal activities such as harassment,
+    Terms & Conditions. It may include harmful or illegal activities such as harassment,
     hate speech, or promotion of violence.
   optionButtonPrefab: {fileID: 288046275904441194, guid: 6cc071fca6faf1b47b25479682dad8d2,
     type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/PlayersNameOpacityControlConfiguration.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/PlayersNameOpacityControlConfiguration.asset
@@ -12,13 +12,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 060c1aa63ccfe124aa3cd640f9286a0b, type: 3}
   m_Name: PlayersNameOpacityControlConfiguration
   m_EditorClassIdentifier: 
-  title: PLAYER'S NAME TRANSPARENCY
+  title: PLAYER NAME TRANSPARENCY
   controlPrefab: {fileID: 6783608136250682537, guid: b07edc69073d61d4bbfb5c70a6b0c833,
     type: 3}
   controlController: {fileID: 11400000, guid: 1eecd579566f32e41afc8b05f07fe083, type: 2}
   flagsThatDisableMe: []
   flagsThatDeactivateMe: []
+  flagsThatOverrideMe: []
   isBeta: 0
+  infoButtonEnabled: 0
+  infoTooltipMessage: 
   sliderMinValue: 0.2
   sliderMaxValue: 1
   storeValueAsNormalized: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/ScenesLoadRadiusControlConfiguration.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Configuration/Controls/ScenesLoadRadiusControlConfiguration.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 060c1aa63ccfe124aa3cd640f9286a0b, type: 3}
   m_Name: ScenesLoadRadiusControlConfiguration
   m_EditorClassIdentifier: 
-  title: SCENES LOAD RADIUS
+  title: SCENE LOAD RADIUS
   controlPrefab: {fileID: 6783608136250682537, guid: b07edc69073d61d4bbfb5c70a6b0c833,
     type: 3}
   controlController: {fileID: 11400000, guid: a5617d48f1af04692a0965b6ff232360, type: 2}
@@ -20,6 +20,8 @@ MonoBehaviour:
   flagsThatDeactivateMe: []
   flagsThatOverrideMe: []
   isBeta: 0
+  infoButtonEnabled: 0
+  infoTooltipMessage: 
   sliderMinValue: 1
   sliderMaxValue: 4
   storeValueAsNormalized: 0


### PR DESCRIPTION
## What does this PR change?
Some visual fixes (most of them were changes in the texts or typo fixes) in the Content Moderation feature.

## How to test the changes?
The content moderation feature should work as usual and some of this texts should be fixed.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69274a8</samp>

Updated the HUDs and assets related to content moderation, adult content, and settings panel. These changes improve the user interface, the terminology, and the information provided for these features. Some examples of the updated HUDs and assets are `AdultContentAgeConfirmationHUD.prefab`, `ContentModerationReportingHUD.prefab`, and `ScenesLoadRadiusControlConfiguration.asset`.