### PR TITLE
revert: "fix: crossplatform profile (#5910)"

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/fetchProfile/index.ts
@@ -16,30 +16,6 @@ import type { ProfileStatus } from '../../types'
 import { fetchPeerProfile } from '../comms'
 import { fetchCatalystProfile } from '../content'
 
-export function* fetchProfileFromCatalyst(userId: string, version: number) {
-  try {
-    const profile = yield call(fetchFromCatalyst, userId, version)
-
-    const avatar: Avatar = ensureAvatarCompatibilityFormat(profile)
-    avatar.userId = userId
-
-    if (yield select(isCurrentUserId, userId)) {
-      avatar.hasConnectedWeb3 = true
-    }
-
-    yield put(profileSuccess(avatar))
-    return avatar
-  } catch (error: any) {
-    debugger
-    trackEvent('error', {
-      context: 'kernel#saga',
-      message: `Error requesting profile for ${userId}: ${error}`,
-      stack: error.stack || ''
-    })
-    yield put(profileFailure(userId, `${error}`))
-  }
-}
-
 export function* fetchProfile(action: ProfileRequestAction): any {
   const { userId, minimumVersion } = action.payload
   const {

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -1,15 +1,15 @@
-import type {Avatar} from '@dcl/schemas'
-import {ETHEREUM_NETWORK, ethereumConfigurations, RESET_TUTORIAL} from 'config'
+import type { Avatar } from '@dcl/schemas'
+import { ethereumConfigurations, ETHEREUM_NETWORK, RESET_TUTORIAL } from 'config'
 import defaultLogger from 'lib/logger'
-import {call, put, select} from 'redux-saga/effects'
-import {BringDownClientAndReportFatalError, ErrorContext} from 'shared/loading/ReportFatalError'
-import {getCurrentIdentity, getCurrentNetwork} from 'shared/session/selectors'
-import type {ExplorerIdentity} from 'shared/session/types'
-import {fetchOwnedENS} from 'lib/web3/fetchOwnedENS'
-import {profileSuccess, saveProfileDelta} from '../actions'
-import {fetchProfileFromCatalyst} from './fetchProfile'
-import {fetchLocalProfile} from './local/index'
-import {getFeatureFlagEnabled} from 'shared/meta/selectors'
+import { call, put, select } from 'redux-saga/effects'
+import { BringDownClientAndReportFatalError, ErrorContext } from 'shared/loading/ReportFatalError'
+import { getCurrentIdentity, getCurrentNetwork } from 'shared/session/selectors'
+import type { ExplorerIdentity } from 'shared/session/types'
+import { fetchOwnedENS } from 'lib/web3/fetchOwnedENS'
+import { profileRequest, profileSuccess, saveProfileDelta } from '../actions'
+import { fetchProfile } from './fetchProfile'
+import { fetchLocalProfile } from './local/index'
+import { getFeatureFlagEnabled } from 'shared/meta/selectors'
 
 export function* initialRemoteProfileLoad() {
   // initialize profile
@@ -19,9 +19,8 @@ export function* initialRemoteProfileLoad() {
   let profile: Avatar | null = yield call(fetchLocalProfile)
   try {
     profile = yield call(
-      fetchProfileFromCatalyst,
-      userId,
-      profile && profile.userId === userId ? profile.version : 0
+      fetchProfile,
+      profileRequest(userId, profile && profile.userId === userId ? profile.version : 0)
     )
   } catch (e: any) {
     BringDownClientAndReportFatalError(e, ErrorContext.KERNEL_INIT, { userId })

--- a/browser-interface/packages/shared/profiles/sagas/local/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/local/index.ts
@@ -1,11 +1,12 @@
 import type { Avatar } from '@dcl/schemas'
 import type { ETHEREUM_NETWORK } from 'config'
 import type { ExplorerIdentity } from 'shared/session/types'
-import { apply, select } from 'redux-saga/effects'
+import { apply, put, select } from 'redux-saga/effects'
 import { ensureAvatarCompatibilityFormat } from 'lib/decentraland/profiles/transformations/profileToServerFormat'
 import { localProfilesRepo } from './localProfilesRepo'
 import { getCurrentIdentity, getCurrentNetwork } from 'shared/session/selectors'
 import defaultLogger from 'lib/logger'
+import { profileSuccess } from 'shared/profiles/actions'
 
 export function* fetchLocalProfile() {
   const network: ETHEREUM_NETWORK = yield select(getCurrentNetwork)
@@ -13,7 +14,8 @@ export function* fetchLocalProfile() {
   const profile = (yield apply(localProfilesRepo, localProfilesRepo.get, [identity.address, network])) as Avatar | null
   if (profile && profile.userId === identity.address) {
     try {
-      return ensureAvatarCompatibilityFormat(profile)
+      const finalProfile = ensureAvatarCompatibilityFormat(profile)
+      yield put(profileSuccess(finalProfile))
     } catch (error) {
       defaultLogger.log(`Invalid profile stored: ${JSON.stringify(profile, null, 2)}`)
       return null


### PR DESCRIPTION
This reverts commit 6635746aa0045729ad80ce0721a2d4bdacbf2b24.

## What does this PR change?

The change is reverted because it makes impossible to log in as a guest.
Will create a PR fixing this issue later.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed5740e</samp>

Refactored the profile fetching logic to use a common `fetchProfile` function that can handle both catalyst and local profiles. Added a redux action to store the local profile in the state. Removed unused `fetchProfileFromCatalyst` function.
