### PR TITLE
fix: hide pending status warning for email subscriptions

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/EmailNotificationsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/EmailNotificationsController.cs
@@ -166,7 +166,7 @@ namespace DCL.MyAccount
                         else
                         {
                             savedEmail = existingSubscription.email;
-                            savedIsPending = existingSubscription.status is "pending" or "validating";
+                            savedIsPending = existingSubscription.status is "pending";
                         }
                     }
                 }
@@ -233,7 +233,7 @@ namespace DCL.MyAccount
                     PlayerPrefsBridge.SetString(CURRENT_SUBSCRIPTION_ID_LOCAL_STORAGE_KEY, newSubscription.id);
                     PlayerPrefsBridge.Save();
                     savedEmail = newEmail;
-                    savedIsPending = newSubscription.status is "pending" or "validating";
+                    savedIsPending = false;
                     wasSuccessfullyUpdated = true;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## What does this PR change?
Since all the emails registered are now being automatically confirmed without the double user's action, we don't need to show the yellow warning message anymore right after we add/modify our email in "**Account Settings**" -> "**Email Notifications**".

![image](https://github.com/decentraland/unity-renderer/assets/64659061/106f0e76-bf0e-42e1-82d8-5f2b080dc1ce)

## How to test the changes?
1. Launch the explorer.
2. Go to Account Settings -> Email Notifications.
3. Add or modify your email.
4. Check that any warning message appears (your email is already confirmed from this point on).

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b6c1f5</samp>

Simplify and fix email subscription logic in `EmailNotificationsController`. Remove unnecessary code and avoid repeated verification messages.