### PR TITLE
feat: sdk7 raycast-result support for non-sdk7 entity colliders

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/RaycastSystem/ECSRaycastSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/RaycastSystem/ECSRaycastSystem.cs
@@ -210,7 +210,8 @@ namespace ECSSystems.ECSRaycastSystem
 
         private RaycastHit CreateSDKRaycastHit(IParcelScene scene, PBRaycast model, UnityEngine.RaycastHit unityRaycastHit, KeyValuePair<IDCLEntity, uint>? hitEntity, Vector3 globalOrigin)
         {
-            RaycastHit hit = new RaycastHit();
+            RaycastHit hit = null;
+            uint modelCollisionLayerMask = model.GetCollisionMask();
 
             if (hitEntity != null) // SDK7 entity, otherwise the ray hit an SDK6 entity
             {
@@ -222,12 +223,18 @@ namespace ECSSystems.ECSRaycastSystem
 
                 // hitEntity has to be evaluated since 'Default' layer represents a combination of ClPointer
                 // and ClPhysics, and 'SDKCustomLayer' layer represents 8 different SDK layers: ClCustom1~8
-                if ((model.GetCollisionMask() & collisionMask) == 0)
+                if ((modelCollisionLayerMask & collisionMask) == 0)
                     return null;
 
+                hit = new RaycastHit();
                 hit.EntityId = (uint)entity.entityId;
             }
+            else if ((modelCollisionLayerMask & (int)ColliderLayer.ClPhysics) == 0) // 'Physics' layer for non-sdk7 colliders
+            {
+                return null;
+            }
 
+            hit ??= new RaycastHit();
             hit.MeshName = unityRaycastHit.collider.name;
             hit.Length = unityRaycastHit.distance;
             hit.GlobalOrigin = globalOrigin;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/RaycastSystem/ECSRaycastSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/RaycastSystem/ECSRaycastSystem.cs
@@ -210,21 +210,24 @@ namespace ECSSystems.ECSRaycastSystem
 
         private RaycastHit CreateSDKRaycastHit(IParcelScene scene, PBRaycast model, UnityEngine.RaycastHit unityRaycastHit, KeyValuePair<IDCLEntity, uint>? hitEntity, Vector3 globalOrigin)
         {
-            if (hitEntity == null) return null;
-
-            // TODO: figure out how we can cache or pool this hit instance to reduce allocations.
-            // since is part of a protobuf message it life span is uncertain, it could be disposed
-            // after message is sent to the scene or dropped for a new message
             RaycastHit hit = new RaycastHit();
-            IDCLEntity entity = hitEntity.Value.Key;
-            uint collisionMask = hitEntity.Value.Value;
 
-            // hitEntity has to be evaluated since 'Default' layer represents a combination of ClPointer
-            // and ClPhysics, and 'SDKCustomLayer' layer represents 8 different SDK layers: ClCustom1~8
-            if ((model.GetCollisionMask() & collisionMask) == 0)
-                return null;
+            if (hitEntity != null) // SDK7 entity, otherwise the ray hit an SDK6 entity
+            {
+                // TODO: figure out how we can cache or pool this hit instance to reduce allocations.
+                // since is part of a protobuf message it life span is uncertain, it could be disposed
+                // after message is sent to the scene or dropped for a new message
+                IDCLEntity entity = hitEntity.Value.Key;
+                uint collisionMask = hitEntity.Value.Value;
 
-            hit.EntityId = (uint)entity.entityId;
+                // hitEntity has to be evaluated since 'Default' layer represents a combination of ClPointer
+                // and ClPhysics, and 'SDKCustomLayer' layer represents 8 different SDK layers: ClCustom1~8
+                if ((model.GetCollisionMask() & collisionMask) == 0)
+                    return null;
+
+                hit.EntityId = (uint)entity.entityId;
+            }
+
             hit.MeshName = unityRaycastHit.collider.name;
             hit.Length = unityRaycastHit.distance;
             hit.GlobalOrigin = globalOrigin;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/RaycastSystem/ECSRaycastSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/RaycastSystem/ECSRaycastSystem.cs
@@ -229,7 +229,8 @@ namespace ECSSystems.ECSRaycastSystem
                 hit = new RaycastHit();
                 hit.EntityId = (uint)entity.entityId;
             }
-            else if ((modelCollisionLayerMask & (int)ColliderLayer.ClPhysics) == 0) // 'Physics' layer for non-sdk7 colliders
+            else if ((!scene.isPersistent && !scene.isPortableExperience)
+                     || (modelCollisionLayerMask & (int)ColliderLayer.ClPhysics) == 0) // 'Physics' layer for non-sdk7 colliders
             {
                 return null;
             }


### PR DESCRIPTION
Mini refactor to allow returning raycast results with partial data when hitting a non-sdk7-entity collider

Issue: https://github.com/decentraland/sdk/issues/1033

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ec7640a</samp>

Fix raycast system to detect hits on SDK6 entities in persistent and portable scenes. Add null check and collision layer mask check for hit entities in `ECSRaycastSystem.cs`.

------------------------------

### QA TEST INSTRUCTIONS

1. Enter the world at the "portal" scene: https://play.decentraland.org/?NETWORK=mainnet&position=-133%2C-40&explorer-branch=feat%2Fsdk7-raycast-result-support-for-sdk6-colliders&realm=main
2. Grab the portal gun and move to the 2nd floor of the scene (pressing 'E' you change the portal that will be shot)

https://github.com/decentraland/unity-renderer/assets/1031741/0e024211-f76f-4c46-b86c-a5ae6d9244f0

3. Grab the portal gun in the 2nd floor, that will trigger the "portable experience" prompt, accept that so that the new gun can be taken with you to outside that scene

https://github.com/decentraland/unity-renderer/assets/1031741/d96b0e2f-88fe-401e-8b7c-5eed5526a4ec

4. Go to any old scene (this has to be tested on an SDK6 scene, that's why) and shoot the gun... **confirm that the portal appears on colliders from old scenes**

https://github.com/decentraland/unity-renderer/assets/1031741/c4dc3a7f-8dab-4055-9f12-d81540d20336

