### PR TITLE
fix: sdk7 worlds scene emotes url

### DIFF
--- a/unity-renderer/Assets/DCLServices/EmotesService/Domain/IEmotesService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesService/Domain/IEmotesService.cs
@@ -5,6 +5,6 @@ namespace DCL.Emotes
 {
     public interface IEmotesService : IService
     {
-        UniTask<IEmoteReference> RequestEmote(EmoteBodyId emoteBodyId, CancellationToken cancellationToken);
+        UniTask<IEmoteReference> RequestEmote(EmoteBodyId emoteBodyId, CancellationToken cancellationToken, string contentUrl = null);
     }
 }

--- a/unity-renderer/Assets/DCLServices/EmotesService/EmotesService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesService/EmotesService.cs
@@ -88,7 +88,7 @@ namespace DCL.Emotes
             embeddedEmotes.Add(new EmoteBodyId(urnPrefix, embeddedEmote.id), new EmbedEmoteReference(embeddedEmote, clipData));
         }
 
-        public async UniTask<IEmoteReference> RequestEmote(EmoteBodyId emoteBodyId, CancellationToken cancellationToken = default)
+        public async UniTask<IEmoteReference> RequestEmote(EmoteBodyId emoteBodyId, CancellationToken cancellationToken = default, string contentUrl = null)
         {
             if (embeddedEmotes.TryGetValue(emoteBodyId, out var value))
                 return value;
@@ -102,7 +102,7 @@ namespace DCL.Emotes
 
             try
             {
-                var emote = await FetchEmote(emoteBodyId, cancellationToken);
+                var emote = await FetchEmote(emoteBodyId, cancellationToken, contentUrl);
 
                 if (emote == null)
                 {
@@ -128,17 +128,24 @@ namespace DCL.Emotes
             }
         }
 
-        private UniTask<WearableItem> FetchEmote(EmoteBodyId emoteBodyId, CancellationToken ct)
+        private UniTask<WearableItem> FetchEmote(EmoteBodyId emoteBodyId, CancellationToken ct, string contentUrl = null)
         {
             string emoteId = emoteBodyId.EmoteId;
 
             if (!SceneEmoteHelper.IsSceneEmote(emoteId))
+            {
                 return emotesCatalogService.RequestEmoteAsync(emoteId, ct);
+            }
 
             if (!emoteId.StartsWith("urn"))
+            {
                 return emotesCatalogService.RequestEmoteFromBuilderAsync(emoteId, ct);
+            }
 
-            WearableItem emoteItem = SceneEmoteHelper.TryGetDataFromEmoteId(emoteId, out string emoteHash, out bool loop) ? new EmoteItem(emoteBodyId.BodyShapeId, emoteId, emoteHash, catalyst.contentUrl, loop) : null;
+            string finalContentUrl = catalyst.contentUrl;
+            if (contentUrl != null)
+                finalContentUrl = contentUrl.Remove(contentUrl.Length - 9); // "contents/"
+            WearableItem emoteItem = SceneEmoteHelper.TryGetDataFromEmoteId(emoteId, out string emoteHash, out bool loop) ? new EmoteItem(emoteBodyId.BodyShapeId, emoteId, emoteHash, finalContentUrl, loop) : null;
 
             return new UniTask<WearableItem>(emoteItem);
         }

--- a/unity-renderer/Assets/DCLServices/EmotesService/EmotesService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesService/EmotesService.cs
@@ -142,10 +142,14 @@ namespace DCL.Emotes
                 return emotesCatalogService.RequestEmoteFromBuilderAsync(emoteId, ct);
             }
 
-            string finalContentUrl = catalyst.contentUrl;
-            if (contentUrl != null)
-                finalContentUrl = contentUrl.Remove(contentUrl.Length - 9); // "contents/"
-            WearableItem emoteItem = SceneEmoteHelper.TryGetDataFromEmoteId(emoteId, out string emoteHash, out bool loop) ? new EmoteItem(emoteBodyId.BodyShapeId, emoteId, emoteHash, finalContentUrl, loop) : null;
+            WearableItem emoteItem = null;
+            if (SceneEmoteHelper.TryGetDataFromEmoteId(emoteId, out string emoteHash, out bool loop))
+            {
+                if (contentUrl != null)
+                    emoteItem = new EmoteItem(emoteBodyId.BodyShapeId, emoteId, emoteHash, contentUrl, loop, false);
+                else
+                    emoteItem = new EmoteItem(emoteBodyId.BodyShapeId, emoteId, emoteHash, catalyst.contentUrl, loop);
+            }
 
             return new UniTask<WearableItem>(emoteItem);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/WearableItem.cs
@@ -441,7 +441,7 @@ public class WearableItem
 [Serializable]
 public class EmoteItem : WearableItem
 {
-    public EmoteItem(string bodyShapeId, string emoteId, string emoteHash, string contentUrl, bool loop)
+    public EmoteItem(string bodyShapeId, string emoteId, string emoteHash, string contentUrl, bool loop, bool needUrlAppend = true)
     {
         data = new Data
         {
@@ -466,7 +466,7 @@ public class EmoteItem : WearableItem
         emoteDataV0 = new EmoteDataV0 { loop = loop };
 
         id = emoteId;
-        baseUrl = $"{contentUrl}contents/";
+        baseUrl = needUrlAppend ? $"{contentUrl}contents/" : contentUrl;
     }
 }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/EmotesService/EmotesRendererServiceImpl.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/EmotesService/EmotesRendererServiceImpl.cs
@@ -125,7 +125,7 @@ namespace RPC.Services
 
                 if (!emotesByScene[scene].Contains(emoteKey))
                 {
-                    var result = await emotesService.RequestEmote(emoteKey, cancellationTokenSource.Token);
+                    var result = await emotesService.RequestEmote(emoteKey, cancellationTokenSource.Token, scene.contentProvider.baseUrl);
                     emotesController.EquipEmote(emoteId, result);
                     emotesByScene[scene].Add(emoteKey);
                 }


### PR DESCRIPTION
Updated `TriggerSceneExpression()` method to inject the scene content url, so that the feature also works in Worlds.

Fixes https://github.com/decentraland/sdk/issues/1042

--------------------------------------

## TEST INSTRUCTIONS

Confirm that after clicking the blue button, the avatar plays a dancing emote animation.

https://play.decentraland.zone/?realm=builder-api.decentraland.zone%2Fv1%2Fprojects%2Fee7b5bbe-f9be-4ae6-9b7a-b5fd2b5786c4&NETWORK=sepolia&DEBUG_SCENE_LOG=&position=0%2C0&explorer-branch=fix/sdk7-worlds-scene-emotes-content-url

https://github.com/decentraland/unity-renderer/assets/1031741/8de47bd2-7fdf-4c63-906c-33e7cc3f710f

