### PR TITLE
fix: emote and movement replication

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
@@ -203,10 +203,7 @@ namespace DCL.ECSComponents
 
             // If the model contains a value for expressionTriggerId then we try it, if value doesn't exist, we skip
             if (model.HasExpressionTriggerId)
-            {
-                OnEntityTransformChanged(entity.gameObject.transform.localPosition, entity.gameObject.transform.localRotation, true);
                 avatar.GetEmotesController().PlayEmote(model.ExpressionTriggerId, model.GetExpressionTriggerTimestamp());
-            }
 
             UpdatePlayerStatus(entity, model);
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
@@ -113,7 +113,11 @@ namespace DCL.ECSComponents
             avatar = avatarFactory.Ref.CreateAvatarWithHologram(avatarContainer, new BaseAvatar(baseAvatarReferences), animator, avatarLOD, visibility);
 
             emotesController = avatar.GetEmotesController();
-            sceneEmoteHandler = new AvatarSceneEmoteHandler(emotesController, Environment.i.serviceLocator.Get<IEmotesService>());
+
+            sceneEmoteHandler = new AvatarSceneEmoteHandler(
+                emotesController,
+                Environment.i.serviceLocator.Get<IEmotesService>(),
+                new UserProfileWebInterfaceBridge());
 
             avatarReporterController ??= new AvatarReporterController(Environment.i.world.state);
 
@@ -213,7 +217,7 @@ namespace DCL.ECSComponents
                    .LoadAndPlayEmote(model.BodyShape, model.ExpressionTriggerId)
                    .Forget();
             else
-                avatar.GetEmotesController().UpdateEmoteStatus(model.ExpressionTriggerId, model.GetExpressionTriggerTimestamp());
+                avatar.GetEmotesController().PlayEmote(model.ExpressionTriggerId, model.GetExpressionTriggerTimestamp());
 
             UpdatePlayerStatus(entity, model);
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
@@ -106,13 +106,14 @@ namespace DCL.ECSComponents
             LOD avatarLOD = new LOD(avatarContainer, visibility, avatarMovementController);
             AvatarAnimatorLegacy animator = GetComponentInChildren<AvatarAnimatorLegacy>();
 
-            emotesController = avatar.GetEmotesController();
-            sceneEmoteHandler = new AvatarSceneEmoteHandler(emotesController, Environment.i.serviceLocator.Get<IEmotesService>());
 
             //Ensure base avatar references
             var baseAvatarReferences = baseAvatarContainer.GetComponentInChildren<IBaseAvatarReferences>() ?? Instantiate(baseAvatarReferencesPrefab, baseAvatarContainer);
 
             avatar = avatarFactory.Ref.CreateAvatarWithHologram(avatarContainer, new BaseAvatar(baseAvatarReferences), animator, avatarLOD, visibility);
+
+            emotesController = avatar.GetEmotesController();
+            sceneEmoteHandler = new AvatarSceneEmoteHandler(emotesController, Environment.i.serviceLocator.Get<IEmotesService>());
 
             avatarReporterController ??= new AvatarReporterController(Environment.i.world.state);
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
@@ -201,9 +201,7 @@ namespace DCL.ECSComponents
                 }
             }
 
-            // If the model contains a value for expressionTriggerId then we try it, if value doesn't exist, we skip
-            if (model.HasExpressionTriggerId)
-                avatar.GetEmotesController().PlayEmote(model.ExpressionTriggerId, model.GetExpressionTriggerTimestamp());
+            avatar.GetEmotesController().UpdateEmoteStatus(model.ExpressionTriggerId, model.GetExpressionTriggerTimestamp());
 
             UpdatePlayerStatus(entity, model);
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
@@ -9,7 +9,6 @@ using DCL.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using UnityEngine;
 using LOD = AvatarSystem.LOD;
@@ -203,8 +202,11 @@ namespace DCL.ECSComponents
             }
 
             // If the model contains a value for expressionTriggerId then we try it, if value doesn't exist, we skip
-            if(model.HasExpressionTriggerId)
+            if (model.HasExpressionTriggerId)
+            {
+                OnEntityTransformChanged(entity.gameObject.transform.localPosition, entity.gameObject.transform.localRotation, true);
                 avatar.GetEmotesController().PlayEmote(model.ExpressionTriggerId, model.GetExpressionTriggerTimestamp());
+            }
 
             UpdatePlayerStatus(entity, model);
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/DCL.ECSComponents.AvatarShape.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/DCL.ECSComponents.AvatarShape.asmdef
@@ -49,7 +49,8 @@
         "GUID:6c1761dc8f737004198eb333521bd665",
         "GUID:c8ea72e806cd2ab47b539b37895b86b7",
         "GUID:9cccce9925d3495d8a5e4fa5b25f54a5",
-        "GUID:2d39cc535b437e749965d4a8258f0c13"
+        "GUID:2d39cc535b437e749965d4a8258f0c13",
+        "GUID:0c0c18c12967b3944b844b79c47c2320"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
@@ -1,11 +1,10 @@
 ﻿using Cysharp.Threading.Tasks;
-using DCL;
-using System.Collections.Generic;
 using DCL.Emotes;
 using DCL.Helpers;
 using DCL.SettingsCommon;
 using DCL.Tasks;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using AudioSettings = DCL.SettingsCommon.AudioSettings;
@@ -49,6 +48,17 @@ namespace AvatarSystem
             visibilityConstraints.Remove(key);
         }
 
+        public void UpdateEmoteStatus(string currentEmoteId, long timestamp)
+        {
+            bool isPlayingEmote = !string.IsNullOrEmpty(animator.GetCurrentEmoteId());
+            bool emoteIsValid = !string.IsNullOrEmpty(currentEmoteId);
+
+            if (isPlayingEmote && !emoteIsValid) { animator.StopEmote(); }
+
+            if (emoteIsValid)
+                PlayEmote(currentEmoteId, timestamp);
+        }
+
         public void Prepare(string bodyShapeId, GameObject container)
         {
             this.bodyShapeId = bodyShapeId;
@@ -86,7 +96,7 @@ namespace AvatarSystem
             catch (Exception e) { Debug.LogException(e); }
         }
 
