### PR TITLE
fix: force publish avatar with extended urns from backpack

### DIFF
--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogDefinitions/IEmotesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogDefinitions/IEmotesCatalogService.cs
@@ -27,4 +27,5 @@ public interface IEmotesCatalogService : IService
 
     void ForgetEmotes(IList<string> ids);
 
+    bool TryGetOwnedUrn(string shortenedUrn, out string extendedUrn);
 }

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogDefinitions/IEmotesRequestSource.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogDefinitions/IEmotesRequestSource.cs
@@ -5,10 +5,11 @@ public delegate void EmoteRejectedDelegate(string emoteId, string errorMessage);
 
 public interface IEmotesRequestSource : IDisposable
 {
+    public delegate void OwnedEmotesReceived(IReadOnlyList<WearableItem> emotes, string userId, IReadOnlyDictionary<string, string> extendedUrns);
 
     event Action<IReadOnlyList<WearableItem>> OnEmotesReceived;
     event EmoteRejectedDelegate OnEmoteRejected;
-    event Action<IReadOnlyList<WearableItem>, string> OnOwnedEmotesReceived;
+    event OwnedEmotesReceived OnOwnedEmotesReceived;
 
     void RequestOwnedEmotes(string userId);
     void RequestEmote(string emoteId) ;

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/EmotesCatalogServiceProxy.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/EmotesCatalogServiceProxy.cs
@@ -135,4 +135,7 @@ public class EmotesCatalogServiceProxy : IEmotesCatalogService
 
     public void ForgetEmotes(IList<string> ids) =>
         emotesCatalogServiceInUse.ForgetEmotes(ids);
+
+    public bool TryGetOwnedUrn(string shortenedUrn, out string extendedUrn) =>
+        emotesCatalogServiceInUse.TryGetOwnedUrn(shortenedUrn, out extendedUrn);
 }

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/LambdasEmotesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/LambdasEmotesCatalogService.cs
@@ -35,6 +35,7 @@ public class LambdasEmotesCatalogService : IEmotesCatalogService
     private readonly ICatalyst catalyst;
     private readonly ILambdasService lambdasService;
     private readonly DataStore dataStore;
+    private readonly Dictionary<string, string> ownedUrns = new ();
 
     private EmbeddedEmotesSO embeddedEmotesSo;
     private CancellationTokenSource addressableCts;
@@ -331,6 +332,9 @@ public class LambdasEmotesCatalogService : IEmotesCatalogService
         }
     }
 
+    public bool TryGetOwnedUrn(string shortenedUrn, out string extendedUrn) =>
+        ownedUrns.TryGetValue(shortenedUrn, out extendedUrn);
+
     public async UniTask<EmbeddedEmotesSO> GetEmbeddedEmotes()
     {
         if (embeddedEmotesSo == null)
@@ -421,8 +425,12 @@ public class LambdasEmotesCatalogService : IEmotesCatalogService
         emotes.Remove(emoteId);
     }
 
-    private void OnOwnedEmotesReceived(IReadOnlyList<WearableItem> receivedEmotes, string userId)
+    private void OnOwnedEmotesReceived(IReadOnlyList<WearableItem> receivedEmotes, string userId,
+        IReadOnlyDictionary<string, string> extendedUrns)
     {
+        foreach ((string shortenedUrn, string extendedUrn) in extendedUrns)
+            ownedUrns[shortenedUrn] = extendedUrn;
+
         if (!ownedEmotesPromisesByUser.TryGetValue(userId, out HashSet<Promise<IReadOnlyList<WearableItem>>> ownedEmotesPromises) || ownedEmotesPromises == null)
             ownedEmotesPromises = new HashSet<Promise<IReadOnlyList<WearableItem>>>();
 

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/WebInterfaceEmotesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/WebInterfaceEmotesCatalogService.cs
@@ -287,6 +287,12 @@ namespace DCLServices.EmotesCatalog.EmotesCatalogService
             }
         }
 
+        public bool TryGetOwnedUrn(string shortenedUrn, out string extendedUrn)
+        {
+            extendedUrn = "";
+            return false;
+        }
+
         public async UniTask<EmbeddedEmotesSO> GetEmbeddedEmotes()
         {
             if(embeddedEmotesSO == null)

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/ExtendedUrnParser.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/ExtendedUrnParser.cs
@@ -12,6 +12,9 @@
                 ? urnReceived.Substring(0, lastIndex)
                 : urnReceived;
         }
