### PR TITLE
feat: add item id in the equip and unequip wearable analytic

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackAnalyticsService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackAnalyticsService.cs
@@ -74,7 +74,7 @@ namespace DCL.Backpack
         public void SendAvatarEditSuccessNuxAnalytic() =>
             newUserExperienceAnalytics.AvatarEditSuccessNux();
 
-        public void SendEquipWearableAnalytic(string category, string rarity, EquipWearableSource source)
+        public void SendEquipWearableAnalytic(string id, string category, string rarity, EquipWearableSource source)
         {
             Dictionary<string, string> data = new Dictionary<string, string>
             {
@@ -87,7 +87,7 @@ namespace DCL.Backpack
             analytics.SendAnalytic(EQUIP_WEARABLE_METRIC, data);
         }
 
-        public void SendUnequippedWearableAnalytic(string category, string rarity, UnequipWearableSource source)
+        public void SendUnequippedWearableAnalytic(string id, string category, string rarity, UnequipWearableSource source)
         {
             Dictionary<string, string> data = new Dictionary<string, string>
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -614,7 +614,7 @@ namespace DCL.Backpack
                 avatarIsDirty = true;
 
             if (source != EquipWearableSource.None)
-                backpackAnalyticsService.SendEquipWearableAnalytic(wearable.data.category, wearable.rarity, source);
+                backpackAnalyticsService.SendEquipWearableAnalytic(wearable.id, wearable.data.category, wearable.rarity, source);
 
             if (updateAvatarPreview)
             {
@@ -685,7 +685,7 @@ namespace DCL.Backpack
             string wearableId = wearable.id;
 
             if (source != UnequipWearableSource.None)
-                backpackAnalyticsService.SendUnequippedWearableAnalytic(wearable.data.category, wearable.rarity, source);
+                backpackAnalyticsService.SendUnequippedWearableAnalytic(wearable.id, wearable.data.category, wearable.rarity, source);
 
             ResetOverridesOfAffectedCategories(wearable, setAsDirty);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/IBackpackAnalyticsService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/IBackpackAnalyticsService.cs
@@ -15,8 +15,8 @@ namespace DCL.Backpack
         void SendWearablePreviewRotated();
         void SendWearableCreatorGoTo(string creatorName);
         void SendAvatarEditSuccessNuxAnalytic();
-        void SendEquipWearableAnalytic(string category, string rarity, EquipWearableSource source);
-        void SendUnequippedWearableAnalytic(string category, string rarity, UnequipWearableSource source);
+        void SendEquipWearableAnalytic(string id, string category, string rarity, EquipWearableSource source);
+        void SendUnequippedWearableAnalytic(string id, string category, string rarity, UnequipWearableSource source);
         void SendAvatarColorPick();
         void SendForceHideWearable(string category);
         void SendForceShowWearable(string category);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/BackpackAnalyticsServiceShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/BackpackAnalyticsServiceShould.cs
@@ -32,7 +32,7 @@ namespace DCL.Backpack
         [Test]
         public void SendEquipAnalyticCorrectly()
         {
-            backpackAnalyticsService.SendEquipWearableAnalytic("testcat", "rare", EquipWearableSource.Wearable);
+            backpackAnalyticsService.SendEquipWearableAnalytic("testid", "testcat", "rare", EquipWearableSource.Wearable);
 
             analytics.Received(1).SendAnalytic("equip_wearable", Arg.Any<Dictionary<string, string>>());
         }
@@ -40,7 +40,7 @@ namespace DCL.Backpack
         [Test]
         public void SendUnEquipAnalyticCorrectly()
         {
-            backpackAnalyticsService.SendUnequippedWearableAnalytic("testcat", "rare", UnequipWearableSource.AvatarSlot);
+            backpackAnalyticsService.SendUnequippedWearableAnalytic("testid", "testcat", "rare", UnequipWearableSource.AvatarSlot);
 
             analytics.Received(1).SendAnalytic("unequip_wearable", Arg.Any<Dictionary<string, string>>());
         }


### PR DESCRIPTION
## What does this PR change?
Add item id in the equip and unequip wearable analytic.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2b044ee</samp>

Added `id` parameter to backpack editor HUD analytics methods to track specific wearable items. Updated controller, interface, and tests to pass and use the `id` parameter.