### PR TITLE
feat: add name query param to wearable collections from builder

### DIFF
--- a/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/LambdasEmotesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/EmotesCatalog/EmotesCatalogService/LambdasEmotesCatalogService.cs
@@ -375,6 +375,8 @@ public class LambdasEmotesCatalogService : IEmotesCatalogService
             if (!success)
                 throw new Exception($"The request for collection of emotes '{collectionId}' failed!");
 
+            if (response.data?.results == null) continue;
+
             foreach (BuilderWearable bw in response.data.results)
             {
                 var wearable = bw.ToWearableItem($"{domain}/storage/contents/",

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/IWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/IWearablesCatalogService.cs
@@ -26,7 +26,7 @@ namespace DCLServices.WearablesCatalogService
         UniTask<WearableItem> RequestWearableAsync(string wearableId, CancellationToken ct);
         UniTask<WearableItem> RequestWearableFromBuilderAsync(string wearableId, CancellationToken ct);
         UniTask<IReadOnlyList<WearableItem>> RequestWearableCollection(IEnumerable<string> collectionIds, CancellationToken cancellationToken, List<WearableItem> collectionBuffer = null);
-        UniTask<IReadOnlyList<WearableItem>> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds, CancellationToken cancellationToken, List<WearableItem> collectionBuffer = null, string nameFilter = null);
+        UniTask<(IReadOnlyList<WearableItem> wearables, int totalAmount)> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds, CancellationToken cancellationToken, List<WearableItem> collectionBuffer = null, string nameFilter = null, int pageNumber = 1, int pageSize = 5000);
 
         void AddWearablesToCatalog(IEnumerable<WearableItem> wearableItems);
         void RemoveWearablesFromCatalog(IEnumerable<string> wearableIds);

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/IWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/IWearablesCatalogService.cs
@@ -26,7 +26,7 @@ namespace DCLServices.WearablesCatalogService
         UniTask<WearableItem> RequestWearableAsync(string wearableId, CancellationToken ct);
         UniTask<WearableItem> RequestWearableFromBuilderAsync(string wearableId, CancellationToken ct);
         UniTask<IReadOnlyList<WearableItem>> RequestWearableCollection(IEnumerable<string> collectionIds, CancellationToken cancellationToken, List<WearableItem> collectionBuffer = null);
-        UniTask<IReadOnlyList<WearableItem>> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds, CancellationToken cancellationToken, List<WearableItem> collectionBuffer = null);
+        UniTask<IReadOnlyList<WearableItem>> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds, CancellationToken cancellationToken, List<WearableItem> collectionBuffer = null, string nameFilter = null);
 
         void AddWearablesToCatalog(IEnumerable<WearableItem> wearableItems);
         void RemoveWearablesFromCatalog(IEnumerable<string> wearableIds);

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -353,15 +353,6 @@ namespace DCLServices.WearablesCatalogService
             string domain = GetBuilderDomainUrl();
             var wearables = collectionBuffer ?? new List<WearableItem>();
 
-            // Dictionary<string, string> queryParams = new ()
-            // {
-            //     { "page", pageNumber.ToString() },
-            //     { "limit", pageSize.ToString() },
-            // };
-            //
-            // if (!string.IsNullOrEmpty(nameFilter))
-            //     queryParams["name"] = nameFilter;
-
             var queryParams = new[]
             {
                 ("page", pageNumber.ToString()),

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/LambdasWearablesCatalogService.cs
@@ -347,7 +347,7 @@ namespace DCLServices.WearablesCatalogService
         }
 
         public async UniTask<IReadOnlyList<WearableItem>> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds,