-        public void PlayEmote(string emoteId, long timestamps, bool spatial, bool occlude, bool forcePlay)
+        public void PlayEmote(string emoteId, long timestamps, bool spatial = true, bool occlude = true, bool forcePlay = false)
         {
             if (string.IsNullOrEmpty(emoteId)) return;
             if (!CanPlayEmote()) return;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
@@ -14,7 +14,8 @@ namespace AvatarSystem
     public class AvatarEmotesController : IAvatarEmotesController
     {
         private const float BASE_VOLUME = 0.2f;
-        private const string INSIDE_CAMERA = "INSIDE_CAMERA";
+        private const string IN_HIDE_AREA = "IN_HIDE_AREA";
+
         public event Action<string, IEmoteReference> OnEmoteEquipped;
         public event Action<string> OnEmoteUnequipped;
 
@@ -108,12 +109,8 @@ namespace AvatarSystem
             animator.PlayEmote(emoteId, timestamps, spatial, volume, occlude, forcePlay);
         }
 
-        private bool CanPlayEmote()
-        {
-            if (visibilityConstraints.Count == 0) return true;
-            if (visibilityConstraints.Count > 1) return false;
-            return visibilityConstraints.Contains(INSIDE_CAMERA);
-        }
+        private bool CanPlayEmote() =>
+            !visibilityConstraints.Contains(IN_HIDE_AREA);
 
         // TODO: We have to decouple this volume logic into an IAudioMixer.GetVolume(float, Channel) since we are doing the same calculations everywhere
         // Using AudioMixer does not work in WebGL so we calculate the volume manually

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
@@ -40,7 +40,7 @@ namespace AvatarSystem
             visibilityConstraints.Add(key);
 
             if (!CanPlayEmote())
-                StopEmote();
+                StopEmote(true);
         }
 
         public void RemoveVisibilityConstraint(string key)
@@ -53,7 +53,7 @@ namespace AvatarSystem
             bool isPlayingEmote = !string.IsNullOrEmpty(animator.GetCurrentEmoteId());
             bool emoteIsValid = !string.IsNullOrEmpty(currentEmoteId);
 
-            if (isPlayingEmote && !emoteIsValid) { animator.StopEmote(); }
+            if (isPlayingEmote && !emoteIsValid) { animator.StopEmote(false); }
 
             if (emoteIsValid)
                 PlayEmote(currentEmoteId, timestamp);
@@ -125,9 +125,9 @@ namespace AvatarSystem
             return baseVolume;
         }
 
-        public void StopEmote()
+        public void StopEmote(bool immediate)
         {
-            animator.StopEmote();
+            animator.StopEmote(immediate);
         }
 
         public void EquipEmote(string emoteId, IEmoteReference emoteReference)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/AvatarEmotesController.cs
@@ -49,17 +49,6 @@ namespace AvatarSystem
             visibilityConstraints.Remove(key);
         }
 