+
+        public static bool IsExtendedUrn(string urn) =>
+            urn.Split(':').Length > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN;
     }
 
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -29,6 +29,7 @@ namespace DCL.Backpack
         private readonly OutfitsController outfitsController;
         private readonly IVRMExporter vrmExporter;
         private readonly IDCLFileBrowserService fileBrowser;
+        private readonly IEmotesCatalogService emotesCatalogService;
         private readonly Dictionary<string, string> extendedWearableUrns = new ();
         private readonly Dictionary<string, Dictionary<string, string>> fallbackWearables = new ()
         {
@@ -87,7 +88,8 @@ namespace DCL.Backpack
             AvatarSlotsHUDController avatarSlotsHUDController,
             OutfitsController outfitsController,
             IVRMExporter vrmExporter,
-            IDCLFileBrowserService fileBrowser)
+            IDCLFileBrowserService fileBrowser,
+            IEmotesCatalogService emotesCatalogService)
         {
             this.view = view;
             this.dataStore = dataStore;
@@ -101,6 +103,7 @@ namespace DCL.Backpack
             this.outfitsController = outfitsController;
             this.vrmExporter = vrmExporter;
             this.fileBrowser = fileBrowser;
+            this.emotesCatalogService = emotesCatalogService;
 
             avatarSlotsHUDController.GenerateSlots();
             ownUserProfile.OnUpdate += LoadUserProfileFromProfileUpdate;
@@ -172,7 +175,7 @@ namespace DCL.Backpack
             EquipWearable(outfit.outfit.bodyShape, EquipWearableSource.Outfit, setAsDirty: false, updateAvatarPreview: false);
 
             foreach (string outfitWearable in outfit.outfit.wearables)
-                EquipWearable(ExtendedUrnParser.GetShortenedUrn(outfitWearable), EquipWearableSource.Outfit, setAsDirty: true, updateAvatarPreview: true);
+                EquipWearable(outfitWearable, EquipWearableSource.Outfit, setAsDirty: true, updateAvatarPreview: true);
 
             SetAllColors(outfit.outfit.eyes.color, outfit.outfit.hair.color, outfit.outfit.skin.color);
 
@@ -340,6 +343,14 @@ namespace DCL.Backpack
             {
                 try
                 {
+                    foreach (string w in userProfile.avatar.wearables)
+                        if (ExtendedUrnParser.IsExtendedUrn(w))
+                            extendedWearableUrns[ExtendedUrnParser.GetShortenedUrn(w)] = w;
+
+                    foreach (AvatarModel.AvatarEmoteEntry emote in userProfile.avatar.emotes)
+                        if (ExtendedUrnParser.IsExtendedUrn(emote.urn))
+                            extendedWearableUrns[ExtendedUrnParser.GetShortenedUrn(emote.urn)] = emote.urn;
+
                     wearablesCatalogService.WearablesCatalog.TryGetValue(userProfile.avatar.bodyShape, out var bodyShape);
                     bodyShape ??= await wearablesCatalogService.RequestWearableAsync(userProfile.avatar.bodyShape, cancellationToken);
 
@@ -511,6 +522,9 @@ namespace DCL.Backpack
 
                 if (extendedWearableUrns.ContainsKey(shortenedUrn))
                     avatarModel.wearables[i] = extendedWearableUrns[shortenedUrn];
+                // else if (wearablesCatalogService.TryGetOwnedUrn(shortenedUrn, out string extendedUrn))
+                //     if (!string.IsNullOrEmpty(extendedUrn))
+                //         avatarModel.wearables[i] = extendedUrn;
             }
 
             // Add the equipped emotes to the avatar model
@@ -524,7 +538,15 @@ namespace DCL.Backpack
                 if (equippedEmote == null)
                     continue;
 
-                emoteEntries.Add(new AvatarModel.AvatarEmoteEntry { slot = i, urn = equippedEmote.id });
+                string id = equippedEmote.id;
+
+                if (extendedWearableUrns.ContainsKey(id))
+                    id = extendedWearableUrns[id];
+                else if (emotesCatalogService.TryGetOwnedUrn(id, out string extendedUrn))
+                    if (!string.IsNullOrEmpty(extendedUrn))
+                        id = extendedUrn;
+
+                emoteEntries.Add(new AvatarModel.AvatarEmoteEntry { slot = i, urn = id });
             }
 
             avatarModel.emotes = emoteEntries;
@@ -581,10 +603,15 @@ namespace DCL.Backpack
             bool updateAvatarPreview = true,
             bool resetOverride = true)
         {
-            if (!wearablesCatalogService.WearablesCatalog.TryGetValue(wearableId, out WearableItem wearable))
+            string shortenedWearableId = ExtendedUrnParser.GetShortenedUrn(wearableId);
+
+            if (!wearablesCatalogService.WearablesCatalog.TryGetValue(shortenedWearableId, out WearableItem wearable))
             {
-                Debug.LogError($"Cannot equip wearable {wearableId}");
-                return;
+                if (!wearablesCatalogService.WearablesCatalog.TryGetValue(wearableId, out wearable))
+                {
+                    Debug.LogError($"Cannot equip wearable {shortenedWearableId}");
+                    return;
+                }
             }
 
             EquipWearable(wearableId, wearable, source, setAsDirty, updateAvatarPreview, resetOverride);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -522,9 +522,6 @@ namespace DCL.Backpack
 
                 if (extendedWearableUrns.ContainsKey(shortenedUrn))
                     avatarModel.wearables[i] = extendedWearableUrns[shortenedUrn];
-                // else if (wearablesCatalogService.TryGetOwnedUrn(shortenedUrn, out string extendedUrn))
-                //     if (!string.IsNullOrEmpty(extendedUrn))
-                //         avatarModel.wearables[i] = extendedUrn;
             }
 
             // Add the equipped emotes to the avatar model

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorV2Plugin.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorV2Plugin.cs
@@ -89,7 +89,8 @@ namespace DCL.Backpack
                 avatarSlotsHUDController,
                 outfitsController,
                 new VRMExporter(vrmExporterReferences),
