### PR TITLE
fix: sdk7 avatar shape transform-tween reaction

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarShape/AvatarShape.cs
@@ -381,13 +381,12 @@ namespace DCL.ECSComponents
             onPointerDown.SetPassportEnabled(true);
         }
 
-        private void OnEntityTransformChanged(object newModel)
+        private void OnEntityTransformChanged(Vector3 newPosition, Quaternion newRotation)
         {
-            DCLTransform.Model newTransformModel = (DCLTransform.Model)newModel;
-            OnEntityTransformChanged(newTransformModel.position, newTransformModel.rotation, !initializedPosition);
+            OnEntityTransformChanged(newPosition, newRotation, !initializedPosition);
         }
 
-        private void OnEntityTransformChanged(in Vector3 position, in Quaternion rotation, bool inmediate)
+        private void OnEntityTransformChanged(Vector3 position, Quaternion rotation, bool inmediate)
         {
             if (entity == null)
                 return;

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -92,6 +92,11 @@ namespace DCL.ECSComponents
 
             if (scaleChange || rotationChange)
                 sbcInternalComponent.OnTransformScaleRotationChanged(scene, entity);
+
+            // Same AvatarShape interpolation used at DCLTransform from SDK6
+            // We only want to trigger it if there's a method subscribed
+            if (entity.OnTransformChange != null)
+                entity.OnTransformChange.Invoke(model.position, model.rotation);
         }
 
         private static void ProcessNewParent(IParcelScene scene, IDCLEntity entity, long parentId)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/Transform/Handler/ECSTransformHandler.cs
@@ -94,9 +94,7 @@ namespace DCL.ECSComponents
                 sbcInternalComponent.OnTransformScaleRotationChanged(scene, entity);
 
             // Same AvatarShape interpolation used at DCLTransform from SDK6
-            // We only want to trigger it if there's a method subscribed
-            if (entity.OnTransformChange != null)
-                entity.OnTransformChange.Invoke(model.position, model.rotation);
+            entity.OnTransformChange?.Invoke(model.position, model.rotation);
         }
 
         private static void ProcessNewParent(IParcelScene scene, IDCLEntity entity, long parentId)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
@@ -94,6 +94,11 @@ namespace ECSSystems.TweenSystem
 
             model.currentTime = currentTime;
             tweenInternalComponent.PutFor(scene, entityId, model);
+
+            // Same AvatarShape interpolation used at DCLTransform from SDK6
+            // We only want to trigger it if there's a method subscribed
+            if (entity.OnTransformChange != null)
+                entity.OnTransformChange.Invoke(model.transform.localPosition, model.transform.localRotation);
         }
 
         private void UpdateTransformComponent(IParcelScene scene, IDCLEntity entity, Transform entityTransform, ComponentWriter writer)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/TweenSystem/ECSTweenSystem.cs
@@ -96,9 +96,7 @@ namespace ECSSystems.TweenSystem
             tweenInternalComponent.PutFor(scene, entityId, model);
 
             // Same AvatarShape interpolation used at DCLTransform from SDK6
-            // We only want to trigger it if there's a method subscribed
-            if (entity.OnTransformChange != null)
-                entity.OnTransformChange.Invoke(model.transform.localPosition, model.transform.localRotation);
+            entity.OnTransformChange?.Invoke(model.transform.localPosition, model.transform.localRotation);
         }
 
         private void UpdateTransformComponent(IParcelScene scene, IDCLEntity entity, Transform entityTransform, ComponentWriter writer)

--- a/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestEntity.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestEntity.cs
@@ -132,7 +132,7 @@ public class ECS7TestEntity : IDCLEntity
         set => throw new NotImplementedException();
     }
 
-    Action<object> IDCLEntity.OnTransformChange
+    Action<Vector3, Quaternion> IDCLEntity.OnTransformChange
     {
         get => throw new NotImplementedException();
         set => throw new NotImplementedException();

--- a/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestEntity.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/TestsUtils/ECS7TestEntity.cs
@@ -134,8 +134,8 @@ public class ECS7TestEntity : IDCLEntity
 
     Action<Vector3, Quaternion> IDCLEntity.OnTransformChange
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get;
+        set;
     }
 
     public Action<IDCLEntity, bool> OnOuterBoundariesChanged

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/AvatarSystem/Definitions/IAvatarMovementController.cs
@@ -15,13 +15,13 @@ namespace AvatarSystem
         /// </summary>
         /// <param name="avatarTransform"></param>
         void SetAvatarTransform(Transform avatarTransform);
