### PR TITLE
fix: sdk7 tween component preview mode hot reload

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Tween/ECSTweenHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Tween/ECSTweenHandler.cs
@@ -89,11 +89,11 @@ public class ECSTweenHandler : IECSComponentHandler<PBTween>
                 // There may be a tween running for the entity transform, even though internalComponentModel.tweener
                 // is null, e.g: during preview mode hot-reload.
                 var transformTweens = DOTween.TweensByTarget(entityTransform, true);
-                transformTweens?[0].Rewind();
+                transformTweens?[0].Rewind(false);
             }
             else
             {
-                tweener.Rewind();
+                tweener.Rewind(false);
             }
 
             internalComponentModel.transform = entityTransform;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Tween/ECSTweenHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Tween/ECSTweenHandler.cs
@@ -65,19 +65,28 @@ public class ECSTweenHandler : IECSComponentHandler<PBTween>
             removed = true
         });
 
+        var transformTweens = DOTween.TweensByTarget(entity.gameObject.transform, true);
+        transformTweens?[0].Kill(false);
+
+        // var tweens = DOTween.PlayingTweens();
+        // if (tweens.Count > 1)
+        // {
+        //     Debug.Log($"PLAYING TWEENS: {tweens.Count}");
+        //     for (int i = 0; i < tweens.Count; i++)
+        //     {
+        //         Debug.Log($"TWEEN {i}", tweens[i].target as Transform);
+        //     }
+        // }
+
         // SBC Internal Component is reset when the Transform component is removed, not here.
     }
 
     public void OnComponentModelUpdated(IParcelScene scene, IDCLEntity entity, PBTween model)
     {
-        if (model.ModeCase == PBTween.ModeOneofCase.None)
-            return;
-
         // by default it's playing
         bool isPlaying = !model.HasPlaying || model.Playing;
 
         var internalComponentModel = internalTweenComponent.GetFor(scene, entity)?.model ?? new InternalTween();
-
         if (!AreSameModels(model, internalComponentModel.lastModel))
         {
             Transform entityTransform = entity.gameObject.transform;
@@ -95,6 +104,9 @@ public class ECSTweenHandler : IECSComponentHandler<PBTween>
             {
                 tweener.Rewind(false);
             }
+
+            if (model.ModeCase == PBTween.ModeOneofCase.None)
+                return;
 
             internalComponentModel.transform = entityTransform;
             internalComponentModel.currentTime = model.CurrentTime;
@@ -133,6 +145,17 @@ public class ECSTweenHandler : IECSComponentHandler<PBTween>
         {
             return;
         }
+
+        // var tweens = DOTween.PlayingTweens();
+        // if (tweens.Count > 2)
+        // {
+        //     Debug.Log($"TWEEN ATTACHED TO ENTITY: {entity.entityId}", entity.gameObject);
+        //     Debug.Log($"PLAYING TWEENS: {tweens.Count}");
+        //     for (int i = 0; i < tweens.Count; i++)
+        //     {
+        //         Debug.Log($"TWEEN {i}", tweens[i].target as Transform);
+        //     }
+        // }
 
         internalComponentModel.playing = isPlaying;
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Tween/Tests/ECSTweenHandlerShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Tween/Tests/ECSTweenHandlerShould.cs
@@ -437,5 +437,33 @@ namespace Tests
             var transformTweens = DOTween.TweensByTarget(entityTransform, true);
             Assert.AreEqual(initialTime, transformTweens[0].ElapsedPercentage());
         }
+
+        [Test]
+        public void KillTweenerImmediatelyOnComponentRemove()
+        {
+            Vector3 startScale = Vector3.one;
+            Vector3 endScale = new Vector3(5f, 5f, 5f);
+
+            var model = new PBTween()
+            {
+                Duration = 3000,
+                Scale = new Scale()
+                {
+                    Start = new Decentraland.Common.Vector3() { X = startScale.x, Y = startScale.y, Z = startScale.z },
+                    End = new Decentraland.Common.Vector3() { X = endScale.x, Y = endScale.y, Z = endScale.z }
+                },
+                Playing = true
+            };
+
+            componentHandler.OnComponentModelUpdated(scene, entity, model);
+
+            // Check tween is running
+            var tweens = DOTween.PlayingTweens();
+            Assert.AreEqual(1, tweens.Count);
+
+            componentHandler.OnComponentRemoved(scene, entity);
+            tweens = DOTween.PlayingTweens();
+            Assert.IsNull(tweens);
+        }
     }
 }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
