### PR TITLE
feat: Enable the deployment of rollouts by paths

### DIFF
--- a/.github/workflows/set-rollout-by-path-manual.yaml
+++ b/.github/workflows/set-rollout-by-path-manual.yaml
@@ -1,0 +1,46 @@
+name: Set rollout by path - Manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      packageVersion:
+        description: "NPM Version of the release (@dcl/explorer)"
+        required: true
+        default: ""
+      rolloutPercentage:
+        description: "Percentage of users getting this version"
+        required: true
+        default: "0"
+      deploymentEnvironment:
+        type: "choice"
+        description: "Deployment environment"
+        required: true
+        default: "zone"
+        options:
+          - zone
+          - today
+          - org
+
+jobs:
+  set-manual-by-path-rollout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/debug-action@v2
+      - name: Set Rollout
+        uses: decentraland/set-rollout-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Repo deployment info
+          ref: ${{ github.event.ref }}
+          sha: ${{ github.sha }}
+
+          # CDN information
+          packageName: "@dcl/explorer"
+          packageVersion: ${{ github.event.inputs.packageVersion }}
+
+          # Rollout information
+          deploymentPath: "play"
+          deploymentEnvironment: ${{ github.event.inputs.deploymentEnvironment }}
+          deploymentName: "@dcl/explorer"
+          percentage: ${{ github.event.inputs.rolloutPercentage }}

--- a/.github/workflows/set-rollout-by-path.yaml
+++ b/.github/workflows/set-rollout-by-path.yaml
@@ -1,0 +1,74 @@
+# This pipeline is triggered after the CDN has succeed uploading a built package
+
+name: Set rollout by path
+
+on: [deployment_status]
+
+jobs:
+  set-rollouts:
+    if: ${{ github.event.deployment.task == 'upload-to-cdn' && github.event.deployment_status.state == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/debug-action@v2
+      # Dev
+      - name: Set Rollout - Zone
+        if: ${{ github.event.deployment.payload.packageTag == 'next' }}
+        uses: decentraland/set-rollout-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Repo deployment info
+          ref: ${{ github.event.deployment.ref }}
+          sha: ${{ github.event.deployment.sha }}
+
+          # CDN information
+          packageName: ${{ github.event.deployment.payload.packageName }}
+          packageVersion: ${{ github.event.deployment.payload.packageVersion }}
+
+          # Rollout information
+          deploymentPath: "play"
+          deploymentEnvironment: "zone"
+          deploymentName: "@dcl/explorer"
+          percentage: 100
+
+      # Stg
+      - name: Set Rollout - Today
+        if: ${{ github.event.deployment.payload.packageTag == 'next' }}
+        uses: decentraland/set-rollout-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Repo deployment info
+          ref: ${{ github.event.deployment.ref }}
+          sha: ${{ github.event.deployment.sha }}
+
+          # CDN information
+          packageName: ${{ github.event.deployment.payload.packageName }}
+          packageVersion: ${{ github.event.deployment.payload.packageVersion }}
+
+          # Rollout information
+          deploymentPath: "play"
+          deploymentEnvironment: "today"
+          deploymentName: "@dcl/explorer"
+          percentage: 100
+
+      # Prod
+      - name: Set Rollout - Org
+        if: ${{ github.event.deployment.payload.packageTag == 'latest' }}
+        uses: decentraland/set-rollout-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Repo deployment info
+          ref: ${{ github.event.deployment.ref }}
+          sha: ${{ github.event.deployment.sha }}
+
+          # CDN information
+          packageName: ${{ github.event.deployment.payload.packageName }}
+          packageVersion: ${{ github.event.deployment.payload.packageVersion }}
+
+          # Rollout information
+          deploymentPath: "play"
+          deploymentEnvironment: "org"
+          deploymentName: "@dcl/explorer"
+          percentage: 0


### PR DESCRIPTION
## What does this PR change?

This PR adds two new Github Actions which are used to set the rollouts by path. This comes from a change that we're implementing on which our site will go from using subdomains `play.decentraland.org` to using paths `decentraland.org/play`.
These two new Github Actions will replace the `set-rollout.yml` and `set-rollout-manual.yml` files. They will eventually be deleted.

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a073e48</samp>

This pull request adds two new workflows for setting the rollout percentage of package versions for different deployment environments and paths. One workflow is manual and allows custom inputs, while the other workflow is automatic and uses package tags. Both workflows use the `set-rollout-action` to update the `rollout.json` file and create a pull request.
