### PR TITLE
Fix/profile crossplatform

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -11,6 +11,7 @@ import {fetchProfileFromCatalyst} from './fetchProfile'
 import {fetchLocalProfile} from './local/index'
 import {getFeatureFlagEnabled} from 'shared/meta/selectors'
 import {generateRandomUserProfile} from "../../../lib/decentraland/profiles";
+import {ensureAvatarCompatibilityFormat} from "../../../lib/decentraland/profiles/transformations";
 
 export function* initialRemoteProfileLoad() {
   // initialize profile
@@ -29,7 +30,7 @@ export function* initialRemoteProfileLoad() {
     }
 
     if (!profile) {
-      profile = generateRandomUserProfile(userId)
+      profile = ensureAvatarCompatibilityFormat(generateRandomUserProfile(userId))
       yield put(profileSuccess(profile))
     }
   } catch (e: any) {

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -10,6 +10,7 @@ import {profileSuccess, saveProfileDelta} from '../actions'
 import {fetchProfileFromCatalyst} from './fetchProfile'
 import {fetchLocalProfile} from './local/index'
 import {getFeatureFlagEnabled} from 'shared/meta/selectors'
+import {generateRandomUserProfile} from "../../../lib/decentraland/profiles";
 
 export function* initialRemoteProfileLoad() {
   // initialize profile
@@ -19,7 +20,11 @@ export function* initialRemoteProfileLoad() {
   const isGuest = yield select(isGuestLogin)
   let profile: Avatar | null = yield call(fetchLocalProfile, isGuest)
   try {
-    if (!isGuest) {
+    if (isGuest && !profile) {
+      if (!profile) {
+        profile = generateRandomUserProfile(userId)
+      }
+    } else {
       profile = yield call(
         fetchProfileFromCatalyst,
         userId,

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -30,6 +30,9 @@ export function* initialRemoteProfileLoad() {
 
     if (!profile) {
       profile = generateRandomUserProfile(userId)
+      if (profile) {
+        yield put(profileSuccess(profile))
+      }
     }
   } catch (e: any) {
     BringDownClientAndReportFatalError(e, ErrorContext.KERNEL_INIT, { userId })

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -30,9 +30,7 @@ export function* initialRemoteProfileLoad() {
 
     if (!profile) {
       profile = generateRandomUserProfile(userId)
-      if (profile) {
-        yield put(profileSuccess(profile))
-      }
+      yield put(profileSuccess(profile))
     }
   } catch (e: any) {
     BringDownClientAndReportFatalError(e, ErrorContext.KERNEL_INIT, { userId })

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -1,15 +1,15 @@
-import type { Avatar } from '@dcl/schemas'
-import { ethereumConfigurations, ETHEREUM_NETWORK, RESET_TUTORIAL } from 'config'
+import type {Avatar} from '@dcl/schemas'
+import {ETHEREUM_NETWORK, ethereumConfigurations, RESET_TUTORIAL} from 'config'
 import defaultLogger from 'lib/logger'
-import { call, put, select } from 'redux-saga/effects'
-import { BringDownClientAndReportFatalError, ErrorContext } from 'shared/loading/ReportFatalError'
-import { getCurrentIdentity, getCurrentNetwork } from 'shared/session/selectors'
-import type { ExplorerIdentity } from 'shared/session/types'
-import { fetchOwnedENS } from 'lib/web3/fetchOwnedENS'
-import { profileRequest, profileSuccess, saveProfileDelta } from '../actions'
-import { fetchProfile } from './fetchProfile'
-import { fetchLocalProfile } from './local/index'
-import { getFeatureFlagEnabled } from 'shared/meta/selectors'
+import {call, put, select} from 'redux-saga/effects'
+import {BringDownClientAndReportFatalError, ErrorContext} from 'shared/loading/ReportFatalError'
+import {getCurrentIdentity, getCurrentNetwork} from 'shared/session/selectors'
+import type {ExplorerIdentity} from 'shared/session/types'
+import {fetchOwnedENS} from 'lib/web3/fetchOwnedENS'
+import {profileSuccess, saveProfileDelta} from '../actions'
+import {fetchProfileFromCatalyst} from './fetchProfile'
+import {fetchLocalProfile} from './local/index'
+import {getFeatureFlagEnabled} from 'shared/meta/selectors'
 
 export function* initialRemoteProfileLoad() {
   // initialize profile
@@ -19,8 +19,9 @@ export function* initialRemoteProfileLoad() {
   let profile: Avatar | null = yield call(fetchLocalProfile)
   try {
     profile = yield call(
-      fetchProfile,
-      profileRequest(userId, profile && profile.userId === userId ? profile.version : 0)
+      fetchProfileFromCatalyst,
+      userId,
+      profile && profile.userId === userId ? profile.version : 0
     )
   } catch (e: any) {
     BringDownClientAndReportFatalError(e, ErrorContext.KERNEL_INIT, { userId })

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -20,16 +20,16 @@ export function* initialRemoteProfileLoad() {
   const isGuest = yield select(isGuestLogin)
   let profile: Avatar | null = yield call(fetchLocalProfile, isGuest)
   try {
-    if (isGuest && !profile) {
-      if (!profile) {
-        profile = generateRandomUserProfile(userId)
-      }
-    } else {
+    if (!isGuest) {
       profile = yield call(
         fetchProfileFromCatalyst,
         userId,
         profile && profile.userId === userId ? profile.version : 0
       )
+    }
+
+    if (!profile) {
+      profile = generateRandomUserProfile(userId)
     }
   } catch (e: any) {
     BringDownClientAndReportFatalError(e, ErrorContext.KERNEL_INIT, { userId })

--- a/browser-interface/packages/shared/profiles/sagas/local/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/local/index.ts
@@ -1,12 +1,11 @@
 import type { Avatar } from '@dcl/schemas'
 import type { ETHEREUM_NETWORK } from 'config'
 import type { ExplorerIdentity } from 'shared/session/types'
-import { apply, put, select } from 'redux-saga/effects'
+import { apply, select } from 'redux-saga/effects'
 import { ensureAvatarCompatibilityFormat } from 'lib/decentraland/profiles/transformations/profileToServerFormat'
 import { localProfilesRepo } from './localProfilesRepo'
 import { getCurrentIdentity, getCurrentNetwork } from 'shared/session/selectors'
 import defaultLogger from 'lib/logger'
-import { profileSuccess } from 'shared/profiles/actions'
 
 export function* fetchLocalProfile() {
   const network: ETHEREUM_NETWORK = yield select(getCurrentNetwork)
@@ -14,8 +13,7 @@ export function* fetchLocalProfile() {
   const profile = (yield apply(localProfilesRepo, localProfilesRepo.get, [identity.address, network])) as Avatar | null
   if (profile && profile.userId === identity.address) {
     try {
-      const finalProfile = ensureAvatarCompatibilityFormat(profile)
-      yield put(profileSuccess(finalProfile))
+      return ensureAvatarCompatibilityFormat(profile)
     } catch (error) {
       defaultLogger.log(`Invalid profile stored: ${JSON.stringify(profile, null, 2)}`)
       return null

--- a/browser-interface/packages/shared/profiles/sagas/local/index.ts
+++ b/browser-interface/packages/shared/profiles/sagas/local/index.ts
@@ -1,19 +1,24 @@
 import type { Avatar } from '@dcl/schemas'
 import type { ETHEREUM_NETWORK } from 'config'
 import type { ExplorerIdentity } from 'shared/session/types'
-import { apply, select } from 'redux-saga/effects'
+import {apply, put, select} from 'redux-saga/effects'
 import { ensureAvatarCompatibilityFormat } from 'lib/decentraland/profiles/transformations/profileToServerFormat'
 import { localProfilesRepo } from './localProfilesRepo'
 import { getCurrentIdentity, getCurrentNetwork } from 'shared/session/selectors'
 import defaultLogger from 'lib/logger'
+import {profileSuccess} from "../../actions";
 
-export function* fetchLocalProfile() {
+export function* fetchLocalProfile(submit: boolean = false) {
   const network: ETHEREUM_NETWORK = yield select(getCurrentNetwork)
   const identity: ExplorerIdentity = yield select(getCurrentIdentity)
   const profile = (yield apply(localProfilesRepo, localProfilesRepo.get, [identity.address, network])) as Avatar | null
   if (profile && profile.userId === identity.address) {
     try {
-      return ensureAvatarCompatibilityFormat(profile)
+      const avatar = ensureAvatarCompatibilityFormat(profile);
+      if (submit) {
+        yield put(profileSuccess(avatar))
+      }
+      return avatar
     } catch (error) {
       defaultLogger.log(`Invalid profile stored: ${JSON.stringify(profile, null, 2)}`)
       return null


### PR DESCRIPTION
## What does this PR change?

Related to: https://github.com/decentraland/unity-renderer/pull/5910
Fixes issues when logging as a guest while supporting cross-platform profile consistency.

## How to test the changes?

1. Follow the steps at https://github.com/decentraland/unity-renderer/pull/5910
2. Guest flows should keep working as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b354ec</samp>

Refactor and improve the profile sagas to support guest login and different profile sources. Add a new function `fetchProfileFromCatalyst` to request profiles from a catalyst server. Enhance the `fetchLocalProfile` and `initialRemoteProfileLoad` sagas to handle different login scenarios and profile formats.