@@ -58,7 +58,6 @@ namespace ECSSystems.TweenSystem
 
             if (model.removed)
             {
-                model.tweener.Kill(false);
                 writer.Remove(entityId, ComponentID.TWEEN_STATE);
                 return;
             }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
@@ -58,7 +58,7 @@ namespace ECSSystems.TweenSystem
 
             if (model.removed)
             {
-                model.tweener.Kill();
+                model.tweener.Kill(false);
                 writer.Remove(entityId, ComponentID.TWEEN_STATE);
                 return;
             }


### PR DESCRIPTION
* Moved Tweener killing from `ECSTweenSystem` into `ECSTweenHandler.OnComponentRemoved()`
* Added test

The problem was basically that in the time between the `ECSTweenHandler.OnComponentRemoved()` and the `ECSTweenSystem.Update()` (which handled the tween killing recognizing the component removal) the hot reload could happen at that point in the middle and an old entity that got recycled could still have its Tweener affecting its transform.

Issue: https://github.com/decentraland/sdk/issues/987

----------------------------------------

## QA

### BUG EXPLANATION

* **HOT RELOAD**: We call Hot Reload the process that re-loads the current scene in development when something is changed in the scene code and the scene is reloaded automatically (this only happens in preview mode, AKA when creators are implementing their scene locally before deploying it)
* **CURRENT BUG**: In preview mode whenever there's a hot reload, and there are entities that are being rotated with a Tween component, sometimes entities that shouldn't be affected by the rotation tween start being affected, in other words: stuff that shouldn't be rotating starts rotating.

#### BUG VIDEO

https://github.com/decentraland/unity-renderer/assets/1031741/88185505-0d00-4b14-b366-ed4df49a3780

#### FIX VIDEO

https://github.com/decentraland/unity-renderer/assets/1031741/f4b245fe-4e98-4544-bc5f-673c06615494

### TEST INSTRUCTIONS

