### PR TITLE
style: replace the word pictures by photos in the camera and camera reel UI

### DIFF
--- a/unity-renderer/Assets/DCLFeatures/CameraReel/Gallery/Prefabs/Header.prefab
+++ b/unity-renderer/Assets/DCLFeatures/CameraReel/Gallery/Prefabs/Header.prefab
@@ -31,7 +31,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3514973599430430845}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -169,7 +168,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7808565566380676151}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -204,7 +202,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Storage 57/100 photo taken
+  m_text: Storage 57/100 photos taken
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 74b83fa9a54124695b9bdd8bea96fa17, type: 2}
@@ -307,7 +305,6 @@ RectTransform:
   - {fileID: 8554240609457613775}
   - {fileID: 8755313427840704956}
   m_Father: {fileID: 7808565566380676151}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -396,7 +393,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3514973599430430845}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -472,7 +468,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8755313427840704956}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -548,7 +543,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6206378532081649024}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -624,7 +618,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8554240609457613775}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -700,7 +693,6 @@ RectTransform:
   - {fileID: 6286612792635787617}
   - {fileID: 2721695826281978811}
   m_Father: {fileID: 7808565566380676151}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -738,7 +730,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7808565566380676151}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -879,7 +870,6 @@ RectTransform:
   - {fileID: 6206378532081649024}
   - {fileID: 3514973599430430845}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -969,7 +959,6 @@ RectTransform:
   m_Children:
   - {fileID: 1511974572317269754}
   m_Father: {fileID: 6206378532081649024}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1006,7 +995,6 @@ RectTransform:
   m_Children:
   - {fileID: 6074696067784206898}
   m_Father: {fileID: 6206378532081649024}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/unity-renderer/Assets/DCLFeatures/CameraReel/Gallery/Prefabs/Header.prefab
+++ b/unity-renderer/Assets/DCLFeatures/CameraReel/Gallery/Prefabs/Header.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 32, y: 0}
-  m_SizeDelta: {x: 638, y: 38}
+  m_SizeDelta: {x: 655.8523, y: 38}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &4021179522505976114
 CanvasRenderer:
@@ -65,8 +65,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: You can't take more pictures because you have reached the storage limit
-    of the camera reel. To make room we recommend you to download your photos and
+  m_text: You can't take more photos because you have reached the storage limit of
+    the camera reel. To make room we recommend you to download all your photos and
     then delete them.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a02669827dd9144f39b4b164e753a21a, type: 2}
@@ -396,7 +396,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 10.000015, y: -0.000011444092}
+  m_AnchoredPosition: {x: 10, y: -0.000011444092}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8420807825748553488
@@ -696,9 +696,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -335.55035, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 671.1007, y: 38}
-  m_Pivot: {x: 0, y: 0.5}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &7649214072965441821
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-renderer/Assets/DCLFeatures/CameraReel/Gallery/Scripts/CameraReelGalleryStorageView.cs
+++ b/unity-renderer/Assets/DCLFeatures/CameraReel/Gallery/Scripts/CameraReelGalleryStorageView.cs
@@ -1,4 +1,4 @@
-﻿using TMPro;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -12,7 +12,7 @@ namespace DCLFeatures.CameraReel.Gallery
 
         public void UpdateStorageBar(int current, int max)
         {
-            storageText.text = $"Storage: {current}/{max} photo taken";
+            storageText.text = $"Storage: {current}/{max} photos taken";
             storageText.gameObject.SetActive(true);
             storageFullMessage.SetActive(current >= max);
 

--- a/unity-renderer/Assets/DCLFeatures/CameraReel/Gallery/Scripts/ThumbnailContextMenuController.cs
+++ b/unity-renderer/Assets/DCLFeatures/CameraReel/Gallery/Scripts/ThumbnailContextMenuController.cs
@@ -76,8 +76,8 @@ namespace DCLFeatures.CameraReel.Gallery
                 }
 
                 dataStore.notifications.GenericConfirmation.Set(new GenericConfirmationNotificationData(
-                    "Are you sure you want to delete this picture?",
-                    "This picture will be removed and you will no longer be able to access it.",
+                    "Are you sure you want to delete this photo?",
+                    "This photo will be removed and you will no longer be able to access it.",
                     "NO",
                     "YES",
                     () => { },

--- a/unity-renderer/Assets/DCLFeatures/CameraReel/ScreenshotViewer/Scripts/ScreenshotViewerController.cs
+++ b/unity-renderer/Assets/DCLFeatures/CameraReel/ScreenshotViewer/Scripts/ScreenshotViewerController.cs
@@ -1,4 +1,4 @@
-﻿using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using DCL;
 using DCL.Browser;
 using DCL.Tasks;
@@ -144,8 +144,8 @@ namespace DCLFeatures.CameraReel.ScreenshotViewer
             }
 
             dataStore.notifications.GenericConfirmation.Set(new GenericConfirmationNotificationData(
-                "Are you sure you want to delete this picture?",
-                "This picture will be removed and you will no longer be able to access it.",
+                "Are you sure you want to delete this photo?",
+                "This photo will be removed and you will no longer be able to access it.",
                 "NO",
                 "YES",
                 () => {},

--- a/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Prefabs/ScreencaptureCameraHUD.prefab
+++ b/unity-renderer/Assets/DCLServices/ScreencaptureCamera/UI/Prefabs/ScreencaptureCameraHUD.prefab
@@ -1873,7 +1873,7 @@ PrefabInstance:
     - target: {fileID: 1448454455420767778, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}
       propertyPath: m_text
-      value: You can't take more pictures because you have reached the storage limit.
+      value: You can't take more photos because you have reached the storage limit.
       objectReference: {fileID: 0}
     - target: {fileID: 1448454455420767778, guid: 0282a050c09634ed299130b8e9c2c035,
         type: 3}


### PR DESCRIPTION
## What does this PR change?
This PR was created to replace the word `pictures` by `photos` in every component of the camera UI in order to keep wording consistency. 

## How to test the changes?

1- Open this [link](https://play.decentraland.org/?explorer-branch=style/replace-pictures-for-photos)

2- Go to the camera reel section in the menu and check the copy says `Storage n/500 **photos** taken` instead of `photo` in singular.
<img width="163" alt="Screenshot 2024-03-13 at 13 04 17" src="https://github.com/decentraland/unity-renderer/assets/51088292/b60a24c8-2a67-4b91-962d-b92b5003c099">

3- Then try to delete one of the pics and check in the prompt the word `pictures` had been replaced by `photos`.
<img width="446" alt="image" src="https://github.com/decentraland/unity-renderer/assets/51088292/c87d1757-30bd-42d9-8eae-be2189e76be8">

4- Now go back to the world and enter the camera mode. Take as many photos as you can until reach the storage limit. Check the warning toast now says `photos` instead of `pictures`.
<img width="324" alt="Screenshot 2024-03-13 at 12 36 47" src="https://github.com/decentraland/unity-renderer/assets/51088292/cdbf1e47-31a0-428b-9900-d1479a8152e9">

5- Then go back to the camera reel and check the storage warning saying pictures now says `photos` in the nav bar.
<img width="342" alt="Screenshot 2024-03-13 at 12 37 01" src="https://github.com/decentraland/unity-renderer/assets/51088292/daefcb6d-690d-48d7-91ca-0592cb55b9a6">
