### PR TITLE
style: re assign missing textures

### DIFF
--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Prefabs/ScreencaptureCameraHUD.prefab
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Prefabs/ScreencaptureCameraHUD.prefab
@@ -31,7 +31,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 405257682719442040}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -115,7 +114,6 @@ RectTransform:
   - {fileID: 8473048732125248195}
   - {fileID: 7984025021315486629}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -139,7 +137,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 100
   m_TargetDisplay: 0
@@ -239,7 +239,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 405257682719442040}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -315,7 +314,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 405257682719442040}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -391,7 +389,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4366054808357660216}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -467,7 +464,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7820822127358193561}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -548,7 +544,6 @@ RectTransform:
   - {fileID: 2982959380832845940}
   - {fileID: 4366054808357660216}
   m_Father: {fileID: 405257682719442040}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -594,7 +589,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8473048732125248195}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -670,7 +664,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 405257682719442040}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -720,6 +713,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 8473048732125248195}
     m_Modifications:
     - target: {fileID: 1193564214144687899, guid: 2198f3202dd33b64db604a96577bb96d,
@@ -1056,6 +1050,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 1152765964377708402, guid: 2198f3202dd33b64db604a96577bb96d, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2198f3202dd33b64db604a96577bb96d, type: 3}
 --- !u!224 &2480688633886466177 stripped
 RectTransform:
@@ -1086,6 +1083,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 8473048732125248195}
     m_Modifications:
     - target: {fileID: 755178142233910029, guid: 2198f3202dd33b64db604a96577bb96d,
@@ -1452,6 +1450,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 1152765964377708402, guid: 2198f3202dd33b64db604a96577bb96d, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2198f3202dd33b64db604a96577bb96d, type: 3}
 --- !u!224 &2935990045080443031 stripped
 RectTransform:
@@ -1488,6 +1489,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 405257682719442040}
     m_Modifications:
     - target: {fileID: 54622623229548845, guid: fb037d81b9c10ad439a13e356a17bab6,
@@ -1782,6 +1784,9 @@ PrefabInstance:
     - {fileID: 4469143239268576428, guid: fb037d81b9c10ad439a13e356a17bab6, type: 3}
     - {fileID: 7703451836026012201, guid: fb037d81b9c10ad439a13e356a17bab6, type: 3}
     - {fileID: 1727543226122190079, guid: fb037d81b9c10ad439a13e356a17bab6, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fb037d81b9c10ad439a13e356a17bab6, type: 3}
 --- !u!224 &1697131806563610462 stripped
 RectTransform:
@@ -1806,6 +1811,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 8473048732125248195}
     m_Modifications:
     - target: {fileID: 471081646976459722, guid: 0282a050c09634ed299130b8e9c2c035,
@@ -1816,7 +1822,7 @@ PrefabInstance:
     - target: {fileID: 471081646976459722, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 471081646976459722, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
@@ -1826,7 +1832,7 @@ PrefabInstance:
     - target: {fileID: 471081646976459722, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 471081646976459722, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
@@ -1836,12 +1842,12 @@ PrefabInstance:
     - target: {fileID: 471081646976459722, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 50
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 471081646976459722, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -3.7999878
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 723221196117829797, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
@@ -1999,7 +2005,7 @@ PrefabInstance:
     - target: {fileID: 3460499450308197912, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3803351338888378958, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
@@ -2015,7 +2021,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 7b4468575e3ab49e1aec3edd88298137,
+      objectReference: {fileID: 21300000, guid: f02af068e11cb4902a1a4faad10b890a,
         type: 3}
     - target: {fileID: 4507316053449197995, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
@@ -2208,6 +2214,13 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 8135970575246782683, guid: 0282a050c09634ed299130b8e9c2c035,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6669107687706767491}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0282a050c09634ed299130b8e9c2c035, type: 3}
 --- !u!1 &4723773448384396983 stripped
 GameObject:
@@ -2232,6 +2245,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 8473048732125248195}
     m_Modifications:
     - target: {fileID: 54622623229548845, guid: fb037d81b9c10ad439a13e356a17bab6,
@@ -2541,6 +2555,13 @@ PrefabInstance:
     - {fileID: 4469143239268576428, guid: fb037d81b9c10ad439a13e356a17bab6, type: 3}
     - {fileID: 7703451836026012201, guid: fb037d81b9c10ad439a13e356a17bab6, type: 3}
     - {fileID: 1727543226122190079, guid: fb037d81b9c10ad439a13e356a17bab6, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 54622623229548845, guid: fb037d81b9c10ad439a13e356a17bab6,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7567935981303909629}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fb037d81b9c10ad439a13e356a17bab6, type: 3}
 --- !u!224 &4366054808357660216 stripped
 RectTransform:
@@ -2577,6 +2598,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 8473048732125248195}
     m_Modifications:
     - target: {fileID: 30168629310970904, guid: 7ed4827c381405e458c685420f6e002b,
@@ -2932,6 +2954,17 @@ PrefabInstance:
         type: 3}
       propertyPath: m_PreferredHeight
       value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 3489705711911365898, guid: 7ed4827c381405e458c685420f6e002b,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 4848194f7bc4d4e509d067d3160eadac,
+        type: 3}
+    - target: {fileID: 3489705711911365898, guid: 7ed4827c381405e458c685420f6e002b,
+        type: 3}
+      propertyPath: m_PixelsPerUnitMultiplier
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3539831530410630326, guid: 7ed4827c381405e458c685420f6e002b,
         type: 3}
