### PR TITLE
test: setting correct base url from about lambdas

### DIFF
--- a/browser-interface/packages/shared/apis/host/EnvironmentAPI.ts
+++ b/browser-interface/packages/shared/apis/host/EnvironmentAPI.ts
@@ -101,7 +101,11 @@ export function getDecentralandTime() {
 
 export function toEnvironmentRealmType(realm: IRealmAdapter, island: string | undefined): EnvironmentRealm {
   const serverName = realmToConnectionString(realm)
-  const hostname = new URL(realm.baseUrl).hostname
+  var hostname = new URL(realm.baseUrl).hostname
+  
+  if(realm.about.configurations?.realmName == 'main' && realm.about.lambdas?.publicUrl !== undefined){
+      hostname = new URL(realm.about.lambdas?.publicUrl).hostname
+  }
   return {
     protocol: realm.about.comms?.protocol || 'v3',
     // domain explicitly expects the URL with the protocol

--- a/browser-interface/packages/shared/apis/host/Runtime.ts
+++ b/browser-interface/packages/shared/apis/host/Runtime.ts
@@ -22,8 +22,12 @@ export function registerRuntimeServiceServerImplementation(port: RpcServerPort<P
       if (!realmAdapter) {
         return {}
       }
-      const baseUrl = urlWithProtocol(new URL(realmAdapter.baseUrl).hostname)
+      var baseUrl = urlWithProtocol(new URL(realmAdapter.baseUrl).hostname)
 
+      if(realmAdapter.about.configurations?.realmName == 'main' && realmAdapter.about.lambdas?.publicUrl !== undefined){
+        baseUrl = new URL(realmAdapter.about.lambdas?.publicUrl).hostname
+      }
+      
       return {
         realmInfo: {
           baseUrl,


### PR DESCRIPTION
## What does this PR change?

When the main realm was introduced, an issue started appearing in which the `baseURL` of the `RealmInfo` was incorrectly set.

This PR changes that. If the real is being set via main, the `baseURL` will be grabbed from `about/lambdas`, using just the hostname.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
