### PR TITLE
fix: show back pending status warning for email subscriptions

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/EmailNotificationsController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/MyAccountHUD/EmailNotificationsController.cs
@@ -233,7 +233,7 @@ namespace DCL.MyAccount
                     PlayerPrefsBridge.SetString(CURRENT_SUBSCRIPTION_ID_LOCAL_STORAGE_KEY, newSubscription.id);
                     PlayerPrefsBridge.Save();
                     savedEmail = newEmail;
-                    savedIsPending = false;
+                    savedIsPending = newSubscription.status is "pending" or "validating";
                     wasSuccessfullyUpdated = true;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## What does this PR change?
Since we have recovered the double user's action for registering the email, we need to show back the yellow warning message right after we add/modify our email in "Account Settings" -> "Email Notifications".

![image](https://github.com/decentraland/unity-renderer/assets/64659061/106f0e76-bf0e-42e1-82d8-5f2b080dc1ce)

## How to test the changes?
1. Launch the explorer.
2. Go to Account Settings -> Email Notifications.
3. Add or modify your email.
4. Check that the warning message appears.
5. Go to your email inbox and confirm your email.
6. Go back to the explorer, go out of the Email Notifications and go back to it.
7. Check that the warning message doesn't appear because your email is already confirmed.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
copilot:summary