-        public void UpdateEmoteStatus(string currentEmoteId, long timestamp)
-        {
-            bool isPlayingEmote = !string.IsNullOrEmpty(animator.GetCurrentEmoteId());
-            bool emoteIsValid = !string.IsNullOrEmpty(currentEmoteId);
-
-            if (isPlayingEmote && !emoteIsValid) { animator.StopEmote(false); }
-
-            if (emoteIsValid)
-                PlayEmote(currentEmoteId, timestamp);
-        }
-
         public void Prepare(string bodyShapeId, GameObject container)
         {
             this.bodyShapeId = bodyShapeId;
@@ -99,7 +88,13 @@ namespace AvatarSystem
 
         public void PlayEmote(string emoteId, long timestamps, bool spatial = true, bool occlude = true, bool forcePlay = false)
         {
-            if (string.IsNullOrEmpty(emoteId)) return;
+            bool isPlayingEmote = !string.IsNullOrEmpty(animator.GetCurrentEmoteId());
+            bool emoteIsValid = !string.IsNullOrEmpty(emoteId);
+
+            if (isPlayingEmote && !emoteIsValid)
+                animator.StopEmote(false);
+
+            if (!emoteIsValid) return;
             if (!CanPlayEmote()) return;
 
             var emoteKey = new EmoteBodyId(bodyShapeId, emoteId);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAnimator.cs
@@ -8,7 +8,8 @@ namespace AvatarSystem
         bool Prepare(string bodyshapeId, GameObject container);
         void PlayEmote(string emoteId, long timestamps, bool spatial, float volume, bool occlude,
             bool forcePlay);
-        void StopEmote();
+
+        void StopEmote(bool immediate);
         void EquipEmote(string emoteId, EmoteClipData emoteClipData);
         void UnequipEmote(string emoteId);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAnimator.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAnimator.cs
@@ -12,5 +12,6 @@ namespace AvatarSystem
         void EquipEmote(string emoteId, EmoteClipData emoteClipData);
         void UnequipEmote(string emoteId);
 
+        string GetCurrentEmoteId();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
@@ -27,7 +27,5 @@ namespace AvatarSystem
         void AddVisibilityConstraint(string key);
 
         void RemoveVisibilityConstraint(string key);
-
-        void UpdateEmoteStatus(string currentEmoteId, long timestamp);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
@@ -27,5 +27,7 @@ namespace AvatarSystem
         void AddVisibilityConstraint(string key);
 
         void RemoveVisibilityConstraint(string key);
+
+        void UpdateEmoteStatus(string currentEmoteId, long timestamp);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarEmotesController.cs
@@ -13,7 +13,7 @@ namespace AvatarSystem
 
         void PlayEmote(string emoteId, long timestamps, bool spatial = true, bool occlude = true, bool forcePlay = false);
 
-        void StopEmote();
+        void StopEmote(bool immediate);
 
         void EquipEmote(string emoteId, IEmoteReference emoteReference);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -406,7 +406,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         // Instantly replicate our emote status and position
         if (isOwnPlayer && !string.IsNullOrEmpty(blackboard.expressionTriggerId))
         {
-            DCLCharacterController.i.ForceReportMovement();
+            DCLCharacterController.i.ReportMovement();
             UserProfile.GetOwnUserProfile().SetAvatarExpression("", UserProfile.EmoteSource.EmoteCancel, true);
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Generic;
 using AvatarSystem;
 using Cysharp.Threading.Tasks;
 using DCL;
 using DCL.Components;
 using DCL.Emotes;
 using DCL.Helpers;
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Environment = DCL.Environment;
 
@@ -32,31 +32,32 @@ public static class AvatarAnimationExtensions
 
 public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnimator
 {
-    const float IDLE_TRANSITION_TIME = 0.2f;
-    const float RUN_TRANSITION_TIME = 0.15f;
-    const float WALK_TRANSITION_TIME = 0.15f;
-    const float WALK_MAX_SPEED = 6;
-    const float RUN_MIN_SPEED = 4f;
-    const float WALK_MIN_SPEED = 0.1f;
-    const float WALK_RUN_SWITCH_TIME = 1.5f;
-    const float JUMP_TRANSITION_TIME = 0.01f;
-    const float FALL_TRANSITION_TIME = 0.5f;
-    const float EXPRESSION_EXIT_TRANSITION_TIME = 0.2f;
-    const float EXPRESSION_ENTER_TRANSITION_TIME = 0.1f;
-    const float OTHER_PLAYER_MOVE_THRESHOLD = 0.02f;
+    private const float ZERO_POSE_LOOP_TIME_SECONDS = 2f;
+    private const float IDLE_TRANSITION_TIME = 0.2f;
+    private const float RUN_TRANSITION_TIME = 0.15f;
+    private const float WALK_TRANSITION_TIME = 0.15f;
+    private const float WALK_MAX_SPEED = 6;
+    private const float RUN_MIN_SPEED = 4f;
+    private const float WALK_MIN_SPEED = 0.1f;
+    private const float WALK_RUN_SWITCH_TIME = 1.5f;
+    private const float JUMP_TRANSITION_TIME = 0.01f;
+    private const float FALL_TRANSITION_TIME = 0.5f;
+    private const float EXPRESSION_EXIT_TRANSITION_TIME = 0.2f;
+    private const float EXPRESSION_ENTER_TRANSITION_TIME = 0.1f;
+    private const float OTHER_PLAYER_MOVE_THRESHOLD = 0.5f;
 
-    const float AIR_EXIT_TRANSITION_TIME = 0.2f;
+    private const float AIR_EXIT_TRANSITION_TIME = 0.2f;
 
-    const float ELEVATION_OFFSET = 0.6f;
-    const float RAY_OFFSET_LENGTH = 3.0f;
+    private const float ELEVATION_OFFSET = 0.6f;
+    private const float RAY_OFFSET_LENGTH = 3.0f;
 
     // Time it takes to determine if a character is grounded when vertical velocity is 0
-    const float FORCE_GROUND_TIME = 0.05f;
+    private const float FORCE_GROUND_TIME = 0.05f;
 
     // Minimum vertical speed used to consider whether an avatar is on air
-    const float MIN_VERTICAL_SPEED_AIR = 0.025f;
+    private const float MIN_VERTICAL_SPEED_AIR = 0.025f;
 
-    [System.Serializable]
+    [Serializable]
     public class AvatarLocomotion
     {
         public AnimationClip idle;
@@ -66,7 +67,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         public AnimationClip fall;
     }
 
-    [System.Serializable]
+    [Serializable]
     public class BlackBoard
     {
         public float walkSpeedFactor;
@@ -82,16 +83,16 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
 
     [SerializeField] internal AvatarLocomotion femaleLocomotions;
     [SerializeField] internal AvatarLocomotion maleLocomotions;
-    AvatarLocomotion currentLocomotions;
+    private AvatarLocomotion currentLocomotions;
 
     public new Animation animation;
     public BlackBoard blackboard;
     public Transform target;
 
-    internal System.Action<BlackBoard> currentState;
+    private Action<BlackBoard> currentState;
 
-    Vector3 lastPosition;
-    bool isOwnPlayer = false;
+    private Vector3 lastPosition;
+    private bool isOwnPlayer;
     private AvatarAnimationEventHandler animEventHandler;
 
     private float lastOnAirTime = 0;
@@ -115,14 +116,21 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
     private AnimationState currentEmote;
     private int lastEmoteLoopCount;
 
+    private float lastZeroPoseTime;
+    private int zeroPoseLoop;
+
     private void Awake()
     {
         hasTarget = target != null;
+
         if (!hasTarget)
             Debug.LogError(message: $"Target is not assigned. {nameof(UpdateInterface)} will not work correctly.", this);
     }
 
-    public void Start() { OnPoolGet(); }
+    public void Start()
+    {
+        OnPoolGet();
+    }
 
     // AvatarSystem entry points
     public bool Prepare(string bodyshapeId, GameObject container)
@@ -142,15 +150,8 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         {
             isUpdateRegistered = true;
 
-            if (isOwnPlayer)
-            {
-                DCLCharacterController.i.OnUpdateFinish += OnUpdateWithDeltaTime;
-            }
-            else
-            {
-                Environment.i.platform.updateEventHandler.AddListener(IUpdateEventHandler.EventType.Update, OnEventHandlerUpdate);
-            }
-
+            if (isOwnPlayer) { DCLCharacterController.i.OnUpdateFinish += OnUpdateWithDeltaTime; }
+            else { Environment.i.platform.updateEventHandler.AddListener(IUpdateEventHandler.EventType.Update, OnEventHandlerUpdate); }
         }
 
         return true;
@@ -158,14 +159,8 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
 
     private void PrepareLocomotionAnims(string bodyshapeId)
     {
-        if (bodyshapeId.Contains(WearableLiterals.BodyShapes.MALE))
-        {
-            currentLocomotions = maleLocomotions;
-        }
-        else if (bodyshapeId.Contains(WearableLiterals.BodyShapes.FEMALE))
-        {
-            currentLocomotions = femaleLocomotions;
-        }
+        if (bodyshapeId.Contains(WearableLiterals.BodyShapes.MALE)) { currentLocomotions = maleLocomotions; }
+        else if (bodyshapeId.Contains(WearableLiterals.BodyShapes.FEMALE)) { currentLocomotions = femaleLocomotions; }
 
         EquipBaseClip(currentLocomotions.idle);
         EquipBaseClip(currentLocomotions.walk);
@@ -182,7 +177,11 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         runAnimationState = animation[runAnimationName];
         walkAnimationState = animation[walkAnimationName];
     }
-    private void OnEventHandlerUpdate() { OnUpdateWithDeltaTime(Time.deltaTime); }
+
+    private void OnEventHandlerUpdate()
+    {
+        OnUpdateWithDeltaTime(Time.deltaTime);
+    }
 
     public void OnPoolGet()
     {
@@ -203,25 +202,19 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         {
             isUpdateRegistered = false;
 
-            if (isOwnPlayer && DCLCharacterController.i)
-            {
-                DCLCharacterController.i.OnUpdateFinish -= OnUpdateWithDeltaTime;
-            }
-            else
-            {
-                Environment.i.platform.updateEventHandler.RemoveListener(IUpdateEventHandler.EventType.Update, OnEventHandlerUpdate);
-            }
+            if (isOwnPlayer && DCLCharacterController.i) { DCLCharacterController.i.OnUpdateFinish -= OnUpdateWithDeltaTime; }
+            else { Environment.i.platform.updateEventHandler.RemoveListener(IUpdateEventHandler.EventType.Update, OnEventHandlerUpdate); }
         }
     }
 
-    void OnUpdateWithDeltaTime(float deltaTime)
+    private void OnUpdateWithDeltaTime(float deltaTime)
     {
         blackboard.deltaTime = deltaTime;
         UpdateInterface();
         currentState?.Invoke(blackboard);
     }
 
-    void UpdateInterface()
+    private void UpdateInterface()
     {
         if (!target) return;
 
@@ -232,10 +225,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         float verticalVelocity = flattenedVelocity.y;
 
         //NOTE(Kinerius): if we have more or less than zero we consider that we are either jumping or falling
-        if (Mathf.Abs(verticalVelocity) > MIN_VERTICAL_SPEED_AIR)
-        {
-            lastOnAirTime = Time.time;
-        }
+        if (Mathf.Abs(verticalVelocity) > MIN_VERTICAL_SPEED_AIR) { lastOnAirTime = Time.time; }
 
         blackboard.verticalSpeed = verticalVelocity;
 
@@ -268,7 +258,6 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
             isGroundedByRaycast = Physics.Raycast(rayCache,
                 RAY_OFFSET_LENGTH - ELEVATION_OFFSET,
                 iGroundLayers);
-
         }
 
         blackboard.isGrounded = isGroundedByCharacterController || isGroundedByVelocity || isGroundedByRaycast;
@@ -276,19 +265,13 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         lastPosition = velocityTargetPosition;
     }
 
-    void State_Init(BlackBoard bb)
+    private void State_Init(BlackBoard bb)
     {
-        if (bb.isGrounded)
-        {
-            currentState = State_Ground;
-        }
-        else
-        {
-            currentState = State_Air;
-        }
+        if (bb.isGrounded) { currentState = State_Ground; }
+        else { currentState = State_Air; }
     }
 
-    void State_Ground(BlackBoard bb)
+    private void State_Ground(BlackBoard bb)
     {
         if (bb.deltaTime <= 0)
             return;
@@ -298,23 +281,13 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         runAnimationState.normalizedSpeed = movementSpeed * bb.runSpeedFactor;
         walkAnimationState.normalizedSpeed = movementSpeed * bb.walkSpeedFactor;
 
-        if (movementSpeed >= WALK_MAX_SPEED)
-        {
-            CrossFadeTo(AvatarAnimation.RUN, runAnimationName, RUN_TRANSITION_TIME);
-        }
+        if (movementSpeed >= WALK_MAX_SPEED) { CrossFadeTo(AvatarAnimation.RUN, runAnimationName, RUN_TRANSITION_TIME); }
         else if (movementSpeed >= RUN_MIN_SPEED && movementSpeed < WALK_MAX_SPEED)
         {
             // Keep current animation, leave empty
         }
-        else if (movementSpeed > WALK_MIN_SPEED)
-        {
-            CrossFadeTo(AvatarAnimation.WALK, walkAnimationName, WALK_TRANSITION_TIME);
-        }
-        else
-        {
-            CrossFadeTo(AvatarAnimation.IDLE, idleAnimationName, IDLE_TRANSITION_TIME);
-        }
-
+        else if (movementSpeed > WALK_MIN_SPEED) { CrossFadeTo(AvatarAnimation.WALK, walkAnimationName, WALK_TRANSITION_TIME); }
+        else { CrossFadeTo(AvatarAnimation.IDLE, idleAnimationName, IDLE_TRANSITION_TIME); }
 
         if (!bb.isGrounded)
         {
@@ -335,16 +308,10 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         animation.CrossFade(lastCrossFade, runTransitionTime, playMode);
     }
 
-    void State_Air(BlackBoard bb)
+    private void State_Air(BlackBoard bb)
     {
-        if (bb.verticalSpeed > 0)
-        {
-            CrossFadeTo(AvatarAnimation.JUMP, jumpAnimationName, JUMP_TRANSITION_TIME, PlayMode.StopAll);
-        }
-        else
-        {
-            CrossFadeTo(AvatarAnimation.FALL, fallAnimationName, FALL_TRANSITION_TIME, PlayMode.StopAll);
-        }
+        if (bb.verticalSpeed > 0) { CrossFadeTo(AvatarAnimation.JUMP, jumpAnimationName, JUMP_TRANSITION_TIME, PlayMode.StopAll); }
+        else { CrossFadeTo(AvatarAnimation.FALL, fallAnimationName, FALL_TRANSITION_TIME, PlayMode.StopAll); }
 
         if (bb.isGrounded)
         {
@@ -386,8 +353,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         {
             int emoteLoop = GetCurrentEmoteLoopCount();
 
-            if (emoteLoop != lastEmoteLoopCount)
-                UserProfile.GetOwnUserProfile().SetAvatarExpression(bb.expressionTriggerId, UserProfile.EmoteSource.EmoteLoop, true);
+            if (emoteLoop != lastEmoteLoopCount) { UserProfile.GetOwnUserProfile().SetAvatarExpression(bb.expressionTriggerId, UserProfile.EmoteSource.EmoteLoop, true); }
 
             lastEmoteLoopCount = emoteLoop;
         }
@@ -398,14 +364,28 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         {
             float timeTillEnd = animationState == null ? 0 : animationState.length - animationState.time;
             bool isAnimationOver = timeTillEnd < EXPRESSION_EXIT_TRANSITION_TIME && !bb.shouldLoop;
-            bool isMoving = isOwnPlayer ? DCLCharacterController.i.isMovingByUserInput : Math.Abs(bb.movementSpeed) > OTHER_PLAYER_MOVE_THRESHOLD;
+            bool isMoving = isOwnPlayer && DCLCharacterController.i.isMovingByUserInput; //Math.Abs(bb.movementSpeed) > OTHER_PLAYER_MOVE_THRESHOLD;
 
-            return isAnimationOver || isMoving;
+            bool expressionGroundTransitionCondition = isAnimationOver || isMoving;
+            return expressionGroundTransitionCondition;
         }
     }
 
-    private int GetCurrentEmoteLoopCount() =>
-        Mathf.RoundToInt(currentEmote.time / currentEmote.length);
+    private int GetCurrentEmoteLoopCount()
+    {
+        // Some scenes might use animations with 0 length as loop poses (not ideal)
+        if (Mathf.Approximately(currentEmote.length, 0))
+        {
+            if (Time.time - lastZeroPoseTime > ZERO_POSE_LOOP_TIME_SECONDS)
+            {
+                zeroPoseLoop++;
+                lastZeroPoseTime = Time.time;
+                return zeroPoseLoop;
+            }
+        }
+
+        return Mathf.RoundToInt(currentEmote.time / currentEmote.length);
+    }
 
     public void StopEmote()
     {
@@ -422,10 +402,18 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         blackboard.shouldLoop = false;
         lastExtendedEmoteData?.Stop();
 
+        // Instantly replicate our emote status and position
+        if (isOwnPlayer)
+        {
+            DCLCharacterController.i.ForceReportMovement();
+            UserProfile.GetOwnUserProfile().SetAvatarExpression("", UserProfile.EmoteSource.EmoteLoop, true);
+        }
+
         if (!immediate) OnUpdateWithDeltaTime(blackboard.deltaTime);
     }
 
     private float lastEmotePlayTime = 0;
+
     private void StartEmote(string emoteId, bool spatial, float volume, bool occlude)
     {
         if (!string.IsNullOrEmpty(emoteId))
@@ -440,10 +428,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
                 emoteClipData.Play(gameObject.layer, spatial, volume, occlude);
             }
         }
-        else
-        {
-            lastExtendedEmoteData?.Stop();
-        }
+        else { lastExtendedEmoteData?.Stop(); }
     }
 
     public void Reset()
@@ -455,11 +440,16 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         animation.Stop();
     }
 
-    public void SetIdleFrame() { animation.Play(currentLocomotions.idle.name); }
+    public void SetIdleFrame()
+    {
+        animation.Play(currentLocomotions.idle.name);
+    }
 
     public void PlayEmote(string emoteId, long timestamps, bool spatial, float volume, bool occlude,
         bool forcePlay)
     {
+        Debug.Log($"Playing {emoteId} ts: {timestamps} force: {forcePlay}");
+
         if (animation == null)
             return;
 
@@ -505,6 +495,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
     public void EquipBaseClip(AnimationClip clip)
     {
         var clipId = clip.name;
+
         if (animation == null)
             return;
 
@@ -564,10 +555,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
             //NOTE(Mordi): If this is a remote avatar, pass the animation component so we can keep track of whether it is culled (off-screen) or not
             AvatarAudioHandlerRemote audioHandlerRemote = audioContainer.GetComponent<AvatarAudioHandlerRemote>();
 
-            if (audioHandlerRemote != null)
-            {
-                audioHandlerRemote.Init(createdAnimation.gameObject);
-            }
+            if (audioHandlerRemote != null) { audioHandlerRemote.Init(createdAnimation.gameObject); }
         }
 
         animEventHandler = animationEventHandler;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -56,7 +56,6 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
 
     // Minimum vertical speed used to consider whether an avatar is on air
     private const float MIN_VERTICAL_SPEED_AIR = 0.025f;
-    private const string STOP_EMOTE = "stop-emote";
 
     [Serializable]
     public class AvatarLocomotion
@@ -405,7 +404,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         if (isOwnPlayer && !string.IsNullOrEmpty(blackboard.expressionTriggerId))
         {
             DCLCharacterController.i.ForceReportMovement();
-            UserProfile.GetOwnUserProfile().SetAvatarExpression(STOP_EMOTE, UserProfile.EmoteSource.EmoteCancel, true);
+            UserProfile.GetOwnUserProfile().SetAvatarExpression("", UserProfile.EmoteSource.EmoteCancel, true);
         }
 
         blackboard.expressionTriggerId = null;
@@ -455,12 +454,6 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
 
         if (string.IsNullOrEmpty(emoteId))
             return;
-
-        if (emoteId == STOP_EMOTE)
-        {
-            StopEmoteInternal(false);
-            return;
-        }
 
         if (animation.GetClip(emoteId) == null)
             return;
@@ -547,6 +540,9 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
                 emoteClipData.ExtraContent.transform.SetParent(null, false);
         }
     }
+
+    public string GetCurrentEmoteId() =>
+        blackboard.expressionTriggerId;
 
     private void InitializeAvatarAudioAndParticleHandlers(Animation createdAnimation)
     {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -135,7 +135,7 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
     // AvatarSystem entry points
     public bool Prepare(string bodyshapeId, GameObject container)
     {
-        StopEmote();
+        StopEmote(true);
 
         animation = container.gameObject.GetOrCreateComponent<Animation>();
         container.gameObject.GetOrCreateComponent<StickerAnimationListener>();
@@ -388,9 +388,9 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         return Mathf.RoundToInt(currentEmote.time / currentEmote.length);
     }
 
-    public void StopEmote()
+    public void StopEmote(bool immediate)
     {
-        StopEmoteInternal(true);
+        StopEmoteInternal(immediate);
     }
 
     private void StopEmoteInternal(bool immediate)
@@ -447,8 +447,6 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
     public void PlayEmote(string emoteId, long timestamps, bool spatial, float volume, bool occlude,
         bool forcePlay)
     {
-        Debug.Log($"Playing {emoteId} ts: {timestamps} force: {forcePlay}");
-
         if (animation == null)
             return;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarAnimatorLegacy.cs
@@ -398,7 +398,10 @@ public class AvatarAnimatorLegacy : MonoBehaviour, IPoolLifecycleHandler, IAnima
         if (animation == null) return;
 
         if (!string.IsNullOrEmpty(blackboard.expressionTriggerId))
+        {
+            Debug.Log($"Emote stopped {blackboard.expressionTriggerId}");
             animation.Blend(blackboard.expressionTriggerId, 0, !immediate ? EXPRESSION_EXIT_TRANSITION_TIME : 0);
+        }
 
         // Instantly replicate our emote status and position
         if (isOwnPlayer && !string.IsNullOrEmpty(blackboard.expressionTriggerId))

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
@@ -8,12 +8,14 @@ namespace DCL
 {
     public class AvatarMovementController : MonoBehaviour, IPoolLifecycleHandler, IAvatarMovementController
     {
-        private const float WALK_SPEED = 4.5f;
-        private const float RUN_SPEED = 11.0f;
+        // Speed values are slightly slower than the player
+        private const float WALK_SPEED = 4f;
+        private const float RUN_SPEED = 10.0f;
+
         private const float SPEED_GRAVITY = 11.0f;
         private const float ROTATION_SPEED = 6.25f;
         private const float SPEED_EPSILON = 0.0001f;
-        private const int WALK_DISTANCE = 1;
+        private const float WALK_DISTANCE = 1.5f;
         private float movementSpeed = WALK_SPEED;
 
         private Transform avatarTransformValue;
@@ -128,9 +130,9 @@ namespace DCL
             if (distance >= 50 || immediate)
                 movementSpeed = float.MaxValue;
             else if (distance >= WALK_DISTANCE)
-                movementSpeed = RUN_SPEED;
+                movementSpeed = Mathf.MoveTowards(movementSpeed, RUN_SPEED, Time.deltaTime * 2);
             else
-                movementSpeed = WALK_SPEED;
+                movementSpeed = Mathf.MoveTowards(movementSpeed, WALK_SPEED, Time.deltaTime * 6);
         }
 
         void UpdateLerp(float deltaTime)
@@ -166,8 +168,6 @@ namespace DCL
 
             Vector3 direction = (targetPosition - CurrentPosition).normalized;
             Vector3 delta = direction * (movementSpeed * deltaTime);
-
-            Debug.Log($"Delta {delta} MS " + movementSpeed);
 
             //NOTE(Brian): We need a separate value for Y movement because the gravity has to be lerped faster.
             delta.y = direction.y * SPEED_GRAVITY * deltaTime;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
@@ -128,9 +128,9 @@ namespace DCL
             if (distance >= 50 || immediate)
                 movementSpeed = float.MaxValue;
             else if (distance >= WALK_DISTANCE)
-                movementSpeed = WALK_SPEED;
-            else
                 movementSpeed = RUN_SPEED;
+            else
+                movementSpeed = WALK_SPEED;
         }
 
         void UpdateLerp(float deltaTime)
@@ -166,6 +166,8 @@ namespace DCL
 
             Vector3 direction = (targetPosition - CurrentPosition).normalized;
             Vector3 delta = direction * (movementSpeed * deltaTime);
+
+            Debug.Log($"Delta {delta} MS " + movementSpeed);
 
             //NOTE(Brian): We need a separate value for Y movement because the gravity has to be lerped faster.
             delta.y = direction.y * SPEED_GRAVITY * deltaTime;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
@@ -125,14 +125,18 @@ namespace DCL
             targetPosition = position;
             targetRotation = rotation;
 
-            float distance = Vector3.Distance(targetPosition, currentWorldPosition);
+            float distance = Vector3.Distance(targetPosition, CurrentPosition);
 
-            if (distance >= 50 || immediate)
-                movementSpeed = float.MaxValue;
-            else if (distance >= WALK_DISTANCE)
-                movementSpeed = Mathf.MoveTowards(movementSpeed, RUN_SPEED, Time.deltaTime * 2);
+            if (distance >= 50)
+            {
+                CurrentPosition = position;
+                AvatarTransform.rotation = rotation;
+            }
+
+            if (distance >= WALK_DISTANCE)
+                movementSpeed = Mathf.MoveTowards(movementSpeed, RUN_SPEED, Time.deltaTime * RUN_SPEED * 10);
             else
-                movementSpeed = Mathf.MoveTowards(movementSpeed, WALK_SPEED, Time.deltaTime * 6);
+                movementSpeed = Mathf.MoveTowards(movementSpeed, WALK_SPEED, Time.deltaTime * RUN_SPEED * 30);
         }
 
         void UpdateLerp(float deltaTime)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
@@ -8,13 +8,13 @@ namespace DCL
 {
     public class AvatarMovementController : MonoBehaviour, IPoolLifecycleHandler, IAvatarMovementController
     {
-        private const float SPEED_SLOW = 2.0f;
-        private const float SPEED_FAST = 4.0f;
-        private const float SPEED_ULTRA_FAST = 8.0f;
-        private const float SPEED_GRAVITY = 8.0f;
+        private const float WALK_SPEED = 4.5f;
+        private const float RUN_SPEED = 11.0f;
+        private const float SPEED_GRAVITY = 11.0f;
         private const float ROTATION_SPEED = 6.25f;
         private const float SPEED_EPSILON = 0.0001f;
-        private float movementSpeed = SPEED_SLOW;
+        private const int WALK_DISTANCE = 1;
+        private float movementSpeed = WALK_SPEED;
 
         private Transform avatarTransformValue;
 
@@ -125,12 +125,12 @@ namespace DCL
 
             float distance = Vector3.Distance(targetPosition, currentWorldPosition);
 
-            if (distance >= 50)
+            if (distance >= 50 || immediate)
                 movementSpeed = float.MaxValue;
-            else if (distance >= 3)
-                movementSpeed = Mathf.Lerp(SPEED_SLOW, SPEED_ULTRA_FAST, (distance - 3) / 10.0f);
+            else if (distance >= WALK_DISTANCE)
+                movementSpeed = WALK_SPEED;
             else
-                movementSpeed = SPEED_SLOW;
+                movementSpeed = RUN_SPEED;
         }
 
         void UpdateLerp(float deltaTime)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarSceneEmoteHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarSceneEmoteHandler.cs
@@ -51,7 +51,10 @@ namespace DCL
                 //avoid playing emote if timestamp has change,
                 //meaning a new emote was trigger while this one was loading
                 if (timestamp == lamportTimestamp)
+                {
                     emotesController.PlayEmote(emoteId, lamportTimestamp);
+                    UserProfile.GetOwnUserProfile().SetAvatarExpression(emoteId, UserProfile.EmoteSource.EmoteLoop, true);
+                }
             }
             catch (OperationCanceledException) { }
             catch (Exception e) { Debug.LogException(e); }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarSceneEmoteHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarSceneEmoteHandler.cs
@@ -14,15 +14,17 @@ namespace DCL
     {
         private readonly IAvatarEmotesController emotesController;
         private readonly IEmotesService emotesService;
+        private readonly IUserProfileBridge userProfileBridge;
         private readonly HashSet<EmoteBodyId> equippedEmotes;
 
         private long lamportTimestamp;
         internal CancellationTokenSource cts;
 
-        public AvatarSceneEmoteHandler(IAvatarEmotesController emotesController, IEmotesService emotesService)
+        public AvatarSceneEmoteHandler(IAvatarEmotesController emotesController, IEmotesService emotesService, IUserProfileBridge userProfileBridge)
         {
             this.emotesController = emotesController;
             this.emotesService = emotesService;
+            this.userProfileBridge = userProfileBridge;
             this.equippedEmotes = new HashSet<EmoteBodyId>();
         }
 
@@ -53,7 +55,7 @@ namespace DCL
                 if (timestamp == lamportTimestamp)
                 {
                     emotesController.PlayEmote(emoteId, lamportTimestamp);
-                    UserProfile.GetOwnUserProfile().SetAvatarExpression(emoteId, UserProfile.EmoteSource.EmoteLoop, true);
+                    userProfileBridge.GetOwn().SetAvatarExpression(emoteId, UserProfile.EmoteSource.EmoteLoop, true);
                 }
             }
             catch (OperationCanceledException) { }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -238,12 +238,18 @@ namespace DCL
 
             if (sceneEmoteHandler.IsSceneEmote(model.expressionTriggerId))
             {
+                OnEntityTransformChanged(entity.gameObject.transform.localPosition,
+                    entity.gameObject.transform.localRotation, true);
+
                 sceneEmoteHandler
                    .LoadAndPlayEmote(model.bodyShape, model.expressionTriggerId)
                    .Forget();
             }
             else
             {
+                OnEntityTransformChanged(entity.gameObject.transform.localPosition,
+                    entity.gameObject.transform.localRotation, true);
+
                 emotesController.PlayEmote(model.expressionTriggerId, model.expressionTriggerTimestamp);
             }
 
@@ -387,6 +393,8 @@ namespace DCL
 
         private void OnEntityTransformChanged(in Vector3 position, in Quaternion rotation, bool inmediate)
         {
+            Debug.Log(position);
+
             if (isGlobalSceneAvatar)
             {
                 avatarMovementController.OnTransformChanged(position, rotation, inmediate);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -237,21 +237,11 @@ namespace DCL
             sceneEmoteHandler.SetExpressionLamportTimestamp(model.expressionTriggerTimestamp);
 
             if (sceneEmoteHandler.IsSceneEmote(model.expressionTriggerId))
-            {
-                OnEntityTransformChanged(entity.gameObject.transform.localPosition,
-                    entity.gameObject.transform.localRotation, true);
-
                 sceneEmoteHandler
                    .LoadAndPlayEmote(model.bodyShape, model.expressionTriggerId)
                    .Forget();
-            }
             else
-            {
-                OnEntityTransformChanged(entity.gameObject.transform.localPosition,
-                    entity.gameObject.transform.localRotation, true);
-
                 emotesController.PlayEmote(model.expressionTriggerId, model.expressionTriggerTimestamp);
-            }
 
             onPointerDown.OnPointerDownReport -= PlayerClicked;
             onPointerDown.OnPointerDownReport += PlayerClicked;
@@ -393,8 +383,6 @@ namespace DCL
 
         private void OnEntityTransformChanged(in Vector3 position, in Quaternion rotation, bool inmediate)
         {
-            Debug.Log(position);
-
             if (isGlobalSceneAvatar)
             {
                 avatarMovementController.OnTransformChanged(position, rotation, inmediate);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -75,7 +75,11 @@ namespace DCL
                 avatar = GetStandardAvatar();
 
             emotesController = avatar.GetEmotesController();
-            sceneEmoteHandler = new AvatarSceneEmoteHandler(emotesController, Environment.i.serviceLocator.Get<IEmotesService>());
+
+            sceneEmoteHandler = new AvatarSceneEmoteHandler(
+                emotesController,
+                Environment.i.serviceLocator.Get<IEmotesService>(),
+                new UserProfileWebInterfaceBridge());
 
             if (avatarReporterController == null)
             {
@@ -240,7 +244,7 @@ namespace DCL
                 sceneEmoteHandler
                    .LoadAndPlayEmote(model.bodyShape, model.expressionTriggerId)
                    .Forget();
-            else { avatar.GetEmotesController().UpdateEmoteStatus(model.expressionTriggerId, model.expressionTriggerTimestamp); }
+            else { avatar.GetEmotesController().PlayEmote(model.expressionTriggerId, model.expressionTriggerTimestamp); }
 
             onPointerDown.OnPointerDownReport -= PlayerClicked;
             onPointerDown.OnPointerDownReport += PlayerClicked;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -240,8 +240,7 @@ namespace DCL
                 sceneEmoteHandler
                    .LoadAndPlayEmote(model.bodyShape, model.expressionTriggerId)
                    .Forget();
-            else
-                emotesController.PlayEmote(model.expressionTriggerId, model.expressionTriggerTimestamp);
+            else { avatar.GetEmotesController().UpdateEmoteStatus(model.expressionTriggerId, model.expressionTriggerTimestamp); }
 
             onPointerDown.OnPointerDownReport -= PlayerClicked;
             onPointerDown.OnPointerDownReport += PlayerClicked;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -23,13 +23,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2845307395157887310}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4675848658069725358}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3389185268529299172
 GameObject:
@@ -56,6 +56,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3389185268529299172}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -67,7 +68,6 @@ Transform:
   - {fileID: 3553539495342899975}
   - {fileID: 7911633839330093525}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5523974814614327640
 MonoBehaviour:
@@ -129,6 +129,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5582000225371496597}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -138,7 +139,6 @@ Transform:
   - {fileID: 80406326182283783}
   - {fileID: 3217162014015595625}
   m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6790643881566083082
 MonoBehaviour:
@@ -166,8 +166,8 @@ MonoBehaviour:
     fall: {fileID: 7400000, guid: cd48d8cde6039fa4fac548ddab2ff277, type: 2}
   animation: {fileID: 0}
   blackboard:
-    walkSpeedFactor: 0.5
-    runSpeedFactor: 0.25
+    walkSpeedFactor: 0.3
+    runSpeedFactor: 0.15
     movementSpeed: 0
     verticalSpeed: 0
     isGrounded: 1
@@ -211,13 +211,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5716359333359460297}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5854254909640412467
 GameObject:
@@ -245,13 +245,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5854254909640412467}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3865137627712764486
 MonoBehaviour:
@@ -274,9 +274,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5854254909640412467}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 0
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &1771187575892058067
@@ -314,13 +322,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6448032256406529926}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.755, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4675848658069725358}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7213221244455466960
 GameObject:
