### PR TITLE
chore: sdk7 improve tween SBC update

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
@@ -55,6 +55,18 @@ namespace ECSSystems.TweenSystem
 
             long entityId = tweenComponentGroup.key2;
             InternalTween model = tweenComponentGroup.value.model;
+            scene.entities.TryGetValue(entityId, out IDCLEntity entity);
+
+            switch (model.tweenMode)
+            {
+                case PBTween.ModeOneofCase.Move:
+                    sbcInternalComponent.SetPosition(scene, entity, model.transform.position);
+                    break;
+                case PBTween.ModeOneofCase.Rotate:
+                case PBTween.ModeOneofCase.Scale:
+                    sbcInternalComponent.OnTransformScaleRotationChanged(scene, entity);
+                    break;
+            }
 
             if (model.removed)
             {
@@ -66,12 +78,10 @@ namespace ECSSystems.TweenSystem
             if (currentTime.Equals(1f) && model.currentTime.Equals(1f))
                 return;
 
-            scene.entities.TryGetValue(entityId, out IDCLEntity entity);
-
             if (model.playing)
             {
                 tweenStateComponentModel.State = currentTime.Equals(1f) ? TweenStateStatus.TsCompleted : TweenStateStatus.TsActive;
-                UpdatePlayingTweenComponentModel(tweenStateComponentModel, currentTime, scene, entity, model);
+                tweenStateComponentModel.CurrentTime = currentTime;
             }
             else
             {
@@ -84,22 +94,6 @@ namespace ECSSystems.TweenSystem
 
             model.currentTime = currentTime;
             tweenInternalComponent.PutFor(scene, entityId, model);
-        }
-
-        private void UpdatePlayingTweenComponentModel(PBTweenState tweenStateComponentModel, float currentTime,
-            IParcelScene scene, IDCLEntity entity, InternalTween model)
-        {
-            tweenStateComponentModel.CurrentTime = currentTime;
-            switch (model.tweenMode)
-            {
-                case PBTween.ModeOneofCase.Move:
-                    sbcInternalComponent.SetPosition(scene, entity, model.transform.position);
-                    break;
-                case PBTween.ModeOneofCase.Rotate:
-                case PBTween.ModeOneofCase.Scale:
-                    sbcInternalComponent.OnTransformScaleRotationChanged(scene, entity);
-                    break;
-            }
         }
 
         private void UpdateTransformComponent(IParcelScene scene, IDCLEntity entity, Transform entityTransform, ComponentWriter writer)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/Tests/ECSTweenSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/Tests/ECSTweenSystemShould.cs
@@ -101,11 +101,11 @@ namespace Tests
         {
             entity.parentId = 6966;
             float currentTime = 0.666f;
+            float duration = 9f;
             Transform entityTransform = entity.gameObject.transform;
 
             // Stuff that the handler does
-            Tweener tweener = entityTransform.DOLocalMove(Vector3.up, 9);
-            tweener.Goto(9 * currentTime);
+            Tweener tweener = entityTransform.DOLocalMove(Vector3.up, duration);
             internalComponents.TweenComponent.PutFor(scene, entity, new InternalTween()
             {
                 transform = entityTransform,
@@ -115,8 +115,8 @@ namespace Tests
                 playing = true,
             });
 
+            tweener.Goto(duration * currentTime);
             systemUpdate();
-
             outgoingMessages.Put_Called<ECSTransform>(
                 entity.entityId,
                 ComponentID.TRANSFORM,
@@ -124,17 +124,30 @@ namespace Tests
                     componentModel.position == entityTransform.localPosition
                     && componentModel.parentId == entity.parentId
             );
+            Vector3 midPosition = entityTransform.localPosition;
+
+            currentTime = 1f;
+            tweener.Goto(duration * currentTime);
+            systemUpdate();
+            outgoingMessages.Put_Called<ECSTransform>(
+                entity.entityId,
+                ComponentID.TRANSFORM,
+                componentModel =>
+                    componentModel.position == entityTransform.localPosition
+                    && componentModel.parentId == entity.parentId
+            );
+            Assert.AreNotEqual(midPosition, entityTransform.localPosition);
         }
 
         [Test]
         public void UpdateInternalSBCComponent()
         {
             float currentTime = 0.666f;
+            float duration = 9f;
             Transform entityTransform = entity.gameObject.transform;
 
             // Stuff that the handler does
-            Tweener tweener = entityTransform.DOLocalMove(Vector3.up, 9);
-            tweener.Goto(9 * currentTime);
+            Tweener tweener = entityTransform.DOLocalMove(Vector3.up, duration);
             internalComponents.TweenComponent.PutFor(scene, entity, new InternalTween()
             {
                 transform = entityTransform,
@@ -144,9 +157,15 @@ namespace Tests
                 playing = true,
             });
 
+            tweener.Goto(duration * currentTime);
             systemUpdate();
-
             var sbcModel = internalComponents.sceneBoundsCheckComponent.GetFor(scene, entity).Value.model;
+            Assert.AreEqual(entityTransform.position, sbcModel.entityPosition);
+
+            currentTime = 1f;
+            tweener.Goto(duration * currentTime);
+            systemUpdate();
+            sbcModel = internalComponents.sceneBoundsCheckComponent.GetFor(scene, entity).Value.model;
             Assert.AreEqual(entityTransform.position, sbcModel.entityPosition);
         }
     }


### PR DESCRIPTION
* Moved sbc check in tween component to an early stage to cover every case
* Updated tests

-------------------------

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b01b226</samp>

This pull request enhances the ECSTweenSystem and its tests. It optimizes the scene bounds check component update for different tween modes, simplifies the tween state component update logic, and removes unused code. It also adds more assertions and refactors some calls in the ECSTweenSystemShould.cs file to improve the test coverage and clarity.