### PR TITLE
fix: pass builder url to renderer

### DIFF
--- a/browser-interface/packages/shared/types.ts
+++ b/browser-interface/packages/shared/types.ts
@@ -606,7 +606,8 @@ export type KernelConfigForRenderer = {
   kernelVersion: string
   rendererVersion: string
   avatarTextureAPIBaseUrl: string
-  urlParamsForWearablesDebug: boolean // temporal field until the whole the wearables catalog sagas flow is migrated to Unity
+  urlParamsForWearablesDebug: boolean, // temporal field until the whole the wearables catalog sagas flow is migrated to Unity
+  builderUrl: string
 }
 
 export type RealmsInfoForRenderer = {

--- a/browser-interface/packages/unity-interface/kernelConfigForRenderer.ts
+++ b/browser-interface/packages/unity-interface/kernelConfigForRenderer.ts
@@ -8,7 +8,7 @@ import {
   PREVIEW,
   DEBUG,
   getTLD,
-  ETHEREUM_NETWORK
+  ETHEREUM_NETWORK, BUILDER_SERVER_URL
 } from 'config'
 import { nameValidCharacterRegex, nameValidRegex } from 'lib/decentraland/profiles/names'
 import { getWorld } from '@dcl/schemas'
@@ -31,6 +31,7 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
     PREVIEW || ((DEBUG || getTLD() !== 'org') && network !== ETHEREUM_NETWORK.MAINNET)
 
   const urlParamsForWearablesDebug = !!(WITH_FIXED_ITEMS || WITH_FIXED_COLLECTIONS || COLLECTIONS_OR_ITEMS_ALLOWED)
+  const builderUrl = BUILDER_SERVER_URL;
 
   return {
     ...globalState.meta.config.world,
@@ -54,6 +55,7 @@ export function kernelConfigForRenderer(): KernelConfigForRenderer {
     /** @deprecated */
     rendererVersion: explorerVersion,
     avatarTextureAPIBaseUrl: getAvatarTextureAPIBaseUrl(getSelectedNetwork(globalState)),
-    urlParamsForWearablesDebug: urlParamsForWearablesDebug
+    urlParamsForWearablesDebug: urlParamsForWearablesDebug,
+    builderUrl: builderUrl
   }
 }

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/Tests/EmotesCatalogServiceShould.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/Tests/EmotesCatalogServiceShould.cs
@@ -27,7 +27,7 @@ public class EmotesCatalogServiceShould
         IAddressableResourceProvider addressableResourceProvider = Substitute.For<IAddressableResourceProvider>();
         addressableResourceProvider.GetAddressable<EmbeddedEmotesSO>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(GetEmbeddedEmotesSO());
         catalog = new LambdasEmotesCatalogService(emotesRequestSource, addressableResourceProvider, Substitute.For<ICatalyst>(),
-            Substitute.For<ILambdasService>(), new DataStore());
+            Substitute.For<ILambdasService>(), new DataStore(), KernelConfig.i);
         catalog.Initialize();
     }
 
@@ -342,7 +342,7 @@ public class EmotesCatalogServiceShould
         IAddressableResourceProvider addressableResourceProvider = Substitute.For<IAddressableResourceProvider>();
         addressableResourceProvider.GetAddressable<EmbeddedEmotesSO>(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(GetExampleEmbeddedEmotesSO());
         catalog = new LambdasEmotesCatalogService(Substitute.For<IEmotesRequestSource>(), addressableResourceProvider,
-            Substitute.For<ICatalyst>(), Substitute.For<ILambdasService>(), new DataStore());
+            Substitute.For<ICatalyst>(), Substitute.For<ILambdasService>(), new DataStore(), KernelConfig.i);
         catalog.Initialize();
 
         Assert.AreEqual(catalog.emotes["id1"], embededEmotes[0]);

--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/Tests/EmotesCatalogTests.asmdef
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/Tests/EmotesCatalogTests.asmdef
@@ -14,7 +14,8 @@
         "GUID:68069f49d86442cd9618861b4d74b1aa",
         "GUID:dffbb581f2650ea4990781f603ac258a",
         "GUID:a4bf61c057a098f4ca05b539a6d8c0fe",
-        "GUID:28f74c468a54948bfa9f625c5d428f56"
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:c44f6fd10d3d94432a107d581e0096b5"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/LambdasWearablesCatalogServiceShould.cs
@@ -70,7 +70,7 @@ namespace DCLServices.WearablesCatalogService
 
             BaseVariable<FeatureFlag> featureFlags = new BaseVariable<FeatureFlag>();
             featureFlags.Set(new FeatureFlag());