-                Environment.i.platform.serviceLocator.Get<IDCLFileBrowserService>());
+                Environment.i.platform.serviceLocator.Get<IDCLFileBrowserService>(),
+                Environment.i.platform.serviceLocator.Get<IEmotesCatalogService>());
 
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/BackpackEditorHUDControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/BackpackEditorHUDControllerShould.cs
@@ -108,7 +108,8 @@ namespace DCL.Backpack
                 avatarSlotsHUDController,
                 new OutfitsController(Substitute.For<IOutfitsSectionComponentView>(), new LambdaOutfitsService(Substitute.For<ILambdasService>(), Substitute.For<IServiceProviders>()), userProfileBridge, Substitute.For<DataStore>(), Substitute.For<IBackpackAnalyticsService>()),
                 vrmExporter,
-                fileBrowserService);
+                fileBrowserService,
+                Substitute.For<IEmotesCatalogService>());
         }
 
         [TearDown]

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/BackpackEditorHUDV2Tests.asmdef
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/BackpackEditorHUDV2Tests.asmdef
@@ -41,7 +41,8 @@
         "GUID:dffbb581f2650ea4990781f603ac258a",
         "GUID:2995626b54c60644988f134a69a77450",
         "GUID:4ad87ae8afda2df4d897ad1a3527cd1d",
-        "GUID:d6fe1b5729e3405d98cf8ff2035d9542"
+        "GUID:d6fe1b5729e3405d98cf8ff2035d9542",
+        "GUID:ce5ce184029b7f34c9188d4ae2aeb3d7"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What does this PR change?

The profile published from the backpack was converting the wearable list into shortened urns. This change forces the wearables to be extended, to comply with the new catalyst rules.

## How to test the changes?

1. Launch the explorer
2. Go to the backpack
3. Change your wearables, either from the base collection or custom
4. Close the backpack so the profile is saved
5. Open the backpack and change outfits
6. Close the backpack and check that the profile is saved correctly
7. Open the backpack and change your emotes, select custom nfts if possible
8. Close the backpack and check that the profile is saved correctly
9. Preferably use this param: `&CATALYST=https://peer.decentraland.zone`
10. Restart the client between the process to check that the profile is persisted correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
