### PR TITLE
fix: add extended urns for saving outfits

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDController.cs
@@ -817,7 +817,7 @@ namespace DCL.Backpack
         private void UpdateAvatarModel(AvatarModel avatarModel)
         {
             view.UpdateAvatarPreview(avatarModel);
-            outfitsController.UpdateAvatarPreview(model.ToAvatarModel());
+            outfitsController.UpdateAvatarPreview(model.ToAvatarModel(extendedWearableUrns));
         }
 
         private void OnColorPickerToggled() =>

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/BackpackEditorHUDModel.cs
@@ -13,12 +13,25 @@ namespace DCL.Backpack
         public Color eyesColor;
         public HashSet<string> forceRender = new ();
 
-        public AvatarModel ToAvatarModel()
+        public AvatarModel ToAvatarModel(Dictionary<string, string> extendedWearableUrns = null)
         {
+            List<string> wearables;
+
+            if (extendedWearableUrns != null)
+            {
+                wearables = new List<string>();
+
+                foreach (string w in this.wearables.Keys)
+                    wearables.Add(extendedWearableUrns.TryGetValue(w, out string extendedUrn)
+                        ? extendedUrn : w);
+            }
+            else
+                wearables = this.wearables.Keys.ToList();
+
             return new AvatarModel
             {
                 bodyShape = bodyShape.id,
-                wearables = wearables.Keys.ToList(),
+                wearables = wearables,
                 hairColor = hairColor,
                 skinColor = skinColor,
                 eyeColor = eyesColor,


### PR DESCRIPTION
## What does this PR change?

Allows the outfit's wearables to be saved as extended urn, required by servers.

## How to test the changes?

1. Launch the explorer with param: `&CATALYST=https://peer.decentraland.zone`
2. Open the backpack
3. Go to outfits
4. Check that are loaded as expected
5. Play with outfits, like editing/removing/adding
6. Close the backpack and restart the client
7. Check that the outfits are persisted as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
