### PR TITLE
fix: sdk7 avatar modifier area dynamic excluded ids

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Handler/AvatarModifierAreaComponentHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Handler/AvatarModifierAreaComponentHandler.cs
@@ -56,7 +56,9 @@ namespace DCL.ECSComponents
                 excludedIds.Add(modelExcludeId.ToLower());
             }
             internalComponentModel.excludedIds = excludedIds;
-            internalComponentModel.avatarsInArea = new HashSet<GameObject>();
+
+            if (internalComponentModel.avatarsInArea?.Count == 0)
+                internalComponentModel.avatarsInArea = new HashSet<GameObject>();
 
             internalAvatarModifierArea.PutFor(scene, entity, internalComponentModel);
         }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Tests/AvatarModiferAreaShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/AvatarModifierArea/Tests/AvatarModiferAreaShould.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using DCL.CRDT;
+using DCL.ECS7.InternalComponents;
 using DCL.ECSRuntime;
 using NUnit.Framework;
 using UnityEngine;
@@ -62,6 +63,33 @@ namespace DCL.ECSComponents.Test
             Assert.IsNotNull(internalComponent.Value.model.OnAvatarExit);
             Assert.IsTrue(internalComponent.Value.model.excludedIds.Contains(excludedId1.ToLower()));
             Assert.IsTrue(internalComponent.Value.model.excludedIds.Contains(excludedId2.ToLower()));
+        }
+
+        [Test]
+        public void KeepExistentInternalComponentAvatarsInArea()
+        {
+            var internalComponent = internalComponents.AvatarModifierAreaComponent.GetFor(scene, entity);
+            Assert.IsNull(internalComponent);
+
+            GameObject dummyGO = new GameObject("avatarInArea");
+            internalComponents.AvatarModifierAreaComponent.PutFor(scene, entity, new InternalAvatarModifierArea()
+            {
+                avatarsInArea = new HashSet<GameObject>(){ dummyGO }
+            });
+
+            var model = new PBAvatarModifierArea()
+            {
+                Area =  new Decentraland.Common.Vector3() { X = 4f, Y = 2.5f, Z = 4f },
+                Modifiers = { AvatarModifierType.AmtHideAvatars },
+            };
+            componentHandler.OnComponentModelUpdated(scene, entity, model);
+
+            internalComponent = internalComponents.AvatarModifierAreaComponent.GetFor(scene, entity);
+            Assert.IsNotNull(internalComponent);
+            Assert.AreEqual(1, internalComponent.Value.model.avatarsInArea.Count);
+            Assert.IsTrue(internalComponent.Value.model.avatarsInArea.Contains(dummyGO));
+
+            GameObject.DestroyImmediate(dummyGO);
         }
 
         [Test]

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/AvatarModifierAreaSystem/ECSAvatarModifierAreaSystem.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/AvatarModifierAreaSystem/ECSAvatarModifierAreaSystem.cs
@@ -33,8 +33,7 @@ namespace ECSSystems.AvatarModifierAreaSystem
                 var model = componentGroup[i].value.model;
                 Transform entityTransform = scene.entities[entityId].gameObject.transform;
 
-                if (model.excludedIds != null && model.excludedIds.Count > 0)
-                    UpdateExcludedCollidersCollection(model.excludedIds);
+                UpdateExcludedCollidersCollection(model.excludedIds);
 
                 HashSet<GameObject> currentAvatarsInArea = ECSAvatarUtils.DetectAvatars(model.area, entityTransform.position,
                     entityTransform.rotation, excludedColliders);
