### PR TITLE
chore: downgrade unity to fix shader issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ references:
       at: *working_directory
 
   .unity_linux_image: &unity_linux_image
-    - image: unityci/editor:ubuntu-2022.3.12f1-linux-il2cpp-2.0.0
+    - image: unityci/editor:ubuntu-2022.3.10f1-linux-il2cpp-2.0.0
       environment:
         DCL_OUTPUT_NAME: linux
         PROJECT_PATH: /tmp/workspace/unity-renderer/unity-renderer
@@ -23,7 +23,7 @@ references:
         #                                                ~~~~~~~~~~~~~~~~~~~~ <- folder name
 
   .unity_mac_image: &unity_mac_image
-    - image: unityci/editor:ubuntu-2022.3.12f1-mac-mono-2.0.0
+    - image: unityci/editor:ubuntu-2022.3.10f1-mac-mono-2.0.0
       environment:
         DCL_OUTPUT_NAME: mac
         PROJECT_PATH: /tmp/workspace/unity-renderer/unity-renderer
@@ -34,7 +34,7 @@ references:
         #                                                ~~~~~~~~~~~~~~~~~~ <- folder name
 
   .unity_windows_image: &unity_windows_image
-    - image: unityci/editor:ubuntu-2022.3.12f1-windows-mono-2.0.0
+    - image: unityci/editor:ubuntu-2022.3.10f1-windows-mono-2.0.0
       environment:
         DCL_OUTPUT_NAME: windows
         PROJECT_PATH: /tmp/workspace/unity-renderer/unity-renderer
@@ -45,7 +45,7 @@ references:
         #                                                ~~~~~~~~~~~~~~~~~~~~~~ <- folder name
 
   .unity_webgl_image: &unity_webgl_image
-    - image: unityci/editor:2022.3.12f1-webgl-2.0.0
+    - image: unityci/editor:2022.3.10f1-webgl-2.0.0
       environment:
         DCL_OUTPUT_NAME: webgl
         PROJECT_PATH: /tmp/workspace/unity-renderer/unity-renderer
@@ -116,13 +116,13 @@ commands:
             echo $DCL_OUTPUT_NAME > /tmp/target
       - restore_cache: &RESTORE_BUILD_CACHE
           keys:
-            - build-{{ checksum "/tmp/target" }}-{{ checksum "../.unitysources-checksum" }}-{{ .Branch }}-2022.3.12f1
-            - build-{{ checksum "/tmp/target" }}-{{ checksum "../.unitysources-checksum" }}-dev-2022.3.12f1
+            - build-{{ checksum "/tmp/target" }}-{{ checksum "../.unitysources-checksum" }}-{{ .Branch }}-2022.3.10f1
+            - build-{{ checksum "/tmp/target" }}-{{ checksum "../.unitysources-checksum" }}-dev-2022.3.10f1
       - restore_cache: &RESTORE_LIBRARY_CACHE
           name: Restore library if exists
           keys:
-            - library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-{{ .Branch }}-2022.3.12f1
-            - library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-dev-2022.3.12f1
+            - library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-{{ .Branch }}-2022.3.10f1
+            - library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-dev-2022.3.10f1
       - run:
           name: Build Unity Project
           no_output_timeout: 45m
@@ -141,11 +141,11 @@ commands:
 
       - save_cache: &SAVE_BUILD_CACHE
           name: Store build cache
-          key: build-{{ checksum "/tmp/target" }}-{{ checksum "../.unitysources-checksum" }}-{{ .Branch }}-2022.3.12f1
+          key: build-{{ checksum "/tmp/target" }}-{{ checksum "../.unitysources-checksum" }}-{{ .Branch }}-2022.3.10f1
           paths: *CACHED_PATHS
       - save_cache: &SAVE_LIBRARY_CACHE
           name: Store library
-          key: library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-{{ .Branch }}-2022.3.12f1
+          key: library-{{ checksum "/tmp/target" }}-{{ .Environment.LIBRARY_CACHE_VERSION }}-{{ .Branch }}-2022.3.10f1
           paths:
             - ./unity-renderer/Library
       - run:

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ This repository contains the reference implementation of the [decentraland explo
     git lfs install
     git lfs pull
 
-* The [Unity](https://unity.com) engine and IDE, currently using version 2022.3.12f1
+* The [Unity](https://unity.com) engine and IDE, currently using version 2022.3.10f1
 * [node.js](https://nodejs.org), version 16 or later
 
 ### Steps
 
 Check: [Multiplatform in Editor](docs/multiplatform-in-editor.md)
 
-1. Download and install Unity 2022.3.12f1
+1. Download and install Unity 2022.3.10f1
 2. Open the scene named `InitialScene`
 3. Within the scene, select the `DebugConfig` GameObject.
 4. On `DebugConfig` inspector, make sure that `Base url mode` is set to `Custom`

--- a/unity-renderer/Packages/packages-lock.json
+++ b/unity-renderer/Packages/packages-lock.json
@@ -123,7 +123,7 @@
       "hash": "b538913dd9e0656b1363db3ffc12a723563242d9"
     },
     "com.unity.burst": {
-      "version": "1.8.9",
+      "version": "1.8.8",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -219,7 +219,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "14.0.9",
+      "version": "14.0.8",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -235,9 +235,9 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
-        "com.unity.burst": "1.8.9",
-        "com.unity.render-pipelines.core": "14.0.9",
-        "com.unity.shadergraph": "14.0.9"
+        "com.unity.burst": "1.8.4",
+        "com.unity.render-pipelines.core": "14.0.8",
+        "com.unity.shadergraph": "14.0.8"
       }
     },
     "com.unity.scriptablebuildpipeline": {
@@ -266,7 +266,7 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "14.0.9",
+        "com.unity.render-pipelines.core": "14.0.8",
         "com.unity.searcher": "4.9.2"
       }
     },

--- a/unity-renderer/ProjectSettings/ProjectVersion.txt
+++ b/unity-renderer/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.12f1
-m_EditorVersionWithRevision: 2022.3.12f1 (4fe6e059c7ef)
+m_EditorVersion: 2022.3.10f1
+m_EditorVersionWithRevision: 2022.3.10f1 (ff3792e53c62)

--- a/unity-renderer/ProjectSettings/ShaderGraphSettings.asset
+++ b/unity-renderer/ProjectSettings/ShaderGraphSettings.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de02f9e1d18f588468e474319d09a723, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shaderVariantLimit: 128
   customInterpolatorErrorThreshold: 32
   customInterpolatorWarningThreshold: 16


### PR DESCRIPTION
## What does this PR change?

Downgraded from 2022.3.12f1 to 2022.3.10f1

## How to test the changes?

- Just make sure that the ghost shader looks properly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a1f0f5</samp>

Downgraded some packages and editor version to fix compatibility and consistency issues. Removed shaderVariantLimit setting to optimize rendering performance and memory.
