### PR TITLE
fix: sometimes the passport doesn't load correctly

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PassportNavigation/PassportNavigationComponentView.cs
@@ -332,6 +332,9 @@ namespace DCL.Social.Passports
 
             foreach (var wearable in wearables)
             {
+                if (wearable == null)
+                    continue;
+
                 if (!hidesList.Contains(wearable.data.category))
                 {
                     PoolableObject poolableObject = nftIconsEntryPool.Get();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -344,6 +344,9 @@ public class WearableItem
         {
             WearableItem wearableItem = wearables[index];
 
+            if (wearableItem == null)
+                continue;
+
             if (result.Contains(wearableItem.data.category)) //Skip hidden elements to avoid two elements hiding each other
                 continue;
 


### PR DESCRIPTION
## What does this PR change?
Fixes #5859 

### BEFORE THE FIX
Sometimes, when we clicked on an avatar to open his passport and, for any reason, any of his equipped wearables could not be resolved, the passport's loading failed and none of the wearables were showed:

![image](https://github.com/decentraland/unity-renderer/assets/64659061/16bc358b-90e2-42b5-aa23-909210846f08)

### AFTER THE FIX
Now, if any of the wearables fails, we skip it and continue loading the rest, so the passport can be loaded correctly:

![image](https://github.com/decentraland/unity-renderer/assets/64659061/93b1e60f-9710-47e7-8959-c4eeb92adfb6)

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer.
2. Click on different avatars to open their passports.
3. Check that the passport always opens and the wearables load correctly.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08ceed8</samp>

This pull request adds null checks for wearable variables in two methods that deal with avatar wearables. This prevents potential errors when updating the passport navigation UI or filtering out hidden wearable categories.