### PR TITLE
fix: handling of third-party wearable on ExtendedUrnParser class

### DIFF
--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/ExtendedUrnParser.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/ExtendedUrnParser.cs
@@ -3,6 +3,7 @@
     public static class ExtendedUrnParser
     {
         private const int QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN = 6;
+        private const string COLLECTIONS_THIRDPARTY = "collections-thirdparty";
 
         public static string GetShortenedUrn(string urnReceived)
         {
@@ -14,7 +15,7 @@
         }
 
         public static bool IsExtendedUrn(string urn) =>
-            urn.Split(':').Length > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN;
+            urn.Split(':').Length > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN && !urn.Contains(COLLECTIONS_THIRDPARTY);
     }
 
 }


### PR DESCRIPTION
## What does this PR change?

This PR addresses how third-party wearables are processed by the ExtendedUrnParser class. This class is responsible for shortening URNs when they are extended (i.e., urn.Split(':').Length > 6). When an extended URN is received, it cuts off the last part and returns the shortened version. This is necessary because the /entities/active endpoint from Catalysts' content servers expects the shortened URN to return the wearable/emote metadata.

The issue was that wearables from third-party providers contain 7 parts, causing the code to mistakenly treat them as extended URNs, which is not the case. Third-party wearables have an additional part but that part do not represent a token id (_which is the part that should be removed_), so we need to call the Catalysts endpoint using the entire URN received instead of shortening it.

The changes in this PR prevent the removal of the last part of the URN when this method receives a wearable's URN from a third-party provider (i.e., urn.Contains("collections-thirdparty")).

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
