### PR TITLE
fix: add feature flag to toggle joining chat by default on start

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatWindowController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/VoiceChatHUD/VoiceChatWindowController.cs
@@ -14,6 +14,7 @@ using static DCL.SettingsCommon.GeneralSettings;
 public class VoiceChatWindowController : IHUD
 {
     internal const string VOICE_CHAT_FEATURE_FLAG = "voice_chat";
+    internal const string VOICE_CHAT_JOINED_ON_START_FEATURE_FLAG = "voice_chat_joined_on_start";
     internal const float MUTE_STATUS_UPDATE_INTERVAL = 0.3f;
     internal const string TALKING_MESSAGE_YOU = "You";
     internal const string TALKING_MESSAGE_JUST_YOU_IN_THE_VOICE_CHAT = "No one else is here";
@@ -24,6 +25,7 @@ public class VoiceChatWindowController : IHUD
     public IVoiceChatBarComponentView VoiceChatBarView => voiceChatBarView;
 
     private bool isVoiceChatFFEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled(VOICE_CHAT_FEATURE_FLAG);
+    private bool isVoiceChatJoinedOnStartFFEnabled => dataStore.featureFlags.flags.Get().IsFeatureEnabled(VOICE_CHAT_JOINED_ON_START_FEATURE_FLAG);
     internal BaseVariable<HashSet<string>> visibleTaskbarPanels => dataStore.HUDs.visibleTaskbarPanels;
     private UserProfile ownProfile => userProfileBridge.GetOwn();
 
@@ -396,7 +398,8 @@ public class VoiceChatWindowController : IHUD
             return;
 
         CommonScriptableObjects.rendererState.OnChange -= RendererState_OnChange;
-        RequestJoinVoiceChat(true);
+
+        RequestJoinVoiceChat(isVoiceChatJoinedOnStartFFEnabled);
     }
 
     internal void SetWhichPlayerIsTalking()


### PR DESCRIPTION
## What does this PR change?

This PR is adding a feature flag to toggle between joined state in voice chat on the start of application.
This is a workaround for https://github.com/decentraland/unity-renderer/issues/6074

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. Add `&ENABLE_voice_chat_joined_on_start` param 
3. The user should be joined to the chat automatically
4. Add `&DISABLE_voice_chat_joined_on_start`
5. The user should not be connected to voice chat

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
