### PR TITLE
fix: Load items from builder-server using peer-testing

### DIFF
--- a/browser-interface/packages/config/index.ts
+++ b/browser-interface/packages/config/index.ts
@@ -107,6 +107,8 @@ export const BYPASS_CONTENT_ALLOWLIST = qs.has('BYPASS_CONTENT_ALLOWLIST')
   ? qs.get('BYPASS_CONTENT_ALLOWLIST') === 'true'
   : PIN_CATALYST || globalThis.location.hostname !== 'play.decentraland.org'
 
+export const PEER_TESTING_CATALYST = 'https://peer-testing.decentraland.org'
+
 const META_CONFIG_URL = ensureSingleString(qs.get('META_CONFIG_URL'))
 
 export const CHANNEL_TO_JOIN_CONFIG_URL = ensureSingleString(qs.get('CHANNEL'))

--- a/browser-interface/packages/shared/catalogs/sagas.ts
+++ b/browser-interface/packages/shared/catalogs/sagas.ts
@@ -9,7 +9,8 @@ import {
   ETHEREUM_NETWORK,
   BUILDER_SERVER_URL,
   rootURLPreviewMode,
-  WITH_FIXED_ITEMS
+  WITH_FIXED_ITEMS,
+  PEER_TESTING_CATALYST
 } from 'config'
 
 import { authorizeBuilderHeaders } from 'lib/decentraland/authentication/authorizeBuilderHeaders'
@@ -122,8 +123,12 @@ function* fetchItemsFromCatalyst(
   const identity: ExplorerIdentity = yield select(getCurrentIdentity)
   const client: CatalystClient = new CatalystClient({ catalystUrl })
   const network: ETHEREUM_NETWORK = yield select(getSelectedNetwork)
-  const COLLECTIONS_OR_ITEMS_ALLOWED =
-    PREVIEW || ((DEBUG || getTLD() !== 'org') && network !== ETHEREUM_NETWORK.MAINNET)
+  const isPreviewMode = PREVIEW
+  const isDebugOrNonOrgTLD = DEBUG || getTLD() !== 'org'
+  const isNonMainnetOrTestingPeer =
+    network !== ETHEREUM_NETWORK.MAINNET ||
+    (network === ETHEREUM_NETWORK.MAINNET && catalystUrl === PEER_TESTING_CATALYST)
+  const COLLECTIONS_OR_ITEMS_ALLOWED = isPreviewMode || (isDebugOrNonOrgTLD && isNonMainnetOrTestingPeer)
   const isRequestingEmotes = action.type === EMOTES_REQUEST
   const catalystFetchFn = isRequestingEmotes ? client.fetchEmotes : client.fetchWearables
   const result: PartialItem[] = []
@@ -264,7 +269,7 @@ function fetchOwnedEmotes(ethAddress: string, client: CatalystClient) {
 
 export function urnWithoutToken(urn: string): string {
   const value = urn.split(':')
-  if (value.length === 7 && !urn.includes("collections-thirdparty")) {
+  if (value.length === 7 && !urn.includes('collections-thirdparty')) {
     return value.slice(0, 6).join(':')
   }
   return urn


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

When creators try to preview an unpublished wearable in mainnet, it's not possible due to validations in the catalog.
This PR introduces a new validation to enable the wearables preview in-world when using the `CATALYST=peer-testing.decentraland.org`.


## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Create a new collection in the builder: https://decentraland.org/builder -- [docs](https://docs.decentraland.org/creator/wearables-and-emotes/manage-collections/creating-collection/)
2. Upload any glb model to the collection [docs](https://docs.decentraland.org/creator/wearables-and-emotes/manage-collections/uploading-wearables/)
3. In the collection detail page, Click on the button: `see in decentraland`
4. Use the Web Explorer version
5. Open the backpack/catalog, and you should see the unpublished item

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

## Copilot summary

copilot:summary
