### PR TITLE
fix: streaming volume

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/DCL.ECSComponents.VideoPlayer.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/DCL.ECSComponents.VideoPlayer.asmdef
@@ -18,7 +18,8 @@
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:b24824f3bc2a60641a01e2083614f802"
+        "GUID:b24824f3bc2a60641a01e2083614f802",
+        "GUID:301149363e31a4bdaa1943465a825c8e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/DCL.ECSComponents.VideoPlayer.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/DCL.ECSComponents.VideoPlayer.asmdef
@@ -18,8 +18,7 @@
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:b24824f3bc2a60641a01e2083614f802",
-        "GUID:301149363e31a4bdaa1943465a825c8e"
+        "GUID:b24824f3bc2a60641a01e2083614f802"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/DCL.ECSComponents.VideoPlayer.Tests.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/DCL.ECSComponents.VideoPlayer.Tests.asmdef
@@ -31,7 +31,8 @@
         "GUID:ac62e852826a4b36aeb22931dad73edb",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:28f74c468a54948bfa9f625c5d428f56"
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:301149363e31a4bdaa1943465a825c8e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/DCL.ECSComponents.VideoPlayer.Tests.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/DCL.ECSComponents.VideoPlayer.Tests.asmdef
@@ -31,8 +31,7 @@
         "GUID:ac62e852826a4b36aeb22931dad73edb",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:301149363e31a4bdaa1943465a825c8e"
+        "GUID:28f74c468a54948bfa9f625c5d428f56"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -1,4 +1,3 @@
-/*
 using DCL;
 using DCL.Components;
 using DCL.Components.Video.Plugin;
@@ -7,12 +6,15 @@ using DCL.ECS7.InternalComponents;
 using DCL.ECSComponents;
 using DCL.ECSRuntime;
 using DCL.Models;
+using DCL.SettingsCommon;
+using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.TestTools;
+using AudioSettings = DCL.SettingsCommon.AudioSettings;
 using Environment = DCL.Environment;
 using VideoState = DCL.Components.Video.Plugin.VideoState;
 
@@ -44,7 +46,9 @@ namespace Tests
             internalVideoPlayerComponent = internalComponents.videoPlayerComponent;
             videoPlayerHandler = new VideoPlayerHandler(
                 internalVideoPlayerComponent,
-                loadingScreenDataStore.decoupledLoadingHUD, null, null);
+                loadingScreenDataStore.decoupledLoadingHUD,
+                Substitute.For<ISettingsRepository<AudioSettings>>(),
+                new DataStore_VirtualAudioMixer());
 
             testUtils = new ECS7TestUtilsScenesAndEntities(componentsManager, executors);
             scene = testUtils.CreateScene(666);
@@ -268,4 +272,3 @@ namespace Tests
         }
     }
 }
-*/

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -30,6 +30,8 @@ namespace Tests
         private ECS7TestScene scene;
         private ECS7TestEntity entity;
         private DataStore_LoadingScreen loadingScreenDataStore;
+        private DataStore_VirtualAudioMixer virtualAudioMixerDatastore;
+        private ISettingsRepository<AudioSettings> audioSettingsRepository;
 
         [SetUp]
         public void SetUp()
@@ -44,11 +46,23 @@ namespace Tests
             var executors = new Dictionary<int, ICRDTExecutor>();
             var internalComponents = new InternalECSComponents(componentsManager, componentsFactory, executors);
             internalVideoPlayerComponent = internalComponents.videoPlayerComponent;
+
+            virtualAudioMixerDatastore = new DataStore_VirtualAudioMixer();
+            virtualAudioMixerDatastore.sceneSFXVolume.Set(1);
+
+            audioSettingsRepository = Substitute.For<ISettingsRepository<AudioSettings>>();
+
+            audioSettingsRepository.Data.Returns(new AudioSettings
+            {
+                masterVolume = 1,
+                sceneSFXVolume = 1,
+            });
+
             videoPlayerHandler = new VideoPlayerHandler(
                 internalVideoPlayerComponent,
                 loadingScreenDataStore.decoupledLoadingHUD,
-                Substitute.For<ISettingsRepository<AudioSettings>>(),
-                new DataStore_VirtualAudioMixer());
+                audioSettingsRepository,
+                virtualAudioMixerDatastore);
 
             testUtils = new ECS7TestUtilsScenesAndEntities(componentsManager, executors);
             scene = testUtils.CreateScene(666);
