### PR TITLE
fix: Duplicate Outfit Slots in Backpack

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Prefabs/WearablesSection.prefab
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Prefabs/WearablesSection.prefab
@@ -2971,7 +2971,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2273205608813961853
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Fixes https://github.com/decentraland/unity-renderer/issues/6181

![Screenshot 2024-04-23 111932](https://github.com/decentraland/unity-renderer/assets/7305682/ae2d044e-0ef6-41e1-8478-58336e8b63ab)

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. Open backpack and go to outfits
3. Check that there are not duplicated slots

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