@@ -345,6 +353,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7213221244455466960}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -352,7 +361,6 @@ Transform:
   m_Children:
   - {fileID: 4161845772322530390}
   m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9158508182074433445
 GameObject:
@@ -378,13 +386,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9158508182074433445}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 0.5, y: 1.8, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2842120016485600253}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &7755590202629118220
 BoxCollider:
@@ -394,9 +402,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9158508182074433445}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &5777784746421811190
@@ -404,6 +420,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 4675848658069725358}
     m_Modifications:
     - target: {fileID: 1933068967218137769, guid: 256ca49022c0ba84abc2a941931ee350,
@@ -482,6 +499,9 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 256ca49022c0ba84abc2a941931ee350, type: 3}
 --- !u!4 &80406326182283783 stripped
 Transform:
@@ -494,6 +514,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 7911633839330093525}
     m_Modifications:
     - target: {fileID: 2343377230149098635, guid: c53ec74589327644bba45b4054fb78dc,
@@ -567,6 +588,9 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c53ec74589327644bba45b4054fb78dc, type: 3}
 --- !u!4 &4161845772322530390 stripped
 Transform:

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarSceneEmoteHandlerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarSceneEmoteHandlerShould.cs
@@ -16,13 +16,15 @@ namespace Tests
         private AvatarSceneEmoteHandler handler;
         private IAvatarEmotesController emotesController;
         private IEmotesService emotesService;
