### PR TITLE
fix: Equipped wearables not loading for peers

### DIFF
--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -558,7 +558,7 @@ namespace DCLServices.WearablesCatalogService
 
             ct.ThrowIfCancellationRequested();
 
-            return result.FirstOrDefault(x => x.id == newWearableId);
+            return result.FirstOrDefault(x => x.id == ExtendedUrnParser.GetShortenedUrn(newWearableId));
         }
 
         private List<WearableItem> ValidateWearables(


### PR DESCRIPTION
## What does this PR change?

Equipped wearables for peers were not loading due to inconsistencies with the Shorten urn

## How to test the changes?


1. Launch the explorer
2. Check that peers equipped wearables load

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