@@ -3516,6 +3549,9 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7ed4827c381405e458c685420f6e002b, type: 3}
 --- !u!224 &2982959380832845940 stripped
 RectTransform:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/Realms/FriendHeadForRealmRow.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/Realms/FriendHeadForRealmRow.prefab
@@ -5,8 +5,19 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 353046624100911067, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 353046624100911067, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 749578138969952630, guid: b681cffe9673cf64482a6cb83368424d,
         type: 3}
       propertyPath: m_Alpha
@@ -52,6 +63,16 @@ PrefabInstance:
       propertyPath: m_Name
       value: FriendHeadForRealmRow
       objectReference: {fileID: 0}
+    - target: {fileID: 2523372156645421838, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 2523372156645421838, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 2683651743952150219, guid: b681cffe9673cf64482a6cb83368424d,
         type: 3}
       propertyPath: m_ChildAlignment
@@ -69,8 +90,29 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2779385022219802126, guid: b681cffe9673cf64482a6cb83368424d,
         type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f02af068e11cb4902a1a4faad10b890a,
+        type: 3}
+    - target: {fileID: 2779385022219802126, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
       propertyPath: m_Enabled
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2779385022219802126, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_PixelsPerUnitMultiplier
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2833658273570704779, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 2833658273570704779, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 4141139218842272861, guid: b681cffe9673cf64482a6cb83368424d,
         type: 3}
@@ -111,6 +153,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5122942420635131921, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5122942420635131921, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5122942420635131921, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7105173608688509660, guid: b681cffe9673cf64482a6cb83368424d,
         type: 3}
@@ -219,6 +276,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 7087135779539621020, guid: b681cffe9673cf64482a6cb83368424d, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 6576774084062198450, guid: b681cffe9673cf64482a6cb83368424d,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8558153756387205110}
   m_SourcePrefab: {fileID: 100100000, guid: b681cffe9673cf64482a6cb83368424d, type: 3}
 --- !u!1 &6129381980265396260 stripped
 GameObject:
@@ -243,7 +307,9 @@ Canvas:
   m_OverrideSorting: 1
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 100
   m_TargetDisplay: 0


### PR DESCRIPTION
This PR was created to fix the missing textures in the ScreenshotCameraHUD and in Friends for realms.

<img width="703" alt="Screenshot 2023-11-07 at 14 35 33" src="https://github.com/decentraland/unity-renderer/assets/51088292/ee9db6a0-9a7d-454e-a79e-4f6ff4211242">

<img width="689" alt="Screenshot 2023-11-07 at 14 35 28" src="https://github.com/decentraland/unity-renderer/assets/51088292/56296637-3c8e-46ed-ac18-b3e168c09cad">

### How to test?
1- Open this link
2- Open the camera mode pressing [C] or clicking the camera icon in the HUD
3- Check that the key texture, the outlined container, is visible instead of a blank square.
4- Take as many pictures as you can to reach the camera reel storage limit and evaluate that the background container corners are rounded.
5- Then go to the main menu and open the realms panel. Hover the face of one of your friends and check the name container corners are rounded.
