### PR TITLE
fix: disabled options menu for your own user

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Passport/Passport/PlayerInfo/PassportPlayerInfoComponentView.cs
@@ -118,6 +118,9 @@ namespace DCL.Social.Passports
             SetHasBlockedOwnUser(model.hasBlocked);
             SetFriendStatus(model.friendshipStatus);
             SetFriendshipVisibility(model.isFriendshipVisible);
+
+            bool isOwnUser = UserProfile.GetOwnUserProfile().userId == model.userId;
+            optionsButton.gameObject.SetActive(!isOwnUser);
         }
 
         public override void Dispose()


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Fixing https://github.com/decentraland/unity-renderer/issues/6170
The option menu is disabled for your own user

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Launch the explorer
2. Click on your own player to open passport view

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
