### PR TITLE
fix: custom wearable pagination in the backpack grid

### DIFF
--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
@@ -299,7 +299,7 @@ namespace DCL.Backpack
                 currentWearables = wearables.Select(ToWearableGridModel)
                                             .ToDictionary(item => ExtendedUrnParser.GetShortenedUrn(item.WearableId), model => model);
 
-                view.SetWearablePages(page, Mathf.Max(1, Mathf.CeilToInt((float) totalAmount / PAGE_SIZE)));
+                view.SetWearablePages(page, Mathf.CeilToInt((float) totalAmount / PAGE_SIZE));
 
                 // TODO: mark the wearables to be disposed if no references left
                 view.ClearWearables();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
@@ -299,7 +299,7 @@ namespace DCL.Backpack
                 currentWearables = wearables.Select(ToWearableGridModel)
                                             .ToDictionary(item => ExtendedUrnParser.GetShortenedUrn(item.WearableId), model => model);
 
-                view.SetWearablePages(page, (totalAmount + PAGE_SIZE - 1) / PAGE_SIZE);
+                view.SetWearablePages(page, Mathf.Max(1, Mathf.CeilToInt((float) totalAmount / PAGE_SIZE)));
 
                 // TODO: mark the wearables to be disposed if no references left
                 view.ClearWearables();


### PR DESCRIPTION
## What does this PR change?

Fixes the display of wearables in the backpack's grid whenever you set a custom collection that has more than 15 items (fixed page size).

Example collection: https://decentraland.org/builder/item-editor?item=bbceb398-1087-4c33-8389-e12bd4ff43df&collection=a78d44ad-4954-4f23-ba96-15e718f62299&reviewing=true

## How to test the changes?

1. Start the client with this url: https://decentraland.org/play/?explorer-branch=fix/builder-nft-collections&BUILDER_SERVER_URL=https%3A%2F%2Fbuilder-api.decentraland.org%2Fv1&NETWORK=sepolia&DEBUG_MODE=true&WITH_COLLECTIONS=a78d44ad-4954-4f23-ba96-15e718f62299&position=100%2C99
2. Open the backpack
3. Enable `ONLY COLLECTIBLES` filter
4. Check that you have two pages
5. Check that one page contains the wearables for men
6. Check that the other page contains the wearables for women

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