-            service = new LambdasWearablesCatalogService(initialCatalog, lambdasService, serviceProviders, featureFlags, new DataStore());
+            service = new LambdasWearablesCatalogService(initialCatalog, lambdasService, serviceProviders, featureFlags, new DataStore(), KernelConfig.i);
             service.Initialize();
         }
 

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/WarablesCatalogServiceTests.asmdef
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/Tests/WarablesCatalogServiceTests.asmdef
@@ -14,7 +14,8 @@
         "CatalystInterfaces",
         "FeatureFlagData",
         "Utils",
-        "DataStore"
+        "DataStore",
+        "KernelConfiguration"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/Factories/ServiceLocatorFactory/ServiceLocatorFactory.cs
@@ -133,7 +133,7 @@ namespace DCL
                     featureFlagsDataStore);
 
                 var lambdasEmotesCatalogService = new LambdasEmotesCatalogService(emotesRequest, addressableResourceProvider,
-                    result.Get<IServiceProviders>().catalyst, result.Get<ILambdasService>(), DataStore.i);
+                    result.Get<IServiceProviders>().catalyst, result.Get<ILambdasService>(), DataStore.i, KernelConfig.i);
                 var webInterfaceEmotesCatalogService = new WebInterfaceEmotesCatalogService(EmotesCatalogBridge.GetOrCreate(), addressableResourceProvider);
                 return new EmotesCatalogServiceProxy(lambdasEmotesCatalogService, webInterfaceEmotesCatalogService, featureFlagsDataStore, KernelConfig.i);
             });
@@ -149,7 +149,8 @@ namespace DCL
                     result.Get<ILambdasService>(),
                     result.Get<IServiceProviders>(),
                     featureFlagsDataStore,
-                    DataStore.i),
+                    DataStore.i,
+                    KernelConfig.i),
                 WebInterfaceWearablesCatalogService.Instance,
                 DataStore.i.common.wearables,
                 KernelConfig.i,

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/KernelConfiguration/KernelConfigModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/KernelConfiguration/KernelConfigModel.cs
@@ -21,6 +21,7 @@ public class KernelConfigModel
     public ProceduralSkybox proceduralSkyboxConfig = new ProceduralSkybox();
     public string avatarTextureAPIBaseUrl = string.Empty;
     public bool urlParamsForWearablesDebug = false;
+    public string builderUrl;
 
     public override bool Equals(object obj) { return obj is KernelConfigModel other && Equals(other); }
 
@@ -48,7 +49,8 @@ public class KernelConfigModel
                && debugConfig.Equals(other.debugConfig)
                && proceduralSkyboxConfig.Equals(other.proceduralSkyboxConfig)
                && avatarTextureAPIBaseUrl == other.avatarTextureAPIBaseUrl
-               && urlParamsForWearablesDebug == other.urlParamsForWearablesDebug;
+               && urlParamsForWearablesDebug == other.urlParamsForWearablesDebug
+               && builderUrl == other.builderUrl;
     }
 
     public string GetTld() =>
@@ -70,6 +72,7 @@ public class KernelConfigModel
         clone.proceduralSkyboxConfig = proceduralSkyboxConfig.Clone();
         clone.avatarTextureAPIBaseUrl = avatarTextureAPIBaseUrl;
         clone.urlParamsForWearablesDebug = urlParamsForWearablesDebug;
+        clone.builderUrl = builderUrl;
         return clone;
     }
 }

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/KernelConfiguration/KernelConfigModel.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/KernelConfiguration/KernelConfigModel.cs
@@ -21,7 +21,7 @@ public class KernelConfigModel
     public ProceduralSkybox proceduralSkyboxConfig = new ProceduralSkybox();
     public string avatarTextureAPIBaseUrl = string.Empty;
     public bool urlParamsForWearablesDebug = false;
-    public string builderUrl;
+    public string builderUrl = string.Empty;
 
     public override bool Equals(object obj) { return obj is KernelConfigModel other && Equals(other); }
 


### PR DESCRIPTION
## What does this PR change?

Allows the kernel to pass the builder url to renderer so it is used while previewing wearables and emotes in the backpack.

## How to test the changes?

1. Try to preview wearables and emote collections from the builder either passing a custom builder url or the default one.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
