### PR TITLE
fix: sdk7 SBC basic check order

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -67,8 +67,11 @@ namespace DCL.ECSComponents
 
         public void OnComponentModelUpdated(IParcelScene scene, IDCLEntity entity, ECSTransform model)
         {
-            bool positionChange = false;
             Transform transform = entity.gameObject.transform;
+
+            bool positionChange = transform.localPosition != model.position;
+            bool scaleChange = transform.localScale != model.scale;
+            bool rotationChange = transform.localRotation != model.rotation;
 
             transform.localPosition = model.position;
             transform.localRotation = model.rotation;
@@ -76,16 +79,13 @@ namespace DCL.ECSComponents
 
             if (entity.parentId != model.parentId)
             {
-                // reparenting may end up changing the entity's position...
                 Vector3 previousGlobalPosition = transform.position;
                 ProcessNewParent(scene, entity, model.parentId);
-                positionChange = transform.position != previousGlobalPosition;
-            }
 
-            if (!positionChange)
-                positionChange = transform.localPosition != model.position;
-            bool scaleChange = transform.localScale != model.scale;
-            bool rotationChange = transform.localRotation != model.rotation;
+                // reparenting may end up changing the entity's position...
+                if (!positionChange)
+                    positionChange = transform.position != previousGlobalPosition;
+            }
 
             if (positionChange)
                 sbcInternalComponent.SetPosition(scene, entity, transform.position);


### PR DESCRIPTION
Corrected entity transformations Scene Bounds Checker check order.

Currently SDK7's SBC doesn't have test coverage at all, I'll add tests in another PR.

-------------------

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at def4322</samp>

Improve performance and clarity of `ECSTransformHandler` component update logic. Refactor `OnComponentModelUpdated` method to avoid redundant operations and simplify reparenting cases.

-------------------

### Test Instructions

1. Enter the snowball fight scene at https://play.decentraland.org/?explorer-branch=fix/sdk7-sbc-basic-check&position=104,51
2. Confirm that if you leave the scene, the UI disappears
3. Confirm that from inside the scene if you shoot a snowball towards outside the scene limits, the snowball disappears