### PR TITLE
feat: Animation LOD Distances

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
@@ -77,7 +77,8 @@
         "GUID:da3e51d19d51a544fa14d43fee843098",
         "GUID:0c0c18c12967b3944b844b79c47c2320",
         "GUID:4d3366a36e77f41cfb7436340334e236",
-        "GUID:2d39cc535b437e749965d4a8258f0c13"
+        "GUID:2d39cc535b437e749965d4a8258f0c13",
+        "GUID:301149363e31a4bdaa1943465a825c8e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/GPUSkinningThrottlingCurve.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/Resources/GPUSkinningThrottlingCurve.asset
@@ -34,14 +34,65 @@ MonoBehaviour:
       inWeight: 0.33333334
       outWeight: 0.33333334
     - serializedVersion: 3
-      time: 29.97296
-      value: 5.9995947
+      time: 22.886015
+      value: 2.0299528
+      inSlope: Infinity
+      outSlope: Infinity
+      tangentMode: 7
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 30
+      value: 4
       inSlope: Infinity
       outSlope: Infinity
       tangentMode: 97
       weightedMode: 0
       inWeight: 0
       outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 45
+      value: 6
+      inSlope: Infinity
+      outSlope: Infinity
+      tangentMode: 103
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  mildCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0.03470943
+      value: 1.0015817
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 136
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 60
+      value: 2
+      inSlope: Infinity
+      outSlope: Infinity
+      tangentMode: 103
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 120
+      value: 3
+      inSlope: Infinity
+      outSlope: Infinity
+      tangentMode: 103
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4


### PR DESCRIPTION
## What does this PR change?

We tweaked the distance in which the Avatar animations get Throttled.
Before it was just 15 meters we throttled the animations by 2 frames.
Then after 30 meters, the throttle was increased to 6.
This is very noticeable on low framerates.

Now the Throttling scales with the Culling limit. 

Fixes https://github.com/decentraland/unity-renderer/issues/5914

## How to test the changes?

- Enter the [link in WebGL](https://play.decentraland.org/?explorer-branch=fix/animation-lod) for the worst performance
- Put one avatar to dance
- Go with your other avatar and take distance from the first one, observe how the animation get's throttled by playing with the culling settings.

Culling OFF = No Throttling
Culling ON:
- Culling size at 0 = Throttling starts at around 50 meters (2 and 1/2 parcels)
- Culling size at 100 = Throttling starts at 7.5 meters (1/2 of a parcel)

`Animation being throttled = Animation looks laggy`

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fafddaa</samp>

The pull request improves the animation throttling logic for avatars based on the quality settings and the detail object culling feature. It adds a new reference to the `DCL.SettingsCommon` assembly and modifies the `GPUSkinningThrottlingCurve` asset to provide different curves for different quality levels. It also does some minor refactoring and cleanup of the code.
