### PR TITLE
chore: re introduce uitext wrapping

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/protocol": "^1.0.0-9115457439.commit-926ebd1",
+        "@dcl/protocol": "^1.0.0-9466805132.commit-365e0bb",
         "@protobuf-ts/protoc": "^2.8.2",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.1",
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-9115457439.commit-926ebd1",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-9115457439.commit-926ebd1.tgz",
-      "integrity": "sha512-4MA1sx4cpfapP+EDAZdpdaONthoDlv4VMc0CwAKcmhp0vxGgExeEpLkPh6gvNXmkl8z8z3nEcDOX1X95dvCYuA==",
+      "version": "1.0.0-9466805132.commit-365e0bb",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-9466805132.commit-365e0bb.tgz",
+      "integrity": "sha512-CMO2/JkdMPLJQj+jdT5yqolKFDPkQF2hkS/HEUtsxCzkLoN3H0xXmDUhRuh2LTmBBl401meH/tJ+fQcPyd9xLQ==",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -569,9 +569,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-9115457439.commit-926ebd1",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-9115457439.commit-926ebd1.tgz",
-      "integrity": "sha512-4MA1sx4cpfapP+EDAZdpdaONthoDlv4VMc0CwAKcmhp0vxGgExeEpLkPh6gvNXmkl8z8z3nEcDOX1X95dvCYuA==",
+      "version": "1.0.0-9466805132.commit-365e0bb",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-9466805132.commit-365e0bb.tgz",
+      "integrity": "sha512-CMO2/JkdMPLJQj+jdT5yqolKFDPkQF2hkS/HEUtsxCzkLoN3H0xXmDUhRuh2LTmBBl401meH/tJ+fQcPyd9xLQ==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@dcl/protocol": "^1.0.0-9115457439.commit-926ebd1",
+    "@dcl/protocol": "^1.0.0-9466805132.commit-365e0bb",
     "@protobuf-ts/protoc": "^2.8.2",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.0.1",

--- a/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/UIText/UiTextHandler.cs
+++ b/unity-renderer/Assets/DCLPlugins/ECS7/ECSComponents/UIText/UiTextHandler.cs
@@ -38,7 +38,13 @@ namespace DCL.ECSComponents.UIText
 
         public void OnComponentModelUpdated(IParcelScene scene, IDCLEntity entity, PBUiText model)
         {
+            var wrapMode = WhiteSpace.NoWrap; // Default mode is No Wrap enabled
+
+            if (model.HasTextWrap && model.TextWrap == TextWrap.TwWrap)
+                wrapMode = WhiteSpace.Normal;
+
             uiElement.text = model.Value;
+            uiElement.style.whiteSpace = wrapMode;
             uiElement.style.color = model.GetColor().ToUnityColor();
             uiElement.style.fontSize = model.GetFontSize();
             uiElement.style.unityTextAlign = model.GetTextAlign().ToUnityTextAlign();

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/DecentralandProtocol/UiText.gen.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/DecentralandProtocol/UiText.gen.cs
@@ -27,23 +27,34 @@ namespace DCL.ECSComponents {
             "CilkZWNlbnRyYWxhbmQvc2RrL2NvbXBvbmVudHMvdWlfdGV4dC5wcm90bxIb",
             "ZGVjZW50cmFsYW5kLnNkay5jb21wb25lbnRzGiBkZWNlbnRyYWxhbmQvY29t",
             "bW9uL2NvbG9ycy5wcm90bxouZGVjZW50cmFsYW5kL3Nkay9jb21wb25lbnRz",
-            "L2NvbW1vbi90ZXh0cy5wcm90byKbAgoIUEJVaVRleHQSDQoFdmFsdWUYASAB",
+            "L2NvbW1vbi90ZXh0cy5wcm90byLoAgoIUEJVaVRleHQSDQoFdmFsdWUYASAB",
             "KAkSLwoFY29sb3IYAiABKAsyGy5kZWNlbnRyYWxhbmQuY29tbW9uLkNvbG9y",
             "NEgAiAEBEkoKCnRleHRfYWxpZ24YAyABKA4yMS5kZWNlbnRyYWxhbmQuc2Rr",
             "LmNvbXBvbmVudHMuY29tbW9uLlRleHRBbGlnbk1vZGVIAYgBARI7CgRmb250",
             "GAQgASgOMiguZGVjZW50cmFsYW5kLnNkay5jb21wb25lbnRzLmNvbW1vbi5G",
-            "b250SAKIAQESFgoJZm9udF9zaXplGAUgASgFSAOIAQFCCAoGX2NvbG9yQg0K",
-            "C190ZXh0X2FsaWduQgcKBV9mb250QgwKCl9mb250X3NpemVCFKoCEURDTC5F",
-            "Q1NDb21wb25lbnRzYgZwcm90bzM="));
+            "b250SAKIAQESFgoJZm9udF9zaXplGAUgASgFSAOIAQESPQoJdGV4dF93cmFw",
+            "GAYgASgOMiUuZGVjZW50cmFsYW5kLnNkay5jb21wb25lbnRzLlRleHRXcmFw",
+            "SASIAQFCCAoGX2NvbG9yQg0KC190ZXh0X2FsaWduQgcKBV9mb250QgwKCl9m",
+            "b250X3NpemVCDAoKX3RleHRfd3JhcConCghUZXh0V3JhcBILCgdUV19XUkFQ",
+            "EAASDgoKVFdfTk9fV1JBUBABQhSqAhFEQ0wuRUNTQ29tcG9uZW50c2IGcHJv",
+            "dG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Decentraland.Common.ColorsReflection.Descriptor, global::DCL.ECSComponents.TextsReflection.Descriptor, },
-          new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBUiText), global::DCL.ECSComponents.PBUiText.Parser, new[]{ "Value", "Color", "TextAlign", "Font", "FontSize" }, new[]{ "Color", "TextAlign", "Font", "FontSize" }, null, null, null)
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::DCL.ECSComponents.TextWrap), }, null, new pbr::GeneratedClrTypeInfo[] {
+            new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBUiText), global::DCL.ECSComponents.PBUiText.Parser, new[]{ "Value", "Color", "TextAlign", "Font", "FontSize", "TextWrap" }, new[]{ "Color", "TextAlign", "Font", "FontSize", "TextWrap" }, null, null, null)
           }));
     }
     #endregion
 
   }
