### PR TITLE
fix: the profile picture display the full image of the avatar

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/SignupHUDPlugin/SignupHUDPlugin.cs
@@ -39,6 +39,8 @@ namespace DCLPlugins.SignupHUDPlugin
                 var loadingScreenDataStore = DataStore.i.Get<DataStore_LoadingScreen>();
                 var hudsDataStore = DataStore.i.HUDs;
                 var featureFlagDataStore = DataStore.i.Get<DataStore_FeatureFlag>();
+                var backpackDataStore = DataStore.i.Get<DataStore_BackpackV2>();
+                var commonDataStore = DataStore.i.Get<DataStore_Common>();
                 var browserBridge = new WebInterfaceBrowserBridge();
                 var subscriptionsAPIService = Environment.i.serviceLocator.Get<ISubscriptionsAPIService>();
                 var userProfileWebInterfaceBridge = new UserProfileWebInterfaceBridge();
@@ -54,6 +56,8 @@ namespace DCLPlugins.SignupHUDPlugin
                     loadingScreenDataStore,
                     hudsDataStore,
                     featureFlagDataStore,
+                    backpackDataStore,
+                    commonDataStore,
                     browserBridge,
                     subscriptionsAPIService);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -106,7 +106,7 @@ namespace DCL.Backpack
             dataStore.HUDs.avatarEditorVisible.OnChange += OnBackpackVisibleChanged;
             dataStore.HUDs.isAvatarEditorInitialized.Set(true);
             dataStore.exploreV2.configureBackpackInFullscreenMenu.OnChange += ConfigureBackpackInFullscreenMenuChanged;
-            dataStore.common.isSignUpFlow.OnChange += OnSignUpFlowChanged;
+            dataStore.backpackV2.isWaitingToBeSavedAfterSignUp.OnChange += OnIsWaitingToBeSavedAfterSignUpChanged;
 
             ConfigureBackpackInFullscreenMenuChanged(dataStore.exploreV2.configureBackpackInFullscreenMenu.Get(), null);
 
@@ -193,7 +193,7 @@ namespace DCL.Backpack
             ownUserProfile.OnUpdate -= LoadUserProfileFromProfileUpdate;
             dataStore.HUDs.avatarEditorVisible.OnChange -= OnBackpackVisibleChanged;
             dataStore.exploreV2.configureBackpackInFullscreenMenu.OnChange -= ConfigureBackpackInFullscreenMenuChanged;
-            dataStore.common.isSignUpFlow.OnChange -= OnSignUpFlowChanged;
+            dataStore.backpackV2.isWaitingToBeSavedAfterSignUp.OnChange -= OnIsWaitingToBeSavedAfterSignUpChanged;
 
             backpackEmotesSectionController.OnNewEmoteAdded -= OnNewEmoteAdded;
             backpackEmotesSectionController.OnEmotePreviewed -= OnEmotePreviewed;
@@ -298,9 +298,9 @@ namespace DCL.Backpack
         private void ConfigureBackpackInFullscreenMenuChanged(Transform currentParentTransform, Transform previousParentTransform) =>
             view.SetAsFullScreenMenuMode(currentParentTransform);
 