-            CancellationToken cancellationToken, List<WearableItem> collectionBuffer = null)
+            CancellationToken cancellationToken, List<WearableItem> collectionBuffer = null, string nameFilter = null)
         {
             string domain = GetBuilderDomainUrl();
             var wearables = collectionBuffer ?? new List<WearableItem>();
@@ -355,13 +355,17 @@ namespace DCLServices.WearablesCatalogService
             var queryParams = new[]
             {
                 ("page", "1"),
-                ("limit", "5000"),
+                // TODO: we should properly calculate pagination from the ui instead of requesting all at once
+                ("limit", "15000"),
             };
 
             foreach (string collectionId in collectionIds)
             {
                 var url = $"{domain}/collections/{collectionId}/items/";
                 var templateUrl = $"{domain}/collections/:collectionId/items/";
+
+                if (!string.IsNullOrEmpty(nameFilter))
+                    url += $"?name={nameFilter}";
 
                 (WearableCollectionResponseFromBuilder response, bool success) = await lambdasService.GetFromSpecificUrl<WearableCollectionResponseFromBuilder>(
                     templateUrl, url,

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearablesCatalogServiceProxy.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearablesCatalogServiceProxy.cs
@@ -124,13 +124,15 @@ namespace DCLServices.WearablesCatalogService
             return await lambdasWearablesCatalogService.RequestWearableCollection(collectionIds, cancellationToken, wearableBuffer);
         }
 
-        public async UniTask<IReadOnlyList<WearableItem>> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds,
-            CancellationToken cancellationToken, List<WearableItem> wearableBuffer = null, string nameFilter = null)
+        public async UniTask<(IReadOnlyList<WearableItem> wearables, int totalAmount)> RequestWearableCollectionInBuilder(
+            IEnumerable<string> collectionIds, CancellationToken cancellationToken,
+            List<WearableItem> collectionBuffer = null, string nameFilter = null, int pageNumber = 1, int pageSize = 5000)
         {
             if (!isInitialized)
                 await UniTask.WaitUntil(() => isInitialized, cancellationToken: cancellationToken);
 
-            return await lambdasWearablesCatalogService.RequestWearableCollectionInBuilder(collectionIds, cancellationToken, wearableBuffer, nameFilter);
+            return await lambdasWearablesCatalogService.RequestWearableCollectionInBuilder(collectionIds, cancellationToken,
+                collectionBuffer, nameFilter, pageNumber, pageSize);
         }
 
         public void AddWearablesToCatalog(IEnumerable<WearableItem> wearableItems) =>

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearablesCatalogServiceProxy.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WearablesCatalogServiceProxy.cs
@@ -125,12 +125,12 @@ namespace DCLServices.WearablesCatalogService
         }
 
         public async UniTask<IReadOnlyList<WearableItem>> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds,
-            CancellationToken cancellationToken, List<WearableItem> wearableBuffer = null)
+            CancellationToken cancellationToken, List<WearableItem> wearableBuffer = null, string nameFilter = null)
         {
             if (!isInitialized)
                 await UniTask.WaitUntil(() => isInitialized, cancellationToken: cancellationToken);
 
-            return await lambdasWearablesCatalogService.RequestWearableCollectionInBuilder(collectionIds, cancellationToken, wearableBuffer);
+            return await lambdasWearablesCatalogService.RequestWearableCollectionInBuilder(collectionIds, cancellationToken, wearableBuffer, nameFilter);
         }
 
         public void AddWearablesToCatalog(IEnumerable<WearableItem> wearableItems) =>

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WebInterfaceWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WebInterfaceWearablesCatalogService.cs
@@ -130,8 +130,9 @@ namespace DCLServices.WearablesCatalogService
             CancellationToken cancellationToken, List<WearableItem> wearableBuffer = null) =>
             throw new NotImplementedException("Supported by LambdasWearablesCatalogService");
 
