### PR TITLE
fix: sdk7 avatar shape reposition on scene reload

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
@@ -433,6 +433,7 @@ namespace DCL.ECSComponents
 
         public void Cleanup()
         {
+            initializedPosition = false;
             playerName?.Hide(true);
             if (player != null)
             {


### PR DESCRIPTION
Added missing variable reset on cleanup: without that any sdk7 avatar shape entity gets wrongly repositioned when its scene is reloaded (by moving away or by hot reload).

Fixes https://github.com/decentraland/sdk/issues/1051.

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 396a36e</samp>

Fix avatar position bug when switching realms by resetting `initializedPosition` flag in `AvatarShape` component.