-        
+
         /// <summary>
         /// This will report the change of the transform, so it can be reported to kernel accordingly
         /// </summary>
         /// <param name="position"></param>
         /// <param name="rotation"></param>
-        /// <param name="inmediate"></param>
-        void OnTransformChanged(in Vector3 position, in Quaternion rotation, bool inmediate);
+        /// <param name="immediate"></param>
+        void OnTransformChanged(Vector3 position, Quaternion rotation, bool immediate);
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarMovementController.cs
@@ -94,20 +94,19 @@ namespace DCL
             AvatarTransform.position = PositionUtils.WorldToUnityPosition(currentWorldPosition);
         }
 
-        public void OnTransformChanged(object model)
+        public void OnTransformChanged(Vector3 newPosition, Quaternion newRotation)
         {
-            DCLTransform.Model transformModel = (DCLTransform.Model)model;
-            OnTransformChanged(transformModel.position, transformModel.rotation, false);
+            OnTransformChanged(newPosition, newRotation, false);
         }
 
-        public void OnTransformChanged(in Vector3 position, in Quaternion rotation, bool inmediate)
+        public void OnTransformChanged(Vector3 position, Quaternion rotation, bool immediate)
         {
             float characterMinHeight = DCLCharacterController.i.characterController.height * 0.5f;
 
             MoveTo(
                 new Vector3(position.x, Math.Max(position.y - characterMinHeight, -characterMinHeight), position.z), // To fix the "always flying" avatars issue, We report the chara's centered position but the body hast its pivot at its feet
                 rotation,
-                inmediate);
+                immediate);
         }
 
         public void MoveTo(Vector3 position, Quaternion rotation, bool immediate = false)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -374,10 +374,9 @@ namespace DCL
             }
         }
 
-        private void OnEntityTransformChanged(object newModel)
+        private void OnEntityTransformChanged(Vector3 newPosition, Quaternion newRotation)
         {
-            DCLTransform.Model newTransformModel = (DCLTransform.Model)newModel;
-            OnEntityTransformChanged(newTransformModel.position, newTransformModel.rotation, !initializedPosition);
+            OnEntityTransformChanged(newPosition, newRotation, !initializedPosition);
         }
 
         private void OnEntityTransformChanged(in Vector3 position, in Quaternion rotation, bool inmediate)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/Transform/DCLTransform.cs
