### PR TITLE
fix: Ensure the URN when equipping emotes is using the shortened URN

### DIFF
--- a/unity-renderer/Assets/DCLPlugins/EquippedEmotes/EquippedEmotesPlugin.asmdef
+++ b/unity-renderer/Assets/DCLPlugins/EquippedEmotes/EquippedEmotesPlugin.asmdef
@@ -9,7 +9,8 @@
         "GUID:2995626b54c60644988f134a69a77450",
         "GUID:1de3566cccb280f4a982c59ad0d08c96",
         "GUID:43315b150e1df4592868fc0fe58b3429",
-        "GUID:a78c5d8dad39efe45ab1b21901f8db0f"
+        "GUID:a78c5d8dad39efe45ab1b21901f8db0f",
+        "GUID:c8ea72e806cd2ab47b539b37895b86b7"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLPlugins/EquippedEmotes/EquippedEmotesPlugin.cs
+++ b/unity-renderer/Assets/DCLPlugins/EquippedEmotes/EquippedEmotesPlugin.cs
@@ -1,8 +1,8 @@
 using DCL.Helpers;
+using DCLServices.WearablesCatalogService;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 
 namespace DCL.EquippedEmotes
 {
@@ -85,18 +85,18 @@ namespace DCL.EquippedEmotes
 
             if (storedEquippedEmotes == null)
                 storedEquippedEmotes = GetDefaultEmotes();
-            
+
             SetEquippedEmotes(storedEquippedEmotes);
         }
 
         internal void OnEquippedEmotesSet(IEnumerable<EquippedEmoteData> equippedEmotes)
         {
-          
+
         }
 
         internal void OnEquippedEmoteAddedOrRemoved(EquippedEmoteData equippedEmote)
         {
-          
+
         }
 
         internal void SaveEquippedEmotesInLocalStorage()
@@ -117,8 +117,12 @@ namespace DCL.EquippedEmotes
             List<EquippedEmoteData> storedEquippedEmotesData = new List<EquippedEmoteData>();
             foreach (string emoteId in storedEquippedEmotes)
             {
-                storedEquippedEmotesData.Add(
-                    string.IsNullOrEmpty(emoteId) ? null : new EquippedEmoteData { id = emoteId, cachedThumbnail = null });
+                var emote = string.IsNullOrEmpty(emoteId) ? null : new EquippedEmoteData
+                {
+                    id = ExtendedUrnParser.GetShortenedUrn(emoteId),
+                    cachedThumbnail = null
+                };
+                storedEquippedEmotesData.Add(emote);
             }
             emotesCustomizationDataStore.equippedEmotes.Set(storedEquippedEmotesData);
         }


### PR DESCRIPTION
## What does this PR change?

Ensures that when NFT emotes are using the long URL that are stored within the profile, the backpack treats it as a shortened url.

...

## How to test the changes?

1. Equip an NFT emote & Close the backpack.
2. Exit 
3. Rejoin and ensure the emotes are still assigned.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
