### PR TITLE
update avatar scene to prevent rendering players when blocked

### DIFF
--- a/browser-interface/packages/shared/comms/peers.ts
+++ b/browser-interface/packages/shared/comms/peers.ts
@@ -16,6 +16,7 @@ import {
   positionReportToCommsPositionRfc4,
   squareDistanceRfc4
 } from './interface/utils'
+import { isBlocked } from 'shared/friends/utils'
 
 /**
  * peerInformationMap contains data received of the current peers that we have
@@ -123,7 +124,7 @@ function sendPeerUserData(address: string) {
       avatarMessageObservable.notifyObservers({
         type: AvatarMessageType.USER_DATA,
         userId: peer.ethereumAddress,
-        data: peer,
+        data: { ...peer, visible: !isBlocked(profile.userId) },
         profile
       })
     }

--- a/browser-interface/packages/ui/avatar/avatarSystem.ts
+++ b/browser-interface/packages/ui/avatar/avatarSystem.ts
@@ -22,7 +22,7 @@ type Position = {
   rotationW: number
 }
 
-const avatarMap = new Map<string, AvatarEntity>()
+export const avatarMap = new Map<string, AvatarEntity>()
 
 export class AvatarEntity extends Entity {
   visible = true

--- a/browser-interface/packages/ui/decentraland-ui.scene.ts
+++ b/browser-interface/packages/ui/decentraland-ui.scene.ts
@@ -1,5 +1,5 @@
 import { executeTask } from '@dcl/legacy-ecs'
-import { avatarMessageObservable } from './avatar/avatarSystem'
+import { avatarMap, avatarMessageObservable } from './avatar/avatarSystem'
 
 declare const dcl: DecentralandInterface
 
@@ -23,7 +23,9 @@ void executeTask(async () => {
       if (payload !== lastProcessed) {
         try {
           lastProcessed = payload
-          avatarMessageObservable.emit('message', JSON.parse(payload))
+          const msg = JSON.parse(payload)
+          const invisible = avatarMap.get(msg.userId)?.visible === false && msg.visible === false
+          if (!invisible) avatarMessageObservable.emit('message', msg)
         } catch (err) {
           console.error(err)
         }


### PR DESCRIPTION
## What does this PR change?

[Shape up - Cycle 5 => Block players visually](https://www.notion.so/decentraland/Block-Players-Visually-7ecdf67bd0b64d76bb29e01b56f60f4f)

## How to test the changes?
Block a player and you should not be able to see them anymore