### PR TITLE
fix: Set realm on signup flow

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/LoadingScreen/Scripts/LoadingScreenController.cs
@@ -105,6 +105,12 @@ namespace DCL.LoadingScreen
         {
             onSignUpFlow = current;
 
+            if (realmDataStore.playerRealmAboutConfiguration.Get() != null)
+            {
+                currentRealm = realmDataStore.playerRealmAboutConfiguration.Get().RealmName;
+                currentRealmIsWorld = commonDataStore.isWorld.Get();
+            }
+
             if (current)
                 FadeOutView();
             else


### PR DESCRIPTION
## What does this PR change?

Sets the realm on signup flow to avoid a double loading screen on scenes deployed with sdk legacy builder

## How to test the changes?

1. Enter as a new guest into enji.dcl.eth and check that you dont get a double sign up flow

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
