### PR TITLE
fix: Logout flow

### DIFF
--- a/browser-interface/packages/shared/session/sagas.ts
+++ b/browser-interface/packages/shared/session/sagas.ts
@@ -143,8 +143,7 @@ function* authenticate(action: AuthenticateAction) {
   // 3. continue with signin/signup (only not in preview)
   let isSignUp = avatar.version <= 0 && !PREVIEW
   if (getFeatureFlagVariantName(store.getState(), 'seamless_login_variant') === 'enabled') {
-
-    const isNewUser : boolean = avatar.version <= 0
+    const isNewUser: boolean = avatar.version <= 0
     const tosAccepted: boolean = !!((yield call(getFromPersistentStorage, 'tos_popup_accepted')) as boolean)
     const tosShown: boolean = !!((yield call(getFromPersistentStorage, 'tos_popup_shown')) as boolean)
     isSignUp = !PREVIEW && (isNewUser || tosShown) && !tosAccepted
@@ -170,7 +169,10 @@ function* SetupTutorial() {
   // from the renderer
   const onboardingRealmName: string | undefined = yield select(getFeatureFlagVariantName, 'new_tutorial_variant')
   const isNewTutorialDisabled =
-    onboardingRealmName === 'disabled' || onboardingRealmName === 'undefined' || HAS_INITIAL_POSITION_MARK || HAS_INITIAL_REALM_MARK
+    onboardingRealmName === 'disabled' ||
+    onboardingRealmName === 'undefined' ||
+    HAS_INITIAL_POSITION_MARK ||
+    HAS_INITIAL_REALM_MARK
   if (!isNewTutorialDisabled) {
     try {
       const realm: string | undefined = yield select(getFeatureFlagVariantValue, 'new_tutorial_variant')
@@ -338,12 +340,11 @@ function* logout() {
   if (identity && identity.address && network) {
     yield call(() => localProfilesRepo.remove(identity.address, network))
     yield call(deleteSession, identity.address)
+    // Page reload is called in the system that is listening to this event
     globalObservable.emit('logout', { address: identity.address, network })
   }
 
   yield put(setRoomConnection(undefined))
-
-  window.location.reload()
 }
 
 function* redirectToSignUp() {


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

This PR fixes the logout flow. Doing the `window.location.reload()` in the `logout` method avoids the provider disconnection handled in the explorer-website app through the `globalObservable.emit('logout', { address: identity.address, network })`.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

Locally: 
1. Run the command: `make npm-link` in the `browser-interface` folder
2. Copy the version from `browser-interface/static/package.json` file
3. Paste the version in the `.env` file in the `explorer-website` project folder
3.1 VITE_APP_EXPLORER_VERSION
3.2 VITE_APP_EXPLORER_BASE_URL 
4. Run the command: `npm link @dcl/explorer` in the `explorer-website` project folder
5. Run the command: `npm run copy-cdn` in the `explorer-website` project folder
6. Launch the `explorer-website` app and test the login and logout flow using WalletConnect as provider

Using the preview-branch:
1. Login using WalletConnect as provider, it should show a Modal with a QR code
2. Logout
3. Login again using WalletConnect as provider, it should show a Modal with a QR code

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
