### PR TITLE
hotfix: if the profile doesn't come from the catalyst, use the local one

### DIFF
--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -22,11 +22,15 @@ export function* initialRemoteProfileLoad() {
   let profile: Avatar | null = yield call(fetchLocalProfile, isGuest)
   try {
     if (!isGuest) {
-      profile = yield call(
+      const profileFromCatalyst = yield call(
         fetchProfileFromCatalyst,
         userId,
         profile && profile.userId === userId ? profile.version : 0
       )
+
+      if (profileFromCatalyst) {
+        profile = profileFromCatalyst;
+      }
     }
 
     if (!profile) {

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -30,14 +30,11 @@ export function* initialRemoteProfileLoad() {
 
       if (profileFromCatalyst) {
         profile = profileFromCatalyst;
-      } else if (profile) {
-        yield put(profileSuccess(profile))
       }
     }
 
     if (!profile) {
       profile = ensureAvatarCompatibilityFormat(generateRandomUserProfile(userId))
-      yield put(profileSuccess(profile))
     }
   } catch (e: any) {
     BringDownClientAndReportFatalError(e, ErrorContext.KERNEL_INIT, { userId })

--- a/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
+++ b/browser-interface/packages/shared/profiles/sagas/initialRemoteProfileLoad.ts
@@ -30,6 +30,8 @@ export function* initialRemoteProfileLoad() {
 
       if (profileFromCatalyst) {
         profile = profileFromCatalyst;
+      } else if (profile) {
+        yield put(profileSuccess(profile))
       }
     }
 


### PR DESCRIPTION
## What does this PR change?
Hotfix

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e16f2d7</samp>

Fixed a bug that reset the profile when switching realms by checking for a local profile when the catalyst server returns null. Modified `initialRemoteProfileLoad.ts` to handle null or undefined profiles.