### PR TITLE
Fix building of Empty Scenes

### DIFF
--- a/browser-interface/public/empty-scenes/common/generate_all.js
+++ b/browser-interface/public/empty-scenes/common/generate_all.js
@@ -36,16 +36,18 @@ for (let dir of dirs) {
       }
     }
   }
+  let sourceFile = path.join(__dirname, dir, 'bin/game.js')
+  let targetFile = path.join(__dirname, 'contents', dir + '.js')
   if (
     fs
-      .readFileSync(path.join(__dirname, dir, 'bin/game.js'))
+      .readFileSync(sourceFile)
       .toString()
       .startsWith('dcl.subscribe')
   ) {
-    fs.copyFileSync(path.join(__dirname, dir, 'bin/game.js'), path.join(__dirname, 'contents', dir + '.js'))
+    fs.copyFileSync(sourceFile, targetFile)
   } else {
     fs.writeFileSync(
-      path.join(__dirname, 'contents', dir + '.js'),
+      targetFile,
       `
 dcl.subscribe('sceneStart')
 
@@ -91,7 +93,7 @@ var engine = {
       dcl.setParent(entity.id, "0")
     }
   }
-}\n` + fs.readFileSync(path.join(__dirname, dir, 'bin/game.js')).toString()
+}\n` + fs.readFileSync(sourceFile).toString()
     )
   }
   data[dir] = sceneMappings

--- a/browser-interface/public/empty-scenes/common/generate_all.js
+++ b/browser-interface/public/empty-scenes/common/generate_all.js
@@ -36,7 +36,7 @@ for (let dir of dirs) {
       }
     }
   }
-  let sourceFile = path.join(__dirname, dir, 'bin/game.js')
+  let sourceFile = path.join(__dirname, dir, 'src/game.ts')
   let targetFile = path.join(__dirname, 'contents', dir + '.js')
   if (
     fs


### PR DESCRIPTION
### Steps to reproduce:
Building the `browser-interface`, following
https://github.com/decentraland/unity-renderer/blob/main/browser-interface/README.md#with-docker-windowsmaclinux-recommended
Reaching the `make watch` step.

### Expected:
No build error

### Actual:
![image](https://github.com/decentraland/unity-renderer/assets/49839773/1150bf83-5b56-442c-8cb5-196b14eca8b9)