+  #region Enums
+  public enum TextWrap {
+    [pbr::OriginalName("TW_WRAP")] TwWrap = 0,
+    [pbr::OriginalName("TW_NO_WRAP")] TwNoWrap = 1,
+  }
+
+  #endregion
+
   #region Messages
   public sealed partial class PBUiText : pb::IMessage<PBUiText>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
@@ -86,6 +97,7 @@ namespace DCL.ECSComponents {
       textAlign_ = other.textAlign_;
       font_ = other.font_;
       fontSize_ = other.fontSize_;
+      textWrap_ = other.textWrap_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -99,7 +111,7 @@ namespace DCL.ECSComponents {
     public const int ValueFieldNumber = 1;
     private string value_ = "";
     /// <summary>
-    /// the text content
+    /// the text content, tag &lt;b> and &lt;i> are supported
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -209,6 +221,34 @@ namespace DCL.ECSComponents {
       _hasBits0 &= ~4;
     }
 
+    /// <summary>Field number for the "text_wrap" field.</summary>
+    public const int TextWrapFieldNumber = 6;
+    private global::DCL.ECSComponents.TextWrap textWrap_;
+    /// <summary>
+    /// wrap text when the border is reached (default: TW_WRAP)
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::DCL.ECSComponents.TextWrap TextWrap {
+      get { if ((_hasBits0 & 8) != 0) { return textWrap_; } else { return global::DCL.ECSComponents.TextWrap.TwWrap; } }
+      set {
+        _hasBits0 |= 8;
+        textWrap_ = value;
+      }
+    }
+    /// <summary>Gets whether the "text_wrap" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasTextWrap {
+      get { return (_hasBits0 & 8) != 0; }
+    }
+    /// <summary>Clears the value of the "text_wrap" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearTextWrap() {
+      _hasBits0 &= ~8;
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -229,6 +269,7 @@ namespace DCL.ECSComponents {
       if (TextAlign != other.TextAlign) return false;
       if (Font != other.Font) return false;
       if (FontSize != other.FontSize) return false;
+      if (TextWrap != other.TextWrap) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -241,6 +282,7 @@ namespace DCL.ECSComponents {
       if (HasTextAlign) hash ^= TextAlign.GetHashCode();
       if (HasFont) hash ^= Font.GetHashCode();
       if (HasFontSize) hash ^= FontSize.GetHashCode();
+      if (HasTextWrap) hash ^= TextWrap.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -279,6 +321,10 @@ namespace DCL.ECSComponents {
         output.WriteRawTag(40);
         output.WriteInt32(FontSize);
       }
+      if (HasTextWrap) {
+        output.WriteRawTag(48);
+        output.WriteEnum((int) TextWrap);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -309,6 +355,10 @@ namespace DCL.ECSComponents {
         output.WriteRawTag(40);
         output.WriteInt32(FontSize);
       }
+      if (HasTextWrap) {
+        output.WriteRawTag(48);
+        output.WriteEnum((int) TextWrap);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -333,6 +383,9 @@ namespace DCL.ECSComponents {
       }
       if (HasFontSize) {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(FontSize);
+      }
+      if (HasTextWrap) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) TextWrap);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -363,6 +416,9 @@ namespace DCL.ECSComponents {
       }
       if (other.HasFontSize) {
         FontSize = other.FontSize;
+      }
+      if (other.HasTextWrap) {
+        TextWrap = other.TextWrap;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -402,6 +458,10 @@ namespace DCL.ECSComponents {
             FontSize = input.ReadInt32();
             break;
           }
+          case 48: {
+            TextWrap = (global::DCL.ECSComponents.TextWrap) input.ReadEnum();
+            break;
+          }
         }
       }
     #endif
@@ -438,6 +498,10 @@ namespace DCL.ECSComponents {
           }
           case 40: {
             FontSize = input.ReadInt32();
+            break;
+          }
+          case 48: {
+            TextWrap = (global::DCL.ECSComponents.TextWrap) input.ReadEnum();
             break;
           }
         }


### PR DESCRIPTION
Re-introduced ui text wrap with no-wrap as the default behavior

## How to test the changes?
1. Use the following url: [PLAYGROUND A](https://playground.decentraland.org/?explorer-branch=chore%2Fre-introduce-uitext-wrapping&code=Cgpjb25zdCB1aUNvbXBvbmVudCA9ICgpID0%2BIFsKICA8VWlFbnRpdHkKICAgIHVpVHJhbnNmb3JtPXt7CiAgICAgIHdpZHRoOiA0MDAsCiAgICAgIGhlaWdodDogMjMwLAogICAgICBtYXJnaW46ICcxNnB4IDAgOHB4IDI3MHB4JywKICAgICAgcGFkZGluZzogNCwKICAgIH19CiAgICB1aUJhY2tncm91bmQ9e3sgY29sb3I6IENvbG9yNC5jcmVhdGUoMC41LCAwLjgsIDAuMSwgMC42KSB9fQogID4KICAgIDxVaUVudGl0eQogICAgICB1aVRyYW5zZm9ybT17ewogICAgICAgIHdpZHRoOiAnMTAwJScsCiAgICAgICAgaGVpZ2h0OiAnMTAwJScsCiAgICAgICAgZmxleERpcmVjdGlvbjogJ2NvbHVtbicsCiAgICAgICAgYWxpZ25JdGVtczogJ2NlbnRlcicsCiAgICAgICAganVzdGlmeUNvbnRlbnQ6ICdzcGFjZS1iZXR3ZWVuJwogICAgICB9fQogICAgICB1aUJhY2tncm91bmQ9e3sgY29sb3I6IENvbG9yNC5mcm9tSGV4U3RyaW5nKCIjNzBhYzc2ZmYiKSB9fQogICAgPgogICAgICA8TGFiZWwKICAgICAgICB2YWx1ZT0iTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bSIKICAgICAgLz4KICAgICAgPExhYmVsCiAgICAgICAgdmFsdWU9IkxvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW0iCiAgICAgICAgdGV4dFdyYXA9Im5vd3JhcCIKICAgICAgLz4KICAgICAgPExhYmVsIHZhbHVlPSJMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtIgogICAgICAgIHRleHRXcmFwPSJ3cmFwIgogICAgICAvPgogICAgPC9VaUVudGl0eT4KICA8L1VpRW50aXR5Pl0KClJlYWN0RWNzUmVuZGVyZXIuc2V0VWlSZW5kZXJlcih1aUNvbXBvbmVudCkKCg%3D%3D)
2. On the URL, note that it contains `explorer-branch=chore%2Fre-introduce-uitext-wrapping` which means the Playground is using this branch. Then the URL follows with `&code=`, note there's no mention of the SDK.  This would be the case where an OLD scene is loaded:
Label 1, doesn't have the property => text is not wrapped
Label 2, does have the property, with the value nowrap => text is not wrapped
Label 3, does have the property, with the value wrap => text is wrapped
![image](https://github.com/decentraland/unity-renderer/assets/163010988/69ed47e0-b33b-4bd0-9003-6da2ce82641e)
On the left we can see the code for the 3 labels.

3. Use the following url: [PLAYGROUND B](https://playground.decentraland.org/?sdk-branch=chore%2Fre-introduce-uitext-wrapping&explorer-branch=chore%2Fre-introduce-uitext-wrapping&code=Cgpjb25zdCB1aUNvbXBvbmVudCA9ICgpID0%2BIFsKICA8VWlFbnRpdHkKICAgIHVpVHJhbnNmb3JtPXt7CiAgICAgIHdpZHRoOiA0MDAsCiAgICAgIGhlaWdodDogMjMwLAogICAgICBtYXJnaW46ICcxNnB4IDAgOHB4IDI3MHB4JywKICAgICAgcGFkZGluZzogNCwKICAgIH19CiAgICB1aUJhY2tncm91bmQ9e3sgY29sb3I6IENvbG9yNC5jcmVhdGUoMC41LCAwLjgsIDAuMSwgMC42KSB9fQogID4KICAgIDxVaUVudGl0eQogICAgICB1aVRyYW5zZm9ybT17ewogICAgICAgIHdpZHRoOiAnMTAwJScsCiAgICAgICAgaGVpZ2h0OiAnMTAwJScsCiAgICAgICAgZmxleERpcmVjdGlvbjogJ2NvbHVtbicsCiAgICAgICAgYWxpZ25JdGVtczogJ2NlbnRlcicsCiAgICAgICAganVzdGlmeUNvbnRlbnQ6ICdzcGFjZS1iZXR3ZWVuJwogICAgICB9fQogICAgICB1aUJhY2tncm91bmQ9e3sgY29sb3I6IENvbG9yNC5mcm9tSGV4U3RyaW5nKCIjNzBhYzc2ZmYiKSB9fQogICAgPgogICAgICA8TGFiZWwKICAgICAgICB2YWx1ZT0iTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bSIKICAgICAgLz4KICAgICAgPExhYmVsCiAgICAgICAgdmFsdWU9IkxvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW0iCiAgICAgICAgdGV4dFdyYXA9Im5vd3JhcCIKICAgICAgLz4KICAgICAgPExhYmVsIHZhbHVlPSJMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW1Mb3JlbWlwc3VtIExvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bUxvcmVtaXBzdW0gTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtTG9yZW1pcHN1bSBMb3JlbWlwc3VtIgogICAgICAgIHRleHRXcmFwPSJ3cmFwIgogICAgICAvPgogICAgPC9VaUVudGl0eT4KICA8L1VpRW50aXR5Pl0KClJlYWN0RWNzUmVuZGVyZXIuc2V0VWlSZW5kZXJlcih1aUNvbXBvbmVudCkKCg%3D%3D)
4. On the URL, note that it contains `explorer-branch=chore%2Fre-introduce-uitext-wrapping` which means the Playground is using this branch. Then the URL follows with `?sdk-branch=chore%2Fre-introduce-uitext-wrapping` which means the Playground is using the SDK version with the new default behavior for wrapping text.  This would be the case where a new scene is created:
Label 1, doesn't have the property => text is wrapped
Label 2, does have the property, with the value nowrap => text is not wrapped
Label 3, does have the property, with the value wrap => text is wrapped
![image](https://github.com/decentraland/unity-renderer/assets/163010988/9af8359d-1a9e-4fbd-bf24-03856d59f9d3)
On the left we can see the code for the 3 labels.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
