### PR TITLE
fix: streaming volume (#5904)

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/DCL.ECSComponents.VideoPlayer.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/DCL.ECSComponents.VideoPlayer.asmdef
@@ -18,7 +18,8 @@
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
-        "GUID:b24824f3bc2a60641a01e2083614f802"
+        "GUID:b24824f3bc2a60641a01e2083614f802",
+        "GUID:301149363e31a4bdaa1943465a825c8e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/DCL.ECSComponents.VideoPlayer.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/DCL.ECSComponents.VideoPlayer.asmdef
@@ -19,7 +19,8 @@
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:28f74c468a54948bfa9f625c5d428f56",
         "GUID:b24824f3bc2a60641a01e2083614f802",
-        "GUID:301149363e31a4bdaa1943465a825c8e"
+        "GUID:301149363e31a4bdaa1943465a825c8e",
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/DCL.ECSComponents.VideoPlayer.Tests.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/DCL.ECSComponents.VideoPlayer.Tests.asmdef
@@ -31,7 +31,8 @@
         "GUID:ac62e852826a4b36aeb22931dad73edb",
         "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:28f74c468a54948bfa9f625c5d428f56"
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:301149363e31a4bdaa1943465a825c8e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -6,12 +6,15 @@ using DCL.ECS7.InternalComponents;
 using DCL.ECSComponents;
 using DCL.ECSRuntime;
 using DCL.Models;
+using DCL.SettingsCommon;
+using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.TestTools;
+using AudioSettings = DCL.SettingsCommon.AudioSettings;
 using Environment = DCL.Environment;
 using VideoState = DCL.Components.Video.Plugin.VideoState;
 
@@ -27,6 +30,8 @@ namespace Tests
         private ECS7TestScene scene;
         private ECS7TestEntity entity;
         private DataStore_LoadingScreen loadingScreenDataStore;
+        private DataStore_VirtualAudioMixer virtualAudioMixerDatastore;
+        private ISettingsRepository<AudioSettings> audioSettingsRepository;
 
         [SetUp]
         public void SetUp()
@@ -41,9 +46,23 @@ namespace Tests
             var executors = new Dictionary<int, ICRDTExecutor>();
             var internalComponents = new InternalECSComponents(componentsManager, componentsFactory, executors);
             internalVideoPlayerComponent = internalComponents.videoPlayerComponent;
+
+            virtualAudioMixerDatastore = new DataStore_VirtualAudioMixer();
+            virtualAudioMixerDatastore.sceneSFXVolume.Set(1);
+
+            audioSettingsRepository = Substitute.For<ISettingsRepository<AudioSettings>>();
+
+            audioSettingsRepository.Data.Returns(new AudioSettings
+            {
+                masterVolume = 1,
+                sceneSFXVolume = 1,
+            });
+
             videoPlayerHandler = new VideoPlayerHandler(
                 internalVideoPlayerComponent,
-                loadingScreenDataStore.decoupledLoadingHUD);
+                loadingScreenDataStore.decoupledLoadingHUD,
+                audioSettingsRepository,
+                virtualAudioMixerDatastore);
 
             testUtils = new ECS7TestUtilsScenesAndEntities(componentsManager, executors);
             scene = testUtils.CreateScene(666);
@@ -131,6 +150,48 @@ namespace Tests
             Assert.AreEqual(videoPlayerHandler.videoPlayer.url, "other-video.mp4");
             Assert.AreEqual(videoPlayerHandler.videoPlayer.playing, true);
             Assert.AreEqual(videoPlayerHandler.videoPlayer.volume, 0.5f);