@@ -136,6 +150,48 @@ namespace Tests
             Assert.AreEqual(videoPlayerHandler.videoPlayer.url, "other-video.mp4");
             Assert.AreEqual(videoPlayerHandler.videoPlayer.playing, true);
             Assert.AreEqual(videoPlayerHandler.videoPlayer.volume, 0.5f);
+        }
+
+        [UnityTest]
+        public IEnumerator VolumeUpdatesWhenSettingsAreChanged()
+        {
+            PBVideoPlayer model = new PBVideoPlayer
+            {
+                Src = "video.mp4",
+            };
+
+            videoPlayerHandler.OnComponentCreated(scene, entity);
+            videoPlayerHandler.OnComponentModelUpdated(scene, entity, model);
+            yield return new WaitUntil(() => videoPlayerHandler.videoPlayer.GetState() == VideoState.READY);
+            videoPlayerHandler.videoPlayer.Update();
+
+            Assert.AreEqual(videoPlayerHandler.videoPlayer.playing, false);
+            Assert.AreEqual(videoPlayerHandler.videoPlayer.volume, 1.0f);
+
+            audioSettingsRepository.OnChanged += Raise.Event<Action<AudioSettings>>(new AudioSettings
+            {
+                masterVolume = 0.5f,
+                sceneSFXVolume = 1,
+            });
+
+            Assert.AreEqual(0.5f, videoPlayerHandler.videoPlayer.volume);
+
+            audioSettingsRepository.OnChanged += Raise.Event<Action<AudioSettings>>(new AudioSettings
+            {
+                masterVolume = 0.25f,
+                sceneSFXVolume = 1,
+            });
+
+            Assert.AreEqual(0.25f, videoPlayerHandler.videoPlayer.volume);
+
+            audioSettingsRepository.OnChanged += Raise.Event<Action<AudioSettings>>(new AudioSettings
+            {
+                masterVolume = 1,
+                sceneSFXVolume = 1,
+            });
+            virtualAudioMixerDatastore.sceneSFXVolume.Set(0.1f, true);
+
+            Assert.AreEqual(0.1f, videoPlayerHandler.videoPlayer.volume);
         }
 
         [Test]

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -6,15 +6,12 @@ using DCL.ECS7.InternalComponents;
 using DCL.ECSComponents;
 using DCL.ECSRuntime;
 using DCL.Models;
-using DCL.SettingsCommon;
-using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.TestTools;
-using AudioSettings = DCL.SettingsCommon.AudioSettings;
 using Environment = DCL.Environment;
 using VideoState = DCL.Components.Video.Plugin.VideoState;
 
@@ -46,9 +43,7 @@ namespace Tests
             internalVideoPlayerComponent = internalComponents.videoPlayerComponent;
             videoPlayerHandler = new VideoPlayerHandler(
                 internalVideoPlayerComponent,
-                loadingScreenDataStore.decoupledLoadingHUD,
-                Substitute.For<ISettingsRepository<AudioSettings>>(),
-                new DataStore_VirtualAudioMixer());
+                loadingScreenDataStore.decoupledLoadingHUD);
 
             testUtils = new ECS7TestUtilsScenesAndEntities(componentsManager, executors);
             scene = testUtils.CreateScene(666);

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -6,12 +6,15 @@ using DCL.ECS7.InternalComponents;
 using DCL.ECSComponents;
 using DCL.ECSRuntime;
 using DCL.Models;
