### PR TITLE
Fix mocha types resolution

### DIFF
--- a/browser-interface/test/tsconfig.json
+++ b/browser-interface/test/tsconfig.json
@@ -6,7 +6,7 @@
     "strictNullChecks": true,
     "lib": ["es2020", "dom"],
     "baseUrl": "../packages",
-    "types": ["mocha", "@dcl/posix"],
+    "types": ["@types/mocha", "@dcl/posix"],
     "typeRoots": ["../node_modules/"]
   },
   "exclude": ["../packages/engine"],


### PR DESCRIPTION
### Steps to reproduce:
In Windows, in Visual Studio Code, open [`browser-interface/test/index.ts` ](https://github.com/decentraland/unity-renderer/blob/dev/browser-interface/test/index.ts).

### Expected:
No compilation error.

### Actual:
`Cannot find name 'Mocha'. ts(2304)`

![image](https://github.com/decentraland/unity-renderer/assets/49839773/e4b835da-ec52-47eb-9682-1b60020d1b1f)