+        }
+
+        [UnityTest]
+        public IEnumerator VolumeUpdatesWhenSettingsAreChanged()
+        {
+            PBVideoPlayer model = new PBVideoPlayer
+            {
+                Src = "video.mp4",
+            };
+
+            videoPlayerHandler.OnComponentCreated(scene, entity);
+            videoPlayerHandler.OnComponentModelUpdated(scene, entity, model);
+            yield return new WaitUntil(() => videoPlayerHandler.videoPlayer.GetState() == VideoState.READY);
+            videoPlayerHandler.videoPlayer.Update();
+
+            Assert.AreEqual(videoPlayerHandler.videoPlayer.playing, false);
+            Assert.AreEqual(videoPlayerHandler.videoPlayer.volume, 1.0f);
+
+            audioSettingsRepository.OnChanged += Raise.Event<Action<AudioSettings>>(new AudioSettings
+            {
+                masterVolume = 0.5f,
+                sceneSFXVolume = 1,
+            });
+
+            Assert.AreEqual(0.5f, videoPlayerHandler.videoPlayer.volume);
+
+            audioSettingsRepository.OnChanged += Raise.Event<Action<AudioSettings>>(new AudioSettings
+            {
+                masterVolume = 0.25f,
+                sceneSFXVolume = 1,
+            });
+
+            Assert.AreEqual(0.25f, videoPlayerHandler.videoPlayer.volume);
+
+            audioSettingsRepository.OnChanged += Raise.Event<Action<AudioSettings>>(new AudioSettings
+            {
+                masterVolume = 1,
+                sceneSFXVolume = 1,
+            });
+            virtualAudioMixerDatastore.sceneSFXVolume.Set(0.1f, true);
+
+            Assert.AreEqual(0.1f, videoPlayerHandler.videoPlayer.volume);
         }
 
         [Test]

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/Tests/VideoPlayerHandlerShould.cs
@@ -32,6 +32,7 @@ namespace Tests
         private DataStore_LoadingScreen loadingScreenDataStore;
         private DataStore_VirtualAudioMixer virtualAudioMixerDatastore;
         private ISettingsRepository<AudioSettings> audioSettingsRepository;
+        private IntVariable currentPlayerSceneNumber;
 
         [SetUp]
         public void SetUp()
@@ -58,11 +59,15 @@ namespace Tests
                 sceneSFXVolume = 1,
             });
 
+            currentPlayerSceneNumber = ScriptableObject.CreateInstance<IntVariable>();
+            currentPlayerSceneNumber.Set(666);
+
             videoPlayerHandler = new VideoPlayerHandler(
                 internalVideoPlayerComponent,
                 loadingScreenDataStore.decoupledLoadingHUD,
                 audioSettingsRepository,
-                virtualAudioMixerDatastore);
+                virtualAudioMixerDatastore,
+                currentPlayerSceneNumber);
 
             testUtils = new ECS7TestUtilsScenesAndEntities(componentsManager, executors);
             scene = testUtils.CreateScene(666);
@@ -113,6 +118,7 @@ namespace Tests
                 Src = "video.mp4"
             };
 
+            videoPlayerHandler.OnComponentCreated(scene, entity);
             videoPlayerHandler.OnComponentModelUpdated(scene, entity, model);
             yield return new WaitUntil(() => videoPlayerHandler.videoPlayer.GetState() == VideoState.READY);
             videoPlayerHandler.videoPlayer.Update();