+using DCL.SettingsCommon;
+using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.TestTools;
+using AudioSettings = DCL.SettingsCommon.AudioSettings;
 using Environment = DCL.Environment;
 using VideoState = DCL.Components.Video.Plugin.VideoState;
 
@@ -43,7 +46,9 @@ namespace Tests
             internalVideoPlayerComponent = internalComponents.videoPlayerComponent;
             videoPlayerHandler = new VideoPlayerHandler(
                 internalVideoPlayerComponent,
-                loadingScreenDataStore.decoupledLoadingHUD);
+                loadingScreenDataStore.decoupledLoadingHUD,
+                Substitute.For<ISettingsRepository<AudioSettings>>(),
+                new DataStore_VirtualAudioMixer());
 
             testUtils = new ECS7TestUtilsScenesAndEntities(componentsManager, executors);
             scene = testUtils.CreateScene(666);

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -1,3 +1,4 @@
+/*
 using DCL;
 using DCL.Components;
 using DCL.Components.Video.Plugin;
@@ -6,15 +7,12 @@ using DCL.ECS7.InternalComponents;
 using DCL.ECSComponents;
 using DCL.ECSRuntime;
 using DCL.Models;
-using DCL.SettingsCommon;
-using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.TestTools;
-using AudioSettings = DCL.SettingsCommon.AudioSettings;
 using Environment = DCL.Environment;
 using VideoState = DCL.Components.Video.Plugin.VideoState;
 
@@ -46,9 +44,7 @@ namespace Tests
             internalVideoPlayerComponent = internalComponents.videoPlayerComponent;
             videoPlayerHandler = new VideoPlayerHandler(
                 internalVideoPlayerComponent,
-                loadingScreenDataStore.decoupledLoadingHUD,
-                Substitute.For<ISettingsRepository<AudioSettings>>(),
-                new DataStore_VirtualAudioMixer());
+                loadingScreenDataStore.decoupledLoadingHUD, null, null);
 
             testUtils = new ECS7TestUtilsScenesAndEntities(componentsManager, executors);
             scene = testUtils.CreateScene(666);
@@ -272,3 +268,4 @@ namespace Tests
         }
     }
 }
+*/

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
@@ -4,7 +4,6 @@ using DCL.Controllers;
 using DCL.ECS7.InternalComponents;
 using DCL.ECSRuntime;
 using DCL.Models;
-using DCL.SettingsCommon;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,8 +15,6 @@ namespace DCL.ECSComponents
         private static readonly string[] NO_STREAM_EXTENSIONS = new[] { ".mp4", ".ogg", ".mov", ".webm" };
 
         internal DataStore_LoadingScreen.DecoupledLoadingScreen loadingScreen;
-        private readonly ISettingsRepository<AudioSettings> audioSettings;
-        private readonly DataStore_VirtualAudioMixer audioMixerDataStore;
         internal PBVideoPlayer lastModel = null;
         internal WebVideoPlayer videoPlayer;
 
@@ -31,14 +28,10 @@ namespace DCL.ECSComponents
 
         public VideoPlayerHandler(
             IInternalECSComponent<InternalVideoPlayer> videoPlayerInternalComponent,
-            DataStore_LoadingScreen.DecoupledLoadingScreen loadingScreen,
-            ISettingsRepository<AudioSettings> audioSettings,
-            DataStore_VirtualAudioMixer audioMixerDataStore)
+            DataStore_LoadingScreen.DecoupledLoadingScreen loadingScreen)
         {
             this.videoPlayerInternalComponent = videoPlayerInternalComponent;
             this.loadingScreen = loadingScreen;
-            this.audioSettings = audioSettings;
-            this.audioMixerDataStore = audioMixerDataStore;
         }
 
         public void OnComponentCreated(IParcelScene scene, IDCLEntity entity)
@@ -103,13 +96,7 @@ namespace DCL.ECSComponents
             float lastPosition = lastModel?.GetPosition() ?? 0.0f;
             if (Math.Abs(lastPosition - model.GetPosition()) > 0.01f) // 0.01s of tolerance
                 videoPlayer.SetTime(model.GetPosition());