-        public UniTask<IReadOnlyList<WearableItem>> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds,
-            CancellationToken cancellationToken, List<WearableItem> wearableBuffer = null, string nameFilter = null) =>
+        public UniTask<(IReadOnlyList<WearableItem> wearables, int totalAmount)> RequestWearableCollectionInBuilder(
+            IEnumerable<string> collectionIds, CancellationToken cancellationToken,
+            List<WearableItem> collectionBuffer = null, string nameFilter = null, int pageNumber = 1, int pageSize = 5000) =>
             throw new NotImplementedException("Supported by LambdasWearablesCatalogService");
 
         private async UniTask<IReadOnlyList<WearableItem>> RequestWearablesByContextAsync(

--- a/unity-renderer/Assets/DCLServices/WearablesCatalogService/WebInterfaceWearablesCatalogService.cs
+++ b/unity-renderer/Assets/DCLServices/WearablesCatalogService/WebInterfaceWearablesCatalogService.cs
@@ -131,7 +131,7 @@ namespace DCLServices.WearablesCatalogService
             throw new NotImplementedException("Supported by LambdasWearablesCatalogService");
 
         public UniTask<IReadOnlyList<WearableItem>> RequestWearableCollectionInBuilder(IEnumerable<string> collectionIds,
-            CancellationToken cancellationToken, List<WearableItem> wearableBuffer = null) =>
+            CancellationToken cancellationToken, List<WearableItem> wearableBuffer = null, string nameFilter = null) =>
             throw new NotImplementedException("Supported by LambdasWearablesCatalogService");
 
         private async UniTask<IReadOnlyList<WearableItem>> RequestWearablesByContextAsync(

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/WearableGridControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/WearableGridControllerShould.cs
@@ -1121,7 +1121,8 @@ namespace DCL.Backpack
             };
 
             wearablesCatalogService.RequestWearableCollectionInBuilder(Arg.Is<IEnumerable<string>>(i => i.Count() == 1 && i.ElementAt(0) == "builder:collection"),
-                                        Arg.Any<CancellationToken>(), Arg.Any<List<WearableItem>>())
+                                        Arg.Any<CancellationToken>(), Arg.Any<List<WearableItem>>(),
+                                        Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
                                    .Returns(call =>
                                     {
                                         List<WearableItem> wearables = (List<WearableItem>) call[2];

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/WearableGridControllerShould.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/Tests/WearableGridControllerShould.cs
@@ -1126,7 +1126,7 @@ namespace DCL.Backpack
                                     {
                                         List<WearableItem> wearables = (List<WearableItem>) call[2];
                                         wearables.AddRange(nonPublishedWearableList);
-                                        return UniTask.FromResult(nonPublishedWearableList);
+                                        return UniTask.FromResult((nonPublishedWearableList, nonPublishedWearableList.Count));
                                     });
 
             wearablesCatalogService.RequestWearableCollection(Arg.Is<IEnumerable<string>>(i => i.Count() == 1 && i.ElementAt(0) == "urn:collection"),

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
@@ -357,7 +357,7 @@ namespace DCL.Backpack
             }
 
             await UniTask.WhenAll(wearablesCatalogService.RequestWearableCollection(publishedCollections, cancellationToken, wearableBuffer),
-                wearablesCatalogService.RequestWearableCollectionInBuilder(collectionsInBuilder, cancellationToken, wearableBuffer));
+                wearablesCatalogService.RequestWearableCollectionInBuilder(collectionsInBuilder, cancellationToken, wearableBuffer, nameFilter));
 
             HashSetPool<string>.Release(publishedCollections);
             HashSetPool<string>.Release(collectionsInBuilder);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