1. Enter at [this playground link](https://playground.decentraland.org/?code=ZnVuY3Rpb24gY3JlYXRlUm90YXRpbmdDdWJlKHBvc2l0aW9uOiBWZWN0b3IzKSB7CiAgY29uc3QgZW50aXR5ID0gZW5naW5lLmFkZEVudGl0eSgpCiAgTWVzaFJlbmRlcmVyLnNldEJveChlbnRpdHkpCiAgTWF0ZXJpYWwuc2V0UGJyTWF0ZXJpYWwoZW50aXR5LCB7CiAgICBhbGJlZG9Db2xvcjogQ29sb3I0LkdyZWVuKCkKICB9KQogIFRyYW5zZm9ybS5jcmVhdGUoZW50aXR5LCB7CiAgICBzY2FsZTogVmVjdG9yMy5jcmVhdGUoMSwgMSwgMSksCiAgICBwb3NpdGlvbgogIH0pCgogIGNvbnN0IHN0YXJ0Um90YXRpb24gPSBRdWF0ZXJuaW9uLmZyb21FdWxlckRlZ3JlZXMoMCwgMCwgMCkKICBjb25zdCBtaWRSb3RhdGlvbiA9IFF1YXRlcm5pb24uZnJvbUV1bGVyRGVncmVlcygwLCAxODAsIDApCiAgY29uc3QgZW5kUm90YXRpb24gPSBRdWF0ZXJuaW9uLmZyb21FdWxlckRlZ3JlZXMoMCwgMzYwLCAwKQogIGNvbnN0IGR1cmF0aW9uID0gMjAwMAogIFR3ZWVuLmNyZWF0ZShlbnRpdHksIHsKICAgIG1vZGU6IFR3ZWVuLk1vZGUuUm90YXRlKHsKICAgICAgc3RhcnQ6IHN0YXJ0Um90YXRpb24sCiAgICAgIGVuZDogbWlkUm90YXRpb24KICAgIH0pLAogICAgZHVyYXRpb246IGR1cmF0aW9uLAogICAgZWFzaW5nRnVuY3Rpb246IEVhc2luZ0Z1bmN0aW9uLkVGX0xJTkVBUgogIH0pCiAgVHdlZW5TZXF1ZW5jZS5jcmVhdGUoZW50aXR5LCB7CiAgICBsb29wOiBUd2Vlbkxvb3AuVExfUkVTVEFSVCwKICAgIHNlcXVlbmNlOiBbCiAgICAgIHsKICAgICAgICBtb2RlOiBUd2Vlbi5Nb2RlLlJvdGF0ZSh7CiAgICAgICAgICBzdGFydDogbWlkUm90YXRpb24sCiAgICAgICAgICBlbmQ6IGVuZFJvdGF0aW9uCiAgICAgICAgfSksCiAgICAgICAgZHVyYXRpb246IGR1cmF0aW9uLAogICAgICAgIGVhc2luZ0Z1bmN0aW9uOiBFYXNpbmdGdW5jdGlvbi5FRl9MSU5FQVIKICAgICAgfQogICAgXQogIH0pCn0KCiAvLyBiYXNlIHBsYXRmb3JtCmNvbnN0IGZsb29yRW50aXR5ID0gZW5naW5lLmFkZEVudGl0eSgpCk1lc2hSZW5kZXJlci5zZXRQbGFuZShmbG9vckVudGl0eSkKTWF0ZXJpYWwuc2V0UGJyTWF0ZXJpYWwoZmxvb3JFbnRpdHksIHsKICBhbGJlZG9Db2xvcjogQ29sb3I0LlB1cnBsZSgpCn0pClRyYW5zZm9ybS5jcmVhdGUoZmxvb3JFbnRpdHksIHsKICBzY2FsZTogVmVjdG9yMy5jcmVhdGUoMTAsIDEwLCAxKSwKICBwb3NpdGlvbjogVmVjdG9yMy5jcmVhdGUoOCwgMC4xLCA4KSwKICByb3RhdGlvbjogUXVhdGVybmlvbi5mcm9tRXVsZXJEZWdyZWVzKDkwLCAwLCAwKQp9KQoKY3JlYXRlUm90YXRpbmdDdWJlKFZlY3RvcjMuY3JlYXRlKDgsIDEsIDgpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoNCwgMSwgNCkpCmNyZWF0ZVJvdGF0aW5nQ3ViZShWZWN0b3IzLmNyZWF0ZSg0LCAxLCA4KSkKY3JlYXRlUm90YXRpbmdDdWJlKFZlY3RvcjMuY3JlYXRlKDgsIDEsIDQpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoNCwgMSwgMTIpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoMTIsIDEsIDQpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoMTIsIDEsIDgpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoOCwgMSwgMTIpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoMTIsIDEsIDEyKSkKCgoKLy8gQUREL1JFTU9WRSBMSU5FUyBCRUxPVyBIRVJFIFRPIFRSSUdHRVIgQlVHIQoKCgoKCgo%3D)
2. Wait until the explorer finishes loading and hit the RUN button
3. After you see the purple floor plane and the rotating cubes, **test triggering the bug** by triggering hot-reload when modifying something in the code. **There is a comment at the bottom of the code so that you just add lines or remove lines after that comment, to trigger hot reload.**
4. After several tried adding and removing empty lines at the bottom of the code, you should at some point see the purple floor plane rotating, **THAT'S THE BUG**.
5. Now close that tab and enter [this other playground link](https://playground.decentraland.org/?explorer-branch=fix%2Fsdk7-hot-reload-tween&code=ZnVuY3Rpb24gY3JlYXRlUm90YXRpbmdDdWJlKHBvc2l0aW9uOiBWZWN0b3IzKSB7CiAgY29uc3QgZW50aXR5ID0gZW5naW5lLmFkZEVudGl0eSgpCiAgTWVzaFJlbmRlcmVyLnNldEJveChlbnRpdHkpCiAgTWF0ZXJpYWwuc2V0UGJyTWF0ZXJpYWwoZW50aXR5LCB7CiAgICBhbGJlZG9Db2xvcjogQ29sb3I0LkdyZWVuKCkKICB9KQogIFRyYW5zZm9ybS5jcmVhdGUoZW50aXR5LCB7CiAgICBzY2FsZTogVmVjdG9yMy5jcmVhdGUoMSwgMSwgMSksCiAgICBwb3NpdGlvbgogIH0pCgogIGNvbnN0IHN0YXJ0Um90YXRpb24gPSBRdWF0ZXJuaW9uLmZyb21FdWxlckRlZ3JlZXMoMCwgMCwgMCkKICBjb25zdCBtaWRSb3RhdGlvbiA9IFF1YXRlcm5pb24uZnJvbUV1bGVyRGVncmVlcygwLCAxODAsIDApCiAgY29uc3QgZW5kUm90YXRpb24gPSBRdWF0ZXJuaW9uLmZyb21FdWxlckRlZ3JlZXMoMCwgMzYwLCAwKQogIGNvbnN0IGR1cmF0aW9uID0gMjAwMAogIFR3ZWVuLmNyZWF0ZShlbnRpdHksIHsKICAgIG1vZGU6IFR3ZWVuLk1vZGUuUm90YXRlKHsKICAgICAgc3RhcnQ6IHN0YXJ0Um90YXRpb24sCiAgICAgIGVuZDogbWlkUm90YXRpb24KICAgIH0pLAogICAgZHVyYXRpb246IGR1cmF0aW9uLAogICAgZWFzaW5nRnVuY3Rpb246IEVhc2luZ0Z1bmN0aW9uLkVGX0xJTkVBUgogIH0pCiAgVHdlZW5TZXF1ZW5jZS5jcmVhdGUoZW50aXR5LCB7CiAgICBsb29wOiBUd2Vlbkxvb3AuVExfUkVTVEFSVCwKICAgIHNlcXVlbmNlOiBbCiAgICAgIHsKICAgICAgICBtb2RlOiBUd2Vlbi5Nb2RlLlJvdGF0ZSh7CiAgICAgICAgICBzdGFydDogbWlkUm90YXRpb24sCiAgICAgICAgICBlbmQ6IGVuZFJvdGF0aW9uCiAgICAgICAgfSksCiAgICAgICAgZHVyYXRpb246IGR1cmF0aW9uLAogICAgICAgIGVhc2luZ0Z1bmN0aW9uOiBFYXNpbmdGdW5jdGlvbi5FRl9MSU5FQVIKICAgICAgfQogICAgXQogIH0pCn0KCiAvLyBiYXNlIHBsYXRmb3JtCmNvbnN0IGZsb29yRW50aXR5ID0gZW5naW5lLmFkZEVudGl0eSgpCk1lc2hSZW5kZXJlci5zZXRQbGFuZShmbG9vckVudGl0eSkKTWF0ZXJpYWwuc2V0UGJyTWF0ZXJpYWwoZmxvb3JFbnRpdHksIHsKICBhbGJlZG9Db2xvcjogQ29sb3I0LlB1cnBsZSgpCn0pClRyYW5zZm9ybS5jcmVhdGUoZmxvb3JFbnRpdHksIHsKICBzY2FsZTogVmVjdG9yMy5jcmVhdGUoMTAsIDEwLCAxKSwKICBwb3NpdGlvbjogVmVjdG9yMy5jcmVhdGUoOCwgMC4xLCA4KSwKICByb3RhdGlvbjogUXVhdGVybmlvbi5mcm9tRXVsZXJEZWdyZWVzKDkwLCAwLCAwKQp9KQoKY3JlYXRlUm90YXRpbmdDdWJlKFZlY3RvcjMuY3JlYXRlKDgsIDEsIDgpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoNCwgMSwgNCkpCmNyZWF0ZVJvdGF0aW5nQ3ViZShWZWN0b3IzLmNyZWF0ZSg0LCAxLCA4KSkKY3JlYXRlUm90YXRpbmdDdWJlKFZlY3RvcjMuY3JlYXRlKDgsIDEsIDQpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoNCwgMSwgMTIpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoMTIsIDEsIDQpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoMTIsIDEsIDgpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoOCwgMSwgMTIpKQpjcmVhdGVSb3RhdGluZ0N1YmUoVmVjdG9yMy5jcmVhdGUoMTIsIDEsIDEyKSkKCgoKLy8gQUREL1JFTU9WRSBMSU5FUyBCRUxPVyBIRVJFIFRPIFRSSUdHRVIgQlVHIQoKCgoKCgo%3D) that uses the fix from this PR
6. Repeat the same process and confirm that now you can't reproduce the bug.