### PR TITLE
fix: changed epic, rare & unique title colors

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Data/InfoPanelSkins/Epic.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Data/InfoPanelSkins/Epic.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: Epic
   m_EditorClassIdentifier: 
   backgroundColor: {r: 0.2627451, g: 0.56078434, b: 1, a: 1}
-  rarityNameColor: {r: 0.6039216, g: 0.87058824, b: 0.99607843, a: 1}
+  rarityNameColor: {r: 0.20392157, g: 0.46666667, b: 0.99607843, a: 1}
   gradientColor: {r: 0, g: 0, b: 0, a: 0}
+  isBase: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Data/InfoPanelSkins/Rare.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Data/InfoPanelSkins/Rare.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: Rare
   m_EditorClassIdentifier: 
   backgroundColor: {r: 0.20392157, g: 0.80784315, b: 0.4627451, a: 1}
-  rarityNameColor: {r: 0.6745098, g: 1, b: 0.7294118, a: 1}
+  rarityNameColor: {r: 0.19215687, g: 0.78431374, b: 0.3882353, a: 1}
   gradientColor: {r: 0, g: 0, b: 0, a: 0}
+  isBase: 0

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Data/InfoPanelSkins/Unique.asset
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Data/InfoPanelSkins/Unique.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: Unique
   m_EditorClassIdentifier: 
   backgroundColor: {r: 0.99607843, g: 0.63529414, b: 0.09019608, a: 1}
-  rarityNameColor: {r: 0.96862745, g: 1, b: 0, a: 1}
+  rarityNameColor: {r: 0.9843137, g: 0.5686275, b: 0.08235294, a: 1}
   gradientColor: {r: 1, g: 0.84705883, b: 0.61960787, a: 1}
+  isBase: 0


### PR DESCRIPTION
## What does this PR change?

Some rarities have contrast issues on the nft info panel. This pr changes the colors of the text to improve it.

How it was:
![epic](https://github.com/decentraland/unity-renderer/assets/56365551/e42d0038-03d9-43b2-8b6f-3104ac1c6478)
![rare](https://github.com/decentraland/unity-renderer/assets/56365551/7673b999-f17e-4143-a6fd-57dd73bd2410)
![unique](https://github.com/decentraland/unity-renderer/assets/56365551/494e4210-92ae-48c2-bc05-1d83fcbd80f3)

How it is now:
![Screenshot 2024-04-12 at 11 16 14](https://github.com/decentraland/unity-renderer/assets/56365551/ec1f94aa-51ea-45a0-90f5-3c166eb24acd)


## How to test the changes?

1. Launch the explorer
2. Preview a profile
3. Hover the mouse over some of the collectibles
4. Check that the rarity is legible

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
