### PR TITLE
fix: equip wearables with caps through outfits

### DIFF
--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/LambdasEmotesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/LambdasEmotesCatalogService.cs
@@ -25,17 +25,19 @@ public class LambdasEmotesCatalogService : IEmotesCatalogService
         public EmoteEntityDto[] entities;
     }
 
-    internal readonly Dictionary<string, WearableItem> emotes = new ();
-    internal readonly Dictionary<string, HashSet<Promise<WearableItem>>> promises = new ();
-    internal readonly Dictionary<string, int> emotesOnUse = new ();
-    internal readonly Dictionary<string, HashSet<Promise<IReadOnlyList<WearableItem>>>> ownedEmotesPromisesByUser = new ();
+    internal readonly Dictionary<string, WearableItem> emotes = new (new Dictionary<string, WearableItem>(), StringIgnoreCaseEqualityComparer.Default);
+    internal readonly Dictionary<string, HashSet<Promise<WearableItem>>> promises = new (new Dictionary<string, HashSet<Promise<WearableItem>>>(),
+        StringIgnoreCaseEqualityComparer.Default);
+    internal readonly Dictionary<string, int> emotesOnUse = new (new Dictionary<string, int>(), StringIgnoreCaseEqualityComparer.Default);
+    internal readonly Dictionary<string, HashSet<Promise<IReadOnlyList<WearableItem>>>> ownedEmotesPromisesByUser = new (
+        new Dictionary<string, HashSet<Promise<IReadOnlyList<WearableItem>>>>(), StringIgnoreCaseEqualityComparer.Default);
 
     private readonly IEmotesRequestSource emoteSource;
     private readonly IAddressableResourceProvider addressableResourceProvider;
     private readonly ICatalyst catalyst;
     private readonly ILambdasService lambdasService;
     private readonly DataStore dataStore;
-    private readonly Dictionary<string, string> ownedUrns = new ();
+    private readonly Dictionary<string, string> ownedUrns = new (new Dictionary<string, string>(), StringIgnoreCaseEqualityComparer.Default);
 
     private EmbeddedEmotesSO embeddedEmotesSo;
     private CancellationTokenSource addressableCts;

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -47,7 +47,7 @@ namespace DCLServices.WearablesCatalogService
         private const int MAX_WEARABLES_PER_REQUEST = 200;
 
         private readonly ILambdasService lambdasService;
-        private readonly Dictionary<string, int> wearablesInUseCounters = new ();
+        private readonly Dictionary<string, int> wearablesInUseCounters = new (new Dictionary<string, int>(), StringIgnoreCaseEqualityComparer.Default);
         private readonly Dictionary<(string userId, int pageSize), LambdaResponsePagePointer<WearableWithDefinitionResponse>> ownerWearablesPagePointers = new ();
         private readonly Dictionary<(string userId, string collectionId, int pageSize), LambdaResponsePagePointer<WearableWithDefinitionResponse>> thirdPartyCollectionPagePointers = new ();
         private readonly List<string> pendingWearablesToRequest = new ();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Common.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/DataStore_Common.cs
@@ -4,7 +4,7 @@ namespace DCL
     {
         public readonly BaseVariable<bool> isSignUpFlow = new ();
         public readonly BaseVariable<bool> isApplicationQuitting = new ();
-        public readonly BaseDictionary<string, WearableItem> wearables = new ();
+        public readonly BaseDictionary<string, WearableItem> wearables = new (StringIgnoreCaseEqualityComparer.Default);
         public readonly BaseVariable<bool> isPlayerRendererLoaded = new ();
         public readonly BaseVariable<AppMode> appMode = new ();
         public readonly BaseVariable<NFTPromptModel> onOpenNFTPrompt = new ();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/StringIgnoreCaseEqualityComparer.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/StringIgnoreCaseEqualityComparer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+
+namespace DCL
+{
+    public class StringIgnoreCaseEqualityComparer : IEqualityComparer<string>
+    {
+        public static StringIgnoreCaseEqualityComparer Default { get; } = new ();
+
+        public bool Equals(string x, string y) =>
+            string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode(string obj) =>
+            StringComparer.OrdinalIgnoreCase.GetHashCode(obj);
+    }
+}

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/StringIgnoreCaseEqualityComparer.cs.meta
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/StringIgnoreCaseEqualityComparer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 06a4d4095e1846a7840aaa9f0438084c
+timeCreated: 1717610698

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseDictionary.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DataStore/Variables/BaseDictionary.cs
@@ -9,11 +9,19 @@ public class BaseDictionary<TKey, TValue> : IBaseDictionary<TKey, TValue>, IEnum
     public event Action<TKey, TValue> OnAdded;
     public event Action<TKey, TValue> OnRemoved;
 
-    internal readonly Dictionary<TKey, TValue> dictionary = new Dictionary<TKey, TValue>();
+    internal readonly Dictionary<TKey, TValue> dictionary;
 
     public TValue this[TKey key] { get => dictionary[key]; set => dictionary[key] = value; }
 
-    public BaseDictionary() { }
+    public BaseDictionary()
+    {
+        dictionary = new Dictionary<TKey, TValue>();
+    }
+
+    public BaseDictionary(IEqualityComparer<TKey> comparer)
+    {
+        dictionary = new Dictionary<TKey, TValue>(new Dictionary<TKey, TValue>(), comparer);
+    }
 
     public BaseDictionary(IEnumerable<(TKey, TValue)> elements)
     {


### PR DESCRIPTION
## What does this PR change?

The outfits might have wearables that have differences with caps in the urn because the server returns urn with caps or not depending on the endpoint requested for the same content. When the outfit was equipped, the wearable was not rendered because the urn equality was failing.

For example a wearable in the profile (/lambdas/profiles/:address):
```
urn:decentraland:matic:collections-thirdparty:dolcegabbana-disco-drip:0x4bD77619a75C8EdA181e3587339E7011DA75bF0E:2a424e9c-c6fb-4783-99ed-63d260d90ed2
```
The same wearable in the content server (/content/entities/active):
```
urn:decentraland:matic:collections-thirdparty:dolcegabbana-disco-drip:0x4bd77619a75c8eda181e3587339e7011da75bf0e:2a424e9c-c6fb-4783-99ed-63d260d90ed2
```

The fix ignores case when checking the urn equality in wearable & emote cache.

## How to test the changes?

1. Launch the explorer
2. Login with the user that has a third party wearable that contains this issue. Address: `0x1B6a2F8F2a12dFFE8F32eafE4e5655ed80AeDd15`. Wearable: `urn:decentraland:matic:collections-thirdparty:dolcegabbana-disco-drip:0x4bD77619a75C8EdA181e3587339E7011DA75bF0E:2a424e9c-c6fb-4783-99ed-63d260d90ed2`
3. Open the backpack and go to the outfits section
4. Equip the outfit that has the third party wearable (the cocoon)
5. All wearables should be equipped in the avatar
6. Since the changes affected all the wearables & emotes, check its overall functionality

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