@@ -267,8 +267,8 @@ namespace DCL.Backpack
 
                 try
                 {
-                    totalAmount += await MergeBuilderWearableCollections(page, wearables, totalAmount, cancellationToken);
                     totalAmount += await MergePublishedWearableCollections(page, wearables, totalAmount, cancellationToken);
+                    totalAmount += await MergeBuilderWearableCollections(page, wearables, totalAmount, cancellationToken);
                     totalAmount += await MergeCustomWearableItems(page, wearables, totalAmount, cancellationToken);
 
                     customWearablesBuffer.Clear();
@@ -300,7 +300,7 @@ namespace DCL.Backpack
 
         private async UniTask<int> MergePublishedWearableCollections(int page, List<WearableItem> wearables, int totalAmount,
             CancellationToken cancellationToken) =>
-            await MergeToWearableResults(page, wearables, totalAmount, FetchPublishedWearableCollections, cancellationToken);
+             await MergeToWearableResults(page, wearables, totalAmount, FetchPublishedWearableCollections, cancellationToken);
 
         private async UniTask<int> MergeToWearableResults(int page, List<WearableItem> wearables, int totalAmount,
             Func<List<WearableItem>, CancellationToken, UniTask> fetchOperation,
@@ -315,6 +315,8 @@ namespace DCL.Backpack
             customWearablesBuffer.Clear();
 
             await fetchOperation.Invoke(customWearablesBuffer, cancellationToken);
+
+            if (skip < 0) return customWearablesBuffer.Count;
 
             for (int i = skip; i < customWearablesBuffer.Count && i < until; i++)
                 wearables.Add(customWearablesBuffer[i]);

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BackpackEditorHUDV2/WearableGridController.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -266,29 +267,9 @@ namespace DCL.Backpack
 
                 try
                 {
-                    int ownedWearablesCount = wearables.Count;
-                    int ownedWearablesTotalAmount = totalAmount;
-
-                    customWearablesBuffer.Clear();
-
-                    await UniTask.WhenAll(FetchCustomWearableCollections(customWearablesBuffer, cancellationToken),
-                        FetchCustomWearableItems(customWearablesBuffer, cancellationToken));
-
-                    int customWearablesCount = customWearablesBuffer.Count;
-                    totalAmount += customWearablesCount;
-
-                    if (ownedWearablesCount < PAGE_SIZE && customWearablesCount > 0)
-                    {
-                        int ownedWearablesStartingPage = (ownedWearablesTotalAmount / PAGE_SIZE) + 1;
-                        int customWearablesOffsetPage = page - ownedWearablesStartingPage;
-                        int skip = customWearablesOffsetPage * PAGE_SIZE;
-                        // Fill the page considering the existing owned wearables
-                        int count = PAGE_SIZE - ownedWearablesCount;
-                        int until = skip + count;
-
-                        for (int i = skip; i < customWearablesBuffer.Count && i < until; i++)
-                            wearables.Add(customWearablesBuffer[i]);
-                    }
+                    totalAmount += await MergeBuilderWearableCollections(page, wearables, totalAmount, cancellationToken);
+                    totalAmount += await MergePublishedWearableCollections(page, wearables, totalAmount, cancellationToken);
+                    totalAmount += await MergeCustomWearableItems(page, wearables, totalAmount, cancellationToken);
 
                     customWearablesBuffer.Clear();
                 }
@@ -299,7 +280,7 @@ namespace DCL.Backpack
                 currentWearables = wearables.Select(ToWearableGridModel)
                                             .ToDictionary(item => ExtendedUrnParser.GetShortenedUrn(item.WearableId), model => model);
 
-                view.SetWearablePages(page, Mathf.CeilToInt((float) totalAmount / PAGE_SIZE));
+                view.SetWearablePages(page, Mathf.CeilToInt((float)totalAmount / PAGE_SIZE));
 
                 // TODO: mark the wearables to be disposed if no references left
                 view.ClearWearables();
@@ -311,6 +292,51 @@ namespace DCL.Backpack
             catch (Exception e) { Debug.LogException(e); }
 
             return 0;
+        }
+
+        private async UniTask<int> MergeCustomWearableItems(int page, List<WearableItem> wearables,
+            int totalAmount, CancellationToken cancellationToken) =>
+            await MergeToWearableResults(page, wearables, totalAmount, FetchCustomWearableItems, cancellationToken);
+
+        private async UniTask<int> MergePublishedWearableCollections(int page, List<WearableItem> wearables, int totalAmount,
+            CancellationToken cancellationToken) =>
+            await MergeToWearableResults(page, wearables, totalAmount, FetchPublishedWearableCollections, cancellationToken);
+
+        private async UniTask<int> MergeToWearableResults(int page, List<WearableItem> wearables, int totalAmount,
+            Func<List<WearableItem>, CancellationToken, UniTask> fetchOperation,
+            CancellationToken cancellationToken)
+        {
+            int startingPage = (totalAmount / PAGE_SIZE) + 1;
+            int pageOffset = page - startingPage;
+            int pageSize = PAGE_SIZE - wearables.Count;
+            int skip = pageOffset * PAGE_SIZE;
+            int until = skip + pageSize;
+
+            customWearablesBuffer.Clear();
+
+            await fetchOperation.Invoke(customWearablesBuffer, cancellationToken);
+
+            for (int i = skip; i < customWearablesBuffer.Count && i < until; i++)
+                wearables.Add(customWearablesBuffer[i]);
+
+            return customWearablesBuffer.Count;
+        }
+
+        private async UniTask<int> MergeBuilderWearableCollections(int page, List<WearableItem> wearables, int totalAmount, CancellationToken cancellationToken)
+        {
+            int startingPage = (totalAmount / PAGE_SIZE) + 1;
+            int pageOffset = Mathf.Max(1, page - startingPage);
+            int pageSize = PAGE_SIZE - wearables.Count;
+
+            customWearablesBuffer.Clear();
+
+            int collectionsWearableCount = await FetchBuilderWearableCollections(pageOffset, PAGE_SIZE,
+                customWearablesBuffer, cancellationToken);
+
+            for (var i = 0; i < pageSize && i < customWearablesBuffer.Count; i++)
+                wearables.Add(customWearablesBuffer[i]);
+
+            return collectionsWearableCount;
         }
 
         private async UniTask FetchCustomWearableItems(ICollection<WearableItem> wearables, CancellationToken cancellationToken)
@@ -337,30 +363,46 @@ namespace DCL.Backpack
             }
         }
 
