### PR TITLE
add support for multiple chain's on nftShape & openNftShapeDialog

### DIFF
--- a/browser-interface/packages/shared/apis/host/RestrictedActions.ts
+++ b/browser-interface/packages/shared/apis/host/RestrictedActions.ts
@@ -151,7 +151,7 @@ export function registerRestrictedActionsServiceServerImplementation(port: RpcSe
     },
     async openExternalUrl(req: OpenExternalUrlRequest, ctx: PortContext) {
       if (!ctx.sdk7) throw new Error('API only available for SDK7')
-      if (ctx.sceneData.isPortableExperience){
+      if (ctx.sceneData.isPortableExperience) {
         assertHasPermission(PermissionItem.PI_OPEN_EXTERNAL_LINK, ctx)
       }
       if (!isPositionValid(lastPlayerPosition, ctx)) {
@@ -171,7 +171,10 @@ export function registerRestrictedActionsServiceServerImplementation(port: RpcSe
         return { success: false }
       }
 
-      const response = await getRendererModules(store.getState())?.restrictedActions?.openNftDialog({ urn: req.urn, sceneNumber: ctx.sceneData.sceneNumber })
+      const response = await getRendererModules(store.getState())?.restrictedActions?.openNftDialog({
+        urn: req.urn,
+        sceneNumber: ctx.sceneData.sceneNumber
+      })
       return { success: response?.success ?? false }
     },
     async setCommunicationsAdapter(req: CommsAdapterRequest, ctx: PortContext) {
@@ -198,7 +201,10 @@ export function registerRestrictedActionsServiceServerImplementation(port: RpcSe
       if (!isPositionValid(lastPlayerPosition, ctx) || !req.worldCoordinates)
         ctx.logger.error('Error: Player is not inside of scene', lastPlayerPosition)
       else
-        getRendererModules(store.getState())?.restrictedActions?.teleportTo({ worldCoordinates: req.worldCoordinates, sceneNumber: ctx.sceneData.sceneNumber })
+        getRendererModules(store.getState())?.restrictedActions?.teleportTo({
+          worldCoordinates: req.worldCoordinates,
+          sceneNumber: ctx.sceneData.sceneNumber
+        })
 
       return {}
     },

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/NFTShape/Handler/ECSNFTShapeComponentHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/NFTShape/Handler/ECSNFTShapeComponentHandler.cs
@@ -117,8 +117,8 @@ namespace DCL.ECSComponents
             try
             {
                 infoRetrieverDisposed = false;
-                NFTUtils.TryParseUrn(urn, out string contractAddress, out string tokenId);
-                NFTInfo? info = await infoRetriever.FetchNFTInfoAsync(contractAddress, tokenId);
+                NFTUtils.TryParseUrn(urn, out string chain, out string contractAddress, out string tokenId);
+                NFTInfo? info = await infoRetriever.FetchNFTInfoAsync(chain, contractAddress, tokenId);
 
                 if (!info.HasValue)
                 {
@@ -135,7 +135,6 @@ namespace DCL.ECSComponents
                     LoadFailed();
                     return;
                 }
-
                 shapeFrame.SetImage(nftInfo.name, nftInfo.imageUrl, nftAsset);
                 nftLoadedScr = urn;
             }

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/NFTShape/Tests/ECSNFTShapeShould.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/NFTShape/Tests/ECSNFTShapeShould.cs
@@ -66,7 +66,7 @@ namespace Tests
         [Test]
         public void UpdateImageCorrectly()
         {
-            infoRetriever.FetchNFTInfoAsync(Arg.Any<string>(), Arg.Any<string>()).Returns(UniTask.FromResult((NFTInfo?)new NFTInfo()));
+            infoRetriever.FetchNFTInfoAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns(UniTask.FromResult((NFTInfo?)new NFTInfo()));
             assetRetriever.LoadNFTAsset(Arg.Any<string>()).Returns(UniTask.FromResult(Substitute.For<INFTAsset>()));
 
             PBNftShape model = new PBNftShape()
@@ -75,14 +75,14 @@ namespace Tests
             };
 
             handler.OnComponentModelUpdated(scene, entity, model);
-            NFTUtils.TryParseUrn(model.Urn, out string contractAddress, out string tokenID);
-            infoRetriever.Received(1).FetchNFTInfoAsync(contractAddress, tokenID);
+            NFTUtils.TryParseUrn(model.Urn, out string chain, out string contractAddress, out string tokenID);
+            infoRetriever.Received(1).FetchNFTInfoAsync(chain, contractAddress, tokenID);
 
             model.Urn = "urn:decentraland:ethereum:erc721:0x8eaa9ae1ac89b1c8c8a8104d08c045f78aadb42d:450";
 
             handler.OnComponentModelUpdated(scene, entity, model);
-            NFTUtils.TryParseUrn(model.Urn, out contractAddress, out tokenID);
-            infoRetriever.Received(1).FetchNFTInfoAsync(contractAddress, tokenID);
+            NFTUtils.TryParseUrn(model.Urn, out chain, out contractAddress, out tokenID);
+            infoRetriever.Received(1).FetchNFTInfoAsync(chain, contractAddress, tokenID);
 
             handler.OnComponentRemoved(scene, entity);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTAsset/NFTAssetLoadHelper.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTAsset/NFTAssetLoadHelper.cs
@@ -21,7 +21,7 @@ namespace DCL
         private const string CONTENT_LENGTH = "Content-Length";
         private const string CONTENT_TYPE_GIF = "image/gif";
         private const string CONTENT_TYPE_WEBP = "image/webp";
-        private const long PREVIEW_IMAGE_SIZE_LIMIT = 750000;
+        private const long PREVIEW_IMAGE_SIZE_LIMIT = 6000000;
 
         protected AssetPromise_Texture imagePromise = null;
         protected AssetPromise_Gif gifPromise = null;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTAsset/NFTAsset_Gif.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTAsset/NFTAsset_Gif.cs
@@ -7,7 +7,7 @@ namespace NFTShape_Internal
     public class NFTAsset_Gif : INFTAsset
     {
         private const int RESOLUTION_HQ = 512;
-        public bool isHQ => hqGifPromise != null;
+        public bool isHQ => true; // hqGifPromise != null;
         public ITexture previewAsset => previewGif;
         public ITexture hqAsset => hqGifPromise?.asset;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTAsset/NFTAsset_Image.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTAsset/NFTAsset_Image.cs
@@ -7,7 +7,7 @@ namespace NFTShape_Internal
     public class NFTAsset_Image : INFTAsset
     {
         private const int RESOLUTION_HQ = 1024;
-        public bool isHQ => hqTexture != null;
+        public bool isHQ => true; // hqTexture != null;
         public ITexture previewAsset { get; }
         public ITexture hqAsset => hqTexture?.asset;
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeHQImageHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeHQImageHandler.cs
@@ -32,8 +32,13 @@ namespace NFTShape_Internal
             {
                 return null;
             }
-
-            return new NFTShapeHQImageHandler(config);
+            /**
+            * We dont have HQ images now.
+            * OpenSEA returns always the best image, there are no thumbnails images.
+            * BUT we keep this function, so when we add a transform image worker so we can resize them,
+            * we can use this mechanism again.
+            */
+            return null; // new NFTShapeHQImageHandler(config);
         }
 
         public void Dispose()

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
@@ -140,15 +140,6 @@ public class NFTShapeLoaderController : MonoBehaviour, INFTShapeLoaderController
         }
 
         darURLProtocol = match.Groups["protocol"].ToString();
-        if (darURLProtocol != "ethereum")
-        {
-            Debug.LogError(string.Format(COULD_NOT_FETCH_DAR_URL + " " + SUPPORTED_PROTOCOL + " " + ACCEPTED_URL_FORMAT, url));
-            ShowErrorFeedback(true);
-            OnLoadingAssetFail?.Invoke();
-
-            return;
-        }
-
         darURLRegistry = match.Groups["registry"].ToString();
         darURLAsset = match.Groups["asset"].ToString();
 
@@ -168,7 +159,7 @@ public class NFTShapeLoaderController : MonoBehaviour, INFTShapeLoaderController
     private void FetchNFTContents()
     {
         ShowLoading(true);
-        nftInfoRetriever.FetchNFTInfo(darURLRegistry, darURLAsset);
+        nftInfoRetriever.FetchNFTInfo(darURLProtocol, darURLRegistry, darURLAsset);
     }
 
     private void FetchNftInfoSuccess(NFTInfo nftInfo)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/NFTAssetLoadHelperShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/NFTAssetLoadHelperShould.cs
@@ -69,7 +69,7 @@ public class NFTAssetLoadHelperShould : IntegrationTestSuite
         Assert.That(success, Is.True);
         Assert.That(resultAsset is NFTAsset_Gif, Is.True);
     }
-    
+
     [UnityTest]
     public IEnumerator FailWhenImageIsTooBig()
     {
@@ -82,7 +82,7 @@ public class NFTAssetLoadHelperShould : IntegrationTestSuite
 
         Assert.That(success, Is.True);
 
-        retriever.contentLengthToReturn = 1000000;
+        retriever.contentLengthToReturn = 7000000;
         retriever.contentTypeToReturn = "image/png";
 
         success = false;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/NFTInfoLoadHelperShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/NFTInfoLoadHelperShould.cs
@@ -17,14 +17,14 @@ public class NFTInfoLoadHelperShould
         //Act - Assert
         retriever.OnFetchInfoSuccess += info => Assert.Fail();
         retriever.OnFetchInfoFail += Assert.Pass;
-        retriever.FetchNFTInfo("testAddress", "testId");
+        retriever.FetchNFTInfo("ethereum", "testAddress", "testId");
     }
 
     [Test]
     public void DisposeCorrectly()
     {
         //Arrange
-        retriever.FetchNFTInfo("testAddress", "testId");
+        retriever.FetchNFTInfo("ethereum", "testAddress", "testId");
 
         //Act
         retriever.Dispose();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/NFTShapeHQImageHandlerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/NFTShapeHQImageHandlerShould.cs
@@ -61,6 +61,7 @@ public class NFTShapeHQImageHandlerShould
     }
 
     [Test]
+     [Ignore("We are not using this till we implement an image resizer")]
     public void SetHQImageCorrectly()
     {
         Assert.IsFalse(isHQAsset, "Shouldn't use HQ image");
@@ -69,6 +70,7 @@ public class NFTShapeHQImageHandlerShould
     }
 
     [Test]
+     [Ignore("We are not using this till we implement an image resizer")]
     public void SetPreviewImageWhenCameraIsBehind()
     {
         SetInFrontAndLookingToNFT();
@@ -80,6 +82,7 @@ public class NFTShapeHQImageHandlerShould
     }
 
     [Test]
+     [Ignore("We are not using this till we implement an image resizer")]
     public void SetPreviewImageWhenCameraLookAway()
     {
         SetInFrontAndLookingToNFT();
@@ -90,6 +93,7 @@ public class NFTShapeHQImageHandlerShould
     }
 
     [Test]
+     [Ignore("We are not using this till we implement an image resizer")]
     public void SetPreviewImageWhenPlayerMovesAway()
     {
         SetInFrontAndLookingToNFT();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/TestUtils_NFT.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/Tests/TestUtils_NFT.cs
@@ -17,7 +17,7 @@ public static class TestUtils_NFT
         INFTAsset mockedNftAsset = Substitute.For<INFTAsset>();
 
         infoRetriever
-            .When((x) => { x.FetchNFTInfo(Arg.Any<string>(), Arg.Any<string>()); })
+            .When((x) => { x.FetchNFTInfo(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()); })
             .Do((x) =>
             {
                 infoRetriever.OnFetchInfoSuccess += Raise.Event<Action<NFTInfo>>(mockedNftInfo);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDController.cs
@@ -62,7 +62,7 @@ public class NFTPromptHUDController : IHUD
 
             view.SetLoading();
 
-            fetchNFTRoutine = CoroutineStarter.Start(NFTUtils.FetchNFTInfoSingleAsset(model.contactAddress, model.tokenId,
+            fetchNFTRoutine = CoroutineStarter.Start(NFTUtils.FetchNFTInfoSingleAsset(model.chain, model.contactAddress, model.tokenId,
                 (nftInfo) => SetNFT(nftInfo, model.comment, true),
                 (error) => view.OnError(string.Format(COULD_NOT_FETCH_NFT_FROM_API + " " + error + ". " + DOES_NOT_SUPPORT_POLYGON, model.contactAddress, model.tokenId))
             ));
@@ -99,9 +99,9 @@ public class NFTPromptHUDController : IHUD
         restrictedActionsContext.OpenNftPrompt -= OpenPromptRequest;
     }
 
-    private void OpenPromptRequest(string contractAddress, string tokenId)
+    private void OpenPromptRequest(string chain, string contractAddress, string tokenId)
     {
-        openNftPromptVariable.Set(new NFTPromptModel(contractAddress, tokenId, string.Empty));
+        openNftPromptVariable.Set(new NFTPromptModel(chain, contractAddress, tokenId, string.Empty));
     }
 
     private void SetNFT(NFTInfo info, string comment, bool shouldRefreshOwners)

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDController.cs
@@ -110,7 +110,7 @@ public class NFTPromptHUDController : IHUD
         view.SetNFTInfo(info, comment);
         if (shouldRefreshOwners)
         {
-            ownersInfoController.SetOwners(info.owners);
+            if(info.owners != null) ownersInfoController.SetOwners(info.owners);
         }
     }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/NFTPromptHUDView.cs
@@ -191,14 +191,14 @@ internal class NFTPromptHUDView : MonoBehaviour, INFTPromptHUDView
         textNftName.text = info.name;
         textNftName.gameObject.SetActive(true);
 
-        bool hasMultipleOwners = info.owners.Length > 1;
+        bool hasMultipleOwners = info.owners is { Length: > 1 };
         if (hasMultipleOwners)
         {
             textMultipleOwner.text = string.Format(MULTIPLE_OWNERS_FORMAT, info.owners.Length);
         }
         else
         {
-            textOwner.text = info.owners.Length == 1
+            textOwner.text = info.owners is { Length: 1 }
                 ? NFTPromptHUDController.FormatOwnerAddress(info.owners[0].address, ADDRESS_MAX_CHARS)
                 : NFTPromptHUDController.FormatOwnerAddress("0x0000000000000000000000000000000000000000", ADDRESS_MAX_CHARS);
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/Scripts/NFTPromptModel/NFTPromptModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/Scripts/NFTPromptModel/NFTPromptModel.cs
@@ -3,9 +3,11 @@ public class NFTPromptModel
     public string contactAddress;
     public string comment;
     public string tokenId;
+    public string chain;
 
-    public NFTPromptModel(string contactAddress, string tokenId, string comment)
+    public NFTPromptModel(string chain, string contactAddress, string tokenId, string comment)
     {
+        this.chain = chain;
         this.contactAddress = contactAddress;
         this.tokenId = tokenId;
         this.comment = comment;

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/Tests/NFTPromptHUDTests.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NFTPromptHUD/Tests/NFTPromptHUDTests.cs
@@ -34,7 +34,7 @@ namespace Tests
         [Test]
         public void OpenAndCloseCorrectly()
         {
-            controller.OpenNftInfoDialog(new NFTPromptModel("0xf64dc33a192e056bb5f0e5049356a0498b502d50",
+            controller.OpenNftInfoDialog(new NFTPromptModel("ethereum", "0xf64dc33a192e056bb5f0e5049356a0498b502d50",
                 "2481", null), null);
             Assert.IsTrue(view.content.activeSelf, "NFT dialog should be visible");
             view.buttonClose.onClick.Invoke();
@@ -96,7 +96,7 @@ namespace Tests
         [Test]
         public void PromptWhenNftPromptIsRequestedByRpcService()
         {
-            restrictedActionsContext.OpenNftPrompt("0x00", "123");
+            restrictedActionsContext.OpenNftPrompt("ethereum", "0x00", "123");
             Assert.IsTrue(view.content.activeSelf, "NFT dialog should be visible");
         }
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/NFTUtils/NFTUtils.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Helpers/NFTUtils/NFTUtils.cs
@@ -32,19 +32,20 @@ namespace DCL.Helpers.NFT
         /// Fetch NFT. Request is added to a batch of requests to reduce the amount of request to the api.
         /// NOTE: for ERC1155 result does not contain the array of owners and sell price for this asset
         /// </summary>
+        /// <param name="chain">chain network id</param>
         /// <param name="assetContractAddress">asset contract address</param>
         /// <param name="tokenId">asset token id</param>
         /// <param name="onSuccess">success callback</param>
         /// <param name="onError">error callback</param>
         /// <returns>IEnumerator</returns>
-        public static IEnumerator FetchNFTInfo(string assetContractAddress, string tokenId, Action<NFTInfo> onSuccess, Action<string> onError)
+        public static IEnumerator FetchNFTInfo(string chain, string assetContractAddress, string tokenId, Action<NFTInfo> onSuccess, Action<string> onError)
         {
             IOpenSea selectedMarket = null;
-            yield return GetMarket(assetContractAddress, tokenId, (mkt) => selectedMarket = mkt);
+            yield return GetMarket(chain, assetContractAddress, tokenId, (mkt) => selectedMarket = mkt);
 
             if (selectedMarket != null)
             {
-                yield return selectedMarket.FetchNFTInfo(assetContractAddress, tokenId, onSuccess, onError);
+                yield return selectedMarket.FetchNFTInfo(chain, assetContractAddress, tokenId, onSuccess, onError);
             }
             else
             {
@@ -57,19 +58,20 @@ namespace DCL.Helpers.NFT
         /// Please try to use `FetchNFTInfo` if ownership info is not relevant for your use case.
         /// NOTE: result it does contain the array of owners for ERC1155 NFTs
         /// </summary>
+        /// <param name="chain">chain network id</param>
         /// <param name="assetContractAddress">asset contract address</param>
         /// <param name="tokenId">asset token id</param>
         /// <param name="onSuccess">success callback</param>
         /// <param name="onError">error callback</param>
         /// <returns>IEnumerator</returns>
-        public static IEnumerator FetchNFTInfoSingleAsset(string assetContractAddress, string tokenId, Action<NFTInfo> onSuccess, Action<string> onError)
+        public static IEnumerator FetchNFTInfoSingleAsset(string chain, string assetContractAddress, string tokenId, Action<NFTInfo> onSuccess, Action<string> onError)
         {
             IOpenSea selectedMarket = null;
-            yield return GetMarket(assetContractAddress, tokenId, (mkt) => selectedMarket = mkt);
+            yield return GetMarket(chain, assetContractAddress, tokenId, (mkt) => selectedMarket = mkt);
 
             if (selectedMarket != null)
             {
-                yield return selectedMarket.FetchNFTInfo(assetContractAddress, tokenId, onSuccess, onError);
+                yield return selectedMarket.FetchNFTInfo(chain, assetContractAddress, tokenId, onSuccess, onError);
             }
             else
             {
@@ -78,7 +80,7 @@ namespace DCL.Helpers.NFT
         }
 
         // NOTE: this method doesn't make sense now, but it will when support for other market is added
-        public static IEnumerator GetMarket(string assetContractAddress, string tokenId, Action<IOpenSea> onSuccess)
+        public static IEnumerator GetMarket(string chain, string assetContractAddress, string tokenId, Action<IOpenSea> onSuccess)
         {
             IServiceProviders serviceProviders = Environment.i.platform.serviceProviders;
             IOpenSea openSea = null;
@@ -108,18 +110,19 @@ namespace DCL.Helpers.NFT
         /// example: urn:decentraland:ethereum:erc721:0x00...000:123
         /// </summary>
         /// <param name="urn">the raw URN of the NFT asset</param>
+        /// <param name="chain">if successful the chain network id is stored in this reference parameter</param>
         /// <param name="contractAddress">if successful the contract address is stored in this reference parameter</param>
         /// <param name="tokenId">if successful the token id is stored in this reference parameter</param>
         /// <returns>bool</returns>
         // TODO: update this method when support for wearables/emotes/etc urn is added
-        public static bool TryParseUrn(string urn, out string contractAddress, out string tokenId)
+        public static bool TryParseUrn(string urn, out string chain, out string contractAddress, out string tokenId)
         {
             const char SEPARATOR = ':';
             const string DCL_URN_ID = "urn:decentraland";
-            const string CHAIN_ETHEREUM = "ethereum";
 
             contractAddress = string.Empty;
             tokenId = string.Empty;
+            chain = string.Empty;
 
             try
             {
@@ -133,9 +136,7 @@ namespace DCL.Helpers.NFT
                 // TODO: allow 'matic' chain when Opensea implements its APIv2 "retrieve assets" endpoint
                 // (https://docs.opensea.io/v2.0/reference/api-overview) in the future
                 // 2: chain/network
-                var chainSpan = urnSpan.Slice(0, CHAIN_ETHEREUM.Length);
-                if (!chainSpan.Equals(CHAIN_ETHEREUM, StringComparison.Ordinal))
-                        return false;
+                var chainSpan = urnSpan.Slice(0, urnSpan.IndexOf(SEPARATOR));
                 urnSpan = urnSpan.Slice(chainSpan.Length + 1);
 
                 // 3: contract standard
@@ -150,6 +151,7 @@ namespace DCL.Helpers.NFT
                 var tokenIdSpan = urnSpan;
                 contractAddress = contractAddressSpan.ToString();
                 tokenId = tokenIdSpan.ToString();
+                chain = chainSpan.ToString();
 
                 return true;
             }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/Interfaces/IOpenSea.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/Interfaces/IOpenSea.cs
@@ -5,7 +5,7 @@ namespace MainScripts.DCL.ServiceProviders.OpenSea.Interfaces
 {
     public interface IOpenSea : IDisposable
     {
-        IEnumerator FetchNFTInfo(string assetContractAddress, string tokenId, Action<NFTInfo> onSuccess, Action<string> onError);
+        IEnumerator FetchNFTInfo(string chain, string assetContractAddress, string tokenId, Action<NFTInfo> onSuccess, Action<string> onError);
 
         IEnumerator FetchNFTsFromOwner(string assetContractAddress, Action<OwnNFTInfo> onSuccess, Action<string> onError);
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/OpenSeaAPI.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/OpenSeaAPI.cs
@@ -5,12 +5,12 @@ namespace MainScripts.DCL.ServiceProviders.OpenSea
         public const int REQUESTS_RETRY_ATTEMPS = 3;
 
         private const string BASE_URL = "https://opensea.decentraland";
-        private const string CHAIN = "ethereum";
+        private const string DEFAULT_CHAIN = "ethereum";
 
-        public static string GetSingleAssetUrl(string address, string id, string tld) =>
-            $"{BASE_URL}{tld}/api/v2/chain/{CHAIN}/contract/{address}/nfts/{id}";
+        public static string GetSingleAssetUrl(string chain, string address, string id, string tld) =>
+            $"{BASE_URL}{tld}/api/v2/chain/{chain}/contract/{address}/nfts/{id}";
 
         public static string GetOwnedAssetsUrl(string address, string tld) =>
-            $"{BASE_URL}{tld}/api/v2/chain/{CHAIN}/account/{address}/nfts";
+            $"{BASE_URL}{tld}/api/v2/chain/{DEFAULT_CHAIN}/account/{address}/nfts";
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/OpenSeaService.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/OpenSeaService.cs
@@ -30,9 +30,9 @@ namespace MainScripts.DCL.ServiceProviders.OpenSea
                 onError?.Invoke(request.error);
         }
 
-        IEnumerator IOpenSea.FetchNFTInfo(string assetContractAddress, string tokenId, Action<NFTInfo> onSuccess, Action<string> onError)
+        IEnumerator IOpenSea.FetchNFTInfo(string chain, string assetContractAddress, string tokenId, Action<NFTInfo> onSuccess, Action<string> onError)
         {
-            RequestBase<OpenSeaNftDto> request = requestController.FetchNFT(assetContractAddress, tokenId);
+            RequestBase<OpenSeaNftDto> request = requestController.FetchNFT(chain, assetContractAddress, tokenId);
 
             yield return new WaitUntil(() => !request.pending);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/RequestController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/RequestController.cs
@@ -31,12 +31,12 @@ namespace MainScripts.DCL.ServiceProviders.OpenSea
 
         public void Dispose() { requestScheduler.OnRequestReadyToSend -= SendRequest; }
 
-        public RequestBase<OpenSeaNftDto> FetchNFT(string contractAddress, string tokenId)
+        public RequestBase<OpenSeaNftDto> FetchNFT(string chain, string contractAddress, string tokenId)
         {
             if (cacheAssetResponses.TryGetValue(RequestAssetSingle.GetId(contractAddress, tokenId), out RequestBase<OpenSeaNftDto> request))
                 return request;
 
-            var newRequest = new RequestAssetSingle(contractAddress, tokenId);
+            var newRequest = new RequestAssetSingle(chain, contractAddress, tokenId);
 
             AddToCache(newRequest);
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/RequestHandlers/SingleAssetRequestHandler.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/RequestHandlers/SingleAssetRequestHandler.cs
@@ -31,7 +31,7 @@ namespace MainScripts.DCL.ServiceProviders.OpenSea.RequestHandlers
         }
 
         string IRequestHandler.GetUrl() =>
-            OpenSeaAPI.GetSingleAssetUrl(request.contractAddress, request.tokenId, kernelConfig.Get().GetTld());
+            OpenSeaAPI.GetSingleAssetUrl(request.chain, request.contractAddress, request.tokenId, kernelConfig.Get().GetTld());
 
         void IRequestHandler.SetApiResponse(string responseJson, Action onSuccess, Action<string> onError)
         {

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/Requests/RequestAssetSingle.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/Requests/RequestAssetSingle.cs
@@ -2,12 +2,15 @@ namespace MainScripts.DCL.ServiceProviders.OpenSea.Requests
 {
     public class RequestAssetSingle : RequestBase<OpenSeaNftDto>
     {
+        public string chain { get; }
         public string contractAddress { get; }
         public string tokenId { get; }
         public override string requestId => GetId(contractAddress, tokenId);
 
-        internal RequestAssetSingle(string contractAddress, string tokenId)
+        internal RequestAssetSingle(string chain, string contractAddress, string tokenId)
         {
+
+            this.chain = chain;
             this.contractAddress = contractAddress;
             this.tokenId = tokenId;
         }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Context/RestrictedActionsContext.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Context/RestrictedActionsContext.cs
@@ -5,7 +5,7 @@ namespace RPC.Context
     public class RestrictedActionsContext
     {
         public Func<string, int, bool> OpenExternalUrlPrompt;
-        public Action<string, string> OpenNftPrompt;
+        public Action<string, string, string> OpenNftPrompt;
         public Func<int, int, bool> TeleportToPrompt;
         public Func<int, bool> IsSceneRestrictedActionEnabled;
     }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/RestrictedActionsService/RestrictedActionsServiceImpl.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/RestrictedActionsService/RestrictedActionsServiceImpl.cs
@@ -85,9 +85,9 @@ namespace RPC.Services
 
                 if (restrictedActions.IsSceneRestrictedActionEnabled(sceneNumber))
                 {
-                    if (NFTUtils.TryParseUrn(request.Urn, out string contractAddress, out string tokenId))
+                    if (NFTUtils.TryParseUrn(request.Urn, out string chain, out string contractAddress, out string tokenId))
                     {
-                        restrictedActions.OpenNftPrompt?.Invoke(contractAddress, tokenId);
+                        restrictedActions.OpenNftPrompt?.Invoke(chain, contractAddress, tokenId);
                         success = true;
                     }
                 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/RestrictedActionsService/Tests/RestrictedActionsServiceImplShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/RestrictedActionsService/Tests/RestrictedActionsServiceImplShould.cs
@@ -119,14 +119,17 @@ namespace Tests
         {
             const string CONTRACT_ADDRESS = "0x0123512313223123123123123";
             const string TOKEN_ID = "645433";
+            const string CHAIN = "matic";
 
             Assert.IsTrue(NFTUtils.TryParseUrn(
-                $"urn:decentraland:ethereum:erc1150:{CONTRACT_ADDRESS}:{TOKEN_ID}",
+                $"urn:decentraland:{CHAIN}:erc1150:{CONTRACT_ADDRESS}:{TOKEN_ID}",
+                out string chain,
                 out string contractAddress,
                 out string tokenId));
 
             Assert.AreEqual(CONTRACT_ADDRESS, contractAddress);
             Assert.AreEqual(TOKEN_ID, tokenId);
+            Assert.AreEqual(CHAIN, chain);
         }
 
         [Test]
@@ -134,40 +137,47 @@ namespace Tests
         {
             string contractAddress;
             string tokenId;
+            string chain;
 
             // "urn:decentraland" missing
             Assert.IsFalse(NFTUtils.TryParseUrn(
                 $"ethereum:erc1150:0x0000temptation:666",
+                out chain,
                 out contractAddress,
                 out tokenId));
 
             // "chain" missing
             Assert.IsFalse(NFTUtils.TryParseUrn(
                 $"urn:decentraland:erc1150:0x0000temptation:666",
+                out chain,
                 out contractAddress,
                 out tokenId));
 
             // "chain" invalid
             Assert.IsFalse(NFTUtils.TryParseUrn(
                 $"urn:decentraland:some-chain:erc1150:0x0000temptation:666",
+                out chain,
                 out contractAddress,
                 out tokenId));
 
             // contract address missing
             Assert.IsFalse(NFTUtils.TryParseUrn(
                 $"urn:decentraland:ethereum:erc1150:666",
+                out chain,
                 out contractAddress,
                 out tokenId));
 
             // token id missing
             Assert.IsFalse(NFTUtils.TryParseUrn(
                 $"urn:decentraland:ethereum:erc1150:0x0000temptation",
+                out chain,
                 out contractAddress,
                 out tokenId));
 
             // empty string
             Assert.IsFalse(NFTUtils.TryParseUrn(
                 "",
+                out chain,
                 out contractAddress,
                 out tokenId));
         }
@@ -179,15 +189,18 @@ namespace Tests
             {
                 const string EXPECTED_CONTRACT_ADDRESS = "0x0temptation";
                 const string EXPECTED_TOKEN_ID = "1234";
+                const string EXPECTED_CHAIN = "ethereum";
 
                 bool requested = false;
 
                 string contractAddress = string.Empty;
                 string tokenId = string.Empty;
+                string chainId = string.Empty;
 
-                restrictedActions.OpenNftPrompt = (contract, token) =>
+                restrictedActions.OpenNftPrompt = (chain, contract, token) =>
                 {
                     requested = true;
+                    chainId = chain;
                     contractAddress = contract;
                     tokenId = token;
                 };
@@ -197,13 +210,13 @@ namespace Tests
                 var result = await rpcClient.OpenNftDialog(
                     new OpenNftDialogRequest()
                     {
-                        Urn = $"urn:decentraland:ethereum:erc1150:{EXPECTED_CONTRACT_ADDRESS}:{EXPECTED_TOKEN_ID}"
+                        Urn = $"urn:decentraland:{EXPECTED_CHAIN}:erc1150:{EXPECTED_CONTRACT_ADDRESS}:{EXPECTED_TOKEN_ID}"
                     });
 
                 Assert.IsTrue(result.Success);
                 Assert.IsTrue(requested);
                 Assert.AreEqual(contractAddress, EXPECTED_CONTRACT_ADDRESS);
-                Assert.AreEqual(tokenId, EXPECTED_TOKEN_ID);
+                Assert.AreEqual(tokenId, EXPECTED_CHAIN);
             });
         }
 
@@ -217,7 +230,7 @@ namespace Tests
 
                 bool requested = false;
 
-                restrictedActions.OpenNftPrompt = (contract, token) =>
+                restrictedActions.OpenNftPrompt = (chain, contract, token) =>
                 {
                     requested = true;
                 };
@@ -242,7 +255,7 @@ namespace Tests
             {
                 bool requested = false;
 
-                restrictedActions.OpenNftPrompt = (contract, token) =>
+                restrictedActions.OpenNftPrompt = (chain, contract, token) =>
                 {
                     requested = true;
                 };

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/RestrictedActionsService/Tests/RestrictedActionsServiceImplShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/KernelCommunication/RPC/Services/RestrictedActionsService/Tests/RestrictedActionsServiceImplShould.cs
@@ -153,8 +153,8 @@ namespace Tests
                 out contractAddress,
                 out tokenId));
 
-            // "chain" invalid
-            Assert.IsFalse(NFTUtils.TryParseUrn(
+            // "we don't have invalid chains now. OpenSea handles them"
+            Assert.IsTrue(NFTUtils.TryParseUrn(
                 $"urn:decentraland:some-chain:erc1150:0x0000temptation:666",
                 out chain,
                 out contractAddress,
@@ -216,7 +216,8 @@ namespace Tests
                 Assert.IsTrue(result.Success);
                 Assert.IsTrue(requested);
                 Assert.AreEqual(contractAddress, EXPECTED_CONTRACT_ADDRESS);
-                Assert.AreEqual(tokenId, EXPECTED_CHAIN);
+                Assert.AreEqual(tokenId, EXPECTED_TOKEN_ID);
+                Assert.AreEqual(chainId, EXPECTED_CHAIN);
             });
         }
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/WorldRuntime/SceneController.cs
@@ -303,8 +303,9 @@ namespace DCL
                     }
                     case MessagingTypes.OPEN_NFT_DIALOG:
                     {
+                        // TODO: update protocol
                         if (msgPayload is Protocol.OpenNftDialog payload)
-                            DataStore.i.common.onOpenNFTPrompt.Set(new NFTPromptModel(payload.contactAddress, payload.tokenId, payload.comment), true);
+                            DataStore.i.common.onOpenNFTPrompt.Set(new NFTPromptModel("ethereum", payload.contactAddress, payload.tokenId, payload.comment), true);
 
                         break;
                     }


### PR DESCRIPTION
## What does this PR change?

- Fix NFTShapes not being rendered on SDK7

- Add support for every chain that [OpenSea supports.](https://docs.opensea.io/reference/get_nft)
- Increase the limit of the MAX_IMAGE_SIZE to 6Mb.
_If some NFT is not being rendered, maybe its because of the image being too big. Ping me and I'll check it out_

![image](https://github.com/decentraland/unity-renderer/assets/16782417/875b323d-e3db-434f-be34-4accc66e77cb)...

## How to test the changes?
- Go to any SDK6 & SDK7 scene on genesis plaza and verify that the NFTShapes & NFT Modals works as expected

- https://decentraland.org/play/?realm=boedo.dcl.eth Has two NFTShapes, one from polygon and the other one from Arbitrum. They should be rendered on this branch.



## Copilot summary

copilot:summary