@@ -74,7 +74,7 @@ namespace DCL.Components
             // and those values are used for the interpolation.
             if (entity.OnTransformChange != null)
             {
-                entity.OnTransformChange.Invoke(DCLTransform.model);
+                entity.OnTransformChange.Invoke(DCLTransform.model.position, DCLTransform.model.rotation);
             }
             else
             {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DecentralandEntity.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/DecentralandEntity.cs
@@ -28,7 +28,7 @@ namespace DCL.Models
         public Action<IDCLEntity> OnShapeUpdated { get; set; }
         public Action<IDCLEntity> OnShapeLoaded { get; set; }
         public Action<object> OnNameChange { get; set; }
-        public Action<object> OnTransformChange { get; set; }
+        public Action<Vector3, Quaternion> OnTransformChange { get; set; }
         public Action<IDCLEntity> OnRemoved { get; set; }
         public Action<IDCLEntity> OnMeshesInfoUpdated { get; set; }
         public Action<IDCLEntity> OnMeshesInfoCleaned { get; set; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IDCLEntity.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/Interfaces/IDCLEntity.cs
@@ -31,7 +31,7 @@ namespace DCL.Models
         Action<CLASS_ID_COMPONENT, IDCLEntity> OnBaseComponentAdded { get; set; }
 
         Action<object> OnNameChange { get; set; }
-        Action<object> OnTransformChange { get; set; }
+        Action<Vector3, Quaternion> OnTransformChange { get; set; }
         Action<IDCLEntity, bool> OnInsideBoundariesChanged { get; set; }
         Action<IDCLEntity, bool> OnOuterBoundariesChanged { get; set; }
         long parentId { get; set; }


### PR DESCRIPTION
* Added needed `OnTransformChanged` event call on sdk7 Transform handler and Tween systems, so that the AvatarShape can reacto to the transform modifications and interpolate accordingly.
* Removed `in` modifier in some `OnTransformChanged()` methods as that is most certainly worsening performance since we don't pass strictly readonly structs as parameters (as explained in the paragraph before the conclusion of [this official blog post](https://devblogs.microsoft.com/premier-developer/the-in-modifier-and-the-readonly-structs-in-c/) regarding the `in` modifier)

Fixes https://github.com/decentraland/sdk/issues/1052

## Copilot summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5dd740a</samp>

The pull request updates the `OnTransformChange` action in the `IDCLEntity` interface and its implementations to use `Vector3` and `Quaternion` parameters instead of an `object` parameter. This improves the code style, avoids unnecessary casting, and matches the ECS model. The pull request also adds calls to the `OnTransformChange` action in the `ECSTransformHandler` and `ECSTweenSystem` classes to trigger the interpolation logic for the `AvatarShape` component.

## Test instructions

* Avatar Tween rotation [playground link](https://playground.decentraland.org/?code=Y29uc3QgYXZhdGFyU2hhcGVFbnRpdHkgPSBlbmdpbmUuYWRkRW50aXR5KCkKVHJhbnNmb3JtLmNyZWF0ZShhdmF0YXJTaGFwZUVudGl0eSwgewogIHBvc2l0aW9uOiBWZWN0b3IzLmNyZWF0ZSg4LCAwLjI1LCA4KSwKfSkKClR3ZWVuLmNyZWF0ZShhdmF0YXJTaGFwZUVudGl0eSwgewogIGR1cmF0aW9uOiA4MDAwLAogIGVhc2luZ0Z1bmN0aW9uOiBFYXNpbmdGdW5jdGlvbi5FRl9MSU5FQVIsCiAgY3VycmVudFRpbWU6IDAsCiAgcGxheWluZzogdHJ1ZSwKICBtb2RlOiBUd2Vlbi5Nb2RlLlJvdGF0ZSh7CiAgICBzdGFydDogUXVhdGVybmlvbi5JZGVudGl0eSgpLAogICAgZW5kOiBRdWF0ZXJuaW9uLmZyb21FdWxlckRlZ3JlZXMoMCwgMTgwLCAwKQogIH0pCn0pCgpBdmF0YXJTaGFwZS5jcmVhdGUoYXZhdGFyU2hhcGVFbnRpdHksIHsKICB3ZWFyYWJsZXM6IFsKICAgICJ1cm46ZGVjZW50cmFsYW5kOm1hdGljOmNvbGxlY3Rpb25zLXYyOjB4ZWU3N2IwYTEwNGNkNmRiMWJiYmNmYTJmMTMwNzZmMjM0NjQ3YzAxNzoyIiwKICAgICJ1cm46ZGVjZW50cmFsYW5kOm1hdGljOmNvbGxlY3Rpb25zLXYyOjB4NzQyOWM4OGUzMzI4ODU5OWRmYTVkZWZiN2VhZTQ5YWU5NWFkNDRjNTowIiwKICAgICJ1cm46ZGVjZW50cmFsYW5kOm1hdGljOmNvbGxlY3Rpb25zLXYyOjB4M2E1M2FmY2Q0ZjNhNDA5NTNmYTEyMTdhNTYyNjU5MDliYjJmNjMwOTozIiwKICAgICJ1cm46ZGVjZW50cmFsYW5kOm1hdGljOmNvbGxlY3Rpb25zLXYyOjB4M2E1M2FmY2Q0ZjNhNDA5NTNmYTEyMTdhNTYyNjU5MDliYjJmNjMwOTowIiwKICAgICJ1cm46ZGVjZW50cmFsYW5kOm1hdGljOmNvbGxlY3Rpb25zLXYyOjB4MzZlOTRkMTI4OTkzMTdkYzc5MmU1NThmOTkzMjEzZWVmOWI4NWM3ODowIiwKICAgICJ1cm46ZGVjZW50cmFsYW5kOm1hdGljOmNvbGxlY3Rpb25zLXYyOjB4ZmY4ZTYzMGJkNDMyNDZiZjVjMzdhZWNjMDIyOGFmNTQxOGE4Y2VlZjo0IgogIF0sCiAgaWQ6ICJ0ZXN0LWF2YXRhciIsCiAgZW1vdGVzOiBbXQp9KQ%3D%3D&explorer-branch=fix/sdk7-avatar-shape-transform-and-tween-reaction): after the scene loads hit the RUN button and confirm that the NPC avatar is rotated.
* Avatar Transform rotation [playground link](https://playground.decentraland.org/?code=Y29uc3QgYXZhdGFyU2hhcGVFbnRpdHkgPSBlbmdpbmUuYWRkRW50aXR5KCkKVHJhbnNmb3JtLmNyZWF0ZShhdmF0YXJTaGFwZUVudGl0eSwgewogIHBvc2l0aW9uOiBWZWN0b3IzLmNyZWF0ZSg4LCAwLjI1LCA4KSwKfSkKCkF2YXRhclNoYXBlLmNyZWF0ZShhdmF0YXJTaGFwZUVudGl0eSwgewogIHdlYXJhYmxlczogWwogICAgInVybjpkZWNlbnRyYWxhbmQ6bWF0aWM6Y29sbGVjdGlvbnMtdjI6MHhlZTc3YjBhMTA0Y2Q2ZGIxYmJiY2ZhMmYxMzA3NmYyMzQ2NDdjMDE3OjIiLAogICAgInVybjpkZWNlbnRyYWxhbmQ6bWF0aWM6Y29sbGVjdGlvbnMtdjI6MHg3NDI5Yzg4ZTMzMjg4NTk5ZGZhNWRlZmI3ZWFlNDlhZTk1YWQ0NGM1OjAiLAogICAgInVybjpkZWNlbnRyYWxhbmQ6bWF0aWM6Y29sbGVjdGlvbnMtdjI6MHgzYTUzYWZjZDRmM2E0MDk1M2ZhMTIxN2E1NjI2NTkwOWJiMmY2MzA5OjMiLAogICAgInVybjpkZWNlbnRyYWxhbmQ6bWF0aWM6Y29sbGVjdGlvbnMtdjI6MHgzYTUzYWZjZDRmM2E0MDk1M2ZhMTIxN2E1NjI2NTkwOWJiMmY2MzA5OjAiLAogICAgInVybjpkZWNlbnRyYWxhbmQ6bWF0aWM6Y29sbGVjdGlvbnMtdjI6MHgzNmU5NGQxMjg5OTMxN2RjNzkyZTU1OGY5OTMyMTNlZWY5Yjg1Yzc4OjAiLAogICAgInVybjpkZWNlbnRyYWxhbmQ6bWF0aWM6Y29sbGVjdGlvbnMtdjI6MHhmZjhlNjMwYmQ0MzI0NmJmNWMzN2FlY2MwMjI4YWY1NDE4YThjZWVmOjQiCiAgXSwKICBpZDogInRlc3QtYXZhdGFyIiwKICBlbW90ZXM6IFtdCn0pCgplbmdpbmUuYWRkU3lzdGVtKChkdCkgPT4gewogIGNvbnN0IGF2YXRhclRyYW5zZm9ybSA9IFRyYW5zZm9ybS5nZXRNdXRhYmxlKGF2YXRhclNoYXBlRW50aXR5KQoKICBhdmF0YXJUcmFuc2Zvcm0ucm90YXRpb24gPSBRdWF0ZXJuaW9uLnJvdGF0ZVRvd2FyZHMoYXZhdGFyVHJhbnNmb3JtLnJvdGF0aW9uLCBRdWF0ZXJuaW9uLmZyb21FdWxlckRlZ3JlZXMoMCwgMTgwLCAwKSwgMC41KQp9KQ%3D%3D&explorer-branch=fix/sdk7-avatar-shape-transform-and-tween-reaction): after the scene loads hit the RUN button and confirm that the NPC avatar is rotated.

The RUN button can be used more than once, to restart the scene.