### PR TITLE
hotfix: bump eth-connect dependency version

### DIFF
--- a/browser-interface/package-lock.json
+++ b/browser-interface/package-lock.json
@@ -32,7 +32,7 @@
         "dcl-social-client": "^1.28.0",
         "decentraland-ecs": "^6.11.11",
         "devtools-protocol": "0.0.1115542",
-        "eth-connect": "^6.1.0",
+        "eth-connect": "^6.2.2",
         "fp-future": "^1.0.1",
         "gifuct-js": "^2.1.2",
         "hls.js": "^1.3.4",
@@ -4206,9 +4206,9 @@
       }
     },
     "node_modules/eth-connect": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.1.0.tgz",
-      "integrity": "sha512-p5FN4GieTxwfJvgmGCPgXqL6w8/2cbLiTmNxpgQg881gSI0RdOShTHHu8amgxlj3VM4crovBx7UEKS2RGOhBLQ=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.2.tgz",
+      "integrity": "sha512-OQcImRiHUKCyMtI7GtGD+nfcGToPvkuYp+REnYOcaWwCXghv6RNESowX0t7OVnHcln3qyAJiH/mCaoq1S6KD5w=="
     },
     "node_modules/ethereum-cryptography": {
       "version": "1.2.0",
@@ -13307,9 +13307,9 @@
       "dev": true
     },
     "eth-connect": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.1.0.tgz",
-      "integrity": "sha512-p5FN4GieTxwfJvgmGCPgXqL6w8/2cbLiTmNxpgQg881gSI0RdOShTHHu8amgxlj3VM4crovBx7UEKS2RGOhBLQ=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.2.tgz",
+      "integrity": "sha512-OQcImRiHUKCyMtI7GtGD+nfcGToPvkuYp+REnYOcaWwCXghv6RNESowX0t7OVnHcln3qyAJiH/mCaoq1S6KD5w=="
     },
     "ethereum-cryptography": {
       "version": "1.2.0",

--- a/browser-interface/package.json
+++ b/browser-interface/package.json
@@ -78,7 +78,7 @@
     "dcl-social-client": "^1.28.0",
     "decentraland-ecs": "^6.11.11",
     "devtools-protocol": "0.0.1115542",
-    "eth-connect": "^6.1.0",
+    "eth-connect": "^6.2.2",
     "fp-future": "^1.0.1",
     "gifuct-js": "^2.1.2",
     "hls.js": "^1.3.4",


### PR DESCRIPTION
## What does this PR change?

> PR re-created from https://github.com/decentraland/unity-renderer/pull/6005 because of a wrong branch's name.

Bump `eth-connect` version to include fix that was causing loging in in firefox not to work. We are checking that the error key is not present or is undefined to make a response valid

## How to test the changes?
Log in using firefox to https://play.decentraland.org/?explorer-branch=fix/bump-eth-connect-version

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7a3ceb3</samp>

This pull request updates the `eth-connect` dependency to version `6.2.2` in the `browser-interface` project. This improves the interaction with Ethereum smart contracts and fixes some issues.