@@ -126,6 +132,7 @@ namespace Tests
         {
             videoPlayerHandler.isRendererActive = true;
             videoPlayerHandler.hadUserInteraction = true;
+            videoPlayerHandler.OnComponentCreated(scene, entity);
             videoPlayerHandler.OnComponentModelUpdated(scene, entity, new PBVideoPlayer()
             {
                 Src = "video.mp4"

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerHandler.cs
@@ -19,6 +19,7 @@ namespace DCL.ECSComponents
         internal DataStore_LoadingScreen.DecoupledLoadingScreen loadingScreen;
         private readonly ISettingsRepository<AudioSettings> audioSettings;
         private readonly DataStore_VirtualAudioMixer audioMixerDataStore;
+        private readonly IntVariable currentPlayerSceneNumber;
         internal PBVideoPlayer lastModel = null;
         internal WebVideoPlayer videoPlayer;
 
@@ -28,18 +29,21 @@ namespace DCL.ECSComponents
         internal bool isValidUrl = false;
 
         private readonly IInternalECSComponent<InternalVideoPlayer> videoPlayerInternalComponent;
+        private IParcelScene currentScene;
         private bool canVideoBePlayed => isRendererActive && hadUserInteraction && isValidUrl;
 
         public VideoPlayerHandler(
             IInternalECSComponent<InternalVideoPlayer> videoPlayerInternalComponent,
             DataStore_LoadingScreen.DecoupledLoadingScreen loadingScreen,
             ISettingsRepository<AudioSettings> audioSettings,
-            DataStore_VirtualAudioMixer audioMixerDataStore)
+            DataStore_VirtualAudioMixer audioMixerDataStore,
+            IntVariable currentPlayerSceneNumber)
         {
             this.videoPlayerInternalComponent = videoPlayerInternalComponent;
             this.loadingScreen = loadingScreen;
             this.audioSettings = audioSettings;
             this.audioMixerDataStore = audioMixerDataStore;
+            this.currentPlayerSceneNumber = currentPlayerSceneNumber;
         }
 
         public void OnComponentCreated(IParcelScene scene, IDCLEntity entity)
@@ -55,6 +59,8 @@ namespace DCL.ECSComponents
             loadingScreen.visible.OnChange += OnLoadingScreenStateChanged;
             audioSettings.OnChanged += OnAudioSettingsChanged;
             audioMixerDataStore.sceneSFXVolume.OnChange += OnSceneSfxVolumeChanged;
+            currentPlayerSceneNumber.OnChange += OnPlayerSceneChanged;
+            currentScene = scene;
         }
 
         public void OnComponentRemoved(IParcelScene scene, IDCLEntity entity)
@@ -63,6 +69,7 @@ namespace DCL.ECSComponents
             loadingScreen.visible.OnChange -= OnLoadingScreenStateChanged;
             audioSettings.OnChanged -= OnAudioSettingsChanged;
             audioMixerDataStore.sceneSFXVolume.OnChange -= OnSceneSfxVolumeChanged;
+            currentPlayerSceneNumber.OnChange -= OnPlayerSceneChanged;
 
             // ECSVideoPlayerSystem.Update() will run a video events check before the component is removed
             videoPlayerInternalComponent.RemoveFor(scene, entity, new InternalVideoPlayer()
@@ -71,6 +78,7 @@ namespace DCL.ECSComponents
             });
 
             videoPlayer?.Dispose();
+            currentScene = null;
         }
 
         public void OnComponentModelUpdated(IParcelScene scene, IDCLEntity entity, PBVideoPlayer model)
@@ -109,7 +117,7 @@ namespace DCL.ECSComponents
             if (Math.Abs(lastPosition - model.GetPosition()) > 0.01f) // 0.01s of tolerance
                 videoPlayer.SetTime(model.GetPosition());
 
-            UpdateVolume(model, audioSettings.Data, audioMixerDataStore.sceneSFXVolume.Get());
+            UpdateVolume(model, audioSettings.Data, audioMixerDataStore.sceneSFXVolume.Get(), currentPlayerSceneNumber);
             videoPlayer.SetPlaybackRate(model.GetPlaybackRate());
             videoPlayer.SetLoop(model.GetLoop());
 
@@ -148,20 +156,40 @@ namespace DCL.ECSComponents
         }
 
         private void OnSceneSfxVolumeChanged(float current, float previous) =>
-            UpdateVolume(lastModel, audioSettings.Data, current);
+            UpdateVolume(lastModel, audioSettings.Data, current, currentPlayerSceneNumber);
 
         private void OnAudioSettingsChanged(AudioSettings settings) =>
-            UpdateVolume(lastModel, settings, audioMixerDataStore.sceneSFXVolume.Get());
+            UpdateVolume(lastModel, settings, audioMixerDataStore.sceneSFXVolume.Get(), currentPlayerSceneNumber);
 
