### PR TITLE
style: update discover banners

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/MainMenu/ExploreV2Menu.prefab
@@ -13392,7 +13392,7 @@ PrefabInstance:
     - target: {fileID: 1768900959223747055, guid: 01095a78852393446834e68bf8628274,
         type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1769823040169016768, guid: 01095a78852393446834e68bf8628274,
         type: 3}
@@ -14018,6 +14018,31 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2149698934118888499, guid: 01095a78852393446834e68bf8628274,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2149698934118888499, guid: 01095a78852393446834e68bf8628274,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2149698934118888499, guid: 01095a78852393446834e68bf8628274,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 921.053
+      objectReference: {fileID: 0}
+    - target: {fileID: 2149698934118888499, guid: 01095a78852393446834e68bf8628274,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -460.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2149698934118888499, guid: 01095a78852393446834e68bf8628274,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -72.442024
       objectReference: {fileID: 0}
     - target: {fileID: 2150171300012380080, guid: 01095a78852393446834e68bf8628274,
         type: 3}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesAndEventsSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/PlacesAndEventsSection.prefab
@@ -8312,6 +8312,31 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4343850142067033455, guid: e7f5a2ca6d845b245990c567955385a0,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4343850142067033455, guid: e7f5a2ca6d845b245990c567955385a0,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4343850142067033455, guid: e7f5a2ca6d845b245990c567955385a0,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1868
+      objectReference: {fileID: 0}
+    - target: {fileID: 4343850142067033455, guid: e7f5a2ca6d845b245990c567955385a0,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 4343850142067033455, guid: e7f5a2ca6d845b245990c567955385a0,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4514692257233509624, guid: e7f5a2ca6d845b245990c567955385a0,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -10269,6 +10294,31 @@ PrefabInstance:
       value: 960
       objectReference: {fileID: 0}
     - target: {fileID: 6374234628015134602, guid: 30885b1234eac474f9ebe15b4d4ad9d6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6503063510664517196, guid: 30885b1234eac474f9ebe15b4d4ad9d6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6503063510664517196, guid: 30885b1234eac474f9ebe15b4d4ad9d6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6503063510664517196, guid: 30885b1234eac474f9ebe15b4d4ad9d6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6503063510664517196, guid: 30885b1234eac474f9ebe15b4d4ad9d6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6503063510664517196, guid: 30885b1234eac474f9ebe15b4d4ad9d6,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/WorldsSubSection/WorldsSubSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/WorldsSubSection/WorldsSubSection.prefab
@@ -1517,7 +1517,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 800, y: -21}
+  m_AnchoredPosition: {x: 817, y: -21}
   m_SizeDelta: {x: 160, y: 46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4060694181056187896
@@ -1934,8 +1934,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -933, y: -73}
-  m_SizeDelta: {x: 1866, y: 182}
+  m_AnchoredPosition: {x: -460.7, y: -72.442024}
+  m_SizeDelta: {x: 921.053, y: 180.9191}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1849199017070512815
 CanvasRenderer:
@@ -1966,7 +1966,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: c9ce4a22ac8da475e9a7e6229efb4c98, type: 3}
-  m_Type: 1
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/WorldsSubSection/WorldsSubSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/ExploreV2/Resources/Sections/PlacesAndEventsSection/WorldsSubSection/WorldsSubSection.prefab
@@ -1961,7 +1961,7 @@ MonoBehaviour:
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
+  m_Maskable: 0
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/unity-renderer/Assets/Textures/UI/Worlds/GenesisCityBanner.png
+++ b/unity-renderer/Assets/Textures/UI/Worlds/GenesisCityBanner.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07db45b6ccc997df18cce179efc6a840d140eea41c72fb7538337697f25f51a6
-size 273558
+oid sha256:9d3166b942ea8e309428521978a64a7e926e7b0e1a080525e6d449f99a5201ca
+size 170719

--- a/unity-renderer/Assets/Textures/UI/Worlds/WorldsBanner.png
+++ b/unity-renderer/Assets/Textures/UI/Worlds/WorldsBanner.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a72343a0a10f744b0970a6b1a7e8df63c3a278e0c5d205328ba72aa8474f3c1
-size 170410
+oid sha256:cefa2453fa624f3f37e6eb1b92fa1d928f5d0b5e0bdf98b6402b780465a0554e
+size 175356


### PR DESCRIPTION
Genesis City and Worlds sections banners now have a brand new style!
<img width="1233" alt="Screenshot 2024-02-23 at 15 41 18" src="https://github.com/decentraland/unity-renderer/assets/51088292/3c13d2ed-a624-460d-9552-2b6a6fc5ca45">

### How to test?
1- Open this [link](https://play.decentraland.org/?explorer-branch=style/discover-banners)
2- Open the menu in the discover section and check that the Genesis City and Worlds banners have been replaced with the new art.