+        private IUserProfileBridge userProfileBridge;
 
         [SetUp]
         public void SetUp()
         {
             emotesService = Substitute.For<IEmotesService>();
             emotesController = Substitute.For<IAvatarEmotesController>();
-            handler = new AvatarSceneEmoteHandler(emotesController, emotesService);
+            userProfileBridge = Substitute.For<IUserProfileBridge>();
+            handler = new AvatarSceneEmoteHandler(emotesController, emotesService, userProfileBridge);
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShapeTests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShapeTests.asmdef
@@ -40,7 +40,8 @@
         "GUID:68069f49d86442cd9618861b4d74b1aa",
         "GUID:fbcc413e192ef9048811d47ab0aca0c0",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
-        "GUID:0c0c18c12967b3944b844b79c47c2320"
+        "GUID:0c0c18c12967b3944b844b79c47c2320",
+        "GUID:1de3566cccb280f4a982c59ad0d08c96"
     ],
     "includePlatforms": [
         "Editor"

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -1,8 +1,11 @@
+using Cinemachine;
 using DCL;
 using DCL.Configuration;
 using DCL.Helpers;
+using DCL.Interface;
+using System;
 using UnityEngine;
-using Cinemachine;
+using Environment = DCL.Environment;
 
 public class DCLCharacterController : MonoBehaviour
 {
@@ -27,13 +30,13 @@ public class DCLCharacterController : MonoBehaviour
     [Header("Additional Camera Layers")]
     public LayerMask cameraLayers;
 
-    [System.NonSerialized]
+    [NonSerialized]
     public bool initialPositionAlreadySet = false;
 
-    [System.NonSerialized]
+    [NonSerialized]
     public bool characterAlwaysEnabled = true;
 
-    [System.NonSerialized]
+    [NonSerialized]
     public CharacterController characterController;
 
     FreeMovementController freeMovementController;
@@ -78,9 +81,9 @@ public class DCLCharacterController : MonoBehaviour
 
     private Vector3NullableVariable characterForward => CommonScriptableObjects.characterForward;
 
-    public static System.Action<DCLCharacterPosition> OnCharacterMoved;
-    public static System.Action<DCLCharacterPosition> OnPositionSet;
-    public event System.Action<float> OnUpdateFinish;
+    public static Action<DCLCharacterPosition> OnCharacterMoved;
+    public static Action<DCLCharacterPosition> OnPositionSet;
+    public event Action<float> OnUpdateFinish;
 
     public GameObject avatarGameObject;
     public GameObject firstPersonCameraGameObject;
@@ -96,13 +99,13 @@ public class DCLCharacterController : MonoBehaviour
 
     private readonly DataStore_Player dataStorePlayer = DataStore.i.player;
 
-    [System.NonSerialized]
+    [NonSerialized]
     public float movingPlatformSpeed;
     private CollisionFlags lastCharacterControllerCollision;
 
-    public event System.Action OnJump;
-    public event System.Action OnHitGround;
-    public event System.Action<float> OnMoved;
+    public event Action OnJump;
+    public event Action OnHitGround;
+    public event Action<float> OnMoved;
 
     public void SetMovementInputToZero()
     {
@@ -143,7 +146,7 @@ public class DCLCharacterController : MonoBehaviour
 
         if (avatarGameObject == null || firstPersonCameraGameObject == null)
         {
-            throw new System.Exception("Both the avatar and first person camera game objects must be set.");
+            throw new Exception("Both the avatar and first person camera game objects must be set.");
         }
 
         var worldData = DataStore.i.Get<DataStore_World>();
@@ -252,7 +255,7 @@ public class DCLCharacterController : MonoBehaviour
         }
     }
 
-    [System.Obsolete("SetPosition is deprecated, please use Teleport instead.", true)]
+    [Obsolete("SetPosition is deprecated, please use Teleport instead.", true)]
     public void SetPosition(string positionVector) { Teleport(positionVector); }
 
     public void SetEnabled(bool enabled) { this.enabled = enabled; }
@@ -564,7 +567,7 @@ public class DCLCharacterController : MonoBehaviour
         //                  - Scenes not being sent for loading, making ActivateRenderer never being sent, only in WSS mode.
         //                  - Random teleports to 0,0 or other positions that shouldn't happen.
         if (initialPositionAlreadySet)
-            DCL.Interface.WebInterface.ReportPosition(reportPosition, compositeRotation, characterController.height, cameraRotation);
+            WebInterface.ReportPosition(reportPosition, compositeRotation, characterController.height, cameraRotation);
 
         lastMovementReportTime = DCLTime.realtimeSinceStartup;
     }