-        private void OnSignUpFlowChanged(bool current, bool previous)
+        private void OnIsWaitingToBeSavedAfterSignUpChanged(bool current, bool previous)
         {
-            if (current)
+            if (!current)
                 return;
 
             view.SetSignUpStage(SignUpStage.CustomizeAvatar);
@@ -453,6 +453,10 @@ namespace DCL.Backpack
             try
             {
                 await TakeSnapshotsAndSaveAvatarAsync(cancellationToken);
+
+                if (dataStore.backpackV2.isWaitingToBeSavedAfterSignUp.Get())
+                    dataStore.backpackV2.isWaitingToBeSavedAfterSignUp.Set(false);
+
                 CloseView();
             }
             catch (OperationCanceledException) { }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -106,7 +106,7 @@ namespace DCL.Backpack
             dataStore.HUDs.avatarEditorVisible.OnChange += OnBackpackVisibleChanged;
             dataStore.HUDs.isAvatarEditorInitialized.Set(true);
             dataStore.exploreV2.configureBackpackInFullscreenMenu.OnChange += ConfigureBackpackInFullscreenMenuChanged;
-            dataStore.backpackV2.isWaitingToBeSavedAfterSignUp.OnChange += OnIsWaitingToBeSavedAfterSignUpChanged;
+            dataStore.backpackV2.isWaitingToBeSavedAfterSignUp.OnChange += SaveBackpackBeforeSignUpFinishes;
 
             ConfigureBackpackInFullscreenMenuChanged(dataStore.exploreV2.configureBackpackInFullscreenMenu.Get(), null);
 
@@ -193,7 +193,7 @@ namespace DCL.Backpack
             ownUserProfile.OnUpdate -= LoadUserProfileFromProfileUpdate;
             dataStore.HUDs.avatarEditorVisible.OnChange -= OnBackpackVisibleChanged;
             dataStore.exploreV2.configureBackpackInFullscreenMenu.OnChange -= ConfigureBackpackInFullscreenMenuChanged;
-            dataStore.backpackV2.isWaitingToBeSavedAfterSignUp.OnChange -= OnIsWaitingToBeSavedAfterSignUpChanged;
+            dataStore.backpackV2.isWaitingToBeSavedAfterSignUp.OnChange -= SaveBackpackBeforeSignUpFinishes;
 
             backpackEmotesSectionController.OnNewEmoteAdded -= OnNewEmoteAdded;
             backpackEmotesSectionController.OnEmotePreviewed -= OnEmotePreviewed;
@@ -298,9 +298,9 @@ namespace DCL.Backpack
         private void ConfigureBackpackInFullscreenMenuChanged(Transform currentParentTransform, Transform previousParentTransform) =>
             view.SetAsFullScreenMenuMode(currentParentTransform);
 
-        private void OnIsWaitingToBeSavedAfterSignUpChanged(bool current, bool previous)
+        private void SaveBackpackBeforeSignUpFinishes(bool isBackpackWaitingToBeSaved, bool _)
         {
-            if (!current)
+            if (!isBackpackWaitingToBeSaved)
                 return;
 
             view.SetSignUpStage(SignUpStage.CustomizeAvatar);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
@@ -105,10 +105,16 @@ namespace SignupHUD
             dataStoreHUDs.avatarEditorVisible.Set(true, true);
         }
 
-        private void OnTermsOfServiceAgreedStepBeforeSaveBackpack()
-        {
-            WebInterface.SendPassport(name, email);
+        private void OnTermsOfServiceAgreedStepBeforeSaveBackpack() =>
             DataStore.i.backpackV2.isWaitingToBeSavedAfterSignUp.Set(true);
+
+        private void OnTermsOfServiceAgreedStepAfterSaveBackpack(bool current, bool previous)
+        {
+            if (current)
+                return;
+
+            WebInterface.SendPassport(name, email);
+            DataStore.i.common.isSignUpFlow.Set(false);
             newUserExperienceAnalytics?.SendTermsOfServiceAcceptedNux(name, email);
 
             if (!isNewTermsOfServiceAndEmailSubscriptionEnabled)
@@ -116,14 +122,6 @@ namespace SignupHUD
 
             createSubscriptionCts = createSubscriptionCts.SafeRestart();
             CreateSubscriptionAsync(email, createSubscriptionCts.Token).Forget();
-        }
-
-        private void OnTermsOfServiceAgreedStepAfterSaveBackpack(bool current, bool previous)
-        {
-            if (current)
-                return;
-
-            DataStore.i.common.isSignUpFlow.Set(false);
         }
 
         private async UniTaskVoid CreateSubscriptionAsync(string emailAddress, CancellationToken cancellationToken)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
@@ -105,23 +105,26 @@ namespace SignupHUD
             dataStoreHUDs.avatarEditorVisible.Set(true, true);
         }
 
-        private void OnTermsOfServiceAgreedStepBeforeSaveBackpack() =>
+        private void OnTermsOfServiceAgreedStepBeforeSaveBackpack()
+        {
+            WebInterface.SendPassport(name, email);
             DataStore.i.backpackV2.isWaitingToBeSavedAfterSignUp.Set(true);
+
+            newUserExperienceAnalytics?.SendTermsOfServiceAcceptedNux(name, email);
+
+                        if (!isNewTermsOfServiceAndEmailSubscriptionEnabled)
+                            return;
+
+                        createSubscriptionCts = createSubscriptionCts.SafeRestart();
+                        CreateSubscriptionAsync(email, createSubscriptionCts.Token).Forget();
+        }
 
         private void OnTermsOfServiceAgreedStepAfterSaveBackpack(bool isBackpackWaitingToBeSaved, bool _)
         {
             if (isBackpackWaitingToBeSaved)
                 return;
 
-            WebInterface.SendPassport(name, email);
             DataStore.i.common.isSignUpFlow.Set(false);
-            newUserExperienceAnalytics?.SendTermsOfServiceAcceptedNux(name, email);
-
-            if (!isNewTermsOfServiceAndEmailSubscriptionEnabled)
-                return;
-
-            createSubscriptionCts = createSubscriptionCts.SafeRestart();
-            CreateSubscriptionAsync(email, createSubscriptionCts.Token).Forget();
         }
 
         private async UniTaskVoid CreateSubscriptionAsync(string emailAddress, CancellationToken cancellationToken)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
@@ -108,9 +108,9 @@ namespace SignupHUD
         private void OnTermsOfServiceAgreedStepBeforeSaveBackpack() =>
             DataStore.i.backpackV2.isWaitingToBeSavedAfterSignUp.Set(true);
 
-        private void OnTermsOfServiceAgreedStepAfterSaveBackpack(bool current, bool previous)
+        private void OnTermsOfServiceAgreedStepAfterSaveBackpack(bool isBackpackWaitingToBeSaved, bool _)
         {
-            if (current)
+            if (isBackpackWaitingToBeSaved)
                 return;
 
             WebInterface.SendPassport(name, email);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/SignupHUDController.cs
@@ -112,11 +112,11 @@ namespace SignupHUD
 
             newUserExperienceAnalytics?.SendTermsOfServiceAcceptedNux(name, email);
 
-                        if (!isNewTermsOfServiceAndEmailSubscriptionEnabled)
-                            return;
+            if (!isNewTermsOfServiceAndEmailSubscriptionEnabled)
+                return;
 
-                        createSubscriptionCts = createSubscriptionCts.SafeRestart();
-                        CreateSubscriptionAsync(email, createSubscriptionCts.Token).Forget();
+            createSubscriptionCts = createSubscriptionCts.SafeRestart();
+            CreateSubscriptionAsync(email, createSubscriptionCts.Token).Forget();
         }
 
         private void OnTermsOfServiceAgreedStepAfterSaveBackpack(bool isBackpackWaitingToBeSaved, bool _)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Tests/SignupHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Tests/SignupHUDControllerShould.cs
@@ -16,6 +16,8 @@ namespace Tests.SignupHUD
         private ISubscriptionsAPIService subscriptionsAPIService;
         private DataStore_HUDs dataStoreHUDs;
         private DataStore_FeatureFlag dataStoreFeatureFlag;
+        private DataStore_BackpackV2 dataStoreBackpack;
+        private DataStore_Common dataStoreCommon;
         private BaseVariable<bool> signupVisible => DataStore.i.HUDs.signupVisible;
 
         [SetUp]
@@ -26,12 +28,16 @@ namespace Tests.SignupHUD
             subscriptionsAPIService = Substitute.For<ISubscriptionsAPIService>();
             dataStoreHUDs = new DataStore_HUDs();
             dataStoreFeatureFlag = new DataStore_FeatureFlag();
+            dataStoreBackpack = new DataStore_BackpackV2();
+            dataStoreCommon = new DataStore_Common();
 
             hudController = new SignupHUDController(Substitute.For<IAnalytics>(),
                 hudView,
                 new DataStore_LoadingScreen(),
                 dataStoreHUDs,
                 dataStoreFeatureFlag,
+                dataStoreBackpack,
+                dataStoreCommon,
                 browserBridge,
                 subscriptionsAPIService);
             hudController.Initialize();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Tests/SignupHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SignupHUD/Tests/SignupHUDControllerShould.cs
@@ -18,7 +18,7 @@ namespace Tests.SignupHUD
         private DataStore_FeatureFlag dataStoreFeatureFlag;
         private DataStore_BackpackV2 dataStoreBackpack;
         private DataStore_Common dataStoreCommon;
-        private BaseVariable<bool> signupVisible => DataStore.i.HUDs.signupVisible;
+        private BaseVariable<bool> signupVisible => dataStoreHUDs.signupVisible;
 
         [SetUp]
         public void SetUp()
@@ -110,7 +110,7 @@ namespace Tests.SignupHUD
             hudView.OnTermsOfServiceAgreed += Raise.Event<Action>();
             //TODO assert webinterface interaction
             Assert.IsFalse(signupVisible.Get());
-            Assert.IsFalse(DataStore.i.common.isSignUpFlow.Get());
+            Assert.IsFalse(dataStoreCommon.isSignUpFlow.Get());
         }
 
         [Test]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_BackpackV2.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_BackpackV2.cs