-
-            float virtualMixerVolume = audioMixerDataStore.sceneSFXVolume.Get();
-            AudioSettings audioSettings = this.audioSettings.Data;
-            float sceneSFXSetting = audioSettings.sceneSFXVolume;
-            float masterSetting = audioSettings.masterVolume;
-            float volume = Helpers.Utils.ToVolumeCurve(model.GetVolume() * virtualMixerVolume * sceneSFXSetting * masterSetting);
-            videoPlayer.SetVolume(volume);
+            videoPlayer.SetVolume(model.GetVolume());
             videoPlayer.SetPlaybackRate(model.GetPlaybackRate());
             videoPlayer.SetLoop(model.GetLoop());
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
@@ -8,6 +8,8 @@ using DCL.SettingsCommon;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
+using AudioSettings = DCL.SettingsCommon.AudioSettings;
 
 namespace DCL.ECSComponents
 {
@@ -108,7 +110,8 @@ namespace DCL.ECSComponents
             AudioSettings audioSettings = this.audioSettings.Data;
             float sceneSFXSetting = audioSettings.sceneSFXVolume;
             float masterSetting = audioSettings.masterVolume;
-            float volume = Helpers.Utils.ToVolumeCurve(model.GetVolume() * virtualMixerVolume * sceneSFXSetting * masterSetting);
+            float volume = model.GetVolume() * virtualMixerVolume * sceneSFXSetting * masterSetting;
+            Debug.Log($"VideoPlayerHandler.OnComponentModelUpdated.volume: {volume}, {model.GetVolume()}");
             videoPlayer.SetVolume(volume);
             videoPlayer.SetPlaybackRate(model.GetPlaybackRate());
             videoPlayer.SetLoop(model.GetLoop());

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
@@ -4,6 +4,7 @@ using DCL.Controllers;
 using DCL.ECS7.InternalComponents;
 using DCL.ECSRuntime;
 using DCL.Models;
+using DCL.SettingsCommon;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,6 +16,8 @@ namespace DCL.ECSComponents
         private static readonly string[] NO_STREAM_EXTENSIONS = new[] { ".mp4", ".ogg", ".mov", ".webm" };
 
         internal DataStore_LoadingScreen.DecoupledLoadingScreen loadingScreen;
+        private readonly ISettingsRepository<AudioSettings> audioSettings;
+        private readonly DataStore_VirtualAudioMixer audioMixerDataStore;
         internal PBVideoPlayer lastModel = null;
         internal WebVideoPlayer videoPlayer;
 
@@ -28,10 +31,14 @@ namespace DCL.ECSComponents
 
         public VideoPlayerHandler(
             IInternalECSComponent<InternalVideoPlayer> videoPlayerInternalComponent,
-            DataStore_LoadingScreen.DecoupledLoadingScreen loadingScreen)
+            DataStore_LoadingScreen.DecoupledLoadingScreen loadingScreen,
+            ISettingsRepository<AudioSettings> audioSettings,
+            DataStore_VirtualAudioMixer audioMixerDataStore)
         {
             this.videoPlayerInternalComponent = videoPlayerInternalComponent;
             this.loadingScreen = loadingScreen;
+            this.audioSettings = audioSettings;
+            this.audioMixerDataStore = audioMixerDataStore;
         }
 
         public void OnComponentCreated(IParcelScene scene, IDCLEntity entity)
@@ -96,7 +103,13 @@ namespace DCL.ECSComponents
             float lastPosition = lastModel?.GetPosition() ?? 0.0f;
             if (Math.Abs(lastPosition - model.GetPosition()) > 0.01f) // 0.01s of tolerance
                 videoPlayer.SetTime(model.GetPosition());
