### PR TITLE
fix: update help and support link

### DIFF
--- a/unity-renderer/Assets/Plugins/IntercomWindow/IntercomWindow.jslib
+++ b/unity-renderer/Assets/Plugins/IntercomWindow/IntercomWindow.jslib
@@ -4,7 +4,7 @@ var IntercomWindow = {
     const windowHeight = window.innerHeight
     const windowWidth = window.innerWidth
     const popupHeight = Math.min(700, windowHeight)
-    const popupWidth = Math.min(400, windowWidth)
+    const popupWidth = Math.min(450, windowWidth)
     const top = Math.max(windowHeight - popupHeight, 0)
     const left = Math.max(windowWidth - popupWidth - 20, 0)
     

--- a/unity-renderer/Assets/Plugins/IntercomWindow/IntercomWindow.jslib
+++ b/unity-renderer/Assets/Plugins/IntercomWindow/IntercomWindow.jslib
@@ -8,7 +8,7 @@ var IntercomWindow = {
     const top = Math.max(windowHeight - popupHeight, 0)
     const left = Math.max(windowWidth - popupWidth - 20, 0)
     
-    window.open('https://intercom.decentraland.org', 'intercom', `popup,top=${top},left=${left},width=${popupWidth},height=${popupHeight}`)
+    window.open('https://decentraland.org/help', 'intercom', `popup,top=${top},left=${left},width=${popupWidth},height=${popupHeight}`)
   }
 };
 

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HelpAndSupportHUD/HelpAndSupportHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HelpAndSupportHUD/HelpAndSupportHUDController.cs
@@ -9,7 +9,7 @@ namespace DCL.HelpAndSupportHUD
 {
     public class HelpAndSupportHUDController : IHUD
     {
-        internal const string CONTACT_SUPPORT_URL = "https://intercom.decentraland.org";
+        internal const string CONTACT_SUPPORT_URL = "https://decentraland.org/help";
         internal const string JOIN_DISCORD_URL = "https://dcl.gg/discord";
         internal const string FAQ_URL = "https://docs.decentraland.org/decentraland/faq/";
         public IHelpAndSupportHUDView view {  get; }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -14,7 +14,7 @@ using UnityEngine.EventSystems;
 
 public class TaskbarHUDController : IHUD
 {
-    private const string INTERCOM_URL = "https://intercom.decentraland.org/";
+    private const string INTERCOM_URL = "https://decentraland.org/help/";
 
     private readonly IChatController chatController;
     private readonly IFriendsController friendsController;


### PR DESCRIPTION
## What does this PR change?
The Decentraland's support page has changed from the url `https://intercom.decentraland.org` to `https://decentraland.org/help`. So we have changed it for the corresponding buttons in the Explorer:
- Taskbar "?" button.
- Explore menu -> Settings -> CONTACT SUPPORT button.

## How to test the changes?
1. Launch the explorer
2. Click on the "?" button in the taskbar and observe the new url is open.
3. Go to Explore menu -> Settings -> CONTACT SUPPORT button and observe the new url is open.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary
copilot:summary