@@ -585,5 +588,10 @@ public class DCLCharacterController : MonoBehaviour
     bool IsLastCollisionGround()
     {
         return (lastCharacterControllerCollision & CollisionFlags.Below) != 0;
+    }
+
+    public void ForceReportMovement()
+    {
+        ReportMovement();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/DCLCharacterController.cs
@@ -554,7 +554,7 @@ public class DCLCharacterController : MonoBehaviour
         return result;
     }
 
-    void ReportMovement()
+    public void ReportMovement()
     {
         var reportPosition = characterPosition.worldPosition;
         var compositeRotation = Quaternion.LookRotation(characterForward.HasValue() ? characterForward.Get().Value : cameraForward.Get());
@@ -588,10 +588,5 @@ public class DCLCharacterController : MonoBehaviour
     bool IsLastCollisionGround()
     {
         return (lastCharacterControllerCollision & CollisionFlags.Below) != 0;
-    }
-
-    public void ForceReportMovement()
-    {
-        ReportMovement();
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/CharacterPreview/CharacterPreviewController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/CharacterPreview/CharacterPreviewController.cs
@@ -1,19 +1,16 @@
 using AvatarSystem;
 using Cysharp.Threading.Tasks;
 using DCL;
-using DCL.Emotes;
-using MainScripts.DCL.Components.Avatar.VRMExporter;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using UnityEngine;
 using Environment = DCL.Environment;
 
 namespace MainScripts.DCL.Controllers.HUD.CharacterPreview
 {
-    using UnityEngine;
-
     public class CharacterPreviewController : MonoBehaviour, ICharacterPreviewController
     {
         private const int SNAPSHOT_BODY_WIDTH_RES = 256;
@@ -142,7 +139,7 @@ namespace MainScripts.DCL.Controllers.HUD.CharacterPreview
 
         public async UniTask<Texture2D> TakeBodySnapshotAsync()
         {
-            global::DCL.Environment.i.platform.cullingController.Stop();
+            Environment.i.platform.cullingController.Stop();
             if (avatar.status != IAvatar.Status.Loaded)
                 return null;
 
@@ -159,7 +156,7 @@ namespace MainScripts.DCL.Controllers.HUD.CharacterPreview
             SetFocus(PreviewCameraFocus.DefaultEditing, false);
 
             cameraController.SetTargetTexture(current);
-            global::DCL.Environment.i.platform.cullingController.Start();
+            Environment.i.platform.cullingController.Start();
 
             return body;
         }
@@ -177,7 +174,7 @@ namespace MainScripts.DCL.Controllers.HUD.CharacterPreview
 
         private IEnumerator TakeSnapshots_Routine(OnSnapshotsReady callback)
         {
-            global::DCL.Environment.i.platform.cullingController.Stop();
+            Environment.i.platform.cullingController.Stop();
 
             var current = cameraController.CurrentTargetTexture;
             cameraController.SetTargetTexture(null);
@@ -197,7 +194,7 @@ namespace MainScripts.DCL.Controllers.HUD.CharacterPreview
 
             cameraController.SetTargetTexture(current);
 
-            global::DCL.Environment.i.platform.cullingController.Start();
+            Environment.i.platform.cullingController.Start();
             callback?.Invoke(face256, body);
         }
 
@@ -232,7 +229,7 @@ namespace MainScripts.DCL.Controllers.HUD.CharacterPreview
 
         public void StopEmote()
         {
-            avatar.GetEmotesController().StopEmote();
+            avatar.GetEmotesController().StopEmote(true);
         }
 
         public void Dispose() =>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -19,6 +19,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
         Command,
         Backpack,
         EmoteLoop,
+        EmoteCancel,
     }
 
     private const string FALLBACK_NAME = "fallback";


### PR DESCRIPTION
## What does this PR change?


This branch fixes certain movement and emote replication issues:
`Replicated Avatars = Not you`
- Fixed Replicated Avatars that were not moving at the correct speed. (walking fast)
- Fixed Replicated Avatars that triggered emotes before they stopped moving, thus canceling the emote. (moving and then clicking the chair or triggering an emote)
- Fixed Replicated Avatars that were not immediately reporting its emote cancel status (ending an emote is instant for all clients and it does not depend on movement speed)

## How to test the changes?

Go to `8,-108` https://play.decentraland.zone/?explorer-branch=fix/emote-replication&position=-8,108
Be with a friend or another client:

- Do emotes and click on the chairs to enter the "Sitting" emote of the scene.
- Try running, clicking, jumping and even triggering an emote while on the chair to cancel or change the emote status.
- Observe avatars triggering and stopping emotes, the replication must be equal, this means that on both clients the same avatar should be doing the same action at (mostly) the same position.
- Observe the avatars movement, it should feel much smoother and closer to the Player's movement than before.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1747d08</samp>

This pull request improves the avatar emote system by fixing some bugs, refactoring some code, and adding some new features. It affects the `AvatarShape`, `AvatarEmotesController`, `AvatarAnimatorLegacy`, `AvatarMovementController`, `DCLCharacterController`, `CharacterPreviewController`, `AvatarSceneEmoteHandler`, and `UserProfile` classes, as well as the `IAvatarEmotesController` and `IAnimator` interfaces, and the `AvatarShape.prefab` file.