-            videoPlayer.SetVolume(model.GetVolume());
+
+            float virtualMixerVolume = audioMixerDataStore.sceneSFXVolume.Get();
+            AudioSettings audioSettings = this.audioSettings.Data;
+            float sceneSFXSetting = audioSettings.sceneSFXVolume;
+            float masterSetting = audioSettings.masterVolume;
+            float volume = Helpers.Utils.ToVolumeCurve(model.GetVolume() * virtualMixerVolume * sceneSFXSetting * masterSetting);
+            videoPlayer.SetVolume(volume);
             videoPlayer.SetPlaybackRate(model.GetPlaybackRate());
             videoPlayer.SetLoop(model.GetLoop());
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
@@ -109,7 +109,7 @@ namespace DCL.ECSComponents
             if (Math.Abs(lastPosition - model.GetPosition()) > 0.01f) // 0.01s of tolerance
                 videoPlayer.SetTime(model.GetPosition());
 
-            UpdateVolume(model);
+            UpdateVolume(model, audioSettings.Data, audioMixerDataStore.sceneSFXVolume.Get());
             videoPlayer.SetPlaybackRate(model.GetPlaybackRate());
             videoPlayer.SetLoop(model.GetLoop());
 
@@ -148,21 +148,19 @@ namespace DCL.ECSComponents
         }
 
         private void OnSceneSfxVolumeChanged(float current, float previous) =>
-            UpdateVolume(lastModel);
+            UpdateVolume(lastModel, audioSettings.Data, current);
 
-        private void OnAudioSettingsChanged(AudioSettings obj) =>
-            UpdateVolume(lastModel);
+        private void OnAudioSettingsChanged(AudioSettings settings) =>
+            UpdateVolume(lastModel, settings, audioMixerDataStore.sceneSFXVolume.Get());
 
-        private void UpdateVolume(PBVideoPlayer model)
+        private void UpdateVolume(PBVideoPlayer model, AudioSettings settings, float sceneMixerSfxVolume)
         {
             if (model == null) return;
             if (videoPlayer == null) return;
 
-            float virtualMixerVolume = audioMixerDataStore.sceneSFXVolume.Get();
-            AudioSettings audioSettings = this.audioSettings.Data;
-            float sceneSFXSetting = audioSettings.sceneSFXVolume;
-            float masterSetting = audioSettings.masterVolume;
-            float volume = model.GetVolume() * virtualMixerVolume * sceneSFXSetting * masterSetting;
+            float sceneSFXSetting = settings.sceneSFXVolume;
+            float masterSetting = settings.masterVolume;
+            float volume = model.GetVolume() * sceneMixerSfxVolume * sceneSFXSetting * masterSetting;
             videoPlayer.SetVolume(volume);
         }
     }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerRegister.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerRegister.cs
@@ -1,6 +1,6 @@
-using DCL.ECS7.InternalComponents;
 using System;
 using DCL.ECSRuntime;
+using DCL.SettingsCommon;
 
 namespace DCL.ECSComponents
 {
@@ -16,7 +16,9 @@ namespace DCL.ECSComponents
                 ProtoSerialization.Deserialize<PBVideoPlayer>,
                 () => new VideoPlayerHandler(
                     internalComponents.videoPlayerComponent,
-                    DataStore.i.Get<DataStore_LoadingScreen>().decoupledLoadingHUD));
+                    DataStore.i.Get<DataStore_LoadingScreen>().decoupledLoadingHUD,
+                    Settings.i.audioSettings,
+                    DataStore.i.virtualAudioMixer));
             componentWriter.AddOrReplaceComponentSerializer<PBVideoPlayer>(componentId, ProtoSerialization.Serialize);
 
             this.factory = factory;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerRegister.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerRegister.cs
@@ -1,6 +1,6 @@
+using DCL.ECS7.InternalComponents;
 using System;
 using DCL.ECSRuntime;