@@ -4,5 +4,6 @@ namespace DCL
     {
         public readonly BaseCollection<string> previewEquippedWearables = new ();
         public readonly BaseVariable<string> previewBodyShape = new ();
+        public readonly BaseVariable<bool> isWaitingToBeSavedAfterSignUp = new (false);
     }
 }


### PR DESCRIPTION
## What does this PR change?
Fix #5967 

During the flow of the sing in, if the avatar was customized, we saw that the avatar profile picture was displayed as the full body instead of just the head.

![image (4)](https://github.com/decentraland/unity-renderer/assets/146741383/921ca855-dd4e-4091-b725-dc7c7f8885c9)

Now the avatar snapshot is saved correctly:

<img width="120" alt="Screenshot at Nov 20 09-28-59" src="https://github.com/decentraland/unity-renderer/assets/146741383/ecd04a1b-887a-4016-bf42-ec9a68400fc1">

## How to test the changes?
1. Launch the explorer as guest.
2. You should enter in the SignIn flow.
3. Apply several changes in your avatar during the avatar customization process. (body shape, hair style and color, change the clothes)
4. Go to the next screen and accept the terms and conditions.
5. Check that, after the world is loaded, your profile picture shows only the face of your customized avatar.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 48e28b9</samp>

This pull request adds a new flag `isWaitingToBeSavedAfterSignUp` to the backpack data store and the HUD controllers for the backpack editor and the signup flow. The flag is used to trigger a terms of service agreement step before saving the backpack in the signup process. The HUD controllers are updated to subscribe and react to the flag changes.