@@ -91,9 +90,11 @@ namespace ECSSystems.AvatarModifierAreaSystem
 
         private void UpdateExcludedCollidersCollection(HashSet<string> excludedIds)
         {
-            var ownPlayer = dataStore.ownPlayer.Get();
             excludedColliders.Clear();
 
+            if (excludedIds == null || excludedIds.Count == 0) return;
+
+            var ownPlayer = dataStore.ownPlayer.Get();
             foreach (string excludedId in excludedIds)
             {
                 if (dataStore.otherPlayers.TryGetValue(excludedId, out Player player))

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/AvatarModifierAreaSystem/Tests/ECSAvatarModifierAreaSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/AvatarModifierAreaSystem/Tests/ECSAvatarModifierAreaSystemShould.cs
@@ -80,6 +80,10 @@ namespace Tests
             Assert.AreEqual(2, internalComponentModel.Value.model.avatarsInArea.Count);
             Assert.IsTrue(internalComponentModel.Value.model.avatarsInArea.Contains(fakeAvatar1));
             Assert.IsTrue(internalComponentModel.Value.model.avatarsInArea.Contains(fakeAvatar2));
+
+            GameObject.DestroyImmediate(fakeAvatar1);
+            GameObject.DestroyImmediate(fakeAvatar2);
+            GameObject.DestroyImmediate(fakeAvatar3);
         }
 
         [Test]
@@ -135,6 +139,8 @@ namespace Tests
             systemUpdate();
             Assert.IsTrue(removeCalled);
             Assert.IsFalse(applyCalled);
+
+            GameObject.DestroyImmediate(fakeAvatar);
         }
 
         [Test]
@@ -152,13 +158,13 @@ namespace Tests
             bool removeCalled = false;
             void ApplyModifier(GameObject avatarGO)
             {
-                Assert.AreEqual(fakeAvatar.GetHashCode(), avatarGO.GetHashCode());
+                Assert.AreEqual(fakeAvatar, avatarGO);
                 applyCalled = true;
             }
 
             void RemoveModifier(GameObject avatarGO)
             {
-                Assert.AreEqual(fakeAvatar.GetHashCode(), avatarGO.GetHashCode());
+                Assert.AreEqual(fakeAvatar, avatarGO);
                 removeCalled = true;
             }
 
@@ -212,6 +218,8 @@ namespace Tests
             systemUpdate();
             Assert.IsTrue(applyCalled);
             Assert.IsFalse(removeCalled);
+
+            GameObject.DestroyImmediate(fakeAvatar);
         }
 
         private GameObject CreateFakeAvatar()

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/AvatarModifierAreaSystem/Tests/ECSAvatarModifierAreaSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/AvatarModifierAreaSystem/Tests/ECSAvatarModifierAreaSystemShould.cs
@@ -152,13 +152,13 @@ namespace Tests
             bool removeCalled = false;
             void ApplyModifier(GameObject avatarGO)
             {
-                Assert.AreEqual(fakeAvatar, avatarGO);
+                Assert.AreEqual(fakeAvatar.GetHashCode(), avatarGO.GetHashCode());
                 applyCalled = true;
             }
 
             void RemoveModifier(GameObject avatarGO)
             {
-                Assert.AreEqual(fakeAvatar, avatarGO);
+                Assert.AreEqual(fakeAvatar.GetHashCode(), avatarGO.GetHashCode());
                 removeCalled = true;
             }
 

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Systems/AvatarModifierAreaSystem/Tests/ECSAvatarModifierAreaSystemShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Systems/AvatarModifierAreaSystem/Tests/ECSAvatarModifierAreaSystemShould.cs
@@ -137,6 +137,83 @@ namespace Tests
             Assert.IsFalse(applyCalled);
         }
 