-using DCL.SettingsCommon;
 
 namespace DCL.ECSComponents
 {
@@ -16,9 +16,7 @@ namespace DCL.ECSComponents
                 ProtoSerialization.Deserialize<PBVideoPlayer>,
                 () => new VideoPlayerHandler(
                     internalComponents.videoPlayerComponent,
-                    DataStore.i.Get<DataStore_LoadingScreen>().decoupledLoadingHUD,
-                    Settings.i.audioSettings,
-                    DataStore.i.virtualAudioMixer));
+                    DataStore.i.Get<DataStore_LoadingScreen>().decoupledLoadingHUD));
             componentWriter.AddOrReplaceComponentSerializer<PBVideoPlayer>(componentId, ProtoSerialization.Serialize);
 
             this.factory = factory;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
@@ -52,7 +52,7 @@ namespace DCL.Components
                 if (pbModel.VideoTexture.HasSeek) pb.seek = pbModel.VideoTexture.Seek;
                 if (pbModel.VideoTexture.HasWrap) pb.wrap = (BabylonWrapMode)pbModel.VideoTexture.Wrap;
                 if (pbModel.VideoTexture.HasSamplingMode) pb.samplingMode = (FilterMode)pbModel.VideoTexture.SamplingMode;
-                
+
                 return pb;
             }
         }
@@ -307,8 +307,10 @@ namespace DCL.Components
                 float sceneSFXSetting = Settings.i.audioSettings.Data.sceneSFXVolume;
                 float masterSetting = Settings.i.audioSettings.Data.masterVolume;
                 targetVolume *= Utils.ToVolumeCurve(virtualMixerVolume * sceneSFXSetting * masterSetting);
+                Debug.Log($"DCLVideoTexture.UpdateVolume.IsPlayerInSameSceneAsComponent.targetVolume: {targetVolume}");
             }
 
+            Debug.Log($"DCLVideoTexture.UpdateVolume.texturePlayer.SetVolume.targetVolume: {targetVolume}");
             texturePlayer.SetVolume(targetVolume);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
@@ -307,10 +307,8 @@ namespace DCL.Components
                 float sceneSFXSetting = Settings.i.audioSettings.Data.sceneSFXVolume;
                 float masterSetting = Settings.i.audioSettings.Data.masterVolume;
                 targetVolume *= Utils.ToVolumeCurve(virtualMixerVolume * sceneSFXSetting * masterSetting);
-                Debug.Log($"DCLVideoTexture.UpdateVolume.IsPlayerInSameSceneAsComponent.targetVolume: {targetVolume}");
             }
 
-            Debug.Log($"DCLVideoTexture.UpdateVolume.texturePlayer.SetVolume.targetVolume: {targetVolume}");
             texturePlayer.SetVolume(targetVolume);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.cs
@@ -108,6 +108,7 @@ namespace DCL.Components.Video.Plugin
             if (isError)
                 return;
 
+            Debug.Log($"WebVideoPlayer.SetVolume: {volume}, {videoPlayerId}, {plugin}");
             plugin.SetVolume(videoPlayerId, volume);
             this.volume = volume;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.cs
@@ -108,7 +108,6 @@ namespace DCL.Components.Video.Plugin
             if (isError)
                 return;
 
-            Debug.Log($"WebVideoPlayer.SetVolume: {volume}, {videoPlayerId}, {plugin}");
             plugin.SetVolume(videoPlayerId, volume);
             this.volume = volume;
         }


### PR DESCRIPTION
## What does this PR change?

`Fixes #1005 `

## How to test the changes?

1. Launch the explorer either web or desktop
2. Start video streaming on -69,69/-107,-94/-98,35/138,-82/-61,59
3. Change the `MASTER` volume or `WORLD SFX` volume from settings
4. Check that the volume of the streaming changes acoordingly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d68c5b</samp>

This pull request adds a feature to the `VideoPlayerHandler` component that allows adjusting the video volume based on the audio settings and the virtual audio mixer. It also updates the `VideoPlayerRegister` class to use the common settings and data store modules for the audio configuration. It modifies the corresponding test classes and assembly definition files to support the new feature and dependencies. It also fixes a minor code style issue in the `DCLVideoTexture` class.
