### PR TITLE
fix: unify to entity.id the scene_id by comms, remove unused code

### DIFF
--- a/browser-interface/packages/shared/apis/host/CommunicationsController.ts
+++ b/browser-interface/packages/shared/apis/host/CommunicationsController.ts
@@ -48,7 +48,7 @@ export function registerCommunicationsControllerServiceServerImplementation(port
      * The `receiveCommsMessage` relays messages in direction: scene -> comms
      */
     const commsController: ICommunicationsController = {
-      cid: ctx.sceneData.id,
+      cid: ctx.sceneData.entity.id || ctx.sceneData.id,
       receiveCommsMessage(preData: Uint8Array, sender: PeerInformation) {
         const [msgType, data] = decodeMessage(preData)
         if (msgType === MsgType.String) {
@@ -85,13 +85,13 @@ export function registerCommunicationsControllerServiceServerImplementation(port
     return {
       async send(req, ctx) {
         const message = textEncoder.encode(req.message)
-        sendParcelSceneCommsMessage(ctx.sceneData.id, encodeMessage(message, MsgType.String))
+        sendParcelSceneCommsMessage(commsController.cid, encodeMessage(message, MsgType.String))
         return {}
       },
       async sendBinary(req, ctx) {
         // Send messages
         for (const data of req.data) {
-          sendParcelSceneCommsMessage(ctx.sceneData.id, encodeMessage(data, MsgType.Uint8Array))
+          sendParcelSceneCommsMessage(commsController.cid, encodeMessage(data, MsgType.Uint8Array))
         }
 
         // Process received messages

--- a/browser-interface/packages/shared/comms/sceneSubscriptions.ts
+++ b/browser-interface/packages/shared/comms/sceneSubscriptions.ts
@@ -14,18 +14,3 @@ export function subscribeParcelSceneToCommsMessages(controller: ICommunicationsC
 export function unsubscribeParcelSceneToCommsMessages(controller: ICommunicationsController) {
   scenesSubscribedToCommsEvents.delete(controller)
 }
-
-/**
- * Retrieve the scene IDs that are subscribed to receive scene messages from comms
- *
- * @returns a list of CIDs, identifying the Scenes by their hash
- */
-export function getParcelSceneSubscriptions(): string[] {
-  const ids: string[] = []
-
-  scenesSubscribedToCommsEvents.forEach(($) => {
-    ids.push($.cid)
-  })
-
-  return ids
-}

--- a/browser-interface/packages/shared/scene-loader/genesis-city-loader-impl/emptyParcelController.ts
+++ b/browser-interface/packages/shared/scene-loader/genesis-city-loader-impl/emptyParcelController.ts
@@ -36,6 +36,7 @@ export class EmptyParcelController {
       id: entityId,
       baseUrl: this.baseUrl + 'contents/',
       entity: {
+        id: entityId,
         content: emptyScenes[sceneName]!,
         pointers: [coordinates],
         timestamp: Date.now(),

--- a/browser-interface/packages/shared/types.ts
+++ b/browser-interface/packages/shared/types.ts
@@ -181,7 +181,7 @@ export type SceneSourcePlacement = {
 export const VOICE_CHAT_FEATURE_TOGGLE: SceneFeatureToggle = { name: 'voiceChat', default: 'enabled' }
 
 export type LoadableScene = {
-  readonly entity: Readonly<Omit<Entity, 'id'>>
+  readonly entity: Readonly<Entity>
   readonly baseUrl: string
   readonly id: string
   /** Id of the parent scene that spawned this scene experience */

--- a/browser-interface/packages/shared/wearablesPortableExperience/sagas.ts
+++ b/browser-interface/packages/shared/wearablesPortableExperience/sagas.ts
@@ -154,6 +154,9 @@ export async function wearableToSceneEntity(wearable: WearableV2, defaultBaseUrl
     baseUrl,
     parentCid: 'avatar',
     entity: {
+      // TODO: the wearable.id is an urn because the wearable was fetched
+      //  from `lambdas/wearables` instead of `content/entities/active`
+      id: wearable.id,
       content,
       metadata,
       pointers: [wearable.id],

--- a/browser-interface/packages/unity-interface/dcl.ts
+++ b/browser-interface/packages/unity-interface/dcl.ts
@@ -110,6 +110,7 @@ async function startGlobalScene(cid: string, title: string, fileContentUrl: stri
     id: cid,
     baseUrl,
     entity: {
+      id: cid,
       content: [...extraContent, { file: 'scene.js', hash: fileContentUrl }],
       pointers: [cid],
       timestamp: 0,

--- a/browser-interface/packages/unity-interface/portableExperiencesUtils.ts
+++ b/browser-interface/packages/unity-interface/portableExperiencesUtils.ts
@@ -85,6 +85,10 @@ export async function getPortableExperienceFromUrn(sceneUrn: string): Promise<Lo
 
   const result = await fetch(resolvedUrl)
   const entity = (await result.json()) as Entity
+  if (!entity.id) {
+    entity.id = resolvedEntity.cid
+  }
+
   const baseUrl: string = resolvedEntity.baseUrl || new URL('.', resolvedUrl).toString()
 
   return {

--- a/browser-interface/test/unit/RestrictedActions.test.tsx
+++ b/browser-interface/test/unit/RestrictedActions.test.tsx
@@ -187,6 +187,7 @@ describe('RestrictedActions tests', () => {
       sceneNumber: 3,
       baseUrl: '',
       entity: {
+        id: 'test',
         version: 'v3',
         content: [],
         pointers: [],

--- a/browser-interface/test/unit/portableExperiences.test.tsx
+++ b/browser-interface/test/unit/portableExperiences.test.tsx
@@ -22,6 +22,7 @@ describe('Portable experiences sagas test', () => {
     id: urn,
     baseUrl: '',
     entity: {
+      id: urn,
       content: [],
       metadata: {
         menuBarIcon: 'icon'


### PR DESCRIPTION
## What does this PR change?
Use always the `entity.id` as scene identifier by comms. Right now the identifier changes if you're in the genesis city, world or custom realm.

## How to test the changes?

Jump to the beer scene using two tabs (that's why the guest=true is on):
https://play.decentraland.org/?explorer-branch=fix/unify-scene-id-by-comms&realm=sdk-team-cdn.decentraland.org%2Fipfs%2Fgoerli-plaza-test-psquad-demo-latest&skipSetup=true&guest=true&position=73%2C-7
If you pick up a glass, you have to be able to see it from the other tab.