-        private void UpdateVolume(PBVideoPlayer model, AudioSettings settings, float sceneMixerSfxVolume)
+        private void OnPlayerSceneChanged(int current, int previous) =>
+            UpdateVolume(lastModel, audioSettings.Data, audioMixerDataStore.sceneSFXVolume.Get(), current);
+
+        private void UpdateVolume(PBVideoPlayer model, AudioSettings settings, float sceneMixerSfxVolume, int currentSceneNumber)
         {
             if (model == null) return;
             if (videoPlayer == null) return;
 
-            float sceneSFXSetting = settings.sceneSFXVolume;
-            float masterSetting = settings.masterVolume;
-            float volume = model.GetVolume() * sceneMixerSfxVolume * sceneSFXSetting * masterSetting;
+            float volume = 0;
+
+            if (IsPlayerInSameSceneAsComponent(currentSceneNumber))
+            {
+                float sceneSFXSetting = settings.sceneSFXVolume;
+                float masterSetting = settings.masterVolume;
+                volume = model.GetVolume() * sceneMixerSfxVolume * sceneSFXSetting * masterSetting;
+            }
+
             videoPlayer.SetVolume(volume);
+        }
+
+        private bool IsPlayerInSameSceneAsComponent(int currentSceneNumber)
+        {
+            if (currentScene == null)
+                return false;
+
+            if (currentSceneNumber <= 0)
+                return false;
+
+            return currentScene.sceneData?.sceneNumber == currentSceneNumber || currentScene.isPersistent;
         }
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerRegister.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerRegister.cs
@@ -18,7 +18,8 @@ namespace DCL.ECSComponents
                     internalComponents.videoPlayerComponent,
                     DataStore.i.Get<DataStore_LoadingScreen>().decoupledLoadingHUD,
                     Settings.i.audioSettings,
-                    DataStore.i.virtualAudioMixer));
+                    DataStore.i.virtualAudioMixer,
+                    CommonScriptableObjects.sceneNumber));
             componentWriter.AddOrReplaceComponentSerializer<PBVideoPlayer>(componentId, ProtoSerialization.Serialize);
 
             this.factory = factory;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerRegister.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/VideoPlayer/VideoPlayerRegister.cs
@@ -1,6 +1,6 @@
-using DCL.ECS7.InternalComponents;
 using System;
 using DCL.ECSRuntime;
+using DCL.SettingsCommon;
 
 namespace DCL.ECSComponents
 {
@@ -16,7 +16,9 @@ namespace DCL.ECSComponents
                 ProtoSerialization.Deserialize<PBVideoPlayer>,
                 () => new VideoPlayerHandler(
                     internalComponents.videoPlayerComponent,
-                    DataStore.i.Get<DataStore_LoadingScreen>().decoupledLoadingHUD));
+                    DataStore.i.Get<DataStore_LoadingScreen>().decoupledLoadingHUD,
+                    Settings.i.audioSettings,
+                    DataStore.i.virtualAudioMixer));
             componentWriter.AddOrReplaceComponentSerializer<PBVideoPlayer>(componentId, ProtoSerialization.Serialize);
 
             this.factory = factory;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
@@ -52,7 +52,7 @@ namespace DCL.Components
                 if (pbModel.VideoTexture.HasSeek) pb.seek = pbModel.VideoTexture.Seek;
                 if (pbModel.VideoTexture.HasWrap) pb.wrap = (BabylonWrapMode)pbModel.VideoTexture.Wrap;
                 if (pbModel.VideoTexture.HasSamplingMode) pb.samplingMode = (FilterMode)pbModel.VideoTexture.SamplingMode;
-                
+
                 return pb;
             }
         }


### PR DESCRIPTION
`Fixes #5907`
`Fixes #1005 `

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 124f1c3</samp>

This pull request adds a new feature to the `VideoPlayer` component that allows the video volume to be adjusted dynamically based on the audio settings and the virtual audio mixer. It modifies the `VideoPlayerHandler` class to inject and subscribe to the audio settings and the virtual audio mixer repositories, and to update the volume accordingly. It also updates the `VideoPlayerRegister` class and the assembly definition files to import the necessary dependencies. It adds and modifies some tests to verify the new behavior. It also fixes a minor code style issue in the `DCLVideoTexture` class.
