### PR TITLE
fix: backpack is always playing the last emote when it’s open

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentController.cs
@@ -100,7 +100,7 @@ namespace DCL.EmotesCustomization
 
             UpdateEmoteSlots();
 
-            view.Refresh();
+            view.RefreshEmotesGrid();
         }
 
         public void SetEquippedBodyShape(string bodyShapeId)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/EmotesCustomizationComponentView.cs
@@ -178,6 +178,9 @@ namespace DCL.EmotesCustomization
             RefreshControl();
         }
 
+        public void RefreshEmotesGrid() =>
+            emotesGrid.RefreshControl();
+
         internal void ClickOnEmote(string emoteId, string emoteName, int slotNumber, bool isAssignedInSelectedSlot)
         {
             if (!isAssignedInSelectedSlot)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/IEmotesCustomizationComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/EmotesCustomization/IEmotesCustomizationComponentView.cs
@@ -120,5 +120,7 @@ namespace DCL.EmotesCustomization
         EmoteSlotCardComponentView GetSlot(int slotNumber);
 
         void Refresh();
+
+        void RefreshEmotesGrid();
     }
 }


### PR DESCRIPTION
## What does this PR change?
Backpack was always playing the last emote when it’s open

## How to test the changes?
1. Launch the explorer.
2. Open the backpack and go to the Emotes tab.
3. Select any emote in order to make the preview avatar to reproduce it.
4. Go to any other tab in the Explore menu: for example: the Map.
5. Go back to the Backpack.
6. The preview avatar shouldn't reproduce any emote.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e50f928</samp>

Improved the performance of the emotes customization UI by adding a `RefreshEmotesGrid` method to the `EmotesCustomizationComponentView` class and its interface, and calling it from the `EmotesCustomizationComponentController` class instead of the generic `Refresh` method.