+        [Test]
+        public void ReactCorrectlyToExcludedIdsUpdates()
+        {
+            entity.gameObject.transform.position = new Vector3(8, 1, 8);
+            Vector3 entityPosition = entity.gameObject.transform.position;
+            Vector3 area = new Vector3(5f, 5f, 5f);
+
+            var fakeAvatar = CreateFakeAvatar();
+            fakeAvatar.transform.position = new Vector3(100, 100, 100);
+            Physics.SyncTransforms();
+
+            bool applyCalled = false;
+            bool removeCalled = false;
+            void ApplyModifier(GameObject avatarGO)
+            {
+                Assert.AreEqual(fakeAvatar, avatarGO);
+                applyCalled = true;
+            }
+
+            void RemoveModifier(GameObject avatarGO)
+            {
+                Assert.AreEqual(fakeAvatar, avatarGO);
+                removeCalled = true;
+            }
+
+            var model = new InternalAvatarModifierArea()
+            {
+                area = area,
+                OnAvatarEnter = ApplyModifier,
+                OnAvatarExit = RemoveModifier,
+                avatarsInArea = new HashSet<GameObject>(),
+                excludedIds = new HashSet<string>()
+            };
+            internalComponents.AvatarModifierAreaComponent.PutFor(scene, entity, model);
+
+            systemUpdate();
+            Assert.IsFalse(applyCalled);
+            Assert.IsFalse(removeCalled);
+
+            // move avatar inside area
+            fakeAvatar.transform.position = entityPosition + (area * 0.5f);
+            Physics.SyncTransforms();
+
+            systemUpdate();
+            Assert.IsTrue(applyCalled);
+            Assert.IsFalse(removeCalled);
+            applyCalled = false;
+            model = internalComponents.AvatarModifierAreaComponent.GetFor(scene, entity).Value.model;
+            Assert.AreEqual(1, model.avatarsInArea.Count);
+
+            // add current avatar user id to the excluded IDs collection
+            string targetUserId = "0x666";
+            dataStorePlayer.otherPlayers.Add(targetUserId, new Player()
+            {
+                id = targetUserId,
+                collider = fakeAvatar.GetComponentInChildren<BoxCollider>(),
+            });
+            model.excludedIds.Add(targetUserId);
+            internalComponents.AvatarModifierAreaComponent.PutFor(scene, entity, model);
+
+            systemUpdate();
+
+            Assert.IsTrue(removeCalled);
+            Assert.IsFalse(applyCalled);
+            removeCalled = false;
+            model = internalComponents.AvatarModifierAreaComponent.GetFor(scene, entity).Value.model;
+            Assert.AreEqual(0, model.avatarsInArea.Count);
+
+            // remove current avatar user id from the excluded IDs collection
+            model.excludedIds.Clear();
+            internalComponents.AvatarModifierAreaComponent.PutFor(scene, entity, model);
+
+            systemUpdate();
+            Assert.IsTrue(applyCalled);
+            Assert.IsFalse(removeCalled);
+        }
+
         private GameObject CreateFakeAvatar()
         {
             GameObject fakeAvatarColliderGO = new GameObject();

--- a/unity-renderer/Assets/DCLPlugins/ECS7/Tests/ECS7Plugin.Tests.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/Tests/ECS7Plugin.Tests.asmdef
@@ -86,7 +86,8 @@
         "GUID:e30cc2f9ee2c45df93dbb8f7f826792f",
         "GUID:091c556278214ab49cfdc87549e3135c",
         "GUID:f334064a9ed3462091d1b06f9e981366",
-        "GUID:59c9e1ae4a4a61c43b19957ad3bfbaf7"
+        "GUID:59c9e1ae4a4a61c43b19957ad3bfbaf7",
+        "GUID:c34e38f41494f834abff029ddf82af43"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Dynamic modification of Avatar Modifier Area component excluded ids property wasn't being handled correctly.

Fixes https://github.com/decentraland/sdk/issues/999#issuecomment-1876163659

------------------

### TEST INSTRUCTIONS

1. Open [this playground link](https://playground.decentraland.org/?code=Y29uc3QgZXhjbHVkZWRVc2VyID0gJ1VTRVItV0FMTEVULUFERFJFU1MtR09FUy1IRVJFJwpjb25zdCBhdmF0YXJNb2RpZmllckFyZWFFbnRpdHkgPSBlbmdpbmUuYWRkRW50aXR5KCkKY29uc3QgYXJlYVNpemUgPSBWZWN0b3IzLmNyZWF0ZSg0LCA0LCA0KQoKVHJhbnNmb3JtLmNyZWF0ZShhdmF0YXJNb2RpZmllckFyZWFFbnRpdHksIHsgCiAgcG9zaXRpb246IFZlY3RvcjMuY3JlYXRlKDgsIDEsIDgpLAogIHNjYWxlOiBhcmVhU2l6ZQp9KQpBdmF0YXJNb2RpZmllckFyZWEuY3JlYXRlKGF2YXRhck1vZGlmaWVyQXJlYUVudGl0eSwgewogIGFyZWE6IGFyZWFTaXplLAogIG1vZGlmaWVyczogW0F2YXRhck1vZGlmaWVyVHlwZS5BTVRfSElERV9BVkFUQVJTXSwKICBleGNsdWRlSWRzOiBbZXhjbHVkZWRVc2VyXQp9KQpNZXNoUmVuZGVyZXIuc2V0Qm94KGF2YXRhck1vZGlmaWVyQXJlYUVudGl0eSkKTWF0ZXJpYWwuc2V0UGJyTWF0ZXJpYWwoYXZhdGFyTW9kaWZpZXJBcmVhRW50aXR5LCB7IGFsYmVkb0NvbG9yOiBDb2xvcjQuY3JlYXRlKDAuNSwgMC41LCAwLjUsIDAuNSkgfSkKCmNvbnN0IGN1YmUgPSBjcmVhdGVDdWJlKDgsIDEsIDExLCBmYWxzZSkKTWVzaENvbGxpZGVyLnNldEJveChjdWJlKQpwb2ludGVyRXZlbnRzU3lzdGVtLm9uUG9pbnRlckRvd24oCiAgICB7IGVudGl0eTogY3ViZSwgb3B0czogeyBidXR0b246IElucHV0QWN0aW9uLklBX1BPSU5URVIsIGhvdmVyVGV4dDogJ3RvZ2dsZSBleGNsdWRlZCBpZCcgfSB9LAogICAgKCkgPT4gewogICAgICBjb25zdCBtdXRhYmxlID0gQXZhdGFyTW9kaWZpZXJBcmVhLmdldE11dGFibGUoYXZhdGFyTW9kaWZpZXJBcmVhRW50aXR5KQogICAgICBpZiAobXV0YWJsZS5leGNsdWRlSWRzLmluY2x1ZGVzKGV4Y2x1ZGVkVXNlcikpIHsKICAgICAgICBtdXRhYmxlLmV4Y2x1ZGVJZHMgPSBbXQogICAgICB9CiAgICAgIGVsc2UgewogICAgICAgIG11dGFibGUuZXhjbHVkZUlkcyA9IFtleGNsdWRlZFVzZXJdCiAgICAgIH0KICAgIH0KKQoKZnVuY3Rpb24gY3JlYXRlQ3ViZSh4OiBudW1iZXIsIHk6IG51bWJlciwgejogbnVtYmVyLCBzcGF3bmVyID0gdHJ1ZSk6IEVudGl0eSB7CiAgY29uc3QgZW50aXR5ID0gZW5naW5lLmFkZEVudGl0eSgpCiAgVHJhbnNmb3JtLmNyZWF0ZShlbnRpdHksIHsgcG9zaXRpb246IHsgeCwgeSwgeiB9IH0pCiAgTWVzaFJlbmRlcmVyLnNldEJveChlbnRpdHkpCiAgTWVzaENvbGxpZGVyLnNldEJveChlbnRpdHkpCiAgTWF0ZXJpYWwuc2V0UGJyTWF0ZXJpYWwoZW50aXR5LCB7IGFsYmVkb0NvbG9yOiBDb2xvcjQuUmVkKCkgfSkKICByZXR1cm4gZW50aXR5Cn0K&ENABLE_WEB3&explorer-branch=fix/sdk7-avatar-modifier-area-dynamic-excluded-ids) and wait for the world to load.
2. Change the `const excludedUser = 'USER-WALLET-ADDRESS-GOES-HERE'` line to use a real user id (metamask wallet address) you own. For example: `const excludedUser = '0x0F5D2fB29fb7d3CFeE444a200298f468908cC942'`
3. Hit the "Run" Button
4. Enter the transparent cube area
5. Confirm that getting close to the red cube and clicking on it (when the toggle appears) toggles your avatar being visible and invisible inside the transparent cube area

https://github.com/decentraland/unity-renderer/assets/1031741/50b57a11-cba5-4017-98c6-719266d03e51