-        private async UniTask FetchCustomWearableCollections(
+        private async UniTask FetchPublishedWearableCollections(
             List<WearableItem> wearableBuffer, CancellationToken cancellationToken)
         {
             IReadOnlyList<string> customCollections =
                 await customNftCollectionService.GetConfiguredCustomNftCollectionAsync(cancellationToken);
 
-            Debug.Log($"FetchCustomWearableCollections: {customCollections}");
-
-            HashSet<string> publishedCollections = HashSetPool<string>.Get();
-            HashSet<string> collectionsInBuilder = HashSetPool<string>.Get();
+            HashSet<string> collectionsToRequest = HashSetPool<string>.Get();
 
             foreach (string collectionId in customCollections)
-            {
                 if (collectionId.StartsWith("urn", StringComparison.OrdinalIgnoreCase))
-                    publishedCollections.Add(collectionId);
-                else
-                    collectionsInBuilder.Add(collectionId);
-            }
+                    collectionsToRequest.Add(collectionId);
 
-            await UniTask.WhenAll(wearablesCatalogService.RequestWearableCollection(publishedCollections, cancellationToken, wearableBuffer),
-                wearablesCatalogService.RequestWearableCollectionInBuilder(collectionsInBuilder, cancellationToken, wearableBuffer, nameFilter));
+            await wearablesCatalogService.RequestWearableCollection(collectionsToRequest, cancellationToken, wearableBuffer);
 
-            HashSetPool<string>.Release(publishedCollections);
-            HashSetPool<string>.Release(collectionsInBuilder);
+            HashSetPool<string>.Release(collectionsToRequest);
+        }
+
+        private async UniTask<int> FetchBuilderWearableCollections(
+            int pageNumber, int pageSize,
+            List<WearableItem> wearableBuffer,
+            CancellationToken cancellationToken)
+        {
+            IReadOnlyList<string> customCollections =
+                await customNftCollectionService.GetConfiguredCustomNftCollectionAsync(cancellationToken);
+
+            HashSet<string> collectionsToRequest = HashSetPool<string>.Get();
+
+            foreach (string collectionId in customCollections)
+                if (!collectionId.StartsWith("urn", StringComparison.OrdinalIgnoreCase))
+                    collectionsToRequest.Add(collectionId);
+
+            (IReadOnlyList<WearableItem> _, int totalAmount) = await wearablesCatalogService.RequestWearableCollectionInBuilder(
+                collectionsToRequest, cancellationToken,
+                collectionBuffer: wearableBuffer,
+                nameFilter: nameFilter,
+                pageNumber: pageNumber, pageSize: pageSize);
+
+            HashSetPool<string>.Release(collectionsToRequest);
+
+            return totalAmount;
         }
 
         private WearableGridItemModel ToWearableGridModel(WearableItem wearable)
@@ -369,8 +411,7 @@ namespace DCL.Backpack
 
             if (string.IsNullOrEmpty(wearable.rarity))
                 rarity = NftRarity.None;
-            else
-            if (!Enum.TryParse(wearable.rarity, true, out NftRarity result))
+            else if (!Enum.TryParse(wearable.rarity, true, out NftRarity result))
             {
                 rarity = NftRarity.None;
                 Debug.LogWarning($"Could not parse the rarity \"{wearable.rarity}\" of the wearable '{wearable.id}'. Fallback to common.");

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/TestEnvironment/ServiceLocatorTestFactory.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Environment/TestEnvironment/ServiceLocatorTestFactory.cs
@@ -39,8 +39,10 @@ namespace DCL
             {
                 IWearablesCatalogService wearablesCatalogService = Substitute.For<IWearablesCatalogService>();
 
+
+
                 wearablesCatalogService.RequestWearableCollectionInBuilder(default, default, default)
-                                       .ReturnsForAnyArgs(UniTask.FromResult((IReadOnlyList<WearableItem>) Array.Empty<WearableItem>()));
+                                       .ReturnsForAnyArgs(UniTask.FromResult(((IReadOnlyList<WearableItem>) Array.Empty<WearableItem>(), 0)));
 
                 wearablesCatalogService.RequestWearableFromBuilderAsync(default, default)
                                        .ReturnsForAnyArgs(UniTask.FromResult<WearableItem>(null));

--- a/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/Tests/Helpers/AvatarAssetsTestHelpers.cs
+++ b/unity-renderer/Assets/Scripts/MainScripts/DCL/Models/AvatarAssets/Tests/Helpers/AvatarAssetsTestHelpers.cs
@@ -91,7 +91,7 @@ namespace MainScripts.DCL.Models.AvatarAssets.Tests.Helpers
                                    .ReturnsForAnyArgs(UniTask.FromResult<IReadOnlyList<WearableItem>>(Array.Empty<WearableItem>()));
 
             wearablesCatalogService.RequestWearableCollectionInBuilder(default, default, default)
-                                   .ReturnsForAnyArgs(UniTask.FromResult<IReadOnlyList<WearableItem>>(Array.Empty<WearableItem>()));
+                                   .ReturnsForAnyArgs(UniTask.FromResult(((IReadOnlyList<WearableItem>) Array.Empty<WearableItem>(), 0)));
 
             return wearablesCatalogService;
         }


### PR DESCRIPTION
## What does this PR change?

Adds the possibility to filter preview wearables (from builder) using the search bar in the backpack.
Additionally the pagination of wearable collections fetched from the builder has been reworked, so we can properly fetch massive collections.

## How to test the changes?

1. Launch the explorer with: [link](https://decentraland.org/play/?explorer-branch=feat/preview-collections-text-filter&BUILDER_SERVER_URL=https%3A%2F%2Fbuilder-api.decentraland.org%2Fv1&DEBUG_MODE=true&WITH_COLLECTIONS=5b11081d-723a-40db-b6e0-fdae75958cc8&position=100%2C100&CATALYST=peer-testing.decentraland.org&realm=testing&island=peer-testing10)
2. Open the backpack
3. Use the search bar
4. Check that the items from the preview collection are filtered by name
5. Check other collections either published or not using the `&WITH_COLLECTIONS` parameter
6. Check that all the items are available to preview
7. Check custom wearables using the parameter `&WITH_ITEMS` either published or not.
8. Check that all the items are available